### PR TITLE
bump Unicode version 15.0.0

### DIFF
--- a/graphemerules.go
+++ b/graphemerules.go
@@ -44,7 +44,7 @@ type grTransitionResult struct {
 //     are equal. Stop.
 //  6. Assume grAny and grBoundary.
 //
-// Unicode version 14.0.0.
+// Unicode version 15.0.0.
 var grTransitions = map[grStateProperty]grTransitionResult{
 	// GB5
 	{grAny, prCR}:      {grCR, true, 50},

--- a/linerules.go
+++ b/linerules.go
@@ -81,7 +81,7 @@ type lbTransitionResult struct {
 }
 
 // The line break parser's state transitions. It's analogous to grTransitions,
-// see comments there for details. Unicode version 14.0.0.
+// see comments there for details. Unicode version 15.0.0.
 var lbTransitions = map[lbStateProperty]lbTransitionResult{
 	// LB4.
 	{lbAny, prBK}: {lbBK, LineCanBreak, 310},

--- a/sentencerules.go
+++ b/sentencerules.go
@@ -33,7 +33,7 @@ type sbTransitionResult struct {
 }
 
 // The sentence break parser's state transitions. It's analogous to
-// grTransitions, see comments there for details. Unicode version 14.0.0.
+// grTransitions, see comments there for details. Unicode version 15.0.0.
 var sbTransitions = map[sbStateProperty]sbTransitionResult{
 	// SB3.
 	{sbAny, prCR}: {sbCR, false, 9990},

--- a/wordrules.go
+++ b/wordrules.go
@@ -37,7 +37,7 @@ type wbTransitionResult struct {
 }
 
 // The word break parser's state transitions. It's analogous to grTransitions,
-// see comments there for details. Unicode version 14.0.0.
+// see comments there for details. Unicode version 15.0.0.
 var wbTransitions = map[wbStateProperty]wbTransitionResult{
 	// WB3b.
 	{wbAny, prNewline}: {wbNewline, true, 32},


### PR DESCRIPTION
Unicode 15.0.0 doesn't have any changes around state transitions rules.

https://www.unicode.org/reports/tr29/tr29-41.html#Modifications

> Reissued for Unicode 15.0.0.
>     Section 4.1.1[ Word Boundary Rules](https://www.unicode.org/reports/tr29/tr29-41.html#Word_Boundary_Rules)
>         Added ‘, such as within “e.g.” or “example.com”’
>     Updated [Acknowledgments](https://www.unicode.org/reports/tr29/tr29-41.html#Acknowledgments)