### PR TITLE
reserve the zero value for the initial state

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ This is orders of magnitude faster than the `Graphemes` class, but it requires t
 
 ```go
 str := "🇩🇪🏳️‍🌈"
-state := -1
 var c string
+var state int
 for len(str) > 0 {
 	c, str, _, state = uniseg.StepString(str, state)
 	fmt.Printf("%x ", []rune(c))
@@ -92,10 +92,10 @@ Breaking into grapheme clusters and evaluating line breaks:
 
 ```go
 str := "First line.\nSecond line."
-state := -1
 var (
 	c          string
 	boundaries int
+	state      int
 )
 for len(str) > 0 {
 	c, str, boundaries, state = uniseg.StepString(str, state)
@@ -114,7 +114,7 @@ If you're only interested in word segmentation, use [`FirstWord`](https://pkg.go
 
 ```go
 str := "Hello, world!"
-state := -1
+var state WordBreakState
 var c string
 for len(str) > 0 {
 	c, str, state = uniseg.FirstWordInString(str, state)

--- a/examples_test.go
+++ b/examples_test.go
@@ -14,7 +14,7 @@ func ExampleGraphemeClusterCount() {
 
 func ExampleFirstGraphemeCluster() {
 	b := []byte("🇩🇪🏳️\u200d🌈!")
-	state := uniseg.State(-1)
+	var state uniseg.State
 	var c []byte
 	for len(b) > 0 {
 		var width int
@@ -29,7 +29,7 @@ func ExampleFirstGraphemeCluster() {
 
 func ExampleFirstGraphemeClusterInString() {
 	str := "🇩🇪🏳️\u200d🌈!"
-	state := uniseg.State(-1)
+	var state uniseg.State
 	var c string
 	for len(str) > 0 {
 		var width int
@@ -44,7 +44,7 @@ func ExampleFirstGraphemeClusterInString() {
 
 func ExampleFirstWord() {
 	b := []byte("Hello, world!")
-	state := uniseg.WordBreakState(-1)
+	var state uniseg.WordBreakState
 	var c []byte
 	for len(b) > 0 {
 		c, b, state = uniseg.FirstWord(b, state)
@@ -60,7 +60,7 @@ func ExampleFirstWord() {
 
 func ExampleFirstWordInString() {
 	str := "Hello, world!"
-	state := uniseg.WordBreakState(-1)
+	var state uniseg.WordBreakState
 	var c string
 	for len(str) > 0 {
 		c, str, state = uniseg.FirstWordInString(str, state)
@@ -76,7 +76,7 @@ func ExampleFirstWordInString() {
 
 func ExampleFirstSentence() {
 	b := []byte("This is sentence 1.0. And this is sentence two.")
-	state := uniseg.SentenceBreakState(-1)
+	var state uniseg.SentenceBreakState
 	var c []byte
 	for len(b) > 0 {
 		c, b, state = uniseg.FirstSentence(b, state)
@@ -89,7 +89,7 @@ func ExampleFirstSentence() {
 
 func ExampleFirstSentenceInString() {
 	str := "This is sentence 1.0. And this is sentence two."
-	state := uniseg.SentenceBreakState(-1)
+	var state uniseg.SentenceBreakState
 	var c string
 	for len(str) > 0 {
 		c, str, state = uniseg.FirstSentenceInString(str, state)
@@ -102,10 +102,10 @@ func ExampleFirstSentenceInString() {
 
 func ExampleFirstLineSegment() {
 	b := []byte("First line.\nSecond line.")
-	state := uniseg.LineBreakState(-1)
 	var (
 		c         []byte
 		mustBreak bool
+		state     uniseg.LineBreakState
 	)
 	for len(b) > 0 {
 		c, b, mustBreak, state = uniseg.FirstLineSegment(b, state)
@@ -121,10 +121,10 @@ func ExampleFirstLineSegment() {
 
 func ExampleFirstLineSegmentInString() {
 	str := "First line.\nSecond line."
-	state := uniseg.LineBreakState(-1)
 	var (
 		c         string
 		mustBreak bool
+		state     uniseg.LineBreakState
 	)
 	for len(str) > 0 {
 		c, str, mustBreak, state = uniseg.FirstLineSegmentInString(str, state)

--- a/examples_test.go
+++ b/examples_test.go
@@ -145,8 +145,8 @@ func ExampleFirstLineSegmentInString() {
 
 func ExampleStep_graphemes() {
 	b := []byte("🇩🇪🏳️\u200d🌈!")
-	state := -1
 	var c []byte
+	var state int
 	for len(b) > 0 {
 		var boundaries int
 		c, b, boundaries, state = uniseg.Step(b, state)
@@ -159,8 +159,8 @@ func ExampleStep_graphemes() {
 
 func ExampleStepString_graphemes() {
 	str := "🇩🇪🏳️\u200d🌈!"
-	state := -1
 	var c string
+	var state int
 	for len(str) > 0 {
 		var boundaries int
 		c, str, boundaries, state = uniseg.StepString(str, state)
@@ -174,10 +174,10 @@ func ExampleStepString_graphemes() {
 
 func ExampleStep_word() {
 	b := []byte("Hello, world!")
-	state := -1
 	var (
 		c          []byte
 		boundaries int
+		state      int
 	)
 	for len(b) > 0 {
 		c, b, boundaries, state = uniseg.Step(b, state)
@@ -191,10 +191,10 @@ func ExampleStep_word() {
 
 func ExampleStepString_word() {
 	str := "Hello, world!"
-	state := -1
 	var (
 		c          string
 		boundaries int
+		state      int
 	)
 	for len(str) > 0 {
 		c, str, boundaries, state = uniseg.StepString(str, state)
@@ -208,10 +208,10 @@ func ExampleStepString_word() {
 
 func ExampleStep_sentence() {
 	b := []byte("This is sentence 1.0. And this is sentence two.")
-	state := -1
 	var (
 		c          []byte
 		boundaries int
+		state      int
 	)
 	for len(b) > 0 {
 		c, b, boundaries, state = uniseg.Step(b, state)
@@ -225,10 +225,10 @@ func ExampleStep_sentence() {
 
 func ExampleStepString_sentence() {
 	str := "This is sentence 1.0. And this is sentence two."
-	state := -1
 	var (
 		c          string
 		boundaries int
+		state      int
 	)
 	for len(str) > 0 {
 		c, str, boundaries, state = uniseg.StepString(str, state)
@@ -242,10 +242,10 @@ func ExampleStepString_sentence() {
 
 func ExampleStep_lineBreaking() {
 	b := []byte("First line.\nSecond line.")
-	state := -1
 	var (
 		c          []byte
 		boundaries int
+		state      int
 	)
 	for len(b) > 0 {
 		c, b, boundaries, state = uniseg.Step(b, state)
@@ -263,10 +263,10 @@ func ExampleStep_lineBreaking() {
 
 func ExampleStepString_lineBreaking() {
 	str := "First line.\nSecond line."
-	state := -1
 	var (
 		c          string
 		boundaries int
+		state      int
 	)
 	for len(str) > 0 {
 		c, str, boundaries, state = uniseg.StepString(str, state)

--- a/grapheme.go
+++ b/grapheme.go
@@ -67,7 +67,7 @@ func (g *Graphemes) Next() bool {
 // grapheme cluster. If the iterator is already past the end or [Graphemes.Next]
 // has not yet been called, nil is returned.
 func (g *Graphemes) Runes() []rune {
-	if g.state < 0 {
+	if g.state <= 0 {
 		return nil
 	}
 	return []rune(g.cluster)
@@ -84,7 +84,7 @@ func (g *Graphemes) Str() string {
 // If the iterator is already past the end or [Graphemes.Next] has not yet been
 // called, nil is returned.
 func (g *Graphemes) Bytes() []byte {
-	if g.state < 0 {
+	if g.state <= 0 {
 		return nil
 	}
 	return []byte(g.cluster)
@@ -108,7 +108,7 @@ func (g *Graphemes) Positions() (int, int) {
 // IsWordBoundary returns true if a word ends after the current grapheme
 // cluster.
 func (g *Graphemes) IsWordBoundary() bool {
-	if g.state < 0 {
+	if g.state <= 0 {
 		return true
 	}
 	return g.boundaries&MaskWord != 0
@@ -117,7 +117,7 @@ func (g *Graphemes) IsWordBoundary() bool {
 // IsSentenceBoundary returns true if a sentence ends after the current
 // grapheme cluster.
 func (g *Graphemes) IsSentenceBoundary() bool {
-	if g.state < 0 {
+	if g.state <= 0 {
 		return true
 	}
 	return g.boundaries&MaskSentence != 0
@@ -139,7 +139,7 @@ func (g *Graphemes) LineBreak() LineBreak {
 
 // Width returns the monospace width of the current grapheme cluster.
 func (g *Graphemes) Width() int {
-	if g.state < 0 {
+	if g.state <= 0 {
 		return 0
 	}
 	return g.boundaries >> ShiftWidth
@@ -157,7 +157,7 @@ func (g *Graphemes) Reset() {
 // GraphemeClusterCount returns the number of user-perceived characters
 // (grapheme clusters) for the given string.
 func GraphemeClusterCount(s string) (n int) {
-	state := State(-1)
+	var state State
 	for len(s) > 0 {
 		_, s, _, state = FirstGraphemeClusterInString(s, state)
 		n++
@@ -170,7 +170,7 @@ func GraphemeClusterCount(s string) (n int) {
 func ReverseString(s string) string {
 	str := []byte(s)
 	reversed := make([]byte, len(str))
-	state := State(-1)
+	var state State
 	index := len(str)
 	for len(str) > 0 {
 		var cluster []byte

--- a/grapheme.go
+++ b/grapheme.go
@@ -204,7 +204,7 @@ func (s State) unpack() (grState, property) {
 // grapheme clusters from a byte slice, as illustrated in the example below.
 //
 // If you don't know the current state, for example when calling the function
-// for the first time, you must pass -1. For consecutive calls, pass the state
+// for the first time, you must pass 0. For consecutive calls, pass the state
 // and rest slice returned by the previous call.
 //
 // The "rest" slice is the sub-slice of the original byte slice "b" starting
@@ -245,7 +245,7 @@ func firstGraphemeCluster[T bytes](str T, state State, decoder runeDecoder[T]) (
 	r, length := decoder(str)
 	if len(str) <= length { // If we're already past the end, there is nothing else to parse.
 		var prop property
-		if state < 0 {
+		if state <= 0 {
 			prop = graphemeCodePoints.search(r)
 		} else {
 			_, prop = state.unpack()
@@ -256,7 +256,7 @@ func firstGraphemeCluster[T bytes](str T, state State, decoder runeDecoder[T]) (
 	// If we don't know the state, determine it now.
 	var myState grState
 	var firstProp property
-	if state < 0 {
+	if state <= 0 {
 		myState, firstProp, _ = transitionGraphemeState(myState, r)
 	} else {
 		myState, firstProp = state.unpack()

--- a/grapheme_test.go
+++ b/grapheme_test.go
@@ -363,10 +363,10 @@ func TestGraphemesFunctionBytes(t *testing.T) {
 		decomposed(testCase.original),
 		[]rune(testCase.original))*/
 		b := []byte(testCase.original)
-		state := State(-1)
 		var (
 			index int
 			c     []byte
+			state State
 		)
 	GraphemeLoop:
 		for len(b) > 0 {
@@ -427,10 +427,10 @@ func TestGraphemesFunctionString(t *testing.T) {
 		decomposed(testCase.original),
 		[]rune(testCase.original))*/
 		str := testCase.original
-		state := State(-1)
 		var (
 			index int
 			c     string
+			state State
 		)
 	GraphemeLoop:
 		for len(str) > 0 {
@@ -495,7 +495,7 @@ func BenchmarkGraphemesFunctionBytes(b *testing.B) {
 	str := []byte(benchmarkStr)
 	for i := 0; i < b.N; i++ {
 		var c []byte
-		state := State(-1)
+		var state State
 		for len(str) > 0 {
 			c, str, _, state = FirstGraphemeCluster(str, state)
 			resultRunes = []rune(string(c))
@@ -508,7 +508,7 @@ func BenchmarkGraphemesFunctionString(b *testing.B) {
 	str := benchmarkStr
 	for i := 0; i < b.N; i++ {
 		var c string
-		state := State(-1)
+		var state State
 		for len(str) > 0 {
 			c, str, _, state = FirstGraphemeClusterInString(str, state)
 			resultRunes = []rune(c)

--- a/graphemerules.go
+++ b/graphemerules.go
@@ -5,7 +5,8 @@ type grState int
 
 // The states of the grapheme cluster parser.
 const (
-	grAny grState = iota
+	_ grState = iota // The zero value is reserved for the initial state.
+	grAny
 	grCR
 	grControlLF
 	grL

--- a/line.go
+++ b/line.go
@@ -71,7 +71,7 @@ func firstLineSegment[T bytes](str T, state LineBreakState, decoder runeDecoder[
 	}
 
 	// If we don't know the state, determine it now.
-	if state < 0 {
+	if state <= 0 {
 		state, _ = transitionLineBreakState(state, r, str[length:], decoder)
 	}
 

--- a/line_test.go
+++ b/line_test.go
@@ -15,8 +15,8 @@ func TestLineCasesBytes(t *testing.T) {
 		var (
 			segment []byte
 			index   int
+			state   LineBreakState
 		)
-		state := LineBreakState(-1)
 		b := []byte(testCase.original)
 	WordLoop:
 		for index = 0; len(b) > 0; index++ {
@@ -76,8 +76,8 @@ func TestLineCasesString(t *testing.T) {
 		var (
 			segment string
 			index   int
+			state   LineBreakState
 		)
-		state := LineBreakState(-1)
 		str := testCase.original
 	WordLoop:
 		for index = 0; len(str) > 0; index++ {
@@ -129,7 +129,7 @@ func BenchmarkLineFunctionBytes(b *testing.B) {
 	str := []byte(benchmarkStr)
 	for i := 0; i < b.N; i++ {
 		var c []byte
-		state := LineBreakState(-1)
+		var state LineBreakState
 		for len(str) > 0 {
 			c, str, _, state = FirstLineSegment(str, state)
 			resultRunes = []rune(string(c))
@@ -142,7 +142,7 @@ func BenchmarkLineFunctionString(b *testing.B) {
 	str := benchmarkStr
 	for i := 0; i < b.N; i++ {
 		var c string
-		state := LineBreakState(-1)
+		var state LineBreakState
 		for len(str) > 0 {
 			c, str, _, state = FirstLineSegmentInString(str, state)
 			resultRunes = []rune(c)

--- a/linerules.go
+++ b/linerules.go
@@ -6,7 +6,8 @@ type LineBreakState int
 
 // The states of the line break parser.
 const (
-	lbAny LineBreakState = iota
+	_ LineBreakState = iota // The zero value is reserved for the initial state.
+	lbAny
 	lbBK
 	lbCR
 	lbLF
@@ -312,11 +313,11 @@ func transitionLineBreakState[T bytes](state LineBreakState, r rune, str T, deco
 
 	// Prepare.
 	var forceNoBreak, isCPeaFWH bool
-	if state >= 0 && state&lbCPeaFWHBit != 0 {
+	if state > 0 && state&lbCPeaFWHBit != 0 {
 		isCPeaFWH = true // LB30: CP but ea is not F, W, or H.
 		state = state &^ lbCPeaFWHBit
 	}
-	if state >= 0 && state&lbZWJBit != 0 {
+	if state > 0 && state&lbZWJBit != 0 {
 		state = state &^ lbZWJBit // Extract zero-width joiner bit.
 		forceNoBreak = true       // LB8a.
 	}
@@ -355,7 +356,7 @@ func transitionLineBreakState[T bytes](state LineBreakState, r rune, str T, deco
 		if nextProperty == prZWJ {
 			bit = lbZWJBit
 		}
-		mustBreakState := state < 0 || state == lbBK || state == lbCR || state == lbLF || state == lbNL
+		mustBreakState := state <= 0 || state == lbBK || state == lbCR || state == lbLF || state == lbNL
 		if !mustBreakState && state != lbSP && state != lbZW && state != lbQUSP && state != lbCLCPSP && state != lbB2SP {
 			// LB9.
 			return state | bit, LineDontBreak

--- a/sentence.go
+++ b/sentence.go
@@ -8,7 +8,7 @@ import "unicode/utf8"
 // slice, as illustrated in the example below.
 //
 // If you don't know the current state, for example when calling the function
-// for the first time, you must pass -1. For consecutive calls, pass the state
+// for the first time, you must pass 0. For consecutive calls, pass the state
 // and rest slice returned by the previous call.
 //
 // The "rest" slice is the sub-slice of the original byte slice "b" starting
@@ -44,7 +44,7 @@ func firstSentence[T bytes](str T, state SentenceBreakState, decoder runeDecoder
 	}
 
 	// If we don't know the state, determine it now.
-	if state < 0 {
+	if state <= 0 {
 		state, _ = transitionSentenceBreakState(state, r, str[length:], decoder)
 	}
 

--- a/sentence_test.go
+++ b/sentence_test.go
@@ -1,6 +1,8 @@
 package uniseg
 
-import "testing"
+import (
+	"testing"
+)
 
 // Test all official Unicode test cases for sentence boundaries using the byte
 // slice function.
@@ -15,8 +17,8 @@ func TestSentenceCasesBytes(t *testing.T) {
 		var (
 			sentence []byte
 			index    int
+			state    SentenceBreakState
 		)
-		state := SentenceBreakState(-1)
 		b := []byte(testCase.original)
 	WordLoop:
 		for index = 0; len(b) > 0; index++ {
@@ -76,8 +78,8 @@ func TestSentenceCasesString(t *testing.T) {
 		var (
 			sentence string
 			index    int
+			state    SentenceBreakState
 		)
-		state := SentenceBreakState(-1)
 		str := testCase.original
 	WordLoop:
 		for index = 0; len(str) > 0; index++ {
@@ -129,7 +131,7 @@ func BenchmarkSentenceFunctionBytes(b *testing.B) {
 	str := []byte(benchmarkStr)
 	for i := 0; i < b.N; i++ {
 		var c []byte
-		state := SentenceBreakState(-1)
+		var state SentenceBreakState
 		for len(str) > 0 {
 			c, str, state = FirstSentence(str, state)
 			resultRunes = []rune(string(c))
@@ -142,7 +144,7 @@ func BenchmarkSentenceFunctionString(b *testing.B) {
 	str := benchmarkStr
 	for i := 0; i < b.N; i++ {
 		var c string
-		state := SentenceBreakState(-1)
+		var state SentenceBreakState
 		for len(str) > 0 {
 			c, str, state = FirstSentenceInString(str, state)
 			resultRunes = []rune(c)

--- a/sentencerules.go
+++ b/sentencerules.go
@@ -7,7 +7,8 @@ type SentenceBreakState int
 
 // The states of the sentence break parser.
 const (
-	sbAny SentenceBreakState = iota
+	_ SentenceBreakState = iota // The zero value is reserved for the initial state.
+	sbAny
 	sbCR
 	sbParaSep
 	sbATerm

--- a/step.go
+++ b/step.go
@@ -68,7 +68,7 @@ const (
 // from a byte slice, as illustrated in the examples below.
 //
 // If you don't know which state to pass, for example when calling the function
-// for the first time, you must pass -1. For consecutive calls, pass the state
+// for the first time, you must pass 0. For consecutive calls, pass the state
 // and rest slice returned by the previous call.
 //
 // The "rest" slice is the sub-slice of the original byte slice "b" starting
@@ -120,11 +120,11 @@ func step[T bytes](str T, state int, decoder runeDecoder[T]) (cluster, rest T, b
 	var lineState LineBreakState
 	var firstProp property
 	remainder := str[length:]
-	if state < 0 {
-		graphemeState, firstProp, _ = transitionGraphemeState(-1, r)
-		wordState, _ = transitionWordBreakState(-1, r, remainder, decoder)
-		sentenceState, _ = transitionSentenceBreakState(-1, r, remainder, decoder)
-		lineState, _ = transitionLineBreakState(-1, r, remainder, decoder)
+	if state <= 0 {
+		graphemeState, firstProp, _ = transitionGraphemeState(0, r)
+		wordState, _ = transitionWordBreakState(0, r, remainder, decoder)
+		sentenceState, _ = transitionSentenceBreakState(0, r, remainder, decoder)
+		lineState, _ = transitionLineBreakState(0, r, remainder, decoder)
 	} else {
 		graphemeState = grState(state & maskGraphemeState)
 		wordState = WordBreakState((state >> shiftWordState) & maskWordState)

--- a/step_test.go
+++ b/step_test.go
@@ -13,10 +13,10 @@ func TestStepBytesGrapheme(t *testing.T) {
 		decomposed(testCase.original),
 		[]rune(testCase.original))*/
 		b := []byte(testCase.original)
-		state := -1
 		var (
 			index int
 			c     []byte
+			state int
 		)
 	GraphemeLoop:
 		for len(b) > 0 {
@@ -84,11 +84,11 @@ func TestStepBytesWord(t *testing.T) {
 		decomposed(testCase.original),
 		[]rune(testCase.original))*/
 		b := []byte(testCase.original)
-		state := -1
 		var (
 			index, boundaries int
 			c                 []byte
 			growingCluster    []rune
+			state             int
 		)
 	GraphemeLoop:
 		for len(b) > 0 {
@@ -154,11 +154,11 @@ func TestStepBytesSentence(t *testing.T) {
 		decomposed(testCase.original),
 		[]rune(testCase.original))*/
 		b := []byte(testCase.original)
-		state := -1
 		var (
 			index, boundaries int
 			c                 []byte
 			growingCluster    []rune
+			state             int
 		)
 	GraphemeLoop:
 		for len(b) > 0 {
@@ -230,10 +230,10 @@ func TestStepStringGrapheme(t *testing.T) {
 		decomposed(testCase.original),
 		[]rune(testCase.original))*/
 		str := testCase.original
-		state := -1
 		var (
 			index int
 			c     string
+			state int
 		)
 	GraphemeLoop:
 		for len(str) > 0 {
@@ -301,11 +301,11 @@ func TestStepStringWord(t *testing.T) {
 		decomposed(testCase.original),
 		[]rune(testCase.original))*/
 		str := testCase.original
-		state := -1
 		var (
 			index, boundaries int
 			c                 string
 			growingCluster    []rune
+			state             int
 		)
 	GraphemeLoop:
 		for len(str) > 0 {
@@ -371,11 +371,11 @@ func TestStepStringSentence(t *testing.T) {
 		decomposed(testCase.original),
 		[]rune(testCase.original))*/
 		str := testCase.original
-		state := -1
 		var (
 			index, boundaries int
 			c                 string
 			growingCluster    []rune
+			state             int
 		)
 	GraphemeLoop:
 		for len(str) > 0 {
@@ -435,7 +435,7 @@ func BenchmarkStepBytes(b *testing.B) {
 	str := []byte(benchmarkStr)
 	for i := 0; i < b.N; i++ {
 		var c []byte
-		state := -1
+		var state int
 		for len(str) > 0 {
 			c, str, _, state = Step(str, state)
 			resultRunes = []rune(string(c))
@@ -448,7 +448,7 @@ func BenchmarkStepString(b *testing.B) {
 	str := benchmarkStr
 	for i := 0; i < b.N; i++ {
 		var c string
-		state := -1
+		var state int
 		for len(str) > 0 {
 			c, str, _, state = StepString(str, state)
 			resultRunes = []rune(c)
@@ -468,7 +468,7 @@ func FuzzStepString(f *testing.F) {
 			boundaries int
 		)
 		str := orig
-		state := -1
+		var state int
 		for len(str) > 0 {
 			c, str, boundaries, state = StepString(str, state)
 			b = append(b, []byte(c)...)

--- a/width.go
+++ b/width.go
@@ -44,7 +44,7 @@ func runeWidth(r rune, graphemeProperty property) int {
 // StringWidth returns the monospace width for the given string, that is, the
 // number of same-size cells to be occupied by the string.
 func StringWidth(s string) (width int) {
-	state := State(-1)
+	var state State
 	for len(s) > 0 {
 		var w int
 		_, s, w, state = FirstGraphemeClusterInString(s, state)

--- a/width_test.go
+++ b/width_test.go
@@ -370,7 +370,7 @@ func TestWidthGraphemes(t *testing.T) {
 func TestWidthGraphemesFunctionBytes(t *testing.T) {
 	for index, testCase := range widthTestCases {
 		var actual, width int
-		state := State(-1)
+		var state State
 		text := []byte(testCase.original)
 		for len(text) > 0 {
 			_, text, width, state = FirstGraphemeCluster(text, state)
@@ -386,7 +386,7 @@ func TestWidthGraphemesFunctionBytes(t *testing.T) {
 func TestWidthGraphemesFunctionString(t *testing.T) {
 	for index, testCase := range widthTestCases {
 		var actual, width int
-		state := State(-1)
+		var state State
 		text := testCase.original
 		for len(text) > 0 {
 			_, text, width, state = FirstGraphemeClusterInString(text, state)
@@ -402,7 +402,7 @@ func TestWidthGraphemesFunctionString(t *testing.T) {
 func TestWidthStepBytes(t *testing.T) {
 	for index, testCase := range widthTestCases {
 		var actual, boundaries int
-		state := -1
+		var state int
 		text := []byte(testCase.original)
 		for len(text) > 0 {
 			_, text, boundaries, state = Step(text, state)
@@ -418,7 +418,7 @@ func TestWidthStepBytes(t *testing.T) {
 func TestWidthStepString(t *testing.T) {
 	for index, testCase := range widthTestCases {
 		var actual, boundaries int
-		state := -1
+		var state int
 		text := testCase.original
 		for len(text) > 0 {
 			_, text, boundaries, state = StepString(text, state)

--- a/word.go
+++ b/word.go
@@ -8,7 +8,7 @@ import "unicode/utf8"
 // in the example below.
 //
 // If you don't know the current state, for example when calling the function
-// for the first time, you must pass -1. For consecutive calls, pass the state
+// for the first time, you must pass 0. For consecutive calls, pass the state
 // and rest slice returned by the previous call.
 //
 // The "rest" slice is the sub-slice of the original byte slice "b" starting
@@ -43,7 +43,7 @@ func firstWord[T bytes](str T, state WordBreakState, decoder runeDecoder[T]) (wo
 	}
 
 	// If we don't know the state, determine it now.
-	if state < 0 {
+	if state <= 0 {
 		state, _ = transitionWordBreakState(state, r, str[length:], decoder)
 	}
 

--- a/word_test.go
+++ b/word_test.go
@@ -16,7 +16,7 @@ func TestWordCasesBytes(t *testing.T) {
 			word  []byte
 			index int
 		)
-		state := WordBreakState(-1)
+		var state WordBreakState
 		b := []byte(testCase.original)
 	WordLoop:
 		for index = 0; len(b) > 0; index++ {
@@ -77,7 +77,7 @@ func TestWordCasesString(t *testing.T) {
 			word  string
 			index int
 		)
-		state := WordBreakState(-1)
+		var state WordBreakState
 		str := testCase.original
 	WordLoop:
 		for index = 0; len(str) > 0; index++ {
@@ -129,7 +129,7 @@ func BenchmarkWordFunctionBytes(b *testing.B) {
 	str := []byte(benchmarkStr)
 	for i := 0; i < b.N; i++ {
 		var c []byte
-		state := WordBreakState(-1)
+		var state WordBreakState
 		for len(str) > 0 {
 			c, str, state = FirstWord(str, state)
 			resultRunes = []rune(string(c))
@@ -142,7 +142,7 @@ func BenchmarkWordFunctionString(b *testing.B) {
 	str := benchmarkStr
 	for i := 0; i < b.N; i++ {
 		var c string
-		state := WordBreakState(-1)
+		var state WordBreakState
 		for len(str) > 0 {
 			c, str, state = FirstWordInString(str, state)
 			resultRunes = []rune(c)

--- a/wordrules.go
+++ b/wordrules.go
@@ -7,7 +7,8 @@ type WordBreakState int
 
 // The states of the word break parser.
 const (
-	wbAny WordBreakState = iota
+	_ WordBreakState = iota // The zero value is reserved for the initial state.
+	wbAny
 	wbCR
 	wbLF
 	wbNewline
@@ -123,7 +124,7 @@ func transitionWordBreakState[T bytes](state WordBreakState, r rune, str T, deco
 		if state == wbNewline || state == wbCR || state == wbLF {
 			return wbAny | wbZWJBit, true // Make sure we don't apply WB4 to WB3a.
 		}
-		if state < 0 {
+		if state <= 0 {
 			return wbAny | wbZWJBit, false
 		}
 		return state | wbZWJBit, false

--- a/wordrules.go
+++ b/wordrules.go
@@ -231,7 +231,7 @@ func transitionWordBreakState[T bytes](state WordBreakState, r rune, str T, deco
 
 	// WB15 and WB16.
 	if newState == wbAny && nextProperty == prRegionalIndicator {
-		if state != wbOddRI && state != wbEvenRI { // Includes state == -1.
+		if state != wbOddRI && state != wbEvenRI { // Includes state == 0.
 			// Transition into the first RI.
 			return wbOddRI, true
 		}


### PR DESCRIPTION
Now we must initialize the state with `-1`.

```go
state := WordBreakState(-1)
```

Since variables are initialized with zero values in the Go language, it is more convenient to be able to declare them as follows:

```
var state WordBreakState
```