### PR TITLE
re-implement transitionLineBreakState with generics

### DIFF
--- a/linerules.go
+++ b/linerules.go
@@ -304,7 +304,7 @@ var lbTransitions = map[lbStateProperty]lbTransitionResult{
 // code point is needed to determine the new state, the byte slice or the string
 // starting after rune "r" can be used (whichever is not nil or empty) for
 // further lookups.
-func transitionLineBreakState(state LineBreakState, r rune, b []byte, str string) (newState LineBreakState, lineBreak LineBreak) {
+func transitionLineBreakState[T bytes](state LineBreakState, r rune, str T, decoder runeDecoder[T]) (newState LineBreakState, lineBreak LineBreak) {
 	// Determine the property of the next character.
 	lbProp := lineBreakCodePoints.search(r)
 	nextProperty := lbProp.property
@@ -426,11 +426,7 @@ func transitionLineBreakState(state LineBreakState, r rune, b []byte, str string
 		(state == lbPR || state == lbPO) &&
 		nextProperty == prOP || nextProperty == prHY {
 		var r rune
-		if b != nil { // Byte slice version.
-			r, _ = utf8.DecodeRune(b)
-		} else { // String version.
-			r, _ = utf8.DecodeRuneInString(str)
-		}
+		r, _ = decoder(str)
 		if r != utf8.RuneError {
 			pr := lineBreakCodePoints.search(r).property
 			if pr == prNU {

--- a/step.go
+++ b/step.go
@@ -118,7 +118,7 @@ func Step(b []byte, state int) (cluster, rest []byte, boundaries int, newState i
 		graphemeState, firstProp, _ = transitionGraphemeState(-1, r)
 		wordState, _ = transitionWordBreakState(-1, r, remainder, utf8.DecodeRune)
 		sentenceState, _ = transitionSentenceBreakState(-1, r, remainder, utf8.DecodeRune)
-		lineState, _ = transitionLineBreakState(-1, r, remainder, "")
+		lineState, _ = transitionLineBreakState(-1, r, remainder, utf8.DecodeRune)
 	} else {
 		graphemeState = grState(state & maskGraphemeState)
 		wordState = WordBreakState((state >> shiftWordState) & maskWordState)
@@ -142,7 +142,7 @@ func Step(b []byte, state int) (cluster, rest []byte, boundaries int, newState i
 		graphemeState, prop, graphemeBoundary = transitionGraphemeState(graphemeState, r)
 		wordState, wordBoundary = transitionWordBreakState(wordState, r, remainder, utf8.DecodeRune)
 		sentenceState, sentenceBoundary = transitionSentenceBreakState(sentenceState, r, remainder, utf8.DecodeRune)
-		lineState, lineBreak = transitionLineBreakState(lineState, r, remainder, "")
+		lineState, lineBreak = transitionLineBreakState(lineState, r, remainder, utf8.DecodeRune)
 
 		if graphemeBoundary {
 			boundary := int(lineBreak) | (width << ShiftWidth)
@@ -199,7 +199,7 @@ func StepString(str string, state int) (cluster, rest string, boundaries int, ne
 		graphemeState, firstProp, _ = transitionGraphemeState(-1, r)
 		wordState, _ = transitionWordBreakState(-1, r, remainder, utf8.DecodeRuneInString)
 		sentenceState, _ = transitionSentenceBreakState(-1, r, remainder, utf8.DecodeRuneInString)
-		lineState, _ = transitionLineBreakState(-1, r, nil, remainder)
+		lineState, _ = transitionLineBreakState(-1, r, remainder, utf8.DecodeRuneInString)
 	} else {
 		graphemeState = grState(state & maskGraphemeState)
 		wordState = WordBreakState((state >> shiftWordState) & maskWordState)
@@ -223,7 +223,7 @@ func StepString(str string, state int) (cluster, rest string, boundaries int, ne
 		graphemeState, prop, graphemeBoundary = transitionGraphemeState(graphemeState, r)
 		wordState, wordBoundary = transitionWordBreakState(wordState, r, remainder, utf8.DecodeRuneInString)
 		sentenceState, sentenceBoundary = transitionSentenceBreakState(sentenceState, r, remainder, utf8.DecodeRuneInString)
-		lineState, lineBreak = transitionLineBreakState(lineState, r, nil, remainder)
+		lineState, lineBreak = transitionLineBreakState(lineState, r, remainder, utf8.DecodeRuneInString)
 
 		if graphemeBoundary {
 			boundary := int(lineBreak) | (width << ShiftWidth)


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/shogo82148/uniseg
                      │   .old.txt   │              .new.txt               │
                      │    sec/op    │    sec/op     vs base               │
LineFunctionBytes-10    0.6215n ± 1%   0.6212n ± 0%       ~ (p=0.305 n=10)
LineFunctionString-10   0.6210n ± 0%   0.6211n ± 0%       ~ (p=0.671 n=10)
geomean                 0.6213n        0.6212n       -0.02%

                      │   .old.txt   │              .new.txt               │
                      │     B/op     │    B/op     vs base                 │
LineFunctionBytes-10    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
LineFunctionString-10   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                            ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                      │   .old.txt   │              .new.txt               │
                      │  allocs/op   │ allocs/op   vs base                 │
LineFunctionBytes-10    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
LineFunctionString-10   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                            ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```