### PR TITLE
re-implement transitionSentenceBreakState with generics

### DIFF
--- a/sentence.go
+++ b/sentence.go
@@ -20,63 +20,39 @@ import "unicode/utf8"
 //
 // [Unicode Standard Annex #29, Sentence Boundaries]: https://www.unicode.org/reports/tr29/tr29-41.html#Sentence_Boundaries
 func FirstSentence(b []byte, state SentenceBreakState) (sentence, rest []byte, newState SentenceBreakState) {
-	// An empty byte slice returns nothing.
-	if len(b) == 0 {
-		return
-	}
-
-	// Extract the first rune.
-	r, length := utf8.DecodeRune(b)
-	if len(b) <= length { // If we're already past the end, there is nothing else to parse.
-		return b, nil, sbAny
-	}
-
-	// If we don't know the state, determine it now.
-	if state < 0 {
-		state, _ = transitionSentenceBreakState(state, r, b[length:], "")
-	}
-
-	// Transition until we find a boundary.
-	var boundary bool
-	for {
-		r, l := utf8.DecodeRune(b[length:])
-		state, boundary = transitionSentenceBreakState(state, r, b[length+l:], "")
-
-		if boundary {
-			return b[:length], b[length:], state
-		}
-
-		length += l
-		if len(b) <= length {
-			return b, nil, sbAny
-		}
-	}
+	return firstSentence(b, state, utf8.DecodeRune)
 }
 
 // FirstSentenceInString is like [FirstSentence] but its input and outputs are
 // strings.
 func FirstSentenceInString(str string, state SentenceBreakState) (sentence, rest string, newState SentenceBreakState) {
+	return firstSentence(str, state, utf8.DecodeRuneInString)
+}
+
+func firstSentence[T bytes](str T, state SentenceBreakState, decoder runeDecoder[T]) (sentence, rest T, newState SentenceBreakState) {
+	var zero T
+
 	// An empty byte slice returns nothing.
 	if len(str) == 0 {
 		return
 	}
 
 	// Extract the first rune.
-	r, length := utf8.DecodeRuneInString(str)
+	r, length := decoder(str)
 	if len(str) <= length { // If we're already past the end, there is nothing else to parse.
-		return str, "", sbAny
+		return str, zero, sbAny
 	}
 
 	// If we don't know the state, determine it now.
 	if state < 0 {
-		state, _ = transitionSentenceBreakState(state, r, nil, str[length:])
+		state, _ = transitionSentenceBreakState(state, r, str[length:], decoder)
 	}
 
 	// Transition until we find a boundary.
 	var boundary bool
 	for {
-		r, l := utf8.DecodeRuneInString(str[length:])
-		state, boundary = transitionSentenceBreakState(state, r, nil, str[length+l:])
+		r, l := decoder(str[length:])
+		state, boundary = transitionSentenceBreakState(state, r, str[length+l:], decoder)
 
 		if boundary {
 			return str[:length], str[length:], state
@@ -84,7 +60,7 @@ func FirstSentenceInString(str string, state SentenceBreakState) (sentence, rest
 
 		length += l
 		if len(str) <= length {
-			return str, "", sbAny
+			return str, zero, sbAny
 		}
 	}
 }

--- a/sentencerules.go
+++ b/sentencerules.go
@@ -132,7 +132,7 @@ var sbTransitions = map[sbStateProperty]sbTransitionResult{
 // needed to determine the new state, the byte slice or the string starting
 // after rune "r" can be used (whichever is not nil or empty) for further
 // lookups.
-func transitionSentenceBreakState(state SentenceBreakState, r rune, b []byte, str string) (newState SentenceBreakState, sentenceBreak bool) {
+func transitionSentenceBreakState[T bytes](state SentenceBreakState, r rune, str T, decoder runeDecoder[T]) (newState SentenceBreakState, sentenceBreak bool) {
 	// Determine the property of the next character.
 	nextProperty := sentenceBreakCodePoints.search(r)
 
@@ -192,13 +192,8 @@ func transitionSentenceBreakState(state SentenceBreakState, r rune, b []byte, st
 			nextProperty != prATerm &&
 			nextProperty != prSTerm {
 			// Move on to the next rune.
-			if b != nil { // Byte slice version.
-				r, length = utf8.DecodeRune(b)
-				b = b[length:]
-			} else { // String version.
-				r, length = utf8.DecodeRuneInString(str)
-				str = str[length:]
-			}
+			r, length = decoder(str)
+			str = str[length:]
 			if r == utf8.RuneError {
 				break
 			}

--- a/step.go
+++ b/step.go
@@ -117,7 +117,7 @@ func Step(b []byte, state int) (cluster, rest []byte, boundaries int, newState i
 	if state < 0 {
 		graphemeState, firstProp, _ = transitionGraphemeState(-1, r)
 		wordState, _ = transitionWordBreakState(-1, r, remainder, utf8.DecodeRune)
-		sentenceState, _ = transitionSentenceBreakState(-1, r, remainder, "")
+		sentenceState, _ = transitionSentenceBreakState(-1, r, remainder, utf8.DecodeRune)
 		lineState, _ = transitionLineBreakState(-1, r, remainder, "")
 	} else {
 		graphemeState = grState(state & maskGraphemeState)
@@ -141,7 +141,7 @@ func Step(b []byte, state int) (cluster, rest []byte, boundaries int, newState i
 
 		graphemeState, prop, graphemeBoundary = transitionGraphemeState(graphemeState, r)
 		wordState, wordBoundary = transitionWordBreakState(wordState, r, remainder, utf8.DecodeRune)
-		sentenceState, sentenceBoundary = transitionSentenceBreakState(sentenceState, r, remainder, "")
+		sentenceState, sentenceBoundary = transitionSentenceBreakState(sentenceState, r, remainder, utf8.DecodeRune)
 		lineState, lineBreak = transitionLineBreakState(lineState, r, remainder, "")
 
 		if graphemeBoundary {
@@ -198,7 +198,7 @@ func StepString(str string, state int) (cluster, rest string, boundaries int, ne
 	if state < 0 {
 		graphemeState, firstProp, _ = transitionGraphemeState(-1, r)
 		wordState, _ = transitionWordBreakState(-1, r, remainder, utf8.DecodeRuneInString)
-		sentenceState, _ = transitionSentenceBreakState(-1, r, nil, remainder)
+		sentenceState, _ = transitionSentenceBreakState(-1, r, remainder, utf8.DecodeRuneInString)
 		lineState, _ = transitionLineBreakState(-1, r, nil, remainder)
 	} else {
 		graphemeState = grState(state & maskGraphemeState)
@@ -222,7 +222,7 @@ func StepString(str string, state int) (cluster, rest string, boundaries int, ne
 
 		graphemeState, prop, graphemeBoundary = transitionGraphemeState(graphemeState, r)
 		wordState, wordBoundary = transitionWordBreakState(wordState, r, remainder, utf8.DecodeRuneInString)
-		sentenceState, sentenceBoundary = transitionSentenceBreakState(sentenceState, r, nil, remainder)
+		sentenceState, sentenceBoundary = transitionSentenceBreakState(sentenceState, r, remainder, utf8.DecodeRuneInString)
 		lineState, lineBreak = transitionLineBreakState(lineState, r, nil, remainder)
 
 		if graphemeBoundary {


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/shogo82148/uniseg
                          │   .old.txt   │              .new.txt               │
                          │    sec/op    │    sec/op     vs base               │
SentenceFunctionBytes-10    0.6211n ± 0%   0.6217n ± 0%  +0.10% (p=0.035 n=20)
SentenceFunctionString-10   0.6217n ± 0%   0.6219n ± 0%       ~ (p=0.973 n=20)
geomean                     0.6214n        0.6218n       +0.06%

                          │   .old.txt   │              .new.txt               │
                          │     B/op     │    B/op     vs base                 │
SentenceFunctionBytes-10    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=20) ¹
SentenceFunctionString-10   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=20) ¹
geomean                                ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                          │   .old.txt   │              .new.txt               │
                          │  allocs/op   │ allocs/op   vs base                 │
SentenceFunctionBytes-10    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=20) ¹
SentenceFunctionString-10   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=20) ¹
geomean                                ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```