### PR TITLE
re-implement transitionWordBreakState with generics

### DIFF
--- a/step.go
+++ b/step.go
@@ -116,7 +116,7 @@ func Step(b []byte, state int) (cluster, rest []byte, boundaries int, newState i
 	remainder := b[length:]
 	if state < 0 {
 		graphemeState, firstProp, _ = transitionGraphemeState(-1, r)
-		wordState, _ = transitionWordBreakState(-1, r, remainder, "")
+		wordState, _ = transitionWordBreakState(-1, r, remainder, utf8.DecodeRune)
 		sentenceState, _ = transitionSentenceBreakState(-1, r, remainder, "")
 		lineState, _ = transitionLineBreakState(-1, r, remainder, "")
 	} else {
@@ -140,7 +140,7 @@ func Step(b []byte, state int) (cluster, rest []byte, boundaries int, newState i
 		remainder = b[length+l:]
 
 		graphemeState, prop, graphemeBoundary = transitionGraphemeState(graphemeState, r)
-		wordState, wordBoundary = transitionWordBreakState(wordState, r, remainder, "")
+		wordState, wordBoundary = transitionWordBreakState(wordState, r, remainder, utf8.DecodeRune)
 		sentenceState, sentenceBoundary = transitionSentenceBreakState(sentenceState, r, remainder, "")
 		lineState, lineBreak = transitionLineBreakState(lineState, r, remainder, "")
 
@@ -197,7 +197,7 @@ func StepString(str string, state int) (cluster, rest string, boundaries int, ne
 	remainder := str[length:]
 	if state < 0 {
 		graphemeState, firstProp, _ = transitionGraphemeState(-1, r)
-		wordState, _ = transitionWordBreakState(-1, r, nil, remainder)
+		wordState, _ = transitionWordBreakState(-1, r, remainder, utf8.DecodeRuneInString)
 		sentenceState, _ = transitionSentenceBreakState(-1, r, nil, remainder)
 		lineState, _ = transitionLineBreakState(-1, r, nil, remainder)
 	} else {
@@ -221,7 +221,7 @@ func StepString(str string, state int) (cluster, rest string, boundaries int, ne
 		remainder = str[length+l:]
 
 		graphemeState, prop, graphemeBoundary = transitionGraphemeState(graphemeState, r)
-		wordState, wordBoundary = transitionWordBreakState(wordState, r, nil, remainder)
+		wordState, wordBoundary = transitionWordBreakState(wordState, r, remainder, utf8.DecodeRuneInString)
 		sentenceState, sentenceBoundary = transitionSentenceBreakState(sentenceState, r, nil, remainder)
 		lineState, lineBreak = transitionLineBreakState(lineState, r, nil, remainder)
 

--- a/uniseg.go
+++ b/uniseg.go
@@ -11,3 +11,11 @@ package uniseg
 //go:generate go run ./internal/cmd/gen_properties LineBreak lineproperties.go lineBreakCodePoints lines gencat
 //go:generate go run ./internal/cmd/gen_properties EastAsianWidth eastasianwidth.go eastAsianWidth eastasianwidth
 //go:generate go run ./internal/cmd/gen_properties - emojipresentation.go emojiPresentation emojipresentation emojis=Emoji_Presentation
+
+// bytes is a type that is either []byte or string.
+type bytes interface {
+	~string | ~[]byte
+}
+
+// runeDecoder is a function that decodes a rune from bytes.
+type runeDecoder[T any] func(s T) (r rune, size int)

--- a/wordrules.go
+++ b/wordrules.go
@@ -113,7 +113,7 @@ var wbTransitions = map[wbStateProperty]wbTransitionResult{
 // word boundary was detected. If more than one code point is needed to
 // determine the new state, the byte slice or the string starting after rune "r"
 // can be used (whichever is not nil or empty) for further lookups.
-func transitionWordBreakState(state WordBreakState, r rune, b []byte, str string) (newState WordBreakState, wordBreak bool) {
+func transitionWordBreakState[T bytes](state WordBreakState, r rune, str T, decoder runeDecoder[T]) (newState WordBreakState, wordBreak bool) {
 	// Determine the property of the next character.
 	nextProperty := workBreakCodePoints.search(r)
 
@@ -190,17 +190,8 @@ func transitionWordBreakState(state WordBreakState, r rune, b []byte, str string
 			nextProperty == prDoubleQuote || // WB7b.
 			nextProperty == prMidNum) { // WB12.
 		for {
-			var (
-				r      rune
-				length int
-			)
-			if b != nil { // Byte slice version.
-				r, length = utf8.DecodeRune(b)
-				b = b[length:]
-			} else { // String version.
-				r, length = utf8.DecodeRuneInString(str)
-				str = str[length:]
-			}
+			r, length := decoder(str)
+			str = str[length:]
 			if r == utf8.RuneError {
 				break
 			}


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/shogo82148/uniseg
                      │   .old.txt   │              .new.txt               │
                      │    sec/op    │    sec/op     vs base               │
WordFunctionBytes-10    0.6242n ± 1%   0.6212n ± 0%  -0.48% (p=0.009 n=10)
WordFunctionString-10   0.6273n ± 0%   0.6211n ± 0%  -1.00% (p=0.000 n=10)
geomean                 0.6258n        0.6211n       -0.74%

                      │   .old.txt   │              .new.txt               │
                      │     B/op     │    B/op     vs base                 │
WordFunctionBytes-10    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
WordFunctionString-10   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                            ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                      │   .old.txt   │              .new.txt               │
                      │  allocs/op   │ allocs/op   vs base                 │
WordFunctionBytes-10    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
WordFunctionString-10   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                            ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```