### PR TITLE
make property tables Eytzinger Layout

### DIFF
--- a/eastasianwidth.go
+++ b/eastasianwidth.go
@@ -6,2579 +6,2579 @@ package uniseg
 // https://www.unicode.org/Public/15.0.0/ucd/EastAsianWidth.txt
 // See https://www.unicode.org/license.html for the Unicode license agreement.
 var eastAsianWidth = dictionary[eawProperty]{
-	{runeRange{0x0000, 0x001F}, eawprN},     // Cc    [32] <control-0000>..<control-001F>
-	{runeRange{0x0020, 0x0020}, eawprNa},    // Zs         SPACE
-	{runeRange{0x0021, 0x0023}, eawprNa},    // Po     [3] EXCLAMATION MARK..NUMBER SIGN
-	{runeRange{0x0024, 0x0024}, eawprNa},    // Sc         DOLLAR SIGN
-	{runeRange{0x0025, 0x0027}, eawprNa},    // Po     [3] PERCENT SIGN..APOSTROPHE
-	{runeRange{0x0028, 0x0028}, eawprNa},    // Ps         LEFT PARENTHESIS
-	{runeRange{0x0029, 0x0029}, eawprNa},    // Pe         RIGHT PARENTHESIS
-	{runeRange{0x002A, 0x002A}, eawprNa},    // Po         ASTERISK
-	{runeRange{0x002B, 0x002B}, eawprNa},    // Sm         PLUS SIGN
-	{runeRange{0x002C, 0x002C}, eawprNa},    // Po         COMMA
-	{runeRange{0x002D, 0x002D}, eawprNa},    // Pd         HYPHEN-MINUS
-	{runeRange{0x002E, 0x002F}, eawprNa},    // Po     [2] FULL STOP..SOLIDUS
-	{runeRange{0x0030, 0x0039}, eawprNa},    // Nd    [10] DIGIT ZERO..DIGIT NINE
-	{runeRange{0x003A, 0x003B}, eawprNa},    // Po     [2] COLON..SEMICOLON
-	{runeRange{0x003C, 0x003E}, eawprNa},    // Sm     [3] LESS-THAN SIGN..GREATER-THAN SIGN
-	{runeRange{0x003F, 0x0040}, eawprNa},    // Po     [2] QUESTION MARK..COMMERCIAL AT
-	{runeRange{0x0041, 0x005A}, eawprNa},    // Lu    [26] LATIN CAPITAL LETTER A..LATIN CAPITAL LETTER Z
-	{runeRange{0x005B, 0x005B}, eawprNa},    // Ps         LEFT SQUARE BRACKET
-	{runeRange{0x005C, 0x005C}, eawprNa},    // Po         REVERSE SOLIDUS
-	{runeRange{0x005D, 0x005D}, eawprNa},    // Pe         RIGHT SQUARE BRACKET
-	{runeRange{0x005E, 0x005E}, eawprNa},    // Sk         CIRCUMFLEX ACCENT
-	{runeRange{0x005F, 0x005F}, eawprNa},    // Pc         LOW LINE
-	{runeRange{0x0060, 0x0060}, eawprNa},    // Sk         GRAVE ACCENT
-	{runeRange{0x0061, 0x007A}, eawprNa},    // Ll    [26] LATIN SMALL LETTER A..LATIN SMALL LETTER Z
-	{runeRange{0x007B, 0x007B}, eawprNa},    // Ps         LEFT CURLY BRACKET
-	{runeRange{0x007C, 0x007C}, eawprNa},    // Sm         VERTICAL LINE
-	{runeRange{0x007D, 0x007D}, eawprNa},    // Pe         RIGHT CURLY BRACKET
-	{runeRange{0x007E, 0x007E}, eawprNa},    // Sm         TILDE
-	{runeRange{0x007F, 0x007F}, eawprN},     // Cc         <control-007F>
-	{runeRange{0x0080, 0x009F}, eawprN},     // Cc    [32] <control-0080>..<control-009F>
-	{runeRange{0x00A0, 0x00A0}, eawprN},     // Zs         NO-BREAK SPACE
-	{runeRange{0x00A1, 0x00A1}, eawprA},     // Po         INVERTED EXCLAMATION MARK
-	{runeRange{0x00A2, 0x00A3}, eawprNa},    // Sc     [2] CENT SIGN..POUND SIGN
-	{runeRange{0x00A4, 0x00A4}, eawprA},     // Sc         CURRENCY SIGN
-	{runeRange{0x00A5, 0x00A5}, eawprNa},    // Sc         YEN SIGN
-	{runeRange{0x00A6, 0x00A6}, eawprNa},    // So         BROKEN BAR
-	{runeRange{0x00A7, 0x00A7}, eawprA},     // Po         SECTION SIGN
-	{runeRange{0x00A8, 0x00A8}, eawprA},     // Sk         DIAERESIS
-	{runeRange{0x00A9, 0x00A9}, eawprN},     // So         COPYRIGHT SIGN
-	{runeRange{0x00AA, 0x00AA}, eawprA},     // Lo         FEMININE ORDINAL INDICATOR
-	{runeRange{0x00AB, 0x00AB}, eawprN},     // Pi         LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
-	{runeRange{0x00AC, 0x00AC}, eawprNa},    // Sm         NOT SIGN
-	{runeRange{0x00AD, 0x00AD}, eawprA},     // Cf         SOFT HYPHEN
-	{runeRange{0x00AE, 0x00AE}, eawprA},     // So         REGISTERED SIGN
-	{runeRange{0x00AF, 0x00AF}, eawprNa},    // Sk         MACRON
-	{runeRange{0x00B0, 0x00B0}, eawprA},     // So         DEGREE SIGN
-	{runeRange{0x00B1, 0x00B1}, eawprA},     // Sm         PLUS-MINUS SIGN
-	{runeRange{0x00B2, 0x00B3}, eawprA},     // No     [2] SUPERSCRIPT TWO..SUPERSCRIPT THREE
-	{runeRange{0x00B4, 0x00B4}, eawprA},     // Sk         ACUTE ACCENT
-	{runeRange{0x00B5, 0x00B5}, eawprN},     // Ll         MICRO SIGN
-	{runeRange{0x00B6, 0x00B7}, eawprA},     // Po     [2] PILCROW SIGN..MIDDLE DOT
-	{runeRange{0x00B8, 0x00B8}, eawprA},     // Sk         CEDILLA
-	{runeRange{0x00B9, 0x00B9}, eawprA},     // No         SUPERSCRIPT ONE
-	{runeRange{0x00BA, 0x00BA}, eawprA},     // Lo         MASCULINE ORDINAL INDICATOR
-	{runeRange{0x00BB, 0x00BB}, eawprN},     // Pf         RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
-	{runeRange{0x00BC, 0x00BE}, eawprA},     // No     [3] VULGAR FRACTION ONE QUARTER..VULGAR FRACTION THREE QUARTERS
-	{runeRange{0x00BF, 0x00BF}, eawprA},     // Po         INVERTED QUESTION MARK
-	{runeRange{0x00C0, 0x00C5}, eawprN},     // Lu     [6] LATIN CAPITAL LETTER A WITH GRAVE..LATIN CAPITAL LETTER A WITH RING ABOVE
-	{runeRange{0x00C6, 0x00C6}, eawprA},     // Lu         LATIN CAPITAL LETTER AE
-	{runeRange{0x00C7, 0x00CF}, eawprN},     // Lu     [9] LATIN CAPITAL LETTER C WITH CEDILLA..LATIN CAPITAL LETTER I WITH DIAERESIS
-	{runeRange{0x00D0, 0x00D0}, eawprA},     // Lu         LATIN CAPITAL LETTER ETH
-	{runeRange{0x00D1, 0x00D6}, eawprN},     // Lu     [6] LATIN CAPITAL LETTER N WITH TILDE..LATIN CAPITAL LETTER O WITH DIAERESIS
-	{runeRange{0x00D7, 0x00D7}, eawprA},     // Sm         MULTIPLICATION SIGN
-	{runeRange{0x00D8, 0x00D8}, eawprA},     // Lu         LATIN CAPITAL LETTER O WITH STROKE
-	{runeRange{0x00D9, 0x00DD}, eawprN},     // Lu     [5] LATIN CAPITAL LETTER U WITH GRAVE..LATIN CAPITAL LETTER Y WITH ACUTE
-	{runeRange{0x00DE, 0x00E1}, eawprA},     // L&     [4] LATIN CAPITAL LETTER THORN..LATIN SMALL LETTER A WITH ACUTE
-	{runeRange{0x00E2, 0x00E5}, eawprN},     // Ll     [4] LATIN SMALL LETTER A WITH CIRCUMFLEX..LATIN SMALL LETTER A WITH RING ABOVE
-	{runeRange{0x00E6, 0x00E6}, eawprA},     // Ll         LATIN SMALL LETTER AE
-	{runeRange{0x00E7, 0x00E7}, eawprN},     // Ll         LATIN SMALL LETTER C WITH CEDILLA
-	{runeRange{0x00E8, 0x00EA}, eawprA},     // Ll     [3] LATIN SMALL LETTER E WITH GRAVE..LATIN SMALL LETTER E WITH CIRCUMFLEX
-	{runeRange{0x00EB, 0x00EB}, eawprN},     // Ll         LATIN SMALL LETTER E WITH DIAERESIS
-	{runeRange{0x00EC, 0x00ED}, eawprA},     // Ll     [2] LATIN SMALL LETTER I WITH GRAVE..LATIN SMALL LETTER I WITH ACUTE
-	{runeRange{0x00EE, 0x00EF}, eawprN},     // Ll     [2] LATIN SMALL LETTER I WITH CIRCUMFLEX..LATIN SMALL LETTER I WITH DIAERESIS
-	{runeRange{0x00F0, 0x00F0}, eawprA},     // Ll         LATIN SMALL LETTER ETH
-	{runeRange{0x00F1, 0x00F1}, eawprN},     // Ll         LATIN SMALL LETTER N WITH TILDE
-	{runeRange{0x00F2, 0x00F3}, eawprA},     // Ll     [2] LATIN SMALL LETTER O WITH GRAVE..LATIN SMALL LETTER O WITH ACUTE
-	{runeRange{0x00F4, 0x00F6}, eawprN},     // Ll     [3] LATIN SMALL LETTER O WITH CIRCUMFLEX..LATIN SMALL LETTER O WITH DIAERESIS
-	{runeRange{0x00F7, 0x00F7}, eawprA},     // Sm         DIVISION SIGN
-	{runeRange{0x00F8, 0x00FA}, eawprA},     // Ll     [3] LATIN SMALL LETTER O WITH STROKE..LATIN SMALL LETTER U WITH ACUTE
-	{runeRange{0x00FB, 0x00FB}, eawprN},     // Ll         LATIN SMALL LETTER U WITH CIRCUMFLEX
-	{runeRange{0x00FC, 0x00FC}, eawprA},     // Ll         LATIN SMALL LETTER U WITH DIAERESIS
-	{runeRange{0x00FD, 0x00FD}, eawprN},     // Ll         LATIN SMALL LETTER Y WITH ACUTE
-	{runeRange{0x00FE, 0x00FE}, eawprA},     // Ll         LATIN SMALL LETTER THORN
-	{runeRange{0x00FF, 0x00FF}, eawprN},     // Ll         LATIN SMALL LETTER Y WITH DIAERESIS
-	{runeRange{0x0100, 0x0100}, eawprN},     // Lu         LATIN CAPITAL LETTER A WITH MACRON
-	{runeRange{0x0101, 0x0101}, eawprA},     // Ll         LATIN SMALL LETTER A WITH MACRON
-	{runeRange{0x0102, 0x0110}, eawprN},     // L&    [15] LATIN CAPITAL LETTER A WITH BREVE..LATIN CAPITAL LETTER D WITH STROKE
-	{runeRange{0x0111, 0x0111}, eawprA},     // Ll         LATIN SMALL LETTER D WITH STROKE
-	{runeRange{0x0112, 0x0112}, eawprN},     // Lu         LATIN CAPITAL LETTER E WITH MACRON
-	{runeRange{0x0113, 0x0113}, eawprA},     // Ll         LATIN SMALL LETTER E WITH MACRON
-	{runeRange{0x0114, 0x011A}, eawprN},     // L&     [7] LATIN CAPITAL LETTER E WITH BREVE..LATIN CAPITAL LETTER E WITH CARON
-	{runeRange{0x011B, 0x011B}, eawprA},     // Ll         LATIN SMALL LETTER E WITH CARON
-	{runeRange{0x011C, 0x0125}, eawprN},     // L&    [10] LATIN CAPITAL LETTER G WITH CIRCUMFLEX..LATIN SMALL LETTER H WITH CIRCUMFLEX
-	{runeRange{0x0126, 0x0127}, eawprA},     // L&     [2] LATIN CAPITAL LETTER H WITH STROKE..LATIN SMALL LETTER H WITH STROKE
-	{runeRange{0x0128, 0x012A}, eawprN},     // L&     [3] LATIN CAPITAL LETTER I WITH TILDE..LATIN CAPITAL LETTER I WITH MACRON
-	{runeRange{0x012B, 0x012B}, eawprA},     // Ll         LATIN SMALL LETTER I WITH MACRON
-	{runeRange{0x012C, 0x0130}, eawprN},     // L&     [5] LATIN CAPITAL LETTER I WITH BREVE..LATIN CAPITAL LETTER I WITH DOT ABOVE
-	{runeRange{0x0131, 0x0133}, eawprA},     // L&     [3] LATIN SMALL LETTER DOTLESS I..LATIN SMALL LIGATURE IJ
-	{runeRange{0x0134, 0x0137}, eawprN},     // L&     [4] LATIN CAPITAL LETTER J WITH CIRCUMFLEX..LATIN SMALL LETTER K WITH CEDILLA
-	{runeRange{0x0138, 0x0138}, eawprA},     // Ll         LATIN SMALL LETTER KRA
-	{runeRange{0x0139, 0x013E}, eawprN},     // L&     [6] LATIN CAPITAL LETTER L WITH ACUTE..LATIN SMALL LETTER L WITH CARON
-	{runeRange{0x013F, 0x0142}, eawprA},     // L&     [4] LATIN CAPITAL LETTER L WITH MIDDLE DOT..LATIN SMALL LETTER L WITH STROKE
-	{runeRange{0x0143, 0x0143}, eawprN},     // Lu         LATIN CAPITAL LETTER N WITH ACUTE
-	{runeRange{0x0144, 0x0144}, eawprA},     // Ll         LATIN SMALL LETTER N WITH ACUTE
-	{runeRange{0x0145, 0x0147}, eawprN},     // L&     [3] LATIN CAPITAL LETTER N WITH CEDILLA..LATIN CAPITAL LETTER N WITH CARON
-	{runeRange{0x0148, 0x014B}, eawprA},     // L&     [4] LATIN SMALL LETTER N WITH CARON..LATIN SMALL LETTER ENG
-	{runeRange{0x014C, 0x014C}, eawprN},     // Lu         LATIN CAPITAL LETTER O WITH MACRON
-	{runeRange{0x014D, 0x014D}, eawprA},     // Ll         LATIN SMALL LETTER O WITH MACRON
-	{runeRange{0x014E, 0x0151}, eawprN},     // L&     [4] LATIN CAPITAL LETTER O WITH BREVE..LATIN SMALL LETTER O WITH DOUBLE ACUTE
-	{runeRange{0x0152, 0x0153}, eawprA},     // L&     [2] LATIN CAPITAL LIGATURE OE..LATIN SMALL LIGATURE OE
-	{runeRange{0x0154, 0x0165}, eawprN},     // L&    [18] LATIN CAPITAL LETTER R WITH ACUTE..LATIN SMALL LETTER T WITH CARON
-	{runeRange{0x0166, 0x0167}, eawprA},     // L&     [2] LATIN CAPITAL LETTER T WITH STROKE..LATIN SMALL LETTER T WITH STROKE
-	{runeRange{0x0168, 0x016A}, eawprN},     // L&     [3] LATIN CAPITAL LETTER U WITH TILDE..LATIN CAPITAL LETTER U WITH MACRON
-	{runeRange{0x016B, 0x016B}, eawprA},     // Ll         LATIN SMALL LETTER U WITH MACRON
-	{runeRange{0x016C, 0x017F}, eawprN},     // L&    [20] LATIN CAPITAL LETTER U WITH BREVE..LATIN SMALL LETTER LONG S
-	{runeRange{0x0180, 0x01BA}, eawprN},     // L&    [59] LATIN SMALL LETTER B WITH STROKE..LATIN SMALL LETTER EZH WITH TAIL
-	{runeRange{0x01BB, 0x01BB}, eawprN},     // Lo         LATIN LETTER TWO WITH STROKE
-	{runeRange{0x01BC, 0x01BF}, eawprN},     // L&     [4] LATIN CAPITAL LETTER TONE FIVE..LATIN LETTER WYNN
-	{runeRange{0x01C0, 0x01C3}, eawprN},     // Lo     [4] LATIN LETTER DENTAL CLICK..LATIN LETTER RETROFLEX CLICK
-	{runeRange{0x01C4, 0x01CD}, eawprN},     // L&    [10] LATIN CAPITAL LETTER DZ WITH CARON..LATIN CAPITAL LETTER A WITH CARON
-	{runeRange{0x01CE, 0x01CE}, eawprA},     // Ll         LATIN SMALL LETTER A WITH CARON
-	{runeRange{0x01CF, 0x01CF}, eawprN},     // Lu         LATIN CAPITAL LETTER I WITH CARON
-	{runeRange{0x01D0, 0x01D0}, eawprA},     // Ll         LATIN SMALL LETTER I WITH CARON
-	{runeRange{0x01D1, 0x01D1}, eawprN},     // Lu         LATIN CAPITAL LETTER O WITH CARON
-	{runeRange{0x01D2, 0x01D2}, eawprA},     // Ll         LATIN SMALL LETTER O WITH CARON
-	{runeRange{0x01D3, 0x01D3}, eawprN},     // Lu         LATIN CAPITAL LETTER U WITH CARON
-	{runeRange{0x01D4, 0x01D4}, eawprA},     // Ll         LATIN SMALL LETTER U WITH CARON
-	{runeRange{0x01D5, 0x01D5}, eawprN},     // Lu         LATIN CAPITAL LETTER U WITH DIAERESIS AND MACRON
-	{runeRange{0x01D6, 0x01D6}, eawprA},     // Ll         LATIN SMALL LETTER U WITH DIAERESIS AND MACRON
-	{runeRange{0x01D7, 0x01D7}, eawprN},     // Lu         LATIN CAPITAL LETTER U WITH DIAERESIS AND ACUTE
-	{runeRange{0x01D8, 0x01D8}, eawprA},     // Ll         LATIN SMALL LETTER U WITH DIAERESIS AND ACUTE
-	{runeRange{0x01D9, 0x01D9}, eawprN},     // Lu         LATIN CAPITAL LETTER U WITH DIAERESIS AND CARON
-	{runeRange{0x01DA, 0x01DA}, eawprA},     // Ll         LATIN SMALL LETTER U WITH DIAERESIS AND CARON
-	{runeRange{0x01DB, 0x01DB}, eawprN},     // Lu         LATIN CAPITAL LETTER U WITH DIAERESIS AND GRAVE
-	{runeRange{0x01DC, 0x01DC}, eawprA},     // Ll         LATIN SMALL LETTER U WITH DIAERESIS AND GRAVE
-	{runeRange{0x01DD, 0x024F}, eawprN},     // L&   [115] LATIN SMALL LETTER TURNED E..LATIN SMALL LETTER Y WITH STROKE
-	{runeRange{0x0250, 0x0250}, eawprN},     // Ll         LATIN SMALL LETTER TURNED A
-	{runeRange{0x0251, 0x0251}, eawprA},     // Ll         LATIN SMALL LETTER ALPHA
-	{runeRange{0x0252, 0x0260}, eawprN},     // Ll    [15] LATIN SMALL LETTER TURNED ALPHA..LATIN SMALL LETTER G WITH HOOK
-	{runeRange{0x0261, 0x0261}, eawprA},     // Ll         LATIN SMALL LETTER SCRIPT G
-	{runeRange{0x0262, 0x0293}, eawprN},     // Ll    [50] LATIN LETTER SMALL CAPITAL G..LATIN SMALL LETTER EZH WITH CURL
-	{runeRange{0x0294, 0x0294}, eawprN},     // Lo         LATIN LETTER GLOTTAL STOP
-	{runeRange{0x0295, 0x02AF}, eawprN},     // Ll    [27] LATIN LETTER PHARYNGEAL VOICED FRICATIVE..LATIN SMALL LETTER TURNED H WITH FISHHOOK AND TAIL
-	{runeRange{0x02B0, 0x02C1}, eawprN},     // Lm    [18] MODIFIER LETTER SMALL H..MODIFIER LETTER REVERSED GLOTTAL STOP
-	{runeRange{0x02C2, 0x02C3}, eawprN},     // Sk     [2] MODIFIER LETTER LEFT ARROWHEAD..MODIFIER LETTER RIGHT ARROWHEAD
-	{runeRange{0x02C4, 0x02C4}, eawprA},     // Sk         MODIFIER LETTER UP ARROWHEAD
-	{runeRange{0x02C5, 0x02C5}, eawprN},     // Sk         MODIFIER LETTER DOWN ARROWHEAD
-	{runeRange{0x02C6, 0x02C6}, eawprN},     // Lm         MODIFIER LETTER CIRCUMFLEX ACCENT
-	{runeRange{0x02C7, 0x02C7}, eawprA},     // Lm         CARON
-	{runeRange{0x02C8, 0x02C8}, eawprN},     // Lm         MODIFIER LETTER VERTICAL LINE
-	{runeRange{0x02C9, 0x02CB}, eawprA},     // Lm     [3] MODIFIER LETTER MACRON..MODIFIER LETTER GRAVE ACCENT
-	{runeRange{0x02CC, 0x02CC}, eawprN},     // Lm         MODIFIER LETTER LOW VERTICAL LINE
-	{runeRange{0x02CD, 0x02CD}, eawprA},     // Lm         MODIFIER LETTER LOW MACRON
-	{runeRange{0x02CE, 0x02CF}, eawprN},     // Lm     [2] MODIFIER LETTER LOW GRAVE ACCENT..MODIFIER LETTER LOW ACUTE ACCENT
-	{runeRange{0x02D0, 0x02D0}, eawprA},     // Lm         MODIFIER LETTER TRIANGULAR COLON
-	{runeRange{0x02D1, 0x02D1}, eawprN},     // Lm         MODIFIER LETTER HALF TRIANGULAR COLON
-	{runeRange{0x02D2, 0x02D7}, eawprN},     // Sk     [6] MODIFIER LETTER CENTRED RIGHT HALF RING..MODIFIER LETTER MINUS SIGN
-	{runeRange{0x02D8, 0x02DB}, eawprA},     // Sk     [4] BREVE..OGONEK
-	{runeRange{0x02DC, 0x02DC}, eawprN},     // Sk         SMALL TILDE
-	{runeRange{0x02DD, 0x02DD}, eawprA},     // Sk         DOUBLE ACUTE ACCENT
-	{runeRange{0x02DE, 0x02DE}, eawprN},     // Sk         MODIFIER LETTER RHOTIC HOOK
-	{runeRange{0x02DF, 0x02DF}, eawprA},     // Sk         MODIFIER LETTER CROSS ACCENT
-	{runeRange{0x02E0, 0x02E4}, eawprN},     // Lm     [5] MODIFIER LETTER SMALL GAMMA..MODIFIER LETTER SMALL REVERSED GLOTTAL STOP
-	{runeRange{0x02E5, 0x02EB}, eawprN},     // Sk     [7] MODIFIER LETTER EXTRA-HIGH TONE BAR..MODIFIER LETTER YANG DEPARTING TONE MARK
-	{runeRange{0x02EC, 0x02EC}, eawprN},     // Lm         MODIFIER LETTER VOICING
-	{runeRange{0x02ED, 0x02ED}, eawprN},     // Sk         MODIFIER LETTER UNASPIRATED
-	{runeRange{0x02EE, 0x02EE}, eawprN},     // Lm         MODIFIER LETTER DOUBLE APOSTROPHE
-	{runeRange{0x02EF, 0x02FF}, eawprN},     // Sk    [17] MODIFIER LETTER LOW DOWN ARROWHEAD..MODIFIER LETTER LOW LEFT ARROW
-	{runeRange{0x0300, 0x036F}, eawprA},     // Mn   [112] COMBINING GRAVE ACCENT..COMBINING LATIN SMALL LETTER X
-	{runeRange{0x0370, 0x0373}, eawprN},     // L&     [4] GREEK CAPITAL LETTER HETA..GREEK SMALL LETTER ARCHAIC SAMPI
-	{runeRange{0x0374, 0x0374}, eawprN},     // Lm         GREEK NUMERAL SIGN
-	{runeRange{0x0375, 0x0375}, eawprN},     // Sk         GREEK LOWER NUMERAL SIGN
-	{runeRange{0x0376, 0x0377}, eawprN},     // L&     [2] GREEK CAPITAL LETTER PAMPHYLIAN DIGAMMA..GREEK SMALL LETTER PAMPHYLIAN DIGAMMA
-	{runeRange{0x037A, 0x037A}, eawprN},     // Lm         GREEK YPOGEGRAMMENI
-	{runeRange{0x037B, 0x037D}, eawprN},     // Ll     [3] GREEK SMALL REVERSED LUNATE SIGMA SYMBOL..GREEK SMALL REVERSED DOTTED LUNATE SIGMA SYMBOL
-	{runeRange{0x037E, 0x037E}, eawprN},     // Po         GREEK QUESTION MARK
-	{runeRange{0x037F, 0x037F}, eawprN},     // Lu         GREEK CAPITAL LETTER YOT
-	{runeRange{0x0384, 0x0385}, eawprN},     // Sk     [2] GREEK TONOS..GREEK DIALYTIKA TONOS
-	{runeRange{0x0386, 0x0386}, eawprN},     // Lu         GREEK CAPITAL LETTER ALPHA WITH TONOS
-	{runeRange{0x0387, 0x0387}, eawprN},     // Po         GREEK ANO TELEIA
-	{runeRange{0x0388, 0x038A}, eawprN},     // Lu     [3] GREEK CAPITAL LETTER EPSILON WITH TONOS..GREEK CAPITAL LETTER IOTA WITH TONOS
-	{runeRange{0x038C, 0x038C}, eawprN},     // Lu         GREEK CAPITAL LETTER OMICRON WITH TONOS
-	{runeRange{0x038E, 0x0390}, eawprN},     // L&     [3] GREEK CAPITAL LETTER UPSILON WITH TONOS..GREEK SMALL LETTER IOTA WITH DIALYTIKA AND TONOS
-	{runeRange{0x0391, 0x03A1}, eawprA},     // Lu    [17] GREEK CAPITAL LETTER ALPHA..GREEK CAPITAL LETTER RHO
-	{runeRange{0x03A3, 0x03A9}, eawprA},     // Lu     [7] GREEK CAPITAL LETTER SIGMA..GREEK CAPITAL LETTER OMEGA
-	{runeRange{0x03AA, 0x03B0}, eawprN},     // L&     [7] GREEK CAPITAL LETTER IOTA WITH DIALYTIKA..GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND TONOS
-	{runeRange{0x03B1, 0x03C1}, eawprA},     // Ll    [17] GREEK SMALL LETTER ALPHA..GREEK SMALL LETTER RHO
-	{runeRange{0x03C2, 0x03C2}, eawprN},     // Ll         GREEK SMALL LETTER FINAL SIGMA
-	{runeRange{0x03C3, 0x03C9}, eawprA},     // Ll     [7] GREEK SMALL LETTER SIGMA..GREEK SMALL LETTER OMEGA
-	{runeRange{0x03CA, 0x03F5}, eawprN},     // L&    [44] GREEK SMALL LETTER IOTA WITH DIALYTIKA..GREEK LUNATE EPSILON SYMBOL
-	{runeRange{0x03F6, 0x03F6}, eawprN},     // Sm         GREEK REVERSED LUNATE EPSILON SYMBOL
-	{runeRange{0x03F7, 0x03FF}, eawprN},     // L&     [9] GREEK CAPITAL LETTER SHO..GREEK CAPITAL REVERSED DOTTED LUNATE SIGMA SYMBOL
-	{runeRange{0x0400, 0x0400}, eawprN},     // Lu         CYRILLIC CAPITAL LETTER IE WITH GRAVE
-	{runeRange{0x0401, 0x0401}, eawprA},     // Lu         CYRILLIC CAPITAL LETTER IO
-	{runeRange{0x0402, 0x040F}, eawprN},     // Lu    [14] CYRILLIC CAPITAL LETTER DJE..CYRILLIC CAPITAL LETTER DZHE
-	{runeRange{0x0410, 0x044F}, eawprA},     // L&    [64] CYRILLIC CAPITAL LETTER A..CYRILLIC SMALL LETTER YA
-	{runeRange{0x0450, 0x0450}, eawprN},     // Ll         CYRILLIC SMALL LETTER IE WITH GRAVE
-	{runeRange{0x0451, 0x0451}, eawprA},     // Ll         CYRILLIC SMALL LETTER IO
-	{runeRange{0x0452, 0x0481}, eawprN},     // L&    [48] CYRILLIC SMALL LETTER DJE..CYRILLIC SMALL LETTER KOPPA
-	{runeRange{0x0482, 0x0482}, eawprN},     // So         CYRILLIC THOUSANDS SIGN
-	{runeRange{0x0483, 0x0487}, eawprN},     // Mn     [5] COMBINING CYRILLIC TITLO..COMBINING CYRILLIC POKRYTIE
-	{runeRange{0x0488, 0x0489}, eawprN},     // Me     [2] COMBINING CYRILLIC HUNDRED THOUSANDS SIGN..COMBINING CYRILLIC MILLIONS SIGN
-	{runeRange{0x048A, 0x04FF}, eawprN},     // L&   [118] CYRILLIC CAPITAL LETTER SHORT I WITH TAIL..CYRILLIC SMALL LETTER HA WITH STROKE
-	{runeRange{0x0500, 0x052F}, eawprN},     // L&    [48] CYRILLIC CAPITAL LETTER KOMI DE..CYRILLIC SMALL LETTER EL WITH DESCENDER
-	{runeRange{0x0531, 0x0556}, eawprN},     // Lu    [38] ARMENIAN CAPITAL LETTER AYB..ARMENIAN CAPITAL LETTER FEH
-	{runeRange{0x0559, 0x0559}, eawprN},     // Lm         ARMENIAN MODIFIER LETTER LEFT HALF RING
-	{runeRange{0x055A, 0x055F}, eawprN},     // Po     [6] ARMENIAN APOSTROPHE..ARMENIAN ABBREVIATION MARK
-	{runeRange{0x0560, 0x0588}, eawprN},     // Ll    [41] ARMENIAN SMALL LETTER TURNED AYB..ARMENIAN SMALL LETTER YI WITH STROKE
-	{runeRange{0x0589, 0x0589}, eawprN},     // Po         ARMENIAN FULL STOP
-	{runeRange{0x058A, 0x058A}, eawprN},     // Pd         ARMENIAN HYPHEN
-	{runeRange{0x058D, 0x058E}, eawprN},     // So     [2] RIGHT-FACING ARMENIAN ETERNITY SIGN..LEFT-FACING ARMENIAN ETERNITY SIGN
-	{runeRange{0x058F, 0x058F}, eawprN},     // Sc         ARMENIAN DRAM SIGN
-	{runeRange{0x0591, 0x05BD}, eawprN},     // Mn    [45] HEBREW ACCENT ETNAHTA..HEBREW POINT METEG
-	{runeRange{0x05BE, 0x05BE}, eawprN},     // Pd         HEBREW PUNCTUATION MAQAF
-	{runeRange{0x05BF, 0x05BF}, eawprN},     // Mn         HEBREW POINT RAFE
-	{runeRange{0x05C0, 0x05C0}, eawprN},     // Po         HEBREW PUNCTUATION PASEQ
-	{runeRange{0x05C1, 0x05C2}, eawprN},     // Mn     [2] HEBREW POINT SHIN DOT..HEBREW POINT SIN DOT
-	{runeRange{0x05C3, 0x05C3}, eawprN},     // Po         HEBREW PUNCTUATION SOF PASUQ
-	{runeRange{0x05C4, 0x05C5}, eawprN},     // Mn     [2] HEBREW MARK UPPER DOT..HEBREW MARK LOWER DOT
-	{runeRange{0x05C6, 0x05C6}, eawprN},     // Po         HEBREW PUNCTUATION NUN HAFUKHA
-	{runeRange{0x05C7, 0x05C7}, eawprN},     // Mn         HEBREW POINT QAMATS QATAN
-	{runeRange{0x05D0, 0x05EA}, eawprN},     // Lo    [27] HEBREW LETTER ALEF..HEBREW LETTER TAV
-	{runeRange{0x05EF, 0x05F2}, eawprN},     // Lo     [4] HEBREW YOD TRIANGLE..HEBREW LIGATURE YIDDISH DOUBLE YOD
-	{runeRange{0x05F3, 0x05F4}, eawprN},     // Po     [2] HEBREW PUNCTUATION GERESH..HEBREW PUNCTUATION GERSHAYIM
-	{runeRange{0x0600, 0x0605}, eawprN},     // Cf     [6] ARABIC NUMBER SIGN..ARABIC NUMBER MARK ABOVE
-	{runeRange{0x0606, 0x0608}, eawprN},     // Sm     [3] ARABIC-INDIC CUBE ROOT..ARABIC RAY
-	{runeRange{0x0609, 0x060A}, eawprN},     // Po     [2] ARABIC-INDIC PER MILLE SIGN..ARABIC-INDIC PER TEN THOUSAND SIGN
-	{runeRange{0x060B, 0x060B}, eawprN},     // Sc         AFGHANI SIGN
-	{runeRange{0x060C, 0x060D}, eawprN},     // Po     [2] ARABIC COMMA..ARABIC DATE SEPARATOR
-	{runeRange{0x060E, 0x060F}, eawprN},     // So     [2] ARABIC POETIC VERSE SIGN..ARABIC SIGN MISRA
-	{runeRange{0x0610, 0x061A}, eawprN},     // Mn    [11] ARABIC SIGN SALLALLAHOU ALAYHE WASSALLAM..ARABIC SMALL KASRA
-	{runeRange{0x061B, 0x061B}, eawprN},     // Po         ARABIC SEMICOLON
-	{runeRange{0x061C, 0x061C}, eawprN},     // Cf         ARABIC LETTER MARK
-	{runeRange{0x061D, 0x061F}, eawprN},     // Po     [3] ARABIC END OF TEXT MARK..ARABIC QUESTION MARK
-	{runeRange{0x0620, 0x063F}, eawprN},     // Lo    [32] ARABIC LETTER KASHMIRI YEH..ARABIC LETTER FARSI YEH WITH THREE DOTS ABOVE
-	{runeRange{0x0640, 0x0640}, eawprN},     // Lm         ARABIC TATWEEL
-	{runeRange{0x0641, 0x064A}, eawprN},     // Lo    [10] ARABIC LETTER FEH..ARABIC LETTER YEH
-	{runeRange{0x064B, 0x065F}, eawprN},     // Mn    [21] ARABIC FATHATAN..ARABIC WAVY HAMZA BELOW
-	{runeRange{0x0660, 0x0669}, eawprN},     // Nd    [10] ARABIC-INDIC DIGIT ZERO..ARABIC-INDIC DIGIT NINE
-	{runeRange{0x066A, 0x066D}, eawprN},     // Po     [4] ARABIC PERCENT SIGN..ARABIC FIVE POINTED STAR
-	{runeRange{0x066E, 0x066F}, eawprN},     // Lo     [2] ARABIC LETTER DOTLESS BEH..ARABIC LETTER DOTLESS QAF
-	{runeRange{0x0670, 0x0670}, eawprN},     // Mn         ARABIC LETTER SUPERSCRIPT ALEF
-	{runeRange{0x0671, 0x06D3}, eawprN},     // Lo    [99] ARABIC LETTER ALEF WASLA..ARABIC LETTER YEH BARREE WITH HAMZA ABOVE
-	{runeRange{0x06D4, 0x06D4}, eawprN},     // Po         ARABIC FULL STOP
-	{runeRange{0x06D5, 0x06D5}, eawprN},     // Lo         ARABIC LETTER AE
-	{runeRange{0x06D6, 0x06DC}, eawprN},     // Mn     [7] ARABIC SMALL HIGH LIGATURE SAD WITH LAM WITH ALEF MAKSURA..ARABIC SMALL HIGH SEEN
-	{runeRange{0x06DD, 0x06DD}, eawprN},     // Cf         ARABIC END OF AYAH
-	{runeRange{0x06DE, 0x06DE}, eawprN},     // So         ARABIC START OF RUB EL HIZB
-	{runeRange{0x06DF, 0x06E4}, eawprN},     // Mn     [6] ARABIC SMALL HIGH ROUNDED ZERO..ARABIC SMALL HIGH MADDA
-	{runeRange{0x06E5, 0x06E6}, eawprN},     // Lm     [2] ARABIC SMALL WAW..ARABIC SMALL YEH
-	{runeRange{0x06E7, 0x06E8}, eawprN},     // Mn     [2] ARABIC SMALL HIGH YEH..ARABIC SMALL HIGH NOON
-	{runeRange{0x06E9, 0x06E9}, eawprN},     // So         ARABIC PLACE OF SAJDAH
-	{runeRange{0x06EA, 0x06ED}, eawprN},     // Mn     [4] ARABIC EMPTY CENTRE LOW STOP..ARABIC SMALL LOW MEEM
-	{runeRange{0x06EE, 0x06EF}, eawprN},     // Lo     [2] ARABIC LETTER DAL WITH INVERTED V..ARABIC LETTER REH WITH INVERTED V
-	{runeRange{0x06F0, 0x06F9}, eawprN},     // Nd    [10] EXTENDED ARABIC-INDIC DIGIT ZERO..EXTENDED ARABIC-INDIC DIGIT NINE
-	{runeRange{0x06FA, 0x06FC}, eawprN},     // Lo     [3] ARABIC LETTER SHEEN WITH DOT BELOW..ARABIC LETTER GHAIN WITH DOT BELOW
-	{runeRange{0x06FD, 0x06FE}, eawprN},     // So     [2] ARABIC SIGN SINDHI AMPERSAND..ARABIC SIGN SINDHI POSTPOSITION MEN
-	{runeRange{0x06FF, 0x06FF}, eawprN},     // Lo         ARABIC LETTER HEH WITH INVERTED V
-	{runeRange{0x0700, 0x070D}, eawprN},     // Po    [14] SYRIAC END OF PARAGRAPH..SYRIAC HARKLEAN ASTERISCUS
-	{runeRange{0x070F, 0x070F}, eawprN},     // Cf         SYRIAC ABBREVIATION MARK
-	{runeRange{0x0710, 0x0710}, eawprN},     // Lo         SYRIAC LETTER ALAPH
-	{runeRange{0x0711, 0x0711}, eawprN},     // Mn         SYRIAC LETTER SUPERSCRIPT ALAPH
-	{runeRange{0x0712, 0x072F}, eawprN},     // Lo    [30] SYRIAC LETTER BETH..SYRIAC LETTER PERSIAN DHALATH
-	{runeRange{0x0730, 0x074A}, eawprN},     // Mn    [27] SYRIAC PTHAHA ABOVE..SYRIAC BARREKH
-	{runeRange{0x074D, 0x074F}, eawprN},     // Lo     [3] SYRIAC LETTER SOGDIAN ZHAIN..SYRIAC LETTER SOGDIAN FE
-	{runeRange{0x0750, 0x077F}, eawprN},     // Lo    [48] ARABIC LETTER BEH WITH THREE DOTS HORIZONTALLY BELOW..ARABIC LETTER KAF WITH TWO DOTS ABOVE
-	{runeRange{0x0780, 0x07A5}, eawprN},     // Lo    [38] THAANA LETTER HAA..THAANA LETTER WAAVU
-	{runeRange{0x07A6, 0x07B0}, eawprN},     // Mn    [11] THAANA ABAFILI..THAANA SUKUN
-	{runeRange{0x07B1, 0x07B1}, eawprN},     // Lo         THAANA LETTER NAA
-	{runeRange{0x07C0, 0x07C9}, eawprN},     // Nd    [10] NKO DIGIT ZERO..NKO DIGIT NINE
-	{runeRange{0x07CA, 0x07EA}, eawprN},     // Lo    [33] NKO LETTER A..NKO LETTER JONA RA
-	{runeRange{0x07EB, 0x07F3}, eawprN},     // Mn     [9] NKO COMBINING SHORT HIGH TONE..NKO COMBINING DOUBLE DOT ABOVE
-	{runeRange{0x07F4, 0x07F5}, eawprN},     // Lm     [2] NKO HIGH TONE APOSTROPHE..NKO LOW TONE APOSTROPHE
-	{runeRange{0x07F6, 0x07F6}, eawprN},     // So         NKO SYMBOL OO DENNEN
-	{runeRange{0x07F7, 0x07F9}, eawprN},     // Po     [3] NKO SYMBOL GBAKURUNEN..NKO EXCLAMATION MARK
-	{runeRange{0x07FA, 0x07FA}, eawprN},     // Lm         NKO LAJANYALAN
-	{runeRange{0x07FD, 0x07FD}, eawprN},     // Mn         NKO DANTAYALAN
-	{runeRange{0x07FE, 0x07FF}, eawprN},     // Sc     [2] NKO DOROME SIGN..NKO TAMAN SIGN
-	{runeRange{0x0800, 0x0815}, eawprN},     // Lo    [22] SAMARITAN LETTER ALAF..SAMARITAN LETTER TAAF
-	{runeRange{0x0816, 0x0819}, eawprN},     // Mn     [4] SAMARITAN MARK IN..SAMARITAN MARK DAGESH
-	{runeRange{0x081A, 0x081A}, eawprN},     // Lm         SAMARITAN MODIFIER LETTER EPENTHETIC YUT
-	{runeRange{0x081B, 0x0823}, eawprN},     // Mn     [9] SAMARITAN MARK EPENTHETIC YUT..SAMARITAN VOWEL SIGN A
-	{runeRange{0x0824, 0x0824}, eawprN},     // Lm         SAMARITAN MODIFIER LETTER SHORT A
-	{runeRange{0x0825, 0x0827}, eawprN},     // Mn     [3] SAMARITAN VOWEL SIGN SHORT A..SAMARITAN VOWEL SIGN U
-	{runeRange{0x0828, 0x0828}, eawprN},     // Lm         SAMARITAN MODIFIER LETTER I
-	{runeRange{0x0829, 0x082D}, eawprN},     // Mn     [5] SAMARITAN VOWEL SIGN LONG I..SAMARITAN MARK NEQUDAA
-	{runeRange{0x0830, 0x083E}, eawprN},     // Po    [15] SAMARITAN PUNCTUATION NEQUDAA..SAMARITAN PUNCTUATION ANNAAU
-	{runeRange{0x0840, 0x0858}, eawprN},     // Lo    [25] MANDAIC LETTER HALQA..MANDAIC LETTER AIN
-	{runeRange{0x0859, 0x085B}, eawprN},     // Mn     [3] MANDAIC AFFRICATION MARK..MANDAIC GEMINATION MARK
-	{runeRange{0x085E, 0x085E}, eawprN},     // Po         MANDAIC PUNCTUATION
-	{runeRange{0x0860, 0x086A}, eawprN},     // Lo    [11] SYRIAC LETTER MALAYALAM NGA..SYRIAC LETTER MALAYALAM SSA
-	{runeRange{0x0870, 0x0887}, eawprN},     // Lo    [24] ARABIC LETTER ALEF WITH ATTACHED FATHA..ARABIC BASELINE ROUND DOT
-	{runeRange{0x0888, 0x0888}, eawprN},     // Sk         ARABIC RAISED ROUND DOT
-	{runeRange{0x0889, 0x088E}, eawprN},     // Lo     [6] ARABIC LETTER NOON WITH INVERTED SMALL V..ARABIC VERTICAL TAIL
-	{runeRange{0x0890, 0x0891}, eawprN},     // Cf     [2] ARABIC POUND MARK ABOVE..ARABIC PIASTRE MARK ABOVE
-	{runeRange{0x0898, 0x089F}, eawprN},     // Mn     [8] ARABIC SMALL HIGH WORD AL-JUZ..ARABIC HALF MADDA OVER MADDA
-	{runeRange{0x08A0, 0x08C8}, eawprN},     // Lo    [41] ARABIC LETTER BEH WITH SMALL V BELOW..ARABIC LETTER GRAF
-	{runeRange{0x08C9, 0x08C9}, eawprN},     // Lm         ARABIC SMALL FARSI YEH
-	{runeRange{0x08CA, 0x08E1}, eawprN},     // Mn    [24] ARABIC SMALL HIGH FARSI YEH..ARABIC SMALL HIGH SIGN SAFHA
-	{runeRange{0x08E2, 0x08E2}, eawprN},     // Cf         ARABIC DISPUTED END OF AYAH
-	{runeRange{0x08E3, 0x08FF}, eawprN},     // Mn    [29] ARABIC TURNED DAMMA BELOW..ARABIC MARK SIDEWAYS NOON GHUNNA
-	{runeRange{0x0900, 0x0902}, eawprN},     // Mn     [3] DEVANAGARI SIGN INVERTED CANDRABINDU..DEVANAGARI SIGN ANUSVARA
-	{runeRange{0x0903, 0x0903}, eawprN},     // Mc         DEVANAGARI SIGN VISARGA
-	{runeRange{0x0904, 0x0939}, eawprN},     // Lo    [54] DEVANAGARI LETTER SHORT A..DEVANAGARI LETTER HA
-	{runeRange{0x093A, 0x093A}, eawprN},     // Mn         DEVANAGARI VOWEL SIGN OE
-	{runeRange{0x093B, 0x093B}, eawprN},     // Mc         DEVANAGARI VOWEL SIGN OOE
-	{runeRange{0x093C, 0x093C}, eawprN},     // Mn         DEVANAGARI SIGN NUKTA
-	{runeRange{0x093D, 0x093D}, eawprN},     // Lo         DEVANAGARI SIGN AVAGRAHA
-	{runeRange{0x093E, 0x0940}, eawprN},     // Mc     [3] DEVANAGARI VOWEL SIGN AA..DEVANAGARI VOWEL SIGN II
-	{runeRange{0x0941, 0x0948}, eawprN},     // Mn     [8] DEVANAGARI VOWEL SIGN U..DEVANAGARI VOWEL SIGN AI
-	{runeRange{0x0949, 0x094C}, eawprN},     // Mc     [4] DEVANAGARI VOWEL SIGN CANDRA O..DEVANAGARI VOWEL SIGN AU
-	{runeRange{0x094D, 0x094D}, eawprN},     // Mn         DEVANAGARI SIGN VIRAMA
-	{runeRange{0x094E, 0x094F}, eawprN},     // Mc     [2] DEVANAGARI VOWEL SIGN PRISHTHAMATRA E..DEVANAGARI VOWEL SIGN AW
-	{runeRange{0x0950, 0x0950}, eawprN},     // Lo         DEVANAGARI OM
-	{runeRange{0x0951, 0x0957}, eawprN},     // Mn     [7] DEVANAGARI STRESS SIGN UDATTA..DEVANAGARI VOWEL SIGN UUE
-	{runeRange{0x0958, 0x0961}, eawprN},     // Lo    [10] DEVANAGARI LETTER QA..DEVANAGARI LETTER VOCALIC LL
-	{runeRange{0x0962, 0x0963}, eawprN},     // Mn     [2] DEVANAGARI VOWEL SIGN VOCALIC L..DEVANAGARI VOWEL SIGN VOCALIC LL
-	{runeRange{0x0964, 0x0965}, eawprN},     // Po     [2] DEVANAGARI DANDA..DEVANAGARI DOUBLE DANDA
-	{runeRange{0x0966, 0x096F}, eawprN},     // Nd    [10] DEVANAGARI DIGIT ZERO..DEVANAGARI DIGIT NINE
-	{runeRange{0x0970, 0x0970}, eawprN},     // Po         DEVANAGARI ABBREVIATION SIGN
-	{runeRange{0x0971, 0x0971}, eawprN},     // Lm         DEVANAGARI SIGN HIGH SPACING DOT
-	{runeRange{0x0972, 0x097F}, eawprN},     // Lo    [14] DEVANAGARI LETTER CANDRA A..DEVANAGARI LETTER BBA
-	{runeRange{0x0980, 0x0980}, eawprN},     // Lo         BENGALI ANJI
-	{runeRange{0x0981, 0x0981}, eawprN},     // Mn         BENGALI SIGN CANDRABINDU
-	{runeRange{0x0982, 0x0983}, eawprN},     // Mc     [2] BENGALI SIGN ANUSVARA..BENGALI SIGN VISARGA
-	{runeRange{0x0985, 0x098C}, eawprN},     // Lo     [8] BENGALI LETTER A..BENGALI LETTER VOCALIC L
-	{runeRange{0x098F, 0x0990}, eawprN},     // Lo     [2] BENGALI LETTER E..BENGALI LETTER AI
-	{runeRange{0x0993, 0x09A8}, eawprN},     // Lo    [22] BENGALI LETTER O..BENGALI LETTER NA
-	{runeRange{0x09AA, 0x09B0}, eawprN},     // Lo     [7] BENGALI LETTER PA..BENGALI LETTER RA
-	{runeRange{0x09B2, 0x09B2}, eawprN},     // Lo         BENGALI LETTER LA
-	{runeRange{0x09B6, 0x09B9}, eawprN},     // Lo     [4] BENGALI LETTER SHA..BENGALI LETTER HA
-	{runeRange{0x09BC, 0x09BC}, eawprN},     // Mn         BENGALI SIGN NUKTA
-	{runeRange{0x09BD, 0x09BD}, eawprN},     // Lo         BENGALI SIGN AVAGRAHA
-	{runeRange{0x09BE, 0x09C0}, eawprN},     // Mc     [3] BENGALI VOWEL SIGN AA..BENGALI VOWEL SIGN II
-	{runeRange{0x09C1, 0x09C4}, eawprN},     // Mn     [4] BENGALI VOWEL SIGN U..BENGALI VOWEL SIGN VOCALIC RR
-	{runeRange{0x09C7, 0x09C8}, eawprN},     // Mc     [2] BENGALI VOWEL SIGN E..BENGALI VOWEL SIGN AI
-	{runeRange{0x09CB, 0x09CC}, eawprN},     // Mc     [2] BENGALI VOWEL SIGN O..BENGALI VOWEL SIGN AU
-	{runeRange{0x09CD, 0x09CD}, eawprN},     // Mn         BENGALI SIGN VIRAMA
-	{runeRange{0x09CE, 0x09CE}, eawprN},     // Lo         BENGALI LETTER KHANDA TA
-	{runeRange{0x09D7, 0x09D7}, eawprN},     // Mc         BENGALI AU LENGTH MARK
-	{runeRange{0x09DC, 0x09DD}, eawprN},     // Lo     [2] BENGALI LETTER RRA..BENGALI LETTER RHA
-	{runeRange{0x09DF, 0x09E1}, eawprN},     // Lo     [3] BENGALI LETTER YYA..BENGALI LETTER VOCALIC LL
-	{runeRange{0x09E2, 0x09E3}, eawprN},     // Mn     [2] BENGALI VOWEL SIGN VOCALIC L..BENGALI VOWEL SIGN VOCALIC LL
-	{runeRange{0x09E6, 0x09EF}, eawprN},     // Nd    [10] BENGALI DIGIT ZERO..BENGALI DIGIT NINE
-	{runeRange{0x09F0, 0x09F1}, eawprN},     // Lo     [2] BENGALI LETTER RA WITH MIDDLE DIAGONAL..BENGALI LETTER RA WITH LOWER DIAGONAL
-	{runeRange{0x09F2, 0x09F3}, eawprN},     // Sc     [2] BENGALI RUPEE MARK..BENGALI RUPEE SIGN
-	{runeRange{0x09F4, 0x09F9}, eawprN},     // No     [6] BENGALI CURRENCY NUMERATOR ONE..BENGALI CURRENCY DENOMINATOR SIXTEEN
-	{runeRange{0x09FA, 0x09FA}, eawprN},     // So         BENGALI ISSHAR
-	{runeRange{0x09FB, 0x09FB}, eawprN},     // Sc         BENGALI GANDA MARK
-	{runeRange{0x09FC, 0x09FC}, eawprN},     // Lo         BENGALI LETTER VEDIC ANUSVARA
-	{runeRange{0x09FD, 0x09FD}, eawprN},     // Po         BENGALI ABBREVIATION SIGN
-	{runeRange{0x09FE, 0x09FE}, eawprN},     // Mn         BENGALI SANDHI MARK
-	{runeRange{0x0A01, 0x0A02}, eawprN},     // Mn     [2] GURMUKHI SIGN ADAK BINDI..GURMUKHI SIGN BINDI
-	{runeRange{0x0A03, 0x0A03}, eawprN},     // Mc         GURMUKHI SIGN VISARGA
-	{runeRange{0x0A05, 0x0A0A}, eawprN},     // Lo     [6] GURMUKHI LETTER A..GURMUKHI LETTER UU
-	{runeRange{0x0A0F, 0x0A10}, eawprN},     // Lo     [2] GURMUKHI LETTER EE..GURMUKHI LETTER AI
-	{runeRange{0x0A13, 0x0A28}, eawprN},     // Lo    [22] GURMUKHI LETTER OO..GURMUKHI LETTER NA
-	{runeRange{0x0A2A, 0x0A30}, eawprN},     // Lo     [7] GURMUKHI LETTER PA..GURMUKHI LETTER RA
-	{runeRange{0x0A32, 0x0A33}, eawprN},     // Lo     [2] GURMUKHI LETTER LA..GURMUKHI LETTER LLA
-	{runeRange{0x0A35, 0x0A36}, eawprN},     // Lo     [2] GURMUKHI LETTER VA..GURMUKHI LETTER SHA
-	{runeRange{0x0A38, 0x0A39}, eawprN},     // Lo     [2] GURMUKHI LETTER SA..GURMUKHI LETTER HA
-	{runeRange{0x0A3C, 0x0A3C}, eawprN},     // Mn         GURMUKHI SIGN NUKTA
-	{runeRange{0x0A3E, 0x0A40}, eawprN},     // Mc     [3] GURMUKHI VOWEL SIGN AA..GURMUKHI VOWEL SIGN II
-	{runeRange{0x0A41, 0x0A42}, eawprN},     // Mn     [2] GURMUKHI VOWEL SIGN U..GURMUKHI VOWEL SIGN UU
-	{runeRange{0x0A47, 0x0A48}, eawprN},     // Mn     [2] GURMUKHI VOWEL SIGN EE..GURMUKHI VOWEL SIGN AI
-	{runeRange{0x0A4B, 0x0A4D}, eawprN},     // Mn     [3] GURMUKHI VOWEL SIGN OO..GURMUKHI SIGN VIRAMA
-	{runeRange{0x0A51, 0x0A51}, eawprN},     // Mn         GURMUKHI SIGN UDAAT
-	{runeRange{0x0A59, 0x0A5C}, eawprN},     // Lo     [4] GURMUKHI LETTER KHHA..GURMUKHI LETTER RRA
-	{runeRange{0x0A5E, 0x0A5E}, eawprN},     // Lo         GURMUKHI LETTER FA
-	{runeRange{0x0A66, 0x0A6F}, eawprN},     // Nd    [10] GURMUKHI DIGIT ZERO..GURMUKHI DIGIT NINE
-	{runeRange{0x0A70, 0x0A71}, eawprN},     // Mn     [2] GURMUKHI TIPPI..GURMUKHI ADDAK
-	{runeRange{0x0A72, 0x0A74}, eawprN},     // Lo     [3] GURMUKHI IRI..GURMUKHI EK ONKAR
-	{runeRange{0x0A75, 0x0A75}, eawprN},     // Mn         GURMUKHI SIGN YAKASH
-	{runeRange{0x0A76, 0x0A76}, eawprN},     // Po         GURMUKHI ABBREVIATION SIGN
-	{runeRange{0x0A81, 0x0A82}, eawprN},     // Mn     [2] GUJARATI SIGN CANDRABINDU..GUJARATI SIGN ANUSVARA
-	{runeRange{0x0A83, 0x0A83}, eawprN},     // Mc         GUJARATI SIGN VISARGA
-	{runeRange{0x0A85, 0x0A8D}, eawprN},     // Lo     [9] GUJARATI LETTER A..GUJARATI VOWEL CANDRA E
-	{runeRange{0x0A8F, 0x0A91}, eawprN},     // Lo     [3] GUJARATI LETTER E..GUJARATI VOWEL CANDRA O
-	{runeRange{0x0A93, 0x0AA8}, eawprN},     // Lo    [22] GUJARATI LETTER O..GUJARATI LETTER NA
-	{runeRange{0x0AAA, 0x0AB0}, eawprN},     // Lo     [7] GUJARATI LETTER PA..GUJARATI LETTER RA
-	{runeRange{0x0AB2, 0x0AB3}, eawprN},     // Lo     [2] GUJARATI LETTER LA..GUJARATI LETTER LLA
-	{runeRange{0x0AB5, 0x0AB9}, eawprN},     // Lo     [5] GUJARATI LETTER VA..GUJARATI LETTER HA
-	{runeRange{0x0ABC, 0x0ABC}, eawprN},     // Mn         GUJARATI SIGN NUKTA
-	{runeRange{0x0ABD, 0x0ABD}, eawprN},     // Lo         GUJARATI SIGN AVAGRAHA
-	{runeRange{0x0ABE, 0x0AC0}, eawprN},     // Mc     [3] GUJARATI VOWEL SIGN AA..GUJARATI VOWEL SIGN II
-	{runeRange{0x0AC1, 0x0AC5}, eawprN},     // Mn     [5] GUJARATI VOWEL SIGN U..GUJARATI VOWEL SIGN CANDRA E
-	{runeRange{0x0AC7, 0x0AC8}, eawprN},     // Mn     [2] GUJARATI VOWEL SIGN E..GUJARATI VOWEL SIGN AI
-	{runeRange{0x0AC9, 0x0AC9}, eawprN},     // Mc         GUJARATI VOWEL SIGN CANDRA O
-	{runeRange{0x0ACB, 0x0ACC}, eawprN},     // Mc     [2] GUJARATI VOWEL SIGN O..GUJARATI VOWEL SIGN AU
-	{runeRange{0x0ACD, 0x0ACD}, eawprN},     // Mn         GUJARATI SIGN VIRAMA
-	{runeRange{0x0AD0, 0x0AD0}, eawprN},     // Lo         GUJARATI OM
-	{runeRange{0x0AE0, 0x0AE1}, eawprN},     // Lo     [2] GUJARATI LETTER VOCALIC RR..GUJARATI LETTER VOCALIC LL
-	{runeRange{0x0AE2, 0x0AE3}, eawprN},     // Mn     [2] GUJARATI VOWEL SIGN VOCALIC L..GUJARATI VOWEL SIGN VOCALIC LL
-	{runeRange{0x0AE6, 0x0AEF}, eawprN},     // Nd    [10] GUJARATI DIGIT ZERO..GUJARATI DIGIT NINE
-	{runeRange{0x0AF0, 0x0AF0}, eawprN},     // Po         GUJARATI ABBREVIATION SIGN
-	{runeRange{0x0AF1, 0x0AF1}, eawprN},     // Sc         GUJARATI RUPEE SIGN
-	{runeRange{0x0AF9, 0x0AF9}, eawprN},     // Lo         GUJARATI LETTER ZHA
-	{runeRange{0x0AFA, 0x0AFF}, eawprN},     // Mn     [6] GUJARATI SIGN SUKUN..GUJARATI SIGN TWO-CIRCLE NUKTA ABOVE
-	{runeRange{0x0B01, 0x0B01}, eawprN},     // Mn         ORIYA SIGN CANDRABINDU
-	{runeRange{0x0B02, 0x0B03}, eawprN},     // Mc     [2] ORIYA SIGN ANUSVARA..ORIYA SIGN VISARGA
-	{runeRange{0x0B05, 0x0B0C}, eawprN},     // Lo     [8] ORIYA LETTER A..ORIYA LETTER VOCALIC L
-	{runeRange{0x0B0F, 0x0B10}, eawprN},     // Lo     [2] ORIYA LETTER E..ORIYA LETTER AI
-	{runeRange{0x0B13, 0x0B28}, eawprN},     // Lo    [22] ORIYA LETTER O..ORIYA LETTER NA
-	{runeRange{0x0B2A, 0x0B30}, eawprN},     // Lo     [7] ORIYA LETTER PA..ORIYA LETTER RA
-	{runeRange{0x0B32, 0x0B33}, eawprN},     // Lo     [2] ORIYA LETTER LA..ORIYA LETTER LLA
-	{runeRange{0x0B35, 0x0B39}, eawprN},     // Lo     [5] ORIYA LETTER VA..ORIYA LETTER HA
-	{runeRange{0x0B3C, 0x0B3C}, eawprN},     // Mn         ORIYA SIGN NUKTA
-	{runeRange{0x0B3D, 0x0B3D}, eawprN},     // Lo         ORIYA SIGN AVAGRAHA
-	{runeRange{0x0B3E, 0x0B3E}, eawprN},     // Mc         ORIYA VOWEL SIGN AA
-	{runeRange{0x0B3F, 0x0B3F}, eawprN},     // Mn         ORIYA VOWEL SIGN I
-	{runeRange{0x0B40, 0x0B40}, eawprN},     // Mc         ORIYA VOWEL SIGN II
-	{runeRange{0x0B41, 0x0B44}, eawprN},     // Mn     [4] ORIYA VOWEL SIGN U..ORIYA VOWEL SIGN VOCALIC RR
-	{runeRange{0x0B47, 0x0B48}, eawprN},     // Mc     [2] ORIYA VOWEL SIGN E..ORIYA VOWEL SIGN AI
-	{runeRange{0x0B4B, 0x0B4C}, eawprN},     // Mc     [2] ORIYA VOWEL SIGN O..ORIYA VOWEL SIGN AU
-	{runeRange{0x0B4D, 0x0B4D}, eawprN},     // Mn         ORIYA SIGN VIRAMA
-	{runeRange{0x0B55, 0x0B56}, eawprN},     // Mn     [2] ORIYA SIGN OVERLINE..ORIYA AI LENGTH MARK
-	{runeRange{0x0B57, 0x0B57}, eawprN},     // Mc         ORIYA AU LENGTH MARK
-	{runeRange{0x0B5C, 0x0B5D}, eawprN},     // Lo     [2] ORIYA LETTER RRA..ORIYA LETTER RHA
-	{runeRange{0x0B5F, 0x0B61}, eawprN},     // Lo     [3] ORIYA LETTER YYA..ORIYA LETTER VOCALIC LL
-	{runeRange{0x0B62, 0x0B63}, eawprN},     // Mn     [2] ORIYA VOWEL SIGN VOCALIC L..ORIYA VOWEL SIGN VOCALIC LL
-	{runeRange{0x0B66, 0x0B6F}, eawprN},     // Nd    [10] ORIYA DIGIT ZERO..ORIYA DIGIT NINE
-	{runeRange{0x0B70, 0x0B70}, eawprN},     // So         ORIYA ISSHAR
-	{runeRange{0x0B71, 0x0B71}, eawprN},     // Lo         ORIYA LETTER WA
-	{runeRange{0x0B72, 0x0B77}, eawprN},     // No     [6] ORIYA FRACTION ONE QUARTER..ORIYA FRACTION THREE SIXTEENTHS
-	{runeRange{0x0B82, 0x0B82}, eawprN},     // Mn         TAMIL SIGN ANUSVARA
-	{runeRange{0x0B83, 0x0B83}, eawprN},     // Lo         TAMIL SIGN VISARGA
-	{runeRange{0x0B85, 0x0B8A}, eawprN},     // Lo     [6] TAMIL LETTER A..TAMIL LETTER UU
-	{runeRange{0x0B8E, 0x0B90}, eawprN},     // Lo     [3] TAMIL LETTER E..TAMIL LETTER AI
-	{runeRange{0x0B92, 0x0B95}, eawprN},     // Lo     [4] TAMIL LETTER O..TAMIL LETTER KA
-	{runeRange{0x0B99, 0x0B9A}, eawprN},     // Lo     [2] TAMIL LETTER NGA..TAMIL LETTER CA
-	{runeRange{0x0B9C, 0x0B9C}, eawprN},     // Lo         TAMIL LETTER JA
-	{runeRange{0x0B9E, 0x0B9F}, eawprN},     // Lo     [2] TAMIL LETTER NYA..TAMIL LETTER TTA
-	{runeRange{0x0BA3, 0x0BA4}, eawprN},     // Lo     [2] TAMIL LETTER NNA..TAMIL LETTER TA
-	{runeRange{0x0BA8, 0x0BAA}, eawprN},     // Lo     [3] TAMIL LETTER NA..TAMIL LETTER PA
-	{runeRange{0x0BAE, 0x0BB9}, eawprN},     // Lo    [12] TAMIL LETTER MA..TAMIL LETTER HA
-	{runeRange{0x0BBE, 0x0BBF}, eawprN},     // Mc     [2] TAMIL VOWEL SIGN AA..TAMIL VOWEL SIGN I
-	{runeRange{0x0BC0, 0x0BC0}, eawprN},     // Mn         TAMIL VOWEL SIGN II
-	{runeRange{0x0BC1, 0x0BC2}, eawprN},     // Mc     [2] TAMIL VOWEL SIGN U..TAMIL VOWEL SIGN UU
-	{runeRange{0x0BC6, 0x0BC8}, eawprN},     // Mc     [3] TAMIL VOWEL SIGN E..TAMIL VOWEL SIGN AI
-	{runeRange{0x0BCA, 0x0BCC}, eawprN},     // Mc     [3] TAMIL VOWEL SIGN O..TAMIL VOWEL SIGN AU
-	{runeRange{0x0BCD, 0x0BCD}, eawprN},     // Mn         TAMIL SIGN VIRAMA
-	{runeRange{0x0BD0, 0x0BD0}, eawprN},     // Lo         TAMIL OM
-	{runeRange{0x0BD7, 0x0BD7}, eawprN},     // Mc         TAMIL AU LENGTH MARK
-	{runeRange{0x0BE6, 0x0BEF}, eawprN},     // Nd    [10] TAMIL DIGIT ZERO..TAMIL DIGIT NINE
-	{runeRange{0x0BF0, 0x0BF2}, eawprN},     // No     [3] TAMIL NUMBER TEN..TAMIL NUMBER ONE THOUSAND
-	{runeRange{0x0BF3, 0x0BF8}, eawprN},     // So     [6] TAMIL DAY SIGN..TAMIL AS ABOVE SIGN
-	{runeRange{0x0BF9, 0x0BF9}, eawprN},     // Sc         TAMIL RUPEE SIGN
-	{runeRange{0x0BFA, 0x0BFA}, eawprN},     // So         TAMIL NUMBER SIGN
-	{runeRange{0x0C00, 0x0C00}, eawprN},     // Mn         TELUGU SIGN COMBINING CANDRABINDU ABOVE
-	{runeRange{0x0C01, 0x0C03}, eawprN},     // Mc     [3] TELUGU SIGN CANDRABINDU..TELUGU SIGN VISARGA
-	{runeRange{0x0C04, 0x0C04}, eawprN},     // Mn         TELUGU SIGN COMBINING ANUSVARA ABOVE
-	{runeRange{0x0C05, 0x0C0C}, eawprN},     // Lo     [8] TELUGU LETTER A..TELUGU LETTER VOCALIC L
-	{runeRange{0x0C0E, 0x0C10}, eawprN},     // Lo     [3] TELUGU LETTER E..TELUGU LETTER AI
-	{runeRange{0x0C12, 0x0C28}, eawprN},     // Lo    [23] TELUGU LETTER O..TELUGU LETTER NA
-	{runeRange{0x0C2A, 0x0C39}, eawprN},     // Lo    [16] TELUGU LETTER PA..TELUGU LETTER HA
-	{runeRange{0x0C3C, 0x0C3C}, eawprN},     // Mn         TELUGU SIGN NUKTA
-	{runeRange{0x0C3D, 0x0C3D}, eawprN},     // Lo         TELUGU SIGN AVAGRAHA
-	{runeRange{0x0C3E, 0x0C40}, eawprN},     // Mn     [3] TELUGU VOWEL SIGN AA..TELUGU VOWEL SIGN II
-	{runeRange{0x0C41, 0x0C44}, eawprN},     // Mc     [4] TELUGU VOWEL SIGN U..TELUGU VOWEL SIGN VOCALIC RR
-	{runeRange{0x0C46, 0x0C48}, eawprN},     // Mn     [3] TELUGU VOWEL SIGN E..TELUGU VOWEL SIGN AI
-	{runeRange{0x0C4A, 0x0C4D}, eawprN},     // Mn     [4] TELUGU VOWEL SIGN O..TELUGU SIGN VIRAMA
-	{runeRange{0x0C55, 0x0C56}, eawprN},     // Mn     [2] TELUGU LENGTH MARK..TELUGU AI LENGTH MARK
-	{runeRange{0x0C58, 0x0C5A}, eawprN},     // Lo     [3] TELUGU LETTER TSA..TELUGU LETTER RRRA
-	{runeRange{0x0C5D, 0x0C5D}, eawprN},     // Lo         TELUGU LETTER NAKAARA POLLU
-	{runeRange{0x0C60, 0x0C61}, eawprN},     // Lo     [2] TELUGU LETTER VOCALIC RR..TELUGU LETTER VOCALIC LL
-	{runeRange{0x0C62, 0x0C63}, eawprN},     // Mn     [2] TELUGU VOWEL SIGN VOCALIC L..TELUGU VOWEL SIGN VOCALIC LL
-	{runeRange{0x0C66, 0x0C6F}, eawprN},     // Nd    [10] TELUGU DIGIT ZERO..TELUGU DIGIT NINE
-	{runeRange{0x0C77, 0x0C77}, eawprN},     // Po         TELUGU SIGN SIDDHAM
-	{runeRange{0x0C78, 0x0C7E}, eawprN},     // No     [7] TELUGU FRACTION DIGIT ZERO FOR ODD POWERS OF FOUR..TELUGU FRACTION DIGIT THREE FOR EVEN POWERS OF FOUR
-	{runeRange{0x0C7F, 0x0C7F}, eawprN},     // So         TELUGU SIGN TUUMU
-	{runeRange{0x0C80, 0x0C80}, eawprN},     // Lo         KANNADA SIGN SPACING CANDRABINDU
-	{runeRange{0x0C81, 0x0C81}, eawprN},     // Mn         KANNADA SIGN CANDRABINDU
-	{runeRange{0x0C82, 0x0C83}, eawprN},     // Mc     [2] KANNADA SIGN ANUSVARA..KANNADA SIGN VISARGA
-	{runeRange{0x0C84, 0x0C84}, eawprN},     // Po         KANNADA SIGN SIDDHAM
-	{runeRange{0x0C85, 0x0C8C}, eawprN},     // Lo     [8] KANNADA LETTER A..KANNADA LETTER VOCALIC L
-	{runeRange{0x0C8E, 0x0C90}, eawprN},     // Lo     [3] KANNADA LETTER E..KANNADA LETTER AI
-	{runeRange{0x0C92, 0x0CA8}, eawprN},     // Lo    [23] KANNADA LETTER O..KANNADA LETTER NA
-	{runeRange{0x0CAA, 0x0CB3}, eawprN},     // Lo    [10] KANNADA LETTER PA..KANNADA LETTER LLA
-	{runeRange{0x0CB5, 0x0CB9}, eawprN},     // Lo     [5] KANNADA LETTER VA..KANNADA LETTER HA
-	{runeRange{0x0CBC, 0x0CBC}, eawprN},     // Mn         KANNADA SIGN NUKTA
-	{runeRange{0x0CBD, 0x0CBD}, eawprN},     // Lo         KANNADA SIGN AVAGRAHA
-	{runeRange{0x0CBE, 0x0CBE}, eawprN},     // Mc         KANNADA VOWEL SIGN AA
-	{runeRange{0x0CBF, 0x0CBF}, eawprN},     // Mn         KANNADA VOWEL SIGN I
-	{runeRange{0x0CC0, 0x0CC4}, eawprN},     // Mc     [5] KANNADA VOWEL SIGN II..KANNADA VOWEL SIGN VOCALIC RR
-	{runeRange{0x0CC6, 0x0CC6}, eawprN},     // Mn         KANNADA VOWEL SIGN E
-	{runeRange{0x0CC7, 0x0CC8}, eawprN},     // Mc     [2] KANNADA VOWEL SIGN EE..KANNADA VOWEL SIGN AI
-	{runeRange{0x0CCA, 0x0CCB}, eawprN},     // Mc     [2] KANNADA VOWEL SIGN O..KANNADA VOWEL SIGN OO
-	{runeRange{0x0CCC, 0x0CCD}, eawprN},     // Mn     [2] KANNADA VOWEL SIGN AU..KANNADA SIGN VIRAMA
-	{runeRange{0x0CD5, 0x0CD6}, eawprN},     // Mc     [2] KANNADA LENGTH MARK..KANNADA AI LENGTH MARK
-	{runeRange{0x0CDD, 0x0CDE}, eawprN},     // Lo     [2] KANNADA LETTER NAKAARA POLLU..KANNADA LETTER FA
-	{runeRange{0x0CE0, 0x0CE1}, eawprN},     // Lo     [2] KANNADA LETTER VOCALIC RR..KANNADA LETTER VOCALIC LL
-	{runeRange{0x0CE2, 0x0CE3}, eawprN},     // Mn     [2] KANNADA VOWEL SIGN VOCALIC L..KANNADA VOWEL SIGN VOCALIC LL
-	{runeRange{0x0CE6, 0x0CEF}, eawprN},     // Nd    [10] KANNADA DIGIT ZERO..KANNADA DIGIT NINE
-	{runeRange{0x0CF1, 0x0CF2}, eawprN},     // Lo     [2] KANNADA SIGN JIHVAMULIYA..KANNADA SIGN UPADHMANIYA
-	{runeRange{0x0CF3, 0x0CF3}, eawprN},     // Mc         KANNADA SIGN COMBINING ANUSVARA ABOVE RIGHT
-	{runeRange{0x0D00, 0x0D01}, eawprN},     // Mn     [2] MALAYALAM SIGN COMBINING ANUSVARA ABOVE..MALAYALAM SIGN CANDRABINDU
-	{runeRange{0x0D02, 0x0D03}, eawprN},     // Mc     [2] MALAYALAM SIGN ANUSVARA..MALAYALAM SIGN VISARGA
-	{runeRange{0x0D04, 0x0D0C}, eawprN},     // Lo     [9] MALAYALAM LETTER VEDIC ANUSVARA..MALAYALAM LETTER VOCALIC L
-	{runeRange{0x0D0E, 0x0D10}, eawprN},     // Lo     [3] MALAYALAM LETTER E..MALAYALAM LETTER AI
-	{runeRange{0x0D12, 0x0D3A}, eawprN},     // Lo    [41] MALAYALAM LETTER O..MALAYALAM LETTER TTTA
-	{runeRange{0x0D3B, 0x0D3C}, eawprN},     // Mn     [2] MALAYALAM SIGN VERTICAL BAR VIRAMA..MALAYALAM SIGN CIRCULAR VIRAMA
-	{runeRange{0x0D3D, 0x0D3D}, eawprN},     // Lo         MALAYALAM SIGN AVAGRAHA
-	{runeRange{0x0D3E, 0x0D40}, eawprN},     // Mc     [3] MALAYALAM VOWEL SIGN AA..MALAYALAM VOWEL SIGN II
-	{runeRange{0x0D41, 0x0D44}, eawprN},     // Mn     [4] MALAYALAM VOWEL SIGN U..MALAYALAM VOWEL SIGN VOCALIC RR
-	{runeRange{0x0D46, 0x0D48}, eawprN},     // Mc     [3] MALAYALAM VOWEL SIGN E..MALAYALAM VOWEL SIGN AI
-	{runeRange{0x0D4A, 0x0D4C}, eawprN},     // Mc     [3] MALAYALAM VOWEL SIGN O..MALAYALAM VOWEL SIGN AU
-	{runeRange{0x0D4D, 0x0D4D}, eawprN},     // Mn         MALAYALAM SIGN VIRAMA
-	{runeRange{0x0D4E, 0x0D4E}, eawprN},     // Lo         MALAYALAM LETTER DOT REPH
-	{runeRange{0x0D4F, 0x0D4F}, eawprN},     // So         MALAYALAM SIGN PARA
-	{runeRange{0x0D54, 0x0D56}, eawprN},     // Lo     [3] MALAYALAM LETTER CHILLU M..MALAYALAM LETTER CHILLU LLL
-	{runeRange{0x0D57, 0x0D57}, eawprN},     // Mc         MALAYALAM AU LENGTH MARK
-	{runeRange{0x0D58, 0x0D5E}, eawprN},     // No     [7] MALAYALAM FRACTION ONE ONE-HUNDRED-AND-SIXTIETH..MALAYALAM FRACTION ONE FIFTH
-	{runeRange{0x0D5F, 0x0D61}, eawprN},     // Lo     [3] MALAYALAM LETTER ARCHAIC II..MALAYALAM LETTER VOCALIC LL
-	{runeRange{0x0D62, 0x0D63}, eawprN},     // Mn     [2] MALAYALAM VOWEL SIGN VOCALIC L..MALAYALAM VOWEL SIGN VOCALIC LL
-	{runeRange{0x0D66, 0x0D6F}, eawprN},     // Nd    [10] MALAYALAM DIGIT ZERO..MALAYALAM DIGIT NINE
-	{runeRange{0x0D70, 0x0D78}, eawprN},     // No     [9] MALAYALAM NUMBER TEN..MALAYALAM FRACTION THREE SIXTEENTHS
-	{runeRange{0x0D79, 0x0D79}, eawprN},     // So         MALAYALAM DATE MARK
-	{runeRange{0x0D7A, 0x0D7F}, eawprN},     // Lo     [6] MALAYALAM LETTER CHILLU NN..MALAYALAM LETTER CHILLU K
-	{runeRange{0x0D81, 0x0D81}, eawprN},     // Mn         SINHALA SIGN CANDRABINDU
-	{runeRange{0x0D82, 0x0D83}, eawprN},     // Mc     [2] SINHALA SIGN ANUSVARAYA..SINHALA SIGN VISARGAYA
-	{runeRange{0x0D85, 0x0D96}, eawprN},     // Lo    [18] SINHALA LETTER AYANNA..SINHALA LETTER AUYANNA
-	{runeRange{0x0D9A, 0x0DB1}, eawprN},     // Lo    [24] SINHALA LETTER ALPAPRAANA KAYANNA..SINHALA LETTER DANTAJA NAYANNA
-	{runeRange{0x0DB3, 0x0DBB}, eawprN},     // Lo     [9] SINHALA LETTER SANYAKA DAYANNA..SINHALA LETTER RAYANNA
-	{runeRange{0x0DBD, 0x0DBD}, eawprN},     // Lo         SINHALA LETTER DANTAJA LAYANNA
-	{runeRange{0x0DC0, 0x0DC6}, eawprN},     // Lo     [7] SINHALA LETTER VAYANNA..SINHALA LETTER FAYANNA
-	{runeRange{0x0DCA, 0x0DCA}, eawprN},     // Mn         SINHALA SIGN AL-LAKUNA
-	{runeRange{0x0DCF, 0x0DD1}, eawprN},     // Mc     [3] SINHALA VOWEL SIGN AELA-PILLA..SINHALA VOWEL SIGN DIGA AEDA-PILLA
-	{runeRange{0x0DD2, 0x0DD4}, eawprN},     // Mn     [3] SINHALA VOWEL SIGN KETTI IS-PILLA..SINHALA VOWEL SIGN KETTI PAA-PILLA
-	{runeRange{0x0DD6, 0x0DD6}, eawprN},     // Mn         SINHALA VOWEL SIGN DIGA PAA-PILLA
-	{runeRange{0x0DD8, 0x0DDF}, eawprN},     // Mc     [8] SINHALA VOWEL SIGN GAETTA-PILLA..SINHALA VOWEL SIGN GAYANUKITTA
-	{runeRange{0x0DE6, 0x0DEF}, eawprN},     // Nd    [10] SINHALA LITH DIGIT ZERO..SINHALA LITH DIGIT NINE
-	{runeRange{0x0DF2, 0x0DF3}, eawprN},     // Mc     [2] SINHALA VOWEL SIGN DIGA GAETTA-PILLA..SINHALA VOWEL SIGN DIGA GAYANUKITTA
-	{runeRange{0x0DF4, 0x0DF4}, eawprN},     // Po         SINHALA PUNCTUATION KUNDDALIYA
-	{runeRange{0x0E01, 0x0E30}, eawprN},     // Lo    [48] THAI CHARACTER KO KAI..THAI CHARACTER SARA A
-	{runeRange{0x0E31, 0x0E31}, eawprN},     // Mn         THAI CHARACTER MAI HAN-AKAT
-	{runeRange{0x0E32, 0x0E33}, eawprN},     // Lo     [2] THAI CHARACTER SARA AA..THAI CHARACTER SARA AM
-	{runeRange{0x0E34, 0x0E3A}, eawprN},     // Mn     [7] THAI CHARACTER SARA I..THAI CHARACTER PHINTHU
-	{runeRange{0x0E3F, 0x0E3F}, eawprN},     // Sc         THAI CURRENCY SYMBOL BAHT
-	{runeRange{0x0E40, 0x0E45}, eawprN},     // Lo     [6] THAI CHARACTER SARA E..THAI CHARACTER LAKKHANGYAO
-	{runeRange{0x0E46, 0x0E46}, eawprN},     // Lm         THAI CHARACTER MAIYAMOK
-	{runeRange{0x0E47, 0x0E4E}, eawprN},     // Mn     [8] THAI CHARACTER MAITAIKHU..THAI CHARACTER YAMAKKAN
-	{runeRange{0x0E4F, 0x0E4F}, eawprN},     // Po         THAI CHARACTER FONGMAN
-	{runeRange{0x0E50, 0x0E59}, eawprN},     // Nd    [10] THAI DIGIT ZERO..THAI DIGIT NINE
-	{runeRange{0x0E5A, 0x0E5B}, eawprN},     // Po     [2] THAI CHARACTER ANGKHANKHU..THAI CHARACTER KHOMUT
-	{runeRange{0x0E81, 0x0E82}, eawprN},     // Lo     [2] LAO LETTER KO..LAO LETTER KHO SUNG
-	{runeRange{0x0E84, 0x0E84}, eawprN},     // Lo         LAO LETTER KHO TAM
-	{runeRange{0x0E86, 0x0E8A}, eawprN},     // Lo     [5] LAO LETTER PALI GHA..LAO LETTER SO TAM
-	{runeRange{0x0E8C, 0x0EA3}, eawprN},     // Lo    [24] LAO LETTER PALI JHA..LAO LETTER LO LING
-	{runeRange{0x0EA5, 0x0EA5}, eawprN},     // Lo         LAO LETTER LO LOOT
-	{runeRange{0x0EA7, 0x0EB0}, eawprN},     // Lo    [10] LAO LETTER WO..LAO VOWEL SIGN A
-	{runeRange{0x0EB1, 0x0EB1}, eawprN},     // Mn         LAO VOWEL SIGN MAI KAN
-	{runeRange{0x0EB2, 0x0EB3}, eawprN},     // Lo     [2] LAO VOWEL SIGN AA..LAO VOWEL SIGN AM
-	{runeRange{0x0EB4, 0x0EBC}, eawprN},     // Mn     [9] LAO VOWEL SIGN I..LAO SEMIVOWEL SIGN LO
-	{runeRange{0x0EBD, 0x0EBD}, eawprN},     // Lo         LAO SEMIVOWEL SIGN NYO
-	{runeRange{0x0EC0, 0x0EC4}, eawprN},     // Lo     [5] LAO VOWEL SIGN E..LAO VOWEL SIGN AI
-	{runeRange{0x0EC6, 0x0EC6}, eawprN},     // Lm         LAO KO LA
-	{runeRange{0x0EC8, 0x0ECE}, eawprN},     // Mn     [7] LAO TONE MAI EK..LAO YAMAKKAN
-	{runeRange{0x0ED0, 0x0ED9}, eawprN},     // Nd    [10] LAO DIGIT ZERO..LAO DIGIT NINE
-	{runeRange{0x0EDC, 0x0EDF}, eawprN},     // Lo     [4] LAO HO NO..LAO LETTER KHMU NYO
-	{runeRange{0x0F00, 0x0F00}, eawprN},     // Lo         TIBETAN SYLLABLE OM
-	{runeRange{0x0F01, 0x0F03}, eawprN},     // So     [3] TIBETAN MARK GTER YIG MGO TRUNCATED A..TIBETAN MARK GTER YIG MGO -UM GTER TSHEG MA
-	{runeRange{0x0F04, 0x0F12}, eawprN},     // Po    [15] TIBETAN MARK INITIAL YIG MGO MDUN MA..TIBETAN MARK RGYA GRAM SHAD
-	{runeRange{0x0F13, 0x0F13}, eawprN},     // So         TIBETAN MARK CARET -DZUD RTAGS ME LONG CAN
-	{runeRange{0x0F14, 0x0F14}, eawprN},     // Po         TIBETAN MARK GTER TSHEG
-	{runeRange{0x0F15, 0x0F17}, eawprN},     // So     [3] TIBETAN LOGOTYPE SIGN CHAD RTAGS..TIBETAN ASTROLOGICAL SIGN SGRA GCAN -CHAR RTAGS
-	{runeRange{0x0F18, 0x0F19}, eawprN},     // Mn     [2] TIBETAN ASTROLOGICAL SIGN -KHYUD PA..TIBETAN ASTROLOGICAL SIGN SDONG TSHUGS
-	{runeRange{0x0F1A, 0x0F1F}, eawprN},     // So     [6] TIBETAN SIGN RDEL DKAR GCIG..TIBETAN SIGN RDEL DKAR RDEL NAG
-	{runeRange{0x0F20, 0x0F29}, eawprN},     // Nd    [10] TIBETAN DIGIT ZERO..TIBETAN DIGIT NINE
-	{runeRange{0x0F2A, 0x0F33}, eawprN},     // No    [10] TIBETAN DIGIT HALF ONE..TIBETAN DIGIT HALF ZERO
-	{runeRange{0x0F34, 0x0F34}, eawprN},     // So         TIBETAN MARK BSDUS RTAGS
-	{runeRange{0x0F35, 0x0F35}, eawprN},     // Mn         TIBETAN MARK NGAS BZUNG NYI ZLA
-	{runeRange{0x0F36, 0x0F36}, eawprN},     // So         TIBETAN MARK CARET -DZUD RTAGS BZHI MIG CAN
-	{runeRange{0x0F37, 0x0F37}, eawprN},     // Mn         TIBETAN MARK NGAS BZUNG SGOR RTAGS
-	{runeRange{0x0F38, 0x0F38}, eawprN},     // So         TIBETAN MARK CHE MGO
-	{runeRange{0x0F39, 0x0F39}, eawprN},     // Mn         TIBETAN MARK TSA -PHRU
-	{runeRange{0x0F3A, 0x0F3A}, eawprN},     // Ps         TIBETAN MARK GUG RTAGS GYON
-	{runeRange{0x0F3B, 0x0F3B}, eawprN},     // Pe         TIBETAN MARK GUG RTAGS GYAS
-	{runeRange{0x0F3C, 0x0F3C}, eawprN},     // Ps         TIBETAN MARK ANG KHANG GYON
-	{runeRange{0x0F3D, 0x0F3D}, eawprN},     // Pe         TIBETAN MARK ANG KHANG GYAS
-	{runeRange{0x0F3E, 0x0F3F}, eawprN},     // Mc     [2] TIBETAN SIGN YAR TSHES..TIBETAN SIGN MAR TSHES
-	{runeRange{0x0F40, 0x0F47}, eawprN},     // Lo     [8] TIBETAN LETTER KA..TIBETAN LETTER JA
-	{runeRange{0x0F49, 0x0F6C}, eawprN},     // Lo    [36] TIBETAN LETTER NYA..TIBETAN LETTER RRA
-	{runeRange{0x0F71, 0x0F7E}, eawprN},     // Mn    [14] TIBETAN VOWEL SIGN AA..TIBETAN SIGN RJES SU NGA RO
-	{runeRange{0x0F7F, 0x0F7F}, eawprN},     // Mc         TIBETAN SIGN RNAM BCAD
-	{runeRange{0x0F80, 0x0F84}, eawprN},     // Mn     [5] TIBETAN VOWEL SIGN REVERSED I..TIBETAN MARK HALANTA
-	{runeRange{0x0F85, 0x0F85}, eawprN},     // Po         TIBETAN MARK PALUTA
-	{runeRange{0x0F86, 0x0F87}, eawprN},     // Mn     [2] TIBETAN SIGN LCI RTAGS..TIBETAN SIGN YANG RTAGS
-	{runeRange{0x0F88, 0x0F8C}, eawprN},     // Lo     [5] TIBETAN SIGN LCE TSA CAN..TIBETAN SIGN INVERTED MCHU CAN
-	{runeRange{0x0F8D, 0x0F97}, eawprN},     // Mn    [11] TIBETAN SUBJOINED SIGN LCE TSA CAN..TIBETAN SUBJOINED LETTER JA
-	{runeRange{0x0F99, 0x0FBC}, eawprN},     // Mn    [36] TIBETAN SUBJOINED LETTER NYA..TIBETAN SUBJOINED LETTER FIXED-FORM RA
-	{runeRange{0x0FBE, 0x0FC5}, eawprN},     // So     [8] TIBETAN KU RU KHA..TIBETAN SYMBOL RDO RJE
-	{runeRange{0x0FC6, 0x0FC6}, eawprN},     // Mn         TIBETAN SYMBOL PADMA GDAN
-	{runeRange{0x0FC7, 0x0FCC}, eawprN},     // So     [6] TIBETAN SYMBOL RDO RJE RGYA GRAM..TIBETAN SYMBOL NOR BU BZHI -KHYIL
-	{runeRange{0x0FCE, 0x0FCF}, eawprN},     // So     [2] TIBETAN SIGN RDEL NAG RDEL DKAR..TIBETAN SIGN RDEL NAG GSUM
-	{runeRange{0x0FD0, 0x0FD4}, eawprN},     // Po     [5] TIBETAN MARK BSKA- SHOG GI MGO RGYAN..TIBETAN MARK CLOSING BRDA RNYING YIG MGO SGAB MA
-	{runeRange{0x0FD5, 0x0FD8}, eawprN},     // So     [4] RIGHT-FACING SVASTI SIGN..LEFT-FACING SVASTI SIGN WITH DOTS
-	{runeRange{0x0FD9, 0x0FDA}, eawprN},     // Po     [2] TIBETAN MARK LEADING MCHAN RTAGS..TIBETAN MARK TRAILING MCHAN RTAGS
-	{runeRange{0x1000, 0x102A}, eawprN},     // Lo    [43] MYANMAR LETTER KA..MYANMAR LETTER AU
-	{runeRange{0x102B, 0x102C}, eawprN},     // Mc     [2] MYANMAR VOWEL SIGN TALL AA..MYANMAR VOWEL SIGN AA
-	{runeRange{0x102D, 0x1030}, eawprN},     // Mn     [4] MYANMAR VOWEL SIGN I..MYANMAR VOWEL SIGN UU
-	{runeRange{0x1031, 0x1031}, eawprN},     // Mc         MYANMAR VOWEL SIGN E
-	{runeRange{0x1032, 0x1037}, eawprN},     // Mn     [6] MYANMAR VOWEL SIGN AI..MYANMAR SIGN DOT BELOW
-	{runeRange{0x1038, 0x1038}, eawprN},     // Mc         MYANMAR SIGN VISARGA
-	{runeRange{0x1039, 0x103A}, eawprN},     // Mn     [2] MYANMAR SIGN VIRAMA..MYANMAR SIGN ASAT
-	{runeRange{0x103B, 0x103C}, eawprN},     // Mc     [2] MYANMAR CONSONANT SIGN MEDIAL YA..MYANMAR CONSONANT SIGN MEDIAL RA
-	{runeRange{0x103D, 0x103E}, eawprN},     // Mn     [2] MYANMAR CONSONANT SIGN MEDIAL WA..MYANMAR CONSONANT SIGN MEDIAL HA
-	{runeRange{0x103F, 0x103F}, eawprN},     // Lo         MYANMAR LETTER GREAT SA
-	{runeRange{0x1040, 0x1049}, eawprN},     // Nd    [10] MYANMAR DIGIT ZERO..MYANMAR DIGIT NINE
-	{runeRange{0x104A, 0x104F}, eawprN},     // Po     [6] MYANMAR SIGN LITTLE SECTION..MYANMAR SYMBOL GENITIVE
-	{runeRange{0x1050, 0x1055}, eawprN},     // Lo     [6] MYANMAR LETTER SHA..MYANMAR LETTER VOCALIC LL
-	{runeRange{0x1056, 0x1057}, eawprN},     // Mc     [2] MYANMAR VOWEL SIGN VOCALIC R..MYANMAR VOWEL SIGN VOCALIC RR
-	{runeRange{0x1058, 0x1059}, eawprN},     // Mn     [2] MYANMAR VOWEL SIGN VOCALIC L..MYANMAR VOWEL SIGN VOCALIC LL
-	{runeRange{0x105A, 0x105D}, eawprN},     // Lo     [4] MYANMAR LETTER MON NGA..MYANMAR LETTER MON BBE
-	{runeRange{0x105E, 0x1060}, eawprN},     // Mn     [3] MYANMAR CONSONANT SIGN MON MEDIAL NA..MYANMAR CONSONANT SIGN MON MEDIAL LA
-	{runeRange{0x1061, 0x1061}, eawprN},     // Lo         MYANMAR LETTER SGAW KAREN SHA
-	{runeRange{0x1062, 0x1064}, eawprN},     // Mc     [3] MYANMAR VOWEL SIGN SGAW KAREN EU..MYANMAR TONE MARK SGAW KAREN KE PHO
-	{runeRange{0x1065, 0x1066}, eawprN},     // Lo     [2] MYANMAR LETTER WESTERN PWO KAREN THA..MYANMAR LETTER WESTERN PWO KAREN PWA
-	{runeRange{0x1067, 0x106D}, eawprN},     // Mc     [7] MYANMAR VOWEL SIGN WESTERN PWO KAREN EU..MYANMAR SIGN WESTERN PWO KAREN TONE-5
-	{runeRange{0x106E, 0x1070}, eawprN},     // Lo     [3] MYANMAR LETTER EASTERN PWO KAREN NNA..MYANMAR LETTER EASTERN PWO KAREN GHWA
-	{runeRange{0x1071, 0x1074}, eawprN},     // Mn     [4] MYANMAR VOWEL SIGN GEBA KAREN I..MYANMAR VOWEL SIGN KAYAH EE
-	{runeRange{0x1075, 0x1081}, eawprN},     // Lo    [13] MYANMAR LETTER SHAN KA..MYANMAR LETTER SHAN HA
-	{runeRange{0x1082, 0x1082}, eawprN},     // Mn         MYANMAR CONSONANT SIGN SHAN MEDIAL WA
-	{runeRange{0x1083, 0x1084}, eawprN},     // Mc     [2] MYANMAR VOWEL SIGN SHAN AA..MYANMAR VOWEL SIGN SHAN E
-	{runeRange{0x1085, 0x1086}, eawprN},     // Mn     [2] MYANMAR VOWEL SIGN SHAN E ABOVE..MYANMAR VOWEL SIGN SHAN FINAL Y
-	{runeRange{0x1087, 0x108C}, eawprN},     // Mc     [6] MYANMAR SIGN SHAN TONE-2..MYANMAR SIGN SHAN COUNCIL TONE-3
-	{runeRange{0x108D, 0x108D}, eawprN},     // Mn         MYANMAR SIGN SHAN COUNCIL EMPHATIC TONE
-	{runeRange{0x108E, 0x108E}, eawprN},     // Lo         MYANMAR LETTER RUMAI PALAUNG FA
-	{runeRange{0x108F, 0x108F}, eawprN},     // Mc         MYANMAR SIGN RUMAI PALAUNG TONE-5
-	{runeRange{0x1090, 0x1099}, eawprN},     // Nd    [10] MYANMAR SHAN DIGIT ZERO..MYANMAR SHAN DIGIT NINE
-	{runeRange{0x109A, 0x109C}, eawprN},     // Mc     [3] MYANMAR SIGN KHAMTI TONE-1..MYANMAR VOWEL SIGN AITON A
-	{runeRange{0x109D, 0x109D}, eawprN},     // Mn         MYANMAR VOWEL SIGN AITON AI
-	{runeRange{0x109E, 0x109F}, eawprN},     // So     [2] MYANMAR SYMBOL SHAN ONE..MYANMAR SYMBOL SHAN EXCLAMATION
-	{runeRange{0x10A0, 0x10C5}, eawprN},     // Lu    [38] GEORGIAN CAPITAL LETTER AN..GEORGIAN CAPITAL LETTER HOE
-	{runeRange{0x10C7, 0x10C7}, eawprN},     // Lu         GEORGIAN CAPITAL LETTER YN
-	{runeRange{0x10CD, 0x10CD}, eawprN},     // Lu         GEORGIAN CAPITAL LETTER AEN
-	{runeRange{0x10D0, 0x10FA}, eawprN},     // Ll    [43] GEORGIAN LETTER AN..GEORGIAN LETTER AIN
-	{runeRange{0x10FB, 0x10FB}, eawprN},     // Po         GEORGIAN PARAGRAPH SEPARATOR
-	{runeRange{0x10FC, 0x10FC}, eawprN},     // Lm         MODIFIER LETTER GEORGIAN NAR
-	{runeRange{0x10FD, 0x10FF}, eawprN},     // Ll     [3] GEORGIAN LETTER AEN..GEORGIAN LETTER LABIAL SIGN
-	{runeRange{0x1100, 0x115F}, eawprW},     // Lo    [96] HANGUL CHOSEONG KIYEOK..HANGUL CHOSEONG FILLER
-	{runeRange{0x1160, 0x11FF}, eawprN},     // Lo   [160] HANGUL JUNGSEONG FILLER..HANGUL JONGSEONG SSANGNIEUN
-	{runeRange{0x1200, 0x1248}, eawprN},     // Lo    [73] ETHIOPIC SYLLABLE HA..ETHIOPIC SYLLABLE QWA
-	{runeRange{0x124A, 0x124D}, eawprN},     // Lo     [4] ETHIOPIC SYLLABLE QWI..ETHIOPIC SYLLABLE QWE
-	{runeRange{0x1250, 0x1256}, eawprN},     // Lo     [7] ETHIOPIC SYLLABLE QHA..ETHIOPIC SYLLABLE QHO
-	{runeRange{0x1258, 0x1258}, eawprN},     // Lo         ETHIOPIC SYLLABLE QHWA
-	{runeRange{0x125A, 0x125D}, eawprN},     // Lo     [4] ETHIOPIC SYLLABLE QHWI..ETHIOPIC SYLLABLE QHWE
-	{runeRange{0x1260, 0x1288}, eawprN},     // Lo    [41] ETHIOPIC SYLLABLE BA..ETHIOPIC SYLLABLE XWA
-	{runeRange{0x128A, 0x128D}, eawprN},     // Lo     [4] ETHIOPIC SYLLABLE XWI..ETHIOPIC SYLLABLE XWE
-	{runeRange{0x1290, 0x12B0}, eawprN},     // Lo    [33] ETHIOPIC SYLLABLE NA..ETHIOPIC SYLLABLE KWA
-	{runeRange{0x12B2, 0x12B5}, eawprN},     // Lo     [4] ETHIOPIC SYLLABLE KWI..ETHIOPIC SYLLABLE KWE
-	{runeRange{0x12B8, 0x12BE}, eawprN},     // Lo     [7] ETHIOPIC SYLLABLE KXA..ETHIOPIC SYLLABLE KXO
-	{runeRange{0x12C0, 0x12C0}, eawprN},     // Lo         ETHIOPIC SYLLABLE KXWA
-	{runeRange{0x12C2, 0x12C5}, eawprN},     // Lo     [4] ETHIOPIC SYLLABLE KXWI..ETHIOPIC SYLLABLE KXWE
-	{runeRange{0x12C8, 0x12D6}, eawprN},     // Lo    [15] ETHIOPIC SYLLABLE WA..ETHIOPIC SYLLABLE PHARYNGEAL O
-	{runeRange{0x12D8, 0x1310}, eawprN},     // Lo    [57] ETHIOPIC SYLLABLE ZA..ETHIOPIC SYLLABLE GWA
-	{runeRange{0x1312, 0x1315}, eawprN},     // Lo     [4] ETHIOPIC SYLLABLE GWI..ETHIOPIC SYLLABLE GWE
-	{runeRange{0x1318, 0x135A}, eawprN},     // Lo    [67] ETHIOPIC SYLLABLE GGA..ETHIOPIC SYLLABLE FYA
-	{runeRange{0x135D, 0x135F}, eawprN},     // Mn     [3] ETHIOPIC COMBINING GEMINATION AND VOWEL LENGTH MARK..ETHIOPIC COMBINING GEMINATION MARK
-	{runeRange{0x1360, 0x1368}, eawprN},     // Po     [9] ETHIOPIC SECTION MARK..ETHIOPIC PARAGRAPH SEPARATOR
-	{runeRange{0x1369, 0x137C}, eawprN},     // No    [20] ETHIOPIC DIGIT ONE..ETHIOPIC NUMBER TEN THOUSAND
-	{runeRange{0x1380, 0x138F}, eawprN},     // Lo    [16] ETHIOPIC SYLLABLE SEBATBEIT MWA..ETHIOPIC SYLLABLE PWE
-	{runeRange{0x1390, 0x1399}, eawprN},     // So    [10] ETHIOPIC TONAL MARK YIZET..ETHIOPIC TONAL MARK KURT
-	{runeRange{0x13A0, 0x13F5}, eawprN},     // Lu    [86] CHEROKEE LETTER A..CHEROKEE LETTER MV
-	{runeRange{0x13F8, 0x13FD}, eawprN},     // Ll     [6] CHEROKEE SMALL LETTER YE..CHEROKEE SMALL LETTER MV
-	{runeRange{0x1400, 0x1400}, eawprN},     // Pd         CANADIAN SYLLABICS HYPHEN
-	{runeRange{0x1401, 0x166C}, eawprN},     // Lo   [620] CANADIAN SYLLABICS E..CANADIAN SYLLABICS CARRIER TTSA
-	{runeRange{0x166D, 0x166D}, eawprN},     // So         CANADIAN SYLLABICS CHI SIGN
-	{runeRange{0x166E, 0x166E}, eawprN},     // Po         CANADIAN SYLLABICS FULL STOP
-	{runeRange{0x166F, 0x167F}, eawprN},     // Lo    [17] CANADIAN SYLLABICS QAI..CANADIAN SYLLABICS BLACKFOOT W
-	{runeRange{0x1680, 0x1680}, eawprN},     // Zs         OGHAM SPACE MARK
-	{runeRange{0x1681, 0x169A}, eawprN},     // Lo    [26] OGHAM LETTER BEITH..OGHAM LETTER PEITH
-	{runeRange{0x169B, 0x169B}, eawprN},     // Ps         OGHAM FEATHER MARK
-	{runeRange{0x169C, 0x169C}, eawprN},     // Pe         OGHAM REVERSED FEATHER MARK
-	{runeRange{0x16A0, 0x16EA}, eawprN},     // Lo    [75] RUNIC LETTER FEHU FEOH FE F..RUNIC LETTER X
-	{runeRange{0x16EB, 0x16ED}, eawprN},     // Po     [3] RUNIC SINGLE PUNCTUATION..RUNIC CROSS PUNCTUATION
-	{runeRange{0x16EE, 0x16F0}, eawprN},     // Nl     [3] RUNIC ARLAUG SYMBOL..RUNIC BELGTHOR SYMBOL
-	{runeRange{0x16F1, 0x16F8}, eawprN},     // Lo     [8] RUNIC LETTER K..RUNIC LETTER FRANKS CASKET AESC
-	{runeRange{0x1700, 0x1711}, eawprN},     // Lo    [18] TAGALOG LETTER A..TAGALOG LETTER HA
-	{runeRange{0x1712, 0x1714}, eawprN},     // Mn     [3] TAGALOG VOWEL SIGN I..TAGALOG SIGN VIRAMA
-	{runeRange{0x1715, 0x1715}, eawprN},     // Mc         TAGALOG SIGN PAMUDPOD
-	{runeRange{0x171F, 0x171F}, eawprN},     // Lo         TAGALOG LETTER ARCHAIC RA
-	{runeRange{0x1720, 0x1731}, eawprN},     // Lo    [18] HANUNOO LETTER A..HANUNOO LETTER HA
-	{runeRange{0x1732, 0x1733}, eawprN},     // Mn     [2] HANUNOO VOWEL SIGN I..HANUNOO VOWEL SIGN U
-	{runeRange{0x1734, 0x1734}, eawprN},     // Mc         HANUNOO SIGN PAMUDPOD
-	{runeRange{0x1735, 0x1736}, eawprN},     // Po     [2] PHILIPPINE SINGLE PUNCTUATION..PHILIPPINE DOUBLE PUNCTUATION
-	{runeRange{0x1740, 0x1751}, eawprN},     // Lo    [18] BUHID LETTER A..BUHID LETTER HA
-	{runeRange{0x1752, 0x1753}, eawprN},     // Mn     [2] BUHID VOWEL SIGN I..BUHID VOWEL SIGN U
-	{runeRange{0x1760, 0x176C}, eawprN},     // Lo    [13] TAGBANWA LETTER A..TAGBANWA LETTER YA
-	{runeRange{0x176E, 0x1770}, eawprN},     // Lo     [3] TAGBANWA LETTER LA..TAGBANWA LETTER SA
-	{runeRange{0x1772, 0x1773}, eawprN},     // Mn     [2] TAGBANWA VOWEL SIGN I..TAGBANWA VOWEL SIGN U
-	{runeRange{0x1780, 0x17B3}, eawprN},     // Lo    [52] KHMER LETTER KA..KHMER INDEPENDENT VOWEL QAU
-	{runeRange{0x17B4, 0x17B5}, eawprN},     // Mn     [2] KHMER VOWEL INHERENT AQ..KHMER VOWEL INHERENT AA
-	{runeRange{0x17B6, 0x17B6}, eawprN},     // Mc         KHMER VOWEL SIGN AA
-	{runeRange{0x17B7, 0x17BD}, eawprN},     // Mn     [7] KHMER VOWEL SIGN I..KHMER VOWEL SIGN UA
-	{runeRange{0x17BE, 0x17C5}, eawprN},     // Mc     [8] KHMER VOWEL SIGN OE..KHMER VOWEL SIGN AU
-	{runeRange{0x17C6, 0x17C6}, eawprN},     // Mn         KHMER SIGN NIKAHIT
-	{runeRange{0x17C7, 0x17C8}, eawprN},     // Mc     [2] KHMER SIGN REAHMUK..KHMER SIGN YUUKALEAPINTU
-	{runeRange{0x17C9, 0x17D3}, eawprN},     // Mn    [11] KHMER SIGN MUUSIKATOAN..KHMER SIGN BATHAMASAT
-	{runeRange{0x17D4, 0x17D6}, eawprN},     // Po     [3] KHMER SIGN KHAN..KHMER SIGN CAMNUC PII KUUH
-	{runeRange{0x17D7, 0x17D7}, eawprN},     // Lm         KHMER SIGN LEK TOO
-	{runeRange{0x17D8, 0x17DA}, eawprN},     // Po     [3] KHMER SIGN BEYYAL..KHMER SIGN KOOMUUT
-	{runeRange{0x17DB, 0x17DB}, eawprN},     // Sc         KHMER CURRENCY SYMBOL RIEL
-	{runeRange{0x17DC, 0x17DC}, eawprN},     // Lo         KHMER SIGN AVAKRAHASANYA
-	{runeRange{0x17DD, 0x17DD}, eawprN},     // Mn         KHMER SIGN ATTHACAN
-	{runeRange{0x17E0, 0x17E9}, eawprN},     // Nd    [10] KHMER DIGIT ZERO..KHMER DIGIT NINE
-	{runeRange{0x17F0, 0x17F9}, eawprN},     // No    [10] KHMER SYMBOL LEK ATTAK SON..KHMER SYMBOL LEK ATTAK PRAM-BUON
-	{runeRange{0x1800, 0x1805}, eawprN},     // Po     [6] MONGOLIAN BIRGA..MONGOLIAN FOUR DOTS
-	{runeRange{0x1806, 0x1806}, eawprN},     // Pd         MONGOLIAN TODO SOFT HYPHEN
-	{runeRange{0x1807, 0x180A}, eawprN},     // Po     [4] MONGOLIAN SIBE SYLLABLE BOUNDARY MARKER..MONGOLIAN NIRUGU
-	{runeRange{0x180B, 0x180D}, eawprN},     // Mn     [3] MONGOLIAN FREE VARIATION SELECTOR ONE..MONGOLIAN FREE VARIATION SELECTOR THREE
-	{runeRange{0x180E, 0x180E}, eawprN},     // Cf         MONGOLIAN VOWEL SEPARATOR
-	{runeRange{0x180F, 0x180F}, eawprN},     // Mn         MONGOLIAN FREE VARIATION SELECTOR FOUR
-	{runeRange{0x1810, 0x1819}, eawprN},     // Nd    [10] MONGOLIAN DIGIT ZERO..MONGOLIAN DIGIT NINE
-	{runeRange{0x1820, 0x1842}, eawprN},     // Lo    [35] MONGOLIAN LETTER A..MONGOLIAN LETTER CHI
-	{runeRange{0x1843, 0x1843}, eawprN},     // Lm         MONGOLIAN LETTER TODO LONG VOWEL SIGN
-	{runeRange{0x1844, 0x1878}, eawprN},     // Lo    [53] MONGOLIAN LETTER TODO E..MONGOLIAN LETTER CHA WITH TWO DOTS
-	{runeRange{0x1880, 0x1884}, eawprN},     // Lo     [5] MONGOLIAN LETTER ALI GALI ANUSVARA ONE..MONGOLIAN LETTER ALI GALI INVERTED UBADAMA
-	{runeRange{0x1885, 0x1886}, eawprN},     // Mn     [2] MONGOLIAN LETTER ALI GALI BALUDA..MONGOLIAN LETTER ALI GALI THREE BALUDA
-	{runeRange{0x1887, 0x18A8}, eawprN},     // Lo    [34] MONGOLIAN LETTER ALI GALI A..MONGOLIAN LETTER MANCHU ALI GALI BHA
-	{runeRange{0x18A9, 0x18A9}, eawprN},     // Mn         MONGOLIAN LETTER ALI GALI DAGALGA
-	{runeRange{0x18AA, 0x18AA}, eawprN},     // Lo         MONGOLIAN LETTER MANCHU ALI GALI LHA
-	{runeRange{0x18B0, 0x18F5}, eawprN},     // Lo    [70] CANADIAN SYLLABICS OY..CANADIAN SYLLABICS CARRIER DENTAL S
-	{runeRange{0x1900, 0x191E}, eawprN},     // Lo    [31] LIMBU VOWEL-CARRIER LETTER..LIMBU LETTER TRA
-	{runeRange{0x1920, 0x1922}, eawprN},     // Mn     [3] LIMBU VOWEL SIGN A..LIMBU VOWEL SIGN U
-	{runeRange{0x1923, 0x1926}, eawprN},     // Mc     [4] LIMBU VOWEL SIGN EE..LIMBU VOWEL SIGN AU
-	{runeRange{0x1927, 0x1928}, eawprN},     // Mn     [2] LIMBU VOWEL SIGN E..LIMBU VOWEL SIGN O
-	{runeRange{0x1929, 0x192B}, eawprN},     // Mc     [3] LIMBU SUBJOINED LETTER YA..LIMBU SUBJOINED LETTER WA
-	{runeRange{0x1930, 0x1931}, eawprN},     // Mc     [2] LIMBU SMALL LETTER KA..LIMBU SMALL LETTER NGA
-	{runeRange{0x1932, 0x1932}, eawprN},     // Mn         LIMBU SMALL LETTER ANUSVARA
-	{runeRange{0x1933, 0x1938}, eawprN},     // Mc     [6] LIMBU SMALL LETTER TA..LIMBU SMALL LETTER LA
-	{runeRange{0x1939, 0x193B}, eawprN},     // Mn     [3] LIMBU SIGN MUKPHRENG..LIMBU SIGN SA-I
-	{runeRange{0x1940, 0x1940}, eawprN},     // So         LIMBU SIGN LOO
-	{runeRange{0x1944, 0x1945}, eawprN},     // Po     [2] LIMBU EXCLAMATION MARK..LIMBU QUESTION MARK
-	{runeRange{0x1946, 0x194F}, eawprN},     // Nd    [10] LIMBU DIGIT ZERO..LIMBU DIGIT NINE
-	{runeRange{0x1950, 0x196D}, eawprN},     // Lo    [30] TAI LE LETTER KA..TAI LE LETTER AI
-	{runeRange{0x1970, 0x1974}, eawprN},     // Lo     [5] TAI LE LETTER TONE-2..TAI LE LETTER TONE-6
-	{runeRange{0x1980, 0x19AB}, eawprN},     // Lo    [44] NEW TAI LUE LETTER HIGH QA..NEW TAI LUE LETTER LOW SUA
-	{runeRange{0x19B0, 0x19C9}, eawprN},     // Lo    [26] NEW TAI LUE VOWEL SIGN VOWEL SHORTENER..NEW TAI LUE TONE MARK-2
-	{runeRange{0x19D0, 0x19D9}, eawprN},     // Nd    [10] NEW TAI LUE DIGIT ZERO..NEW TAI LUE DIGIT NINE
-	{runeRange{0x19DA, 0x19DA}, eawprN},     // No         NEW TAI LUE THAM DIGIT ONE
-	{runeRange{0x19DE, 0x19DF}, eawprN},     // So     [2] NEW TAI LUE SIGN LAE..NEW TAI LUE SIGN LAEV
-	{runeRange{0x19E0, 0x19FF}, eawprN},     // So    [32] KHMER SYMBOL PATHAMASAT..KHMER SYMBOL DAP-PRAM ROC
-	{runeRange{0x1A00, 0x1A16}, eawprN},     // Lo    [23] BUGINESE LETTER KA..BUGINESE LETTER HA
-	{runeRange{0x1A17, 0x1A18}, eawprN},     // Mn     [2] BUGINESE VOWEL SIGN I..BUGINESE VOWEL SIGN U
-	{runeRange{0x1A19, 0x1A1A}, eawprN},     // Mc     [2] BUGINESE VOWEL SIGN E..BUGINESE VOWEL SIGN O
-	{runeRange{0x1A1B, 0x1A1B}, eawprN},     // Mn         BUGINESE VOWEL SIGN AE
-	{runeRange{0x1A1E, 0x1A1F}, eawprN},     // Po     [2] BUGINESE PALLAWA..BUGINESE END OF SECTION
-	{runeRange{0x1A20, 0x1A54}, eawprN},     // Lo    [53] TAI THAM LETTER HIGH KA..TAI THAM LETTER GREAT SA
-	{runeRange{0x1A55, 0x1A55}, eawprN},     // Mc         TAI THAM CONSONANT SIGN MEDIAL RA
-	{runeRange{0x1A56, 0x1A56}, eawprN},     // Mn         TAI THAM CONSONANT SIGN MEDIAL LA
-	{runeRange{0x1A57, 0x1A57}, eawprN},     // Mc         TAI THAM CONSONANT SIGN LA TANG LAI
-	{runeRange{0x1A58, 0x1A5E}, eawprN},     // Mn     [7] TAI THAM SIGN MAI KANG LAI..TAI THAM CONSONANT SIGN SA
-	{runeRange{0x1A60, 0x1A60}, eawprN},     // Mn         TAI THAM SIGN SAKOT
-	{runeRange{0x1A61, 0x1A61}, eawprN},     // Mc         TAI THAM VOWEL SIGN A
-	{runeRange{0x1A62, 0x1A62}, eawprN},     // Mn         TAI THAM VOWEL SIGN MAI SAT
-	{runeRange{0x1A63, 0x1A64}, eawprN},     // Mc     [2] TAI THAM VOWEL SIGN AA..TAI THAM VOWEL SIGN TALL AA
-	{runeRange{0x1A65, 0x1A6C}, eawprN},     // Mn     [8] TAI THAM VOWEL SIGN I..TAI THAM VOWEL SIGN OA BELOW
-	{runeRange{0x1A6D, 0x1A72}, eawprN},     // Mc     [6] TAI THAM VOWEL SIGN OY..TAI THAM VOWEL SIGN THAM AI
-	{runeRange{0x1A73, 0x1A7C}, eawprN},     // Mn    [10] TAI THAM VOWEL SIGN OA ABOVE..TAI THAM SIGN KHUEN-LUE KARAN
-	{runeRange{0x1A7F, 0x1A7F}, eawprN},     // Mn         TAI THAM COMBINING CRYPTOGRAMMIC DOT
-	{runeRange{0x1A80, 0x1A89}, eawprN},     // Nd    [10] TAI THAM HORA DIGIT ZERO..TAI THAM HORA DIGIT NINE
-	{runeRange{0x1A90, 0x1A99}, eawprN},     // Nd    [10] TAI THAM THAM DIGIT ZERO..TAI THAM THAM DIGIT NINE
-	{runeRange{0x1AA0, 0x1AA6}, eawprN},     // Po     [7] TAI THAM SIGN WIANG..TAI THAM SIGN REVERSED ROTATED RANA
-	{runeRange{0x1AA7, 0x1AA7}, eawprN},     // Lm         TAI THAM SIGN MAI YAMOK
-	{runeRange{0x1AA8, 0x1AAD}, eawprN},     // Po     [6] TAI THAM SIGN KAAN..TAI THAM SIGN CAANG
-	{runeRange{0x1AB0, 0x1ABD}, eawprN},     // Mn    [14] COMBINING DOUBLED CIRCUMFLEX ACCENT..COMBINING PARENTHESES BELOW
-	{runeRange{0x1ABE, 0x1ABE}, eawprN},     // Me         COMBINING PARENTHESES OVERLAY
-	{runeRange{0x1ABF, 0x1ACE}, eawprN},     // Mn    [16] COMBINING LATIN SMALL LETTER W BELOW..COMBINING LATIN SMALL LETTER INSULAR T
-	{runeRange{0x1B00, 0x1B03}, eawprN},     // Mn     [4] BALINESE SIGN ULU RICEM..BALINESE SIGN SURANG
-	{runeRange{0x1B04, 0x1B04}, eawprN},     // Mc         BALINESE SIGN BISAH
-	{runeRange{0x1B05, 0x1B33}, eawprN},     // Lo    [47] BALINESE LETTER AKARA..BALINESE LETTER HA
-	{runeRange{0x1B34, 0x1B34}, eawprN},     // Mn         BALINESE SIGN REREKAN
-	{runeRange{0x1B35, 0x1B35}, eawprN},     // Mc         BALINESE VOWEL SIGN TEDUNG
-	{runeRange{0x1B36, 0x1B3A}, eawprN},     // Mn     [5] BALINESE VOWEL SIGN ULU..BALINESE VOWEL SIGN RA REPA
-	{runeRange{0x1B3B, 0x1B3B}, eawprN},     // Mc         BALINESE VOWEL SIGN RA REPA TEDUNG
-	{runeRange{0x1B3C, 0x1B3C}, eawprN},     // Mn         BALINESE VOWEL SIGN LA LENGA
-	{runeRange{0x1B3D, 0x1B41}, eawprN},     // Mc     [5] BALINESE VOWEL SIGN LA LENGA TEDUNG..BALINESE VOWEL SIGN TALING REPA TEDUNG
-	{runeRange{0x1B42, 0x1B42}, eawprN},     // Mn         BALINESE VOWEL SIGN PEPET
-	{runeRange{0x1B43, 0x1B44}, eawprN},     // Mc     [2] BALINESE VOWEL SIGN PEPET TEDUNG..BALINESE ADEG ADEG
-	{runeRange{0x1B45, 0x1B4C}, eawprN},     // Lo     [8] BALINESE LETTER KAF SASAK..BALINESE LETTER ARCHAIC JNYA
-	{runeRange{0x1B50, 0x1B59}, eawprN},     // Nd    [10] BALINESE DIGIT ZERO..BALINESE DIGIT NINE
-	{runeRange{0x1B5A, 0x1B60}, eawprN},     // Po     [7] BALINESE PANTI..BALINESE PAMENENG
-	{runeRange{0x1B61, 0x1B6A}, eawprN},     // So    [10] BALINESE MUSICAL SYMBOL DONG..BALINESE MUSICAL SYMBOL DANG GEDE
-	{runeRange{0x1B6B, 0x1B73}, eawprN},     // Mn     [9] BALINESE MUSICAL SYMBOL COMBINING TEGEH..BALINESE MUSICAL SYMBOL COMBINING GONG
-	{runeRange{0x1B74, 0x1B7C}, eawprN},     // So     [9] BALINESE MUSICAL SYMBOL RIGHT-HAND OPEN DUG..BALINESE MUSICAL SYMBOL LEFT-HAND OPEN PING
-	{runeRange{0x1B7D, 0x1B7E}, eawprN},     // Po     [2] BALINESE PANTI LANTANG..BALINESE PAMADA LANTANG
-	{runeRange{0x1B80, 0x1B81}, eawprN},     // Mn     [2] SUNDANESE SIGN PANYECEK..SUNDANESE SIGN PANGLAYAR
-	{runeRange{0x1B82, 0x1B82}, eawprN},     // Mc         SUNDANESE SIGN PANGWISAD
-	{runeRange{0x1B83, 0x1BA0}, eawprN},     // Lo    [30] SUNDANESE LETTER A..SUNDANESE LETTER HA
-	{runeRange{0x1BA1, 0x1BA1}, eawprN},     // Mc         SUNDANESE CONSONANT SIGN PAMINGKAL
-	{runeRange{0x1BA2, 0x1BA5}, eawprN},     // Mn     [4] SUNDANESE CONSONANT SIGN PANYAKRA..SUNDANESE VOWEL SIGN PANYUKU
-	{runeRange{0x1BA6, 0x1BA7}, eawprN},     // Mc     [2] SUNDANESE VOWEL SIGN PANAELAENG..SUNDANESE VOWEL SIGN PANOLONG
-	{runeRange{0x1BA8, 0x1BA9}, eawprN},     // Mn     [2] SUNDANESE VOWEL SIGN PAMEPET..SUNDANESE VOWEL SIGN PANEULEUNG
-	{runeRange{0x1BAA, 0x1BAA}, eawprN},     // Mc         SUNDANESE SIGN PAMAAEH
-	{runeRange{0x1BAB, 0x1BAD}, eawprN},     // Mn     [3] SUNDANESE SIGN VIRAMA..SUNDANESE CONSONANT SIGN PASANGAN WA
-	{runeRange{0x1BAE, 0x1BAF}, eawprN},     // Lo     [2] SUNDANESE LETTER KHA..SUNDANESE LETTER SYA
-	{runeRange{0x1BB0, 0x1BB9}, eawprN},     // Nd    [10] SUNDANESE DIGIT ZERO..SUNDANESE DIGIT NINE
-	{runeRange{0x1BBA, 0x1BBF}, eawprN},     // Lo     [6] SUNDANESE AVAGRAHA..SUNDANESE LETTER FINAL M
-	{runeRange{0x1BC0, 0x1BE5}, eawprN},     // Lo    [38] BATAK LETTER A..BATAK LETTER U
-	{runeRange{0x1BE6, 0x1BE6}, eawprN},     // Mn         BATAK SIGN TOMPI
-	{runeRange{0x1BE7, 0x1BE7}, eawprN},     // Mc         BATAK VOWEL SIGN E
-	{runeRange{0x1BE8, 0x1BE9}, eawprN},     // Mn     [2] BATAK VOWEL SIGN PAKPAK E..BATAK VOWEL SIGN EE
-	{runeRange{0x1BEA, 0x1BEC}, eawprN},     // Mc     [3] BATAK VOWEL SIGN I..BATAK VOWEL SIGN O
-	{runeRange{0x1BED, 0x1BED}, eawprN},     // Mn         BATAK VOWEL SIGN KARO O
-	{runeRange{0x1BEE, 0x1BEE}, eawprN},     // Mc         BATAK VOWEL SIGN U
-	{runeRange{0x1BEF, 0x1BF1}, eawprN},     // Mn     [3] BATAK VOWEL SIGN U FOR SIMALUNGUN SA..BATAK CONSONANT SIGN H
-	{runeRange{0x1BF2, 0x1BF3}, eawprN},     // Mc     [2] BATAK PANGOLAT..BATAK PANONGONAN
-	{runeRange{0x1BFC, 0x1BFF}, eawprN},     // Po     [4] BATAK SYMBOL BINDU NA METEK..BATAK SYMBOL BINDU PANGOLAT
-	{runeRange{0x1C00, 0x1C23}, eawprN},     // Lo    [36] LEPCHA LETTER KA..LEPCHA LETTER A
-	{runeRange{0x1C24, 0x1C2B}, eawprN},     // Mc     [8] LEPCHA SUBJOINED LETTER YA..LEPCHA VOWEL SIGN UU
-	{runeRange{0x1C2C, 0x1C33}, eawprN},     // Mn     [8] LEPCHA VOWEL SIGN E..LEPCHA CONSONANT SIGN T
-	{runeRange{0x1C34, 0x1C35}, eawprN},     // Mc     [2] LEPCHA CONSONANT SIGN NYIN-DO..LEPCHA CONSONANT SIGN KANG
-	{runeRange{0x1C36, 0x1C37}, eawprN},     // Mn     [2] LEPCHA SIGN RAN..LEPCHA SIGN NUKTA
-	{runeRange{0x1C3B, 0x1C3F}, eawprN},     // Po     [5] LEPCHA PUNCTUATION TA-ROL..LEPCHA PUNCTUATION TSHOOK
-	{runeRange{0x1C40, 0x1C49}, eawprN},     // Nd    [10] LEPCHA DIGIT ZERO..LEPCHA DIGIT NINE
-	{runeRange{0x1C4D, 0x1C4F}, eawprN},     // Lo     [3] LEPCHA LETTER TTA..LEPCHA LETTER DDA
-	{runeRange{0x1C50, 0x1C59}, eawprN},     // Nd    [10] OL CHIKI DIGIT ZERO..OL CHIKI DIGIT NINE
-	{runeRange{0x1C5A, 0x1C77}, eawprN},     // Lo    [30] OL CHIKI LETTER LA..OL CHIKI LETTER OH
-	{runeRange{0x1C78, 0x1C7D}, eawprN},     // Lm     [6] OL CHIKI MU TTUDDAG..OL CHIKI AHAD
-	{runeRange{0x1C7E, 0x1C7F}, eawprN},     // Po     [2] OL CHIKI PUNCTUATION MUCAAD..OL CHIKI PUNCTUATION DOUBLE MUCAAD
-	{runeRange{0x1C80, 0x1C88}, eawprN},     // Ll     [9] CYRILLIC SMALL LETTER ROUNDED VE..CYRILLIC SMALL LETTER UNBLENDED UK
-	{runeRange{0x1C90, 0x1CBA}, eawprN},     // Lu    [43] GEORGIAN MTAVRULI CAPITAL LETTER AN..GEORGIAN MTAVRULI CAPITAL LETTER AIN
-	{runeRange{0x1CBD, 0x1CBF}, eawprN},     // Lu     [3] GEORGIAN MTAVRULI CAPITAL LETTER AEN..GEORGIAN MTAVRULI CAPITAL LETTER LABIAL SIGN
-	{runeRange{0x1CC0, 0x1CC7}, eawprN},     // Po     [8] SUNDANESE PUNCTUATION BINDU SURYA..SUNDANESE PUNCTUATION BINDU BA SATANGA
-	{runeRange{0x1CD0, 0x1CD2}, eawprN},     // Mn     [3] VEDIC TONE KARSHANA..VEDIC TONE PRENKHA
-	{runeRange{0x1CD3, 0x1CD3}, eawprN},     // Po         VEDIC SIGN NIHSHVASA
-	{runeRange{0x1CD4, 0x1CE0}, eawprN},     // Mn    [13] VEDIC SIGN YAJURVEDIC MIDLINE SVARITA..VEDIC TONE RIGVEDIC KASHMIRI INDEPENDENT SVARITA
-	{runeRange{0x1CE1, 0x1CE1}, eawprN},     // Mc         VEDIC TONE ATHARVAVEDIC INDEPENDENT SVARITA
-	{runeRange{0x1CE2, 0x1CE8}, eawprN},     // Mn     [7] VEDIC SIGN VISARGA SVARITA..VEDIC SIGN VISARGA ANUDATTA WITH TAIL
-	{runeRange{0x1CE9, 0x1CEC}, eawprN},     // Lo     [4] VEDIC SIGN ANUSVARA ANTARGOMUKHA..VEDIC SIGN ANUSVARA VAMAGOMUKHA WITH TAIL
-	{runeRange{0x1CED, 0x1CED}, eawprN},     // Mn         VEDIC SIGN TIRYAK
-	{runeRange{0x1CEE, 0x1CF3}, eawprN},     // Lo     [6] VEDIC SIGN HEXIFORM LONG ANUSVARA..VEDIC SIGN ROTATED ARDHAVISARGA
-	{runeRange{0x1CF4, 0x1CF4}, eawprN},     // Mn         VEDIC TONE CANDRA ABOVE
-	{runeRange{0x1CF5, 0x1CF6}, eawprN},     // Lo     [2] VEDIC SIGN JIHVAMULIYA..VEDIC SIGN UPADHMANIYA
-	{runeRange{0x1CF7, 0x1CF7}, eawprN},     // Mc         VEDIC SIGN ATIKRAMA
-	{runeRange{0x1CF8, 0x1CF9}, eawprN},     // Mn     [2] VEDIC TONE RING ABOVE..VEDIC TONE DOUBLE RING ABOVE
-	{runeRange{0x1CFA, 0x1CFA}, eawprN},     // Lo         VEDIC SIGN DOUBLE ANUSVARA ANTARGOMUKHA
-	{runeRange{0x1D00, 0x1D2B}, eawprN},     // Ll    [44] LATIN LETTER SMALL CAPITAL A..CYRILLIC LETTER SMALL CAPITAL EL
-	{runeRange{0x1D2C, 0x1D6A}, eawprN},     // Lm    [63] MODIFIER LETTER CAPITAL A..GREEK SUBSCRIPT SMALL LETTER CHI
-	{runeRange{0x1D6B, 0x1D77}, eawprN},     // Ll    [13] LATIN SMALL LETTER UE..LATIN SMALL LETTER TURNED G
-	{runeRange{0x1D78, 0x1D78}, eawprN},     // Lm         MODIFIER LETTER CYRILLIC EN
-	{runeRange{0x1D79, 0x1D7F}, eawprN},     // Ll     [7] LATIN SMALL LETTER INSULAR G..LATIN SMALL LETTER UPSILON WITH STROKE
-	{runeRange{0x1D80, 0x1D9A}, eawprN},     // Ll    [27] LATIN SMALL LETTER B WITH PALATAL HOOK..LATIN SMALL LETTER EZH WITH RETROFLEX HOOK
-	{runeRange{0x1D9B, 0x1DBF}, eawprN},     // Lm    [37] MODIFIER LETTER SMALL TURNED ALPHA..MODIFIER LETTER SMALL THETA
-	{runeRange{0x1DC0, 0x1DFF}, eawprN},     // Mn    [64] COMBINING DOTTED GRAVE ACCENT..COMBINING RIGHT ARROWHEAD AND DOWN ARROWHEAD BELOW
-	{runeRange{0x1E00, 0x1EFF}, eawprN},     // L&   [256] LATIN CAPITAL LETTER A WITH RING BELOW..LATIN SMALL LETTER Y WITH LOOP
-	{runeRange{0x1F00, 0x1F15}, eawprN},     // L&    [22] GREEK SMALL LETTER ALPHA WITH PSILI..GREEK SMALL LETTER EPSILON WITH DASIA AND OXIA
-	{runeRange{0x1F18, 0x1F1D}, eawprN},     // Lu     [6] GREEK CAPITAL LETTER EPSILON WITH PSILI..GREEK CAPITAL LETTER EPSILON WITH DASIA AND OXIA
-	{runeRange{0x1F20, 0x1F45}, eawprN},     // L&    [38] GREEK SMALL LETTER ETA WITH PSILI..GREEK SMALL LETTER OMICRON WITH DASIA AND OXIA
-	{runeRange{0x1F48, 0x1F4D}, eawprN},     // Lu     [6] GREEK CAPITAL LETTER OMICRON WITH PSILI..GREEK CAPITAL LETTER OMICRON WITH DASIA AND OXIA
-	{runeRange{0x1F50, 0x1F57}, eawprN},     // Ll     [8] GREEK SMALL LETTER UPSILON WITH PSILI..GREEK SMALL LETTER UPSILON WITH DASIA AND PERISPOMENI
-	{runeRange{0x1F59, 0x1F59}, eawprN},     // Lu         GREEK CAPITAL LETTER UPSILON WITH DASIA
-	{runeRange{0x1F5B, 0x1F5B}, eawprN},     // Lu         GREEK CAPITAL LETTER UPSILON WITH DASIA AND VARIA
-	{runeRange{0x1F5D, 0x1F5D}, eawprN},     // Lu         GREEK CAPITAL LETTER UPSILON WITH DASIA AND OXIA
-	{runeRange{0x1F5F, 0x1F7D}, eawprN},     // L&    [31] GREEK CAPITAL LETTER UPSILON WITH DASIA AND PERISPOMENI..GREEK SMALL LETTER OMEGA WITH OXIA
-	{runeRange{0x1F80, 0x1FB4}, eawprN},     // L&    [53] GREEK SMALL LETTER ALPHA WITH PSILI AND YPOGEGRAMMENI..GREEK SMALL LETTER ALPHA WITH OXIA AND YPOGEGRAMMENI
-	{runeRange{0x1FB6, 0x1FBC}, eawprN},     // L&     [7] GREEK SMALL LETTER ALPHA WITH PERISPOMENI..GREEK CAPITAL LETTER ALPHA WITH PROSGEGRAMMENI
-	{runeRange{0x1FBD, 0x1FBD}, eawprN},     // Sk         GREEK KORONIS
-	{runeRange{0x1FBE, 0x1FBE}, eawprN},     // Ll         GREEK PROSGEGRAMMENI
-	{runeRange{0x1FBF, 0x1FC1}, eawprN},     // Sk     [3] GREEK PSILI..GREEK DIALYTIKA AND PERISPOMENI
-	{runeRange{0x1FC2, 0x1FC4}, eawprN},     // Ll     [3] GREEK SMALL LETTER ETA WITH VARIA AND YPOGEGRAMMENI..GREEK SMALL LETTER ETA WITH OXIA AND YPOGEGRAMMENI
-	{runeRange{0x1FC6, 0x1FCC}, eawprN},     // L&     [7] GREEK SMALL LETTER ETA WITH PERISPOMENI..GREEK CAPITAL LETTER ETA WITH PROSGEGRAMMENI
-	{runeRange{0x1FCD, 0x1FCF}, eawprN},     // Sk     [3] GREEK PSILI AND VARIA..GREEK PSILI AND PERISPOMENI
-	{runeRange{0x1FD0, 0x1FD3}, eawprN},     // Ll     [4] GREEK SMALL LETTER IOTA WITH VRACHY..GREEK SMALL LETTER IOTA WITH DIALYTIKA AND OXIA
-	{runeRange{0x1FD6, 0x1FDB}, eawprN},     // L&     [6] GREEK SMALL LETTER IOTA WITH PERISPOMENI..GREEK CAPITAL LETTER IOTA WITH OXIA
-	{runeRange{0x1FDD, 0x1FDF}, eawprN},     // Sk     [3] GREEK DASIA AND VARIA..GREEK DASIA AND PERISPOMENI
-	{runeRange{0x1FE0, 0x1FEC}, eawprN},     // L&    [13] GREEK SMALL LETTER UPSILON WITH VRACHY..GREEK CAPITAL LETTER RHO WITH DASIA
-	{runeRange{0x1FED, 0x1FEF}, eawprN},     // Sk     [3] GREEK DIALYTIKA AND VARIA..GREEK VARIA
-	{runeRange{0x1FF2, 0x1FF4}, eawprN},     // Ll     [3] GREEK SMALL LETTER OMEGA WITH VARIA AND YPOGEGRAMMENI..GREEK SMALL LETTER OMEGA WITH OXIA AND YPOGEGRAMMENI
-	{runeRange{0x1FF6, 0x1FFC}, eawprN},     // L&     [7] GREEK SMALL LETTER OMEGA WITH PERISPOMENI..GREEK CAPITAL LETTER OMEGA WITH PROSGEGRAMMENI
-	{runeRange{0x1FFD, 0x1FFE}, eawprN},     // Sk     [2] GREEK OXIA..GREEK DASIA
-	{runeRange{0x2000, 0x200A}, eawprN},     // Zs    [11] EN QUAD..HAIR SPACE
-	{runeRange{0x200B, 0x200F}, eawprN},     // Cf     [5] ZERO WIDTH SPACE..RIGHT-TO-LEFT MARK
-	{runeRange{0x2010, 0x2010}, eawprA},     // Pd         HYPHEN
-	{runeRange{0x2011, 0x2012}, eawprN},     // Pd     [2] NON-BREAKING HYPHEN..FIGURE DASH
-	{runeRange{0x2013, 0x2015}, eawprA},     // Pd     [3] EN DASH..HORIZONTAL BAR
-	{runeRange{0x2016, 0x2016}, eawprA},     // Po         DOUBLE VERTICAL LINE
-	{runeRange{0x2017, 0x2017}, eawprN},     // Po         DOUBLE LOW LINE
-	{runeRange{0x2018, 0x2018}, eawprA},     // Pi         LEFT SINGLE QUOTATION MARK
-	{runeRange{0x2019, 0x2019}, eawprA},     // Pf         RIGHT SINGLE QUOTATION MARK
-	{runeRange{0x201A, 0x201A}, eawprN},     // Ps         SINGLE LOW-9 QUOTATION MARK
-	{runeRange{0x201B, 0x201B}, eawprN},     // Pi         SINGLE HIGH-REVERSED-9 QUOTATION MARK
-	{runeRange{0x201C, 0x201C}, eawprA},     // Pi         LEFT DOUBLE QUOTATION MARK
-	{runeRange{0x201D, 0x201D}, eawprA},     // Pf         RIGHT DOUBLE QUOTATION MARK
-	{runeRange{0x201E, 0x201E}, eawprN},     // Ps         DOUBLE LOW-9 QUOTATION MARK
-	{runeRange{0x201F, 0x201F}, eawprN},     // Pi         DOUBLE HIGH-REVERSED-9 QUOTATION MARK
-	{runeRange{0x2020, 0x2022}, eawprA},     // Po     [3] DAGGER..BULLET
-	{runeRange{0x2023, 0x2023}, eawprN},     // Po         TRIANGULAR BULLET
-	{runeRange{0x2024, 0x2027}, eawprA},     // Po     [4] ONE DOT LEADER..HYPHENATION POINT
-	{runeRange{0x2028, 0x2028}, eawprN},     // Zl         LINE SEPARATOR
-	{runeRange{0x2029, 0x2029}, eawprN},     // Zp         PARAGRAPH SEPARATOR
-	{runeRange{0x202A, 0x202E}, eawprN},     // Cf     [5] LEFT-TO-RIGHT EMBEDDING..RIGHT-TO-LEFT OVERRIDE
-	{runeRange{0x202F, 0x202F}, eawprN},     // Zs         NARROW NO-BREAK SPACE
-	{runeRange{0x2030, 0x2030}, eawprA},     // Po         PER MILLE SIGN
-	{runeRange{0x2031, 0x2031}, eawprN},     // Po         PER TEN THOUSAND SIGN
-	{runeRange{0x2032, 0x2033}, eawprA},     // Po     [2] PRIME..DOUBLE PRIME
-	{runeRange{0x2034, 0x2034}, eawprN},     // Po         TRIPLE PRIME
-	{runeRange{0x2035, 0x2035}, eawprA},     // Po         REVERSED PRIME
-	{runeRange{0x2036, 0x2038}, eawprN},     // Po     [3] REVERSED DOUBLE PRIME..CARET
-	{runeRange{0x2039, 0x2039}, eawprN},     // Pi         SINGLE LEFT-POINTING ANGLE QUOTATION MARK
-	{runeRange{0x203A, 0x203A}, eawprN},     // Pf         SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
-	{runeRange{0x203B, 0x203B}, eawprA},     // Po         REFERENCE MARK
-	{runeRange{0x203C, 0x203D}, eawprN},     // Po     [2] DOUBLE EXCLAMATION MARK..INTERROBANG
-	{runeRange{0x203E, 0x203E}, eawprA},     // Po         OVERLINE
-	{runeRange{0x203F, 0x2040}, eawprN},     // Pc     [2] UNDERTIE..CHARACTER TIE
-	{runeRange{0x2041, 0x2043}, eawprN},     // Po     [3] CARET INSERTION POINT..HYPHEN BULLET
-	{runeRange{0x2044, 0x2044}, eawprN},     // Sm         FRACTION SLASH
-	{runeRange{0x2045, 0x2045}, eawprN},     // Ps         LEFT SQUARE BRACKET WITH QUILL
-	{runeRange{0x2046, 0x2046}, eawprN},     // Pe         RIGHT SQUARE BRACKET WITH QUILL
-	{runeRange{0x2047, 0x2051}, eawprN},     // Po    [11] DOUBLE QUESTION MARK..TWO ASTERISKS ALIGNED VERTICALLY
-	{runeRange{0x2052, 0x2052}, eawprN},     // Sm         COMMERCIAL MINUS SIGN
-	{runeRange{0x2053, 0x2053}, eawprN},     // Po         SWUNG DASH
-	{runeRange{0x2054, 0x2054}, eawprN},     // Pc         INVERTED UNDERTIE
-	{runeRange{0x2055, 0x205E}, eawprN},     // Po    [10] FLOWER PUNCTUATION MARK..VERTICAL FOUR DOTS
-	{runeRange{0x205F, 0x205F}, eawprN},     // Zs         MEDIUM MATHEMATICAL SPACE
-	{runeRange{0x2060, 0x2064}, eawprN},     // Cf     [5] WORD JOINER..INVISIBLE PLUS
-	{runeRange{0x2066, 0x206F}, eawprN},     // Cf    [10] LEFT-TO-RIGHT ISOLATE..NOMINAL DIGIT SHAPES
-	{runeRange{0x2070, 0x2070}, eawprN},     // No         SUPERSCRIPT ZERO
-	{runeRange{0x2071, 0x2071}, eawprN},     // Lm         SUPERSCRIPT LATIN SMALL LETTER I
-	{runeRange{0x2074, 0x2074}, eawprA},     // No         SUPERSCRIPT FOUR
-	{runeRange{0x2075, 0x2079}, eawprN},     // No     [5] SUPERSCRIPT FIVE..SUPERSCRIPT NINE
-	{runeRange{0x207A, 0x207C}, eawprN},     // Sm     [3] SUPERSCRIPT PLUS SIGN..SUPERSCRIPT EQUALS SIGN
-	{runeRange{0x207D, 0x207D}, eawprN},     // Ps         SUPERSCRIPT LEFT PARENTHESIS
-	{runeRange{0x207E, 0x207E}, eawprN},     // Pe         SUPERSCRIPT RIGHT PARENTHESIS
-	{runeRange{0x207F, 0x207F}, eawprA},     // Lm         SUPERSCRIPT LATIN SMALL LETTER N
-	{runeRange{0x2080, 0x2080}, eawprN},     // No         SUBSCRIPT ZERO
-	{runeRange{0x2081, 0x2084}, eawprA},     // No     [4] SUBSCRIPT ONE..SUBSCRIPT FOUR
-	{runeRange{0x2085, 0x2089}, eawprN},     // No     [5] SUBSCRIPT FIVE..SUBSCRIPT NINE
-	{runeRange{0x208A, 0x208C}, eawprN},     // Sm     [3] SUBSCRIPT PLUS SIGN..SUBSCRIPT EQUALS SIGN
-	{runeRange{0x208D, 0x208D}, eawprN},     // Ps         SUBSCRIPT LEFT PARENTHESIS
-	{runeRange{0x208E, 0x208E}, eawprN},     // Pe         SUBSCRIPT RIGHT PARENTHESIS
-	{runeRange{0x2090, 0x209C}, eawprN},     // Lm    [13] LATIN SUBSCRIPT SMALL LETTER A..LATIN SUBSCRIPT SMALL LETTER T
-	{runeRange{0x20A0, 0x20A8}, eawprN},     // Sc     [9] EURO-CURRENCY SIGN..RUPEE SIGN
-	{runeRange{0x20A9, 0x20A9}, eawprH},     // Sc         WON SIGN
-	{runeRange{0x20AA, 0x20AB}, eawprN},     // Sc     [2] NEW SHEQEL SIGN..DONG SIGN
-	{runeRange{0x20AC, 0x20AC}, eawprA},     // Sc         EURO SIGN
-	{runeRange{0x20AD, 0x20C0}, eawprN},     // Sc    [20] KIP SIGN..SOM SIGN
-	{runeRange{0x20D0, 0x20DC}, eawprN},     // Mn    [13] COMBINING LEFT HARPOON ABOVE..COMBINING FOUR DOTS ABOVE
-	{runeRange{0x20DD, 0x20E0}, eawprN},     // Me     [4] COMBINING ENCLOSING CIRCLE..COMBINING ENCLOSING CIRCLE BACKSLASH
-	{runeRange{0x20E1, 0x20E1}, eawprN},     // Mn         COMBINING LEFT RIGHT ARROW ABOVE
-	{runeRange{0x20E2, 0x20E4}, eawprN},     // Me     [3] COMBINING ENCLOSING SCREEN..COMBINING ENCLOSING UPWARD POINTING TRIANGLE
-	{runeRange{0x20E5, 0x20F0}, eawprN},     // Mn    [12] COMBINING REVERSE SOLIDUS OVERLAY..COMBINING ASTERISK ABOVE
-	{runeRange{0x2100, 0x2101}, eawprN},     // So     [2] ACCOUNT OF..ADDRESSED TO THE SUBJECT
-	{runeRange{0x2102, 0x2102}, eawprN},     // Lu         DOUBLE-STRUCK CAPITAL C
-	{runeRange{0x2103, 0x2103}, eawprA},     // So         DEGREE CELSIUS
-	{runeRange{0x2104, 0x2104}, eawprN},     // So         CENTRE LINE SYMBOL
-	{runeRange{0x2105, 0x2105}, eawprA},     // So         CARE OF
-	{runeRange{0x2106, 0x2106}, eawprN},     // So         CADA UNA
-	{runeRange{0x2107, 0x2107}, eawprN},     // Lu         EULER CONSTANT
-	{runeRange{0x2108, 0x2108}, eawprN},     // So         SCRUPLE
-	{runeRange{0x2109, 0x2109}, eawprA},     // So         DEGREE FAHRENHEIT
-	{runeRange{0x210A, 0x2112}, eawprN},     // L&     [9] SCRIPT SMALL G..SCRIPT CAPITAL L
-	{runeRange{0x2113, 0x2113}, eawprA},     // Ll         SCRIPT SMALL L
-	{runeRange{0x2114, 0x2114}, eawprN},     // So         L B BAR SYMBOL
-	{runeRange{0x2115, 0x2115}, eawprN},     // Lu         DOUBLE-STRUCK CAPITAL N
-	{runeRange{0x2116, 0x2116}, eawprA},     // So         NUMERO SIGN
-	{runeRange{0x2117, 0x2117}, eawprN},     // So         SOUND RECORDING COPYRIGHT
-	{runeRange{0x2118, 0x2118}, eawprN},     // Sm         SCRIPT CAPITAL P
-	{runeRange{0x2119, 0x211D}, eawprN},     // Lu     [5] DOUBLE-STRUCK CAPITAL P..DOUBLE-STRUCK CAPITAL R
-	{runeRange{0x211E, 0x2120}, eawprN},     // So     [3] PRESCRIPTION TAKE..SERVICE MARK
-	{runeRange{0x2121, 0x2122}, eawprA},     // So     [2] TELEPHONE SIGN..TRADE MARK SIGN
-	{runeRange{0x2123, 0x2123}, eawprN},     // So         VERSICLE
-	{runeRange{0x2124, 0x2124}, eawprN},     // Lu         DOUBLE-STRUCK CAPITAL Z
-	{runeRange{0x2125, 0x2125}, eawprN},     // So         OUNCE SIGN
-	{runeRange{0x2126, 0x2126}, eawprA},     // Lu         OHM SIGN
-	{runeRange{0x2127, 0x2127}, eawprN},     // So         INVERTED OHM SIGN
-	{runeRange{0x2128, 0x2128}, eawprN},     // Lu         BLACK-LETTER CAPITAL Z
-	{runeRange{0x2129, 0x2129}, eawprN},     // So         TURNED GREEK SMALL LETTER IOTA
-	{runeRange{0x212A, 0x212A}, eawprN},     // Lu         KELVIN SIGN
-	{runeRange{0x212B, 0x212B}, eawprA},     // Lu         ANGSTROM SIGN
-	{runeRange{0x212C, 0x212D}, eawprN},     // Lu     [2] SCRIPT CAPITAL B..BLACK-LETTER CAPITAL C
-	{runeRange{0x212E, 0x212E}, eawprN},     // So         ESTIMATED SYMBOL
-	{runeRange{0x212F, 0x2134}, eawprN},     // L&     [6] SCRIPT SMALL E..SCRIPT SMALL O
-	{runeRange{0x2135, 0x2138}, eawprN},     // Lo     [4] ALEF SYMBOL..DALET SYMBOL
-	{runeRange{0x2139, 0x2139}, eawprN},     // Ll         INFORMATION SOURCE
-	{runeRange{0x213A, 0x213B}, eawprN},     // So     [2] ROTATED CAPITAL Q..FACSIMILE SIGN
-	{runeRange{0x213C, 0x213F}, eawprN},     // L&     [4] DOUBLE-STRUCK SMALL PI..DOUBLE-STRUCK CAPITAL PI
-	{runeRange{0x2140, 0x2144}, eawprN},     // Sm     [5] DOUBLE-STRUCK N-ARY SUMMATION..TURNED SANS-SERIF CAPITAL Y
-	{runeRange{0x2145, 0x2149}, eawprN},     // L&     [5] DOUBLE-STRUCK ITALIC CAPITAL D..DOUBLE-STRUCK ITALIC SMALL J
-	{runeRange{0x214A, 0x214A}, eawprN},     // So         PROPERTY LINE
-	{runeRange{0x214B, 0x214B}, eawprN},     // Sm         TURNED AMPERSAND
-	{runeRange{0x214C, 0x214D}, eawprN},     // So     [2] PER SIGN..AKTIESELSKAB
-	{runeRange{0x214E, 0x214E}, eawprN},     // Ll         TURNED SMALL F
-	{runeRange{0x214F, 0x214F}, eawprN},     // So         SYMBOL FOR SAMARITAN SOURCE
-	{runeRange{0x2150, 0x2152}, eawprN},     // No     [3] VULGAR FRACTION ONE SEVENTH..VULGAR FRACTION ONE TENTH
-	{runeRange{0x2153, 0x2154}, eawprA},     // No     [2] VULGAR FRACTION ONE THIRD..VULGAR FRACTION TWO THIRDS
-	{runeRange{0x2155, 0x215A}, eawprN},     // No     [6] VULGAR FRACTION ONE FIFTH..VULGAR FRACTION FIVE SIXTHS
-	{runeRange{0x215B, 0x215E}, eawprA},     // No     [4] VULGAR FRACTION ONE EIGHTH..VULGAR FRACTION SEVEN EIGHTHS
-	{runeRange{0x215F, 0x215F}, eawprN},     // No         FRACTION NUMERATOR ONE
-	{runeRange{0x2160, 0x216B}, eawprA},     // Nl    [12] ROMAN NUMERAL ONE..ROMAN NUMERAL TWELVE
-	{runeRange{0x216C, 0x216F}, eawprN},     // Nl     [4] ROMAN NUMERAL FIFTY..ROMAN NUMERAL ONE THOUSAND
-	{runeRange{0x2170, 0x2179}, eawprA},     // Nl    [10] SMALL ROMAN NUMERAL ONE..SMALL ROMAN NUMERAL TEN
-	{runeRange{0x217A, 0x2182}, eawprN},     // Nl     [9] SMALL ROMAN NUMERAL ELEVEN..ROMAN NUMERAL TEN THOUSAND
-	{runeRange{0x2183, 0x2184}, eawprN},     // L&     [2] ROMAN NUMERAL REVERSED ONE HUNDRED..LATIN SMALL LETTER REVERSED C
-	{runeRange{0x2185, 0x2188}, eawprN},     // Nl     [4] ROMAN NUMERAL SIX LATE FORM..ROMAN NUMERAL ONE HUNDRED THOUSAND
-	{runeRange{0x2189, 0x2189}, eawprA},     // No         VULGAR FRACTION ZERO THIRDS
-	{runeRange{0x218A, 0x218B}, eawprN},     // So     [2] TURNED DIGIT TWO..TURNED DIGIT THREE
-	{runeRange{0x2190, 0x2194}, eawprA},     // Sm     [5] LEFTWARDS ARROW..LEFT RIGHT ARROW
-	{runeRange{0x2195, 0x2199}, eawprA},     // So     [5] UP DOWN ARROW..SOUTH WEST ARROW
-	{runeRange{0x219A, 0x219B}, eawprN},     // Sm     [2] LEFTWARDS ARROW WITH STROKE..RIGHTWARDS ARROW WITH STROKE
-	{runeRange{0x219C, 0x219F}, eawprN},     // So     [4] LEFTWARDS WAVE ARROW..UPWARDS TWO HEADED ARROW
-	{runeRange{0x21A0, 0x21A0}, eawprN},     // Sm         RIGHTWARDS TWO HEADED ARROW
-	{runeRange{0x21A1, 0x21A2}, eawprN},     // So     [2] DOWNWARDS TWO HEADED ARROW..LEFTWARDS ARROW WITH TAIL
-	{runeRange{0x21A3, 0x21A3}, eawprN},     // Sm         RIGHTWARDS ARROW WITH TAIL
-	{runeRange{0x21A4, 0x21A5}, eawprN},     // So     [2] LEFTWARDS ARROW FROM BAR..UPWARDS ARROW FROM BAR
-	{runeRange{0x21A6, 0x21A6}, eawprN},     // Sm         RIGHTWARDS ARROW FROM BAR
-	{runeRange{0x21A7, 0x21AD}, eawprN},     // So     [7] DOWNWARDS ARROW FROM BAR..LEFT RIGHT WAVE ARROW
-	{runeRange{0x21AE, 0x21AE}, eawprN},     // Sm         LEFT RIGHT ARROW WITH STROKE
-	{runeRange{0x21AF, 0x21B7}, eawprN},     // So     [9] DOWNWARDS ZIGZAG ARROW..CLOCKWISE TOP SEMICIRCLE ARROW
-	{runeRange{0x21B8, 0x21B9}, eawprA},     // So     [2] NORTH WEST ARROW TO LONG BAR..LEFTWARDS ARROW TO BAR OVER RIGHTWARDS ARROW TO BAR
-	{runeRange{0x21BA, 0x21CD}, eawprN},     // So    [20] ANTICLOCKWISE OPEN CIRCLE ARROW..LEFTWARDS DOUBLE ARROW WITH STROKE
-	{runeRange{0x21CE, 0x21CF}, eawprN},     // Sm     [2] LEFT RIGHT DOUBLE ARROW WITH STROKE..RIGHTWARDS DOUBLE ARROW WITH STROKE
-	{runeRange{0x21D0, 0x21D1}, eawprN},     // So     [2] LEFTWARDS DOUBLE ARROW..UPWARDS DOUBLE ARROW
-	{runeRange{0x21D2, 0x21D2}, eawprA},     // Sm         RIGHTWARDS DOUBLE ARROW
-	{runeRange{0x21D3, 0x21D3}, eawprN},     // So         DOWNWARDS DOUBLE ARROW
-	{runeRange{0x21D4, 0x21D4}, eawprA},     // Sm         LEFT RIGHT DOUBLE ARROW
-	{runeRange{0x21D5, 0x21E6}, eawprN},     // So    [18] UP DOWN DOUBLE ARROW..LEFTWARDS WHITE ARROW
-	{runeRange{0x21E7, 0x21E7}, eawprA},     // So         UPWARDS WHITE ARROW
-	{runeRange{0x21E8, 0x21F3}, eawprN},     // So    [12] RIGHTWARDS WHITE ARROW..UP DOWN WHITE ARROW
-	{runeRange{0x21F4, 0x21FF}, eawprN},     // Sm    [12] RIGHT ARROW WITH SMALL CIRCLE..LEFT RIGHT OPEN-HEADED ARROW
-	{runeRange{0x2200, 0x2200}, eawprA},     // Sm         FOR ALL
-	{runeRange{0x2201, 0x2201}, eawprN},     // Sm         COMPLEMENT
-	{runeRange{0x2202, 0x2203}, eawprA},     // Sm     [2] PARTIAL DIFFERENTIAL..THERE EXISTS
-	{runeRange{0x2204, 0x2206}, eawprN},     // Sm     [3] THERE DOES NOT EXIST..INCREMENT
-	{runeRange{0x2207, 0x2208}, eawprA},     // Sm     [2] NABLA..ELEMENT OF
-	{runeRange{0x2209, 0x220A}, eawprN},     // Sm     [2] NOT AN ELEMENT OF..SMALL ELEMENT OF
-	{runeRange{0x220B, 0x220B}, eawprA},     // Sm         CONTAINS AS MEMBER
-	{runeRange{0x220C, 0x220E}, eawprN},     // Sm     [3] DOES NOT CONTAIN AS MEMBER..END OF PROOF
-	{runeRange{0x220F, 0x220F}, eawprA},     // Sm         N-ARY PRODUCT
-	{runeRange{0x2210, 0x2210}, eawprN},     // Sm         N-ARY COPRODUCT
-	{runeRange{0x2211, 0x2211}, eawprA},     // Sm         N-ARY SUMMATION
-	{runeRange{0x2212, 0x2214}, eawprN},     // Sm     [3] MINUS SIGN..DOT PLUS
-	{runeRange{0x2215, 0x2215}, eawprA},     // Sm         DIVISION SLASH
-	{runeRange{0x2216, 0x2219}, eawprN},     // Sm     [4] SET MINUS..BULLET OPERATOR
-	{runeRange{0x221A, 0x221A}, eawprA},     // Sm         SQUARE ROOT
-	{runeRange{0x221B, 0x221C}, eawprN},     // Sm     [2] CUBE ROOT..FOURTH ROOT
-	{runeRange{0x221D, 0x2220}, eawprA},     // Sm     [4] PROPORTIONAL TO..ANGLE
-	{runeRange{0x2221, 0x2222}, eawprN},     // Sm     [2] MEASURED ANGLE..SPHERICAL ANGLE
-	{runeRange{0x2223, 0x2223}, eawprA},     // Sm         DIVIDES
-	{runeRange{0x2224, 0x2224}, eawprN},     // Sm         DOES NOT DIVIDE
-	{runeRange{0x2225, 0x2225}, eawprA},     // Sm         PARALLEL TO
-	{runeRange{0x2226, 0x2226}, eawprN},     // Sm         NOT PARALLEL TO
-	{runeRange{0x2227, 0x222C}, eawprA},     // Sm     [6] LOGICAL AND..DOUBLE INTEGRAL
-	{runeRange{0x222D, 0x222D}, eawprN},     // Sm         TRIPLE INTEGRAL
-	{runeRange{0x222E, 0x222E}, eawprA},     // Sm         CONTOUR INTEGRAL
-	{runeRange{0x222F, 0x2233}, eawprN},     // Sm     [5] SURFACE INTEGRAL..ANTICLOCKWISE CONTOUR INTEGRAL
-	{runeRange{0x2234, 0x2237}, eawprA},     // Sm     [4] THEREFORE..PROPORTION
-	{runeRange{0x2238, 0x223B}, eawprN},     // Sm     [4] DOT MINUS..HOMOTHETIC
-	{runeRange{0x223C, 0x223D}, eawprA},     // Sm     [2] TILDE OPERATOR..REVERSED TILDE
-	{runeRange{0x223E, 0x2247}, eawprN},     // Sm    [10] INVERTED LAZY S..NEITHER APPROXIMATELY NOR ACTUALLY EQUAL TO
-	{runeRange{0x2248, 0x2248}, eawprA},     // Sm         ALMOST EQUAL TO
-	{runeRange{0x2249, 0x224B}, eawprN},     // Sm     [3] NOT ALMOST EQUAL TO..TRIPLE TILDE
-	{runeRange{0x224C, 0x224C}, eawprA},     // Sm         ALL EQUAL TO
-	{runeRange{0x224D, 0x2251}, eawprN},     // Sm     [5] EQUIVALENT TO..GEOMETRICALLY EQUAL TO
-	{runeRange{0x2252, 0x2252}, eawprA},     // Sm         APPROXIMATELY EQUAL TO OR THE IMAGE OF
-	{runeRange{0x2253, 0x225F}, eawprN},     // Sm    [13] IMAGE OF OR APPROXIMATELY EQUAL TO..QUESTIONED EQUAL TO
-	{runeRange{0x2260, 0x2261}, eawprA},     // Sm     [2] NOT EQUAL TO..IDENTICAL TO
-	{runeRange{0x2262, 0x2263}, eawprN},     // Sm     [2] NOT IDENTICAL TO..STRICTLY EQUIVALENT TO
-	{runeRange{0x2264, 0x2267}, eawprA},     // Sm     [4] LESS-THAN OR EQUAL TO..GREATER-THAN OVER EQUAL TO
-	{runeRange{0x2268, 0x2269}, eawprN},     // Sm     [2] LESS-THAN BUT NOT EQUAL TO..GREATER-THAN BUT NOT EQUAL TO
-	{runeRange{0x226A, 0x226B}, eawprA},     // Sm     [2] MUCH LESS-THAN..MUCH GREATER-THAN
-	{runeRange{0x226C, 0x226D}, eawprN},     // Sm     [2] BETWEEN..NOT EQUIVALENT TO
-	{runeRange{0x226E, 0x226F}, eawprA},     // Sm     [2] NOT LESS-THAN..NOT GREATER-THAN
-	{runeRange{0x2270, 0x2281}, eawprN},     // Sm    [18] NEITHER LESS-THAN NOR EQUAL TO..DOES NOT SUCCEED
-	{runeRange{0x2282, 0x2283}, eawprA},     // Sm     [2] SUBSET OF..SUPERSET OF
-	{runeRange{0x2284, 0x2285}, eawprN},     // Sm     [2] NOT A SUBSET OF..NOT A SUPERSET OF
-	{runeRange{0x2286, 0x2287}, eawprA},     // Sm     [2] SUBSET OF OR EQUAL TO..SUPERSET OF OR EQUAL TO
-	{runeRange{0x2288, 0x2294}, eawprN},     // Sm    [13] NEITHER A SUBSET OF NOR EQUAL TO..SQUARE CUP
-	{runeRange{0x2295, 0x2295}, eawprA},     // Sm         CIRCLED PLUS
-	{runeRange{0x2296, 0x2298}, eawprN},     // Sm     [3] CIRCLED MINUS..CIRCLED DIVISION SLASH
-	{runeRange{0x2299, 0x2299}, eawprA},     // Sm         CIRCLED DOT OPERATOR
-	{runeRange{0x229A, 0x22A4}, eawprN},     // Sm    [11] CIRCLED RING OPERATOR..DOWN TACK
-	{runeRange{0x22A5, 0x22A5}, eawprA},     // Sm         UP TACK
-	{runeRange{0x22A6, 0x22BE}, eawprN},     // Sm    [25] ASSERTION..RIGHT ANGLE WITH ARC
-	{runeRange{0x22BF, 0x22BF}, eawprA},     // Sm         RIGHT TRIANGLE
-	{runeRange{0x22C0, 0x22FF}, eawprN},     // Sm    [64] N-ARY LOGICAL AND..Z NOTATION BAG MEMBERSHIP
-	{runeRange{0x2300, 0x2307}, eawprN},     // So     [8] DIAMETER SIGN..WAVY LINE
-	{runeRange{0x2308, 0x2308}, eawprN},     // Ps         LEFT CEILING
-	{runeRange{0x2309, 0x2309}, eawprN},     // Pe         RIGHT CEILING
-	{runeRange{0x230A, 0x230A}, eawprN},     // Ps         LEFT FLOOR
-	{runeRange{0x230B, 0x230B}, eawprN},     // Pe         RIGHT FLOOR
-	{runeRange{0x230C, 0x2311}, eawprN},     // So     [6] BOTTOM RIGHT CROP..SQUARE LOZENGE
-	{runeRange{0x2312, 0x2312}, eawprA},     // So         ARC
-	{runeRange{0x2313, 0x2319}, eawprN},     // So     [7] SEGMENT..TURNED NOT SIGN
-	{runeRange{0x231A, 0x231B}, eawprW},     // So     [2] WATCH..HOURGLASS
-	{runeRange{0x231C, 0x231F}, eawprN},     // So     [4] TOP LEFT CORNER..BOTTOM RIGHT CORNER
-	{runeRange{0x2320, 0x2321}, eawprN},     // Sm     [2] TOP HALF INTEGRAL..BOTTOM HALF INTEGRAL
-	{runeRange{0x2322, 0x2328}, eawprN},     // So     [7] FROWN..KEYBOARD
-	{runeRange{0x2329, 0x2329}, eawprW},     // Ps         LEFT-POINTING ANGLE BRACKET
-	{runeRange{0x232A, 0x232A}, eawprW},     // Pe         RIGHT-POINTING ANGLE BRACKET
-	{runeRange{0x232B, 0x237B}, eawprN},     // So    [81] ERASE TO THE LEFT..NOT CHECK MARK
-	{runeRange{0x237C, 0x237C}, eawprN},     // Sm         RIGHT ANGLE WITH DOWNWARDS ZIGZAG ARROW
-	{runeRange{0x237D, 0x239A}, eawprN},     // So    [30] SHOULDERED OPEN BOX..CLEAR SCREEN SYMBOL
-	{runeRange{0x239B, 0x23B3}, eawprN},     // Sm    [25] LEFT PARENTHESIS UPPER HOOK..SUMMATION BOTTOM
-	{runeRange{0x23B4, 0x23DB}, eawprN},     // So    [40] TOP SQUARE BRACKET..FUSE
-	{runeRange{0x23DC, 0x23E1}, eawprN},     // Sm     [6] TOP PARENTHESIS..BOTTOM TORTOISE SHELL BRACKET
-	{runeRange{0x23E2, 0x23E8}, eawprN},     // So     [7] WHITE TRAPEZIUM..DECIMAL EXPONENT SYMBOL
-	{runeRange{0x23E9, 0x23EC}, eawprW},     // So     [4] BLACK RIGHT-POINTING DOUBLE TRIANGLE..BLACK DOWN-POINTING DOUBLE TRIANGLE
-	{runeRange{0x23ED, 0x23EF}, eawprN},     // So     [3] BLACK RIGHT-POINTING DOUBLE TRIANGLE WITH VERTICAL BAR..BLACK RIGHT-POINTING TRIANGLE WITH DOUBLE VERTICAL BAR
-	{runeRange{0x23F0, 0x23F0}, eawprW},     // So         ALARM CLOCK
-	{runeRange{0x23F1, 0x23F2}, eawprN},     // So     [2] STOPWATCH..TIMER CLOCK
-	{runeRange{0x23F3, 0x23F3}, eawprW},     // So         HOURGLASS WITH FLOWING SAND
-	{runeRange{0x23F4, 0x23FF}, eawprN},     // So    [12] BLACK MEDIUM LEFT-POINTING TRIANGLE..OBSERVER EYE SYMBOL
-	{runeRange{0x2400, 0x2426}, eawprN},     // So    [39] SYMBOL FOR NULL..SYMBOL FOR SUBSTITUTE FORM TWO
-	{runeRange{0x2440, 0x244A}, eawprN},     // So    [11] OCR HOOK..OCR DOUBLE BACKSLASH
-	{runeRange{0x2460, 0x249B}, eawprA},     // No    [60] CIRCLED DIGIT ONE..NUMBER TWENTY FULL STOP
-	{runeRange{0x249C, 0x24E9}, eawprA},     // So    [78] PARENTHESIZED LATIN SMALL LETTER A..CIRCLED LATIN SMALL LETTER Z
-	{runeRange{0x24EA, 0x24EA}, eawprN},     // No         CIRCLED DIGIT ZERO
-	{runeRange{0x24EB, 0x24FF}, eawprA},     // No    [21] NEGATIVE CIRCLED NUMBER ELEVEN..NEGATIVE CIRCLED DIGIT ZERO
-	{runeRange{0x2500, 0x254B}, eawprA},     // So    [76] BOX DRAWINGS LIGHT HORIZONTAL..BOX DRAWINGS HEAVY VERTICAL AND HORIZONTAL
-	{runeRange{0x254C, 0x254F}, eawprN},     // So     [4] BOX DRAWINGS LIGHT DOUBLE DASH HORIZONTAL..BOX DRAWINGS HEAVY DOUBLE DASH VERTICAL
-	{runeRange{0x2550, 0x2573}, eawprA},     // So    [36] BOX DRAWINGS DOUBLE HORIZONTAL..BOX DRAWINGS LIGHT DIAGONAL CROSS
-	{runeRange{0x2574, 0x257F}, eawprN},     // So    [12] BOX DRAWINGS LIGHT LEFT..BOX DRAWINGS HEAVY UP AND LIGHT DOWN
-	{runeRange{0x2580, 0x258F}, eawprA},     // So    [16] UPPER HALF BLOCK..LEFT ONE EIGHTH BLOCK
-	{runeRange{0x2590, 0x2591}, eawprN},     // So     [2] RIGHT HALF BLOCK..LIGHT SHADE
-	{runeRange{0x2592, 0x2595}, eawprA},     // So     [4] MEDIUM SHADE..RIGHT ONE EIGHTH BLOCK
-	{runeRange{0x2596, 0x259F}, eawprN},     // So    [10] QUADRANT LOWER LEFT..QUADRANT UPPER RIGHT AND LOWER LEFT AND LOWER RIGHT
-	{runeRange{0x25A0, 0x25A1}, eawprA},     // So     [2] BLACK SQUARE..WHITE SQUARE
-	{runeRange{0x25A2, 0x25A2}, eawprN},     // So         WHITE SQUARE WITH ROUNDED CORNERS
-	{runeRange{0x25A3, 0x25A9}, eawprA},     // So     [7] WHITE SQUARE CONTAINING BLACK SMALL SQUARE..SQUARE WITH DIAGONAL CROSSHATCH FILL
-	{runeRange{0x25AA, 0x25B1}, eawprN},     // So     [8] BLACK SMALL SQUARE..WHITE PARALLELOGRAM
-	{runeRange{0x25B2, 0x25B3}, eawprA},     // So     [2] BLACK UP-POINTING TRIANGLE..WHITE UP-POINTING TRIANGLE
-	{runeRange{0x25B4, 0x25B5}, eawprN},     // So     [2] BLACK UP-POINTING SMALL TRIANGLE..WHITE UP-POINTING SMALL TRIANGLE
-	{runeRange{0x25B6, 0x25B6}, eawprA},     // So         BLACK RIGHT-POINTING TRIANGLE
-	{runeRange{0x25B7, 0x25B7}, eawprA},     // Sm         WHITE RIGHT-POINTING TRIANGLE
-	{runeRange{0x25B8, 0x25BB}, eawprN},     // So     [4] BLACK RIGHT-POINTING SMALL TRIANGLE..WHITE RIGHT-POINTING POINTER
-	{runeRange{0x25BC, 0x25BD}, eawprA},     // So     [2] BLACK DOWN-POINTING TRIANGLE..WHITE DOWN-POINTING TRIANGLE
-	{runeRange{0x25BE, 0x25BF}, eawprN},     // So     [2] BLACK DOWN-POINTING SMALL TRIANGLE..WHITE DOWN-POINTING SMALL TRIANGLE
-	{runeRange{0x25C0, 0x25C0}, eawprA},     // So         BLACK LEFT-POINTING TRIANGLE
-	{runeRange{0x25C1, 0x25C1}, eawprA},     // Sm         WHITE LEFT-POINTING TRIANGLE
-	{runeRange{0x25C2, 0x25C5}, eawprN},     // So     [4] BLACK LEFT-POINTING SMALL TRIANGLE..WHITE LEFT-POINTING POINTER
-	{runeRange{0x25C6, 0x25C8}, eawprA},     // So     [3] BLACK DIAMOND..WHITE DIAMOND CONTAINING BLACK SMALL DIAMOND
-	{runeRange{0x25C9, 0x25CA}, eawprN},     // So     [2] FISHEYE..LOZENGE
-	{runeRange{0x25CB, 0x25CB}, eawprA},     // So         WHITE CIRCLE
-	{runeRange{0x25CC, 0x25CD}, eawprN},     // So     [2] DOTTED CIRCLE..CIRCLE WITH VERTICAL FILL
-	{runeRange{0x25CE, 0x25D1}, eawprA},     // So     [4] BULLSEYE..CIRCLE WITH RIGHT HALF BLACK
-	{runeRange{0x25D2, 0x25E1}, eawprN},     // So    [16] CIRCLE WITH LOWER HALF BLACK..LOWER HALF CIRCLE
-	{runeRange{0x25E2, 0x25E5}, eawprA},     // So     [4] BLACK LOWER RIGHT TRIANGLE..BLACK UPPER RIGHT TRIANGLE
-	{runeRange{0x25E6, 0x25EE}, eawprN},     // So     [9] WHITE BULLET..UP-POINTING TRIANGLE WITH RIGHT HALF BLACK
-	{runeRange{0x25EF, 0x25EF}, eawprA},     // So         LARGE CIRCLE
-	{runeRange{0x25F0, 0x25F7}, eawprN},     // So     [8] WHITE SQUARE WITH UPPER LEFT QUADRANT..WHITE CIRCLE WITH UPPER RIGHT QUADRANT
-	{runeRange{0x25F8, 0x25FC}, eawprN},     // Sm     [5] UPPER LEFT TRIANGLE..BLACK MEDIUM SQUARE
-	{runeRange{0x25FD, 0x25FE}, eawprW},     // Sm     [2] WHITE MEDIUM SMALL SQUARE..BLACK MEDIUM SMALL SQUARE
-	{runeRange{0x25FF, 0x25FF}, eawprN},     // Sm         LOWER RIGHT TRIANGLE
-	{runeRange{0x2600, 0x2604}, eawprN},     // So     [5] BLACK SUN WITH RAYS..COMET
-	{runeRange{0x2605, 0x2606}, eawprA},     // So     [2] BLACK STAR..WHITE STAR
-	{runeRange{0x2607, 0x2608}, eawprN},     // So     [2] LIGHTNING..THUNDERSTORM
-	{runeRange{0x2609, 0x2609}, eawprA},     // So         SUN
-	{runeRange{0x260A, 0x260D}, eawprN},     // So     [4] ASCENDING NODE..OPPOSITION
-	{runeRange{0x260E, 0x260F}, eawprA},     // So     [2] BLACK TELEPHONE..WHITE TELEPHONE
-	{runeRange{0x2610, 0x2613}, eawprN},     // So     [4] BALLOT BOX..SALTIRE
-	{runeRange{0x2614, 0x2615}, eawprW},     // So     [2] UMBRELLA WITH RAIN DROPS..HOT BEVERAGE
-	{runeRange{0x2616, 0x261B}, eawprN},     // So     [6] WHITE SHOGI PIECE..BLACK RIGHT POINTING INDEX
-	{runeRange{0x261C, 0x261C}, eawprA},     // So         WHITE LEFT POINTING INDEX
-	{runeRange{0x261D, 0x261D}, eawprN},     // So         WHITE UP POINTING INDEX
-	{runeRange{0x261E, 0x261E}, eawprA},     // So         WHITE RIGHT POINTING INDEX
-	{runeRange{0x261F, 0x263F}, eawprN},     // So    [33] WHITE DOWN POINTING INDEX..MERCURY
-	{runeRange{0x2640, 0x2640}, eawprA},     // So         FEMALE SIGN
-	{runeRange{0x2641, 0x2641}, eawprN},     // So         EARTH
-	{runeRange{0x2642, 0x2642}, eawprA},     // So         MALE SIGN
-	{runeRange{0x2643, 0x2647}, eawprN},     // So     [5] JUPITER..PLUTO
-	{runeRange{0x2648, 0x2653}, eawprW},     // So    [12] ARIES..PISCES
-	{runeRange{0x2654, 0x265F}, eawprN},     // So    [12] WHITE CHESS KING..BLACK CHESS PAWN
-	{runeRange{0x2660, 0x2661}, eawprA},     // So     [2] BLACK SPADE SUIT..WHITE HEART SUIT
-	{runeRange{0x2662, 0x2662}, eawprN},     // So         WHITE DIAMOND SUIT
-	{runeRange{0x2663, 0x2665}, eawprA},     // So     [3] BLACK CLUB SUIT..BLACK HEART SUIT
-	{runeRange{0x2666, 0x2666}, eawprN},     // So         BLACK DIAMOND SUIT
-	{runeRange{0x2667, 0x266A}, eawprA},     // So     [4] WHITE CLUB SUIT..EIGHTH NOTE
-	{runeRange{0x266B, 0x266B}, eawprN},     // So         BEAMED EIGHTH NOTES
-	{runeRange{0x266C, 0x266D}, eawprA},     // So     [2] BEAMED SIXTEENTH NOTES..MUSIC FLAT SIGN
-	{runeRange{0x266E, 0x266E}, eawprN},     // So         MUSIC NATURAL SIGN
-	{runeRange{0x266F, 0x266F}, eawprA},     // Sm         MUSIC SHARP SIGN
-	{runeRange{0x2670, 0x267E}, eawprN},     // So    [15] WEST SYRIAC CROSS..PERMANENT PAPER SIGN
-	{runeRange{0x267F, 0x267F}, eawprW},     // So         WHEELCHAIR SYMBOL
-	{runeRange{0x2680, 0x2692}, eawprN},     // So    [19] DIE FACE-1..HAMMER AND PICK
-	{runeRange{0x2693, 0x2693}, eawprW},     // So         ANCHOR
-	{runeRange{0x2694, 0x269D}, eawprN},     // So    [10] CROSSED SWORDS..OUTLINED WHITE STAR
-	{runeRange{0x269E, 0x269F}, eawprA},     // So     [2] THREE LINES CONVERGING RIGHT..THREE LINES CONVERGING LEFT
-	{runeRange{0x26A0, 0x26A0}, eawprN},     // So         WARNING SIGN
-	{runeRange{0x26A1, 0x26A1}, eawprW},     // So         HIGH VOLTAGE SIGN
-	{runeRange{0x26A2, 0x26A9}, eawprN},     // So     [8] DOUBLED FEMALE SIGN..HORIZONTAL MALE WITH STROKE SIGN
-	{runeRange{0x26AA, 0x26AB}, eawprW},     // So     [2] MEDIUM WHITE CIRCLE..MEDIUM BLACK CIRCLE
-	{runeRange{0x26AC, 0x26BC}, eawprN},     // So    [17] MEDIUM SMALL WHITE CIRCLE..SESQUIQUADRATE
-	{runeRange{0x26BD, 0x26BE}, eawprW},     // So     [2] SOCCER BALL..BASEBALL
-	{runeRange{0x26BF, 0x26BF}, eawprA},     // So         SQUARED KEY
-	{runeRange{0x26C0, 0x26C3}, eawprN},     // So     [4] WHITE DRAUGHTS MAN..BLACK DRAUGHTS KING
-	{runeRange{0x26C4, 0x26C5}, eawprW},     // So     [2] SNOWMAN WITHOUT SNOW..SUN BEHIND CLOUD
-	{runeRange{0x26C6, 0x26CD}, eawprA},     // So     [8] RAIN..DISABLED CAR
-	{runeRange{0x26CE, 0x26CE}, eawprW},     // So         OPHIUCHUS
-	{runeRange{0x26CF, 0x26D3}, eawprA},     // So     [5] PICK..CHAINS
-	{runeRange{0x26D4, 0x26D4}, eawprW},     // So         NO ENTRY
-	{runeRange{0x26D5, 0x26E1}, eawprA},     // So    [13] ALTERNATE ONE-WAY LEFT WAY TRAFFIC..RESTRICTED LEFT ENTRY-2
-	{runeRange{0x26E2, 0x26E2}, eawprN},     // So         ASTRONOMICAL SYMBOL FOR URANUS
-	{runeRange{0x26E3, 0x26E3}, eawprA},     // So         HEAVY CIRCLE WITH STROKE AND TWO DOTS ABOVE
-	{runeRange{0x26E4, 0x26E7}, eawprN},     // So     [4] PENTAGRAM..INVERTED PENTAGRAM
-	{runeRange{0x26E8, 0x26E9}, eawprA},     // So     [2] BLACK CROSS ON SHIELD..SHINTO SHRINE
-	{runeRange{0x26EA, 0x26EA}, eawprW},     // So         CHURCH
-	{runeRange{0x26EB, 0x26F1}, eawprA},     // So     [7] CASTLE..UMBRELLA ON GROUND
-	{runeRange{0x26F2, 0x26F3}, eawprW},     // So     [2] FOUNTAIN..FLAG IN HOLE
-	{runeRange{0x26F4, 0x26F4}, eawprA},     // So         FERRY
-	{runeRange{0x26F5, 0x26F5}, eawprW},     // So         SAILBOAT
-	{runeRange{0x26F6, 0x26F9}, eawprA},     // So     [4] SQUARE FOUR CORNERS..PERSON WITH BALL
-	{runeRange{0x26FA, 0x26FA}, eawprW},     // So         TENT
-	{runeRange{0x26FB, 0x26FC}, eawprA},     // So     [2] JAPANESE BANK SYMBOL..HEADSTONE GRAVEYARD SYMBOL
-	{runeRange{0x26FD, 0x26FD}, eawprW},     // So         FUEL PUMP
-	{runeRange{0x26FE, 0x26FF}, eawprA},     // So     [2] CUP ON BLACK SQUARE..WHITE FLAG WITH HORIZONTAL MIDDLE BLACK STRIPE
-	{runeRange{0x2700, 0x2704}, eawprN},     // So     [5] BLACK SAFETY SCISSORS..WHITE SCISSORS
-	{runeRange{0x2705, 0x2705}, eawprW},     // So         WHITE HEAVY CHECK MARK
-	{runeRange{0x2706, 0x2709}, eawprN},     // So     [4] TELEPHONE LOCATION SIGN..ENVELOPE
-	{runeRange{0x270A, 0x270B}, eawprW},     // So     [2] RAISED FIST..RAISED HAND
-	{runeRange{0x270C, 0x2727}, eawprN},     // So    [28] VICTORY HAND..WHITE FOUR POINTED STAR
-	{runeRange{0x2728, 0x2728}, eawprW},     // So         SPARKLES
-	{runeRange{0x2729, 0x273C}, eawprN},     // So    [20] STRESS OUTLINED WHITE STAR..OPEN CENTRE TEARDROP-SPOKED ASTERISK
-	{runeRange{0x273D, 0x273D}, eawprA},     // So         HEAVY TEARDROP-SPOKED ASTERISK
-	{runeRange{0x273E, 0x274B}, eawprN},     // So    [14] SIX PETALLED BLACK AND WHITE FLORETTE..HEAVY EIGHT TEARDROP-SPOKED PROPELLER ASTERISK
-	{runeRange{0x274C, 0x274C}, eawprW},     // So         CROSS MARK
-	{runeRange{0x274D, 0x274D}, eawprN},     // So         SHADOWED WHITE CIRCLE
-	{runeRange{0x274E, 0x274E}, eawprW},     // So         NEGATIVE SQUARED CROSS MARK
-	{runeRange{0x274F, 0x2752}, eawprN},     // So     [4] LOWER RIGHT DROP-SHADOWED WHITE SQUARE..UPPER RIGHT SHADOWED WHITE SQUARE
-	{runeRange{0x2753, 0x2755}, eawprW},     // So     [3] BLACK QUESTION MARK ORNAMENT..WHITE EXCLAMATION MARK ORNAMENT
-	{runeRange{0x2756, 0x2756}, eawprN},     // So         BLACK DIAMOND MINUS WHITE X
-	{runeRange{0x2757, 0x2757}, eawprW},     // So         HEAVY EXCLAMATION MARK SYMBOL
-	{runeRange{0x2758, 0x2767}, eawprN},     // So    [16] LIGHT VERTICAL BAR..ROTATED FLORAL HEART BULLET
-	{runeRange{0x2768, 0x2768}, eawprN},     // Ps         MEDIUM LEFT PARENTHESIS ORNAMENT
-	{runeRange{0x2769, 0x2769}, eawprN},     // Pe         MEDIUM RIGHT PARENTHESIS ORNAMENT
-	{runeRange{0x276A, 0x276A}, eawprN},     // Ps         MEDIUM FLATTENED LEFT PARENTHESIS ORNAMENT
-	{runeRange{0x276B, 0x276B}, eawprN},     // Pe         MEDIUM FLATTENED RIGHT PARENTHESIS ORNAMENT
-	{runeRange{0x276C, 0x276C}, eawprN},     // Ps         MEDIUM LEFT-POINTING ANGLE BRACKET ORNAMENT
-	{runeRange{0x276D, 0x276D}, eawprN},     // Pe         MEDIUM RIGHT-POINTING ANGLE BRACKET ORNAMENT
-	{runeRange{0x276E, 0x276E}, eawprN},     // Ps         HEAVY LEFT-POINTING ANGLE QUOTATION MARK ORNAMENT
-	{runeRange{0x276F, 0x276F}, eawprN},     // Pe         HEAVY RIGHT-POINTING ANGLE QUOTATION MARK ORNAMENT
-	{runeRange{0x2770, 0x2770}, eawprN},     // Ps         HEAVY LEFT-POINTING ANGLE BRACKET ORNAMENT
-	{runeRange{0x2771, 0x2771}, eawprN},     // Pe         HEAVY RIGHT-POINTING ANGLE BRACKET ORNAMENT
-	{runeRange{0x2772, 0x2772}, eawprN},     // Ps         LIGHT LEFT TORTOISE SHELL BRACKET ORNAMENT
-	{runeRange{0x2773, 0x2773}, eawprN},     // Pe         LIGHT RIGHT TORTOISE SHELL BRACKET ORNAMENT
-	{runeRange{0x2774, 0x2774}, eawprN},     // Ps         MEDIUM LEFT CURLY BRACKET ORNAMENT
-	{runeRange{0x2775, 0x2775}, eawprN},     // Pe         MEDIUM RIGHT CURLY BRACKET ORNAMENT
-	{runeRange{0x2776, 0x277F}, eawprA},     // No    [10] DINGBAT NEGATIVE CIRCLED DIGIT ONE..DINGBAT NEGATIVE CIRCLED NUMBER TEN
-	{runeRange{0x2780, 0x2793}, eawprN},     // No    [20] DINGBAT CIRCLED SANS-SERIF DIGIT ONE..DINGBAT NEGATIVE CIRCLED SANS-SERIF NUMBER TEN
-	{runeRange{0x2794, 0x2794}, eawprN},     // So         HEAVY WIDE-HEADED RIGHTWARDS ARROW
-	{runeRange{0x2795, 0x2797}, eawprW},     // So     [3] HEAVY PLUS SIGN..HEAVY DIVISION SIGN
-	{runeRange{0x2798, 0x27AF}, eawprN},     // So    [24] HEAVY SOUTH EAST ARROW..NOTCHED LOWER RIGHT-SHADOWED WHITE RIGHTWARDS ARROW
-	{runeRange{0x27B0, 0x27B0}, eawprW},     // So         CURLY LOOP
-	{runeRange{0x27B1, 0x27BE}, eawprN},     // So    [14] NOTCHED UPPER RIGHT-SHADOWED WHITE RIGHTWARDS ARROW..OPEN-OUTLINED RIGHTWARDS ARROW
-	{runeRange{0x27BF, 0x27BF}, eawprW},     // So         DOUBLE CURLY LOOP
-	{runeRange{0x27C0, 0x27C4}, eawprN},     // Sm     [5] THREE DIMENSIONAL ANGLE..OPEN SUPERSET
-	{runeRange{0x27C5, 0x27C5}, eawprN},     // Ps         LEFT S-SHAPED BAG DELIMITER
-	{runeRange{0x27C6, 0x27C6}, eawprN},     // Pe         RIGHT S-SHAPED BAG DELIMITER
-	{runeRange{0x27C7, 0x27E5}, eawprN},     // Sm    [31] OR WITH DOT INSIDE..WHITE SQUARE WITH RIGHTWARDS TICK
-	{runeRange{0x27E6, 0x27E6}, eawprNa},    // Ps         MATHEMATICAL LEFT WHITE SQUARE BRACKET
-	{runeRange{0x27E7, 0x27E7}, eawprNa},    // Pe         MATHEMATICAL RIGHT WHITE SQUARE BRACKET
-	{runeRange{0x27E8, 0x27E8}, eawprNa},    // Ps         MATHEMATICAL LEFT ANGLE BRACKET
-	{runeRange{0x27E9, 0x27E9}, eawprNa},    // Pe         MATHEMATICAL RIGHT ANGLE BRACKET
-	{runeRange{0x27EA, 0x27EA}, eawprNa},    // Ps         MATHEMATICAL LEFT DOUBLE ANGLE BRACKET
-	{runeRange{0x27EB, 0x27EB}, eawprNa},    // Pe         MATHEMATICAL RIGHT DOUBLE ANGLE BRACKET
-	{runeRange{0x27EC, 0x27EC}, eawprNa},    // Ps         MATHEMATICAL LEFT WHITE TORTOISE SHELL BRACKET
-	{runeRange{0x27ED, 0x27ED}, eawprNa},    // Pe         MATHEMATICAL RIGHT WHITE TORTOISE SHELL BRACKET
-	{runeRange{0x27EE, 0x27EE}, eawprN},     // Ps         MATHEMATICAL LEFT FLATTENED PARENTHESIS
-	{runeRange{0x27EF, 0x27EF}, eawprN},     // Pe         MATHEMATICAL RIGHT FLATTENED PARENTHESIS
-	{runeRange{0x27F0, 0x27FF}, eawprN},     // Sm    [16] UPWARDS QUADRUPLE ARROW..LONG RIGHTWARDS SQUIGGLE ARROW
-	{runeRange{0x2800, 0x28FF}, eawprN},     // So   [256] BRAILLE PATTERN BLANK..BRAILLE PATTERN DOTS-12345678
-	{runeRange{0x2900, 0x297F}, eawprN},     // Sm   [128] RIGHTWARDS TWO-HEADED ARROW WITH VERTICAL STROKE..DOWN FISH TAIL
-	{runeRange{0x2980, 0x2982}, eawprN},     // Sm     [3] TRIPLE VERTICAL BAR DELIMITER..Z NOTATION TYPE COLON
-	{runeRange{0x2983, 0x2983}, eawprN},     // Ps         LEFT WHITE CURLY BRACKET
-	{runeRange{0x2984, 0x2984}, eawprN},     // Pe         RIGHT WHITE CURLY BRACKET
-	{runeRange{0x2985, 0x2985}, eawprNa},    // Ps         LEFT WHITE PARENTHESIS
-	{runeRange{0x2986, 0x2986}, eawprNa},    // Pe         RIGHT WHITE PARENTHESIS
-	{runeRange{0x2987, 0x2987}, eawprN},     // Ps         Z NOTATION LEFT IMAGE BRACKET
-	{runeRange{0x2988, 0x2988}, eawprN},     // Pe         Z NOTATION RIGHT IMAGE BRACKET
-	{runeRange{0x2989, 0x2989}, eawprN},     // Ps         Z NOTATION LEFT BINDING BRACKET
-	{runeRange{0x298A, 0x298A}, eawprN},     // Pe         Z NOTATION RIGHT BINDING BRACKET
-	{runeRange{0x298B, 0x298B}, eawprN},     // Ps         LEFT SQUARE BRACKET WITH UNDERBAR
-	{runeRange{0x298C, 0x298C}, eawprN},     // Pe         RIGHT SQUARE BRACKET WITH UNDERBAR
-	{runeRange{0x298D, 0x298D}, eawprN},     // Ps         LEFT SQUARE BRACKET WITH TICK IN TOP CORNER
-	{runeRange{0x298E, 0x298E}, eawprN},     // Pe         RIGHT SQUARE BRACKET WITH TICK IN BOTTOM CORNER
-	{runeRange{0x298F, 0x298F}, eawprN},     // Ps         LEFT SQUARE BRACKET WITH TICK IN BOTTOM CORNER
-	{runeRange{0x2990, 0x2990}, eawprN},     // Pe         RIGHT SQUARE BRACKET WITH TICK IN TOP CORNER
-	{runeRange{0x2991, 0x2991}, eawprN},     // Ps         LEFT ANGLE BRACKET WITH DOT
-	{runeRange{0x2992, 0x2992}, eawprN},     // Pe         RIGHT ANGLE BRACKET WITH DOT
-	{runeRange{0x2993, 0x2993}, eawprN},     // Ps         LEFT ARC LESS-THAN BRACKET
-	{runeRange{0x2994, 0x2994}, eawprN},     // Pe         RIGHT ARC GREATER-THAN BRACKET
-	{runeRange{0x2995, 0x2995}, eawprN},     // Ps         DOUBLE LEFT ARC GREATER-THAN BRACKET
-	{runeRange{0x2996, 0x2996}, eawprN},     // Pe         DOUBLE RIGHT ARC LESS-THAN BRACKET
-	{runeRange{0x2997, 0x2997}, eawprN},     // Ps         LEFT BLACK TORTOISE SHELL BRACKET
-	{runeRange{0x2998, 0x2998}, eawprN},     // Pe         RIGHT BLACK TORTOISE SHELL BRACKET
-	{runeRange{0x2999, 0x29D7}, eawprN},     // Sm    [63] DOTTED FENCE..BLACK HOURGLASS
-	{runeRange{0x29D8, 0x29D8}, eawprN},     // Ps         LEFT WIGGLY FENCE
-	{runeRange{0x29D9, 0x29D9}, eawprN},     // Pe         RIGHT WIGGLY FENCE
-	{runeRange{0x29DA, 0x29DA}, eawprN},     // Ps         LEFT DOUBLE WIGGLY FENCE
-	{runeRange{0x29DB, 0x29DB}, eawprN},     // Pe         RIGHT DOUBLE WIGGLY FENCE
-	{runeRange{0x29DC, 0x29FB}, eawprN},     // Sm    [32] INCOMPLETE INFINITY..TRIPLE PLUS
-	{runeRange{0x29FC, 0x29FC}, eawprN},     // Ps         LEFT-POINTING CURVED ANGLE BRACKET
-	{runeRange{0x29FD, 0x29FD}, eawprN},     // Pe         RIGHT-POINTING CURVED ANGLE BRACKET
-	{runeRange{0x29FE, 0x29FF}, eawprN},     // Sm     [2] TINY..MINY
-	{runeRange{0x2A00, 0x2AFF}, eawprN},     // Sm   [256] N-ARY CIRCLED DOT OPERATOR..N-ARY WHITE VERTICAL BAR
-	{runeRange{0x2B00, 0x2B1A}, eawprN},     // So    [27] NORTH EAST WHITE ARROW..DOTTED SQUARE
-	{runeRange{0x2B1B, 0x2B1C}, eawprW},     // So     [2] BLACK LARGE SQUARE..WHITE LARGE SQUARE
-	{runeRange{0x2B1D, 0x2B2F}, eawprN},     // So    [19] BLACK VERY SMALL SQUARE..WHITE VERTICAL ELLIPSE
-	{runeRange{0x2B30, 0x2B44}, eawprN},     // Sm    [21] LEFT ARROW WITH SMALL CIRCLE..RIGHTWARDS ARROW THROUGH SUPERSET
-	{runeRange{0x2B45, 0x2B46}, eawprN},     // So     [2] LEFTWARDS QUADRUPLE ARROW..RIGHTWARDS QUADRUPLE ARROW
-	{runeRange{0x2B47, 0x2B4C}, eawprN},     // Sm     [6] REVERSE TILDE OPERATOR ABOVE RIGHTWARDS ARROW..RIGHTWARDS ARROW ABOVE REVERSE TILDE OPERATOR
-	{runeRange{0x2B4D, 0x2B4F}, eawprN},     // So     [3] DOWNWARDS TRIANGLE-HEADED ZIGZAG ARROW..SHORT BACKSLANTED SOUTH ARROW
-	{runeRange{0x2B50, 0x2B50}, eawprW},     // So         WHITE MEDIUM STAR
-	{runeRange{0x2B51, 0x2B54}, eawprN},     // So     [4] BLACK SMALL STAR..WHITE RIGHT-POINTING PENTAGON
-	{runeRange{0x2B55, 0x2B55}, eawprW},     // So         HEAVY LARGE CIRCLE
-	{runeRange{0x2B56, 0x2B59}, eawprA},     // So     [4] HEAVY OVAL WITH OVAL INSIDE..HEAVY CIRCLED SALTIRE
-	{runeRange{0x2B5A, 0x2B73}, eawprN},     // So    [26] SLANTED NORTH ARROW WITH HOOKED HEAD..DOWNWARDS TRIANGLE-HEADED ARROW TO BAR
-	{runeRange{0x2B76, 0x2B95}, eawprN},     // So    [32] NORTH WEST TRIANGLE-HEADED ARROW TO BAR..RIGHTWARDS BLACK ARROW
-	{runeRange{0x2B97, 0x2BFF}, eawprN},     // So   [105] SYMBOL FOR TYPE A ELECTRONICS..HELLSCHREIBER PAUSE SYMBOL
-	{runeRange{0x2C00, 0x2C5F}, eawprN},     // L&    [96] GLAGOLITIC CAPITAL LETTER AZU..GLAGOLITIC SMALL LETTER CAUDATE CHRIVI
-	{runeRange{0x2C60, 0x2C7B}, eawprN},     // L&    [28] LATIN CAPITAL LETTER L WITH DOUBLE BAR..LATIN LETTER SMALL CAPITAL TURNED E
-	{runeRange{0x2C7C, 0x2C7D}, eawprN},     // Lm     [2] LATIN SUBSCRIPT SMALL LETTER J..MODIFIER LETTER CAPITAL V
-	{runeRange{0x2C7E, 0x2C7F}, eawprN},     // Lu     [2] LATIN CAPITAL LETTER S WITH SWASH TAIL..LATIN CAPITAL LETTER Z WITH SWASH TAIL
-	{runeRange{0x2C80, 0x2CE4}, eawprN},     // L&   [101] COPTIC CAPITAL LETTER ALFA..COPTIC SYMBOL KAI
-	{runeRange{0x2CE5, 0x2CEA}, eawprN},     // So     [6] COPTIC SYMBOL MI RO..COPTIC SYMBOL SHIMA SIMA
-	{runeRange{0x2CEB, 0x2CEE}, eawprN},     // L&     [4] COPTIC CAPITAL LETTER CRYPTOGRAMMIC SHEI..COPTIC SMALL LETTER CRYPTOGRAMMIC GANGIA
-	{runeRange{0x2CEF, 0x2CF1}, eawprN},     // Mn     [3] COPTIC COMBINING NI ABOVE..COPTIC COMBINING SPIRITUS LENIS
-	{runeRange{0x2CF2, 0x2CF3}, eawprN},     // L&     [2] COPTIC CAPITAL LETTER BOHAIRIC KHEI..COPTIC SMALL LETTER BOHAIRIC KHEI
-	{runeRange{0x2CF9, 0x2CFC}, eawprN},     // Po     [4] COPTIC OLD NUBIAN FULL STOP..COPTIC OLD NUBIAN VERSE DIVIDER
-	{runeRange{0x2CFD, 0x2CFD}, eawprN},     // No         COPTIC FRACTION ONE HALF
-	{runeRange{0x2CFE, 0x2CFF}, eawprN},     // Po     [2] COPTIC FULL STOP..COPTIC MORPHOLOGICAL DIVIDER
-	{runeRange{0x2D00, 0x2D25}, eawprN},     // Ll    [38] GEORGIAN SMALL LETTER AN..GEORGIAN SMALL LETTER HOE
-	{runeRange{0x2D27, 0x2D27}, eawprN},     // Ll         GEORGIAN SMALL LETTER YN
-	{runeRange{0x2D2D, 0x2D2D}, eawprN},     // Ll         GEORGIAN SMALL LETTER AEN
-	{runeRange{0x2D30, 0x2D67}, eawprN},     // Lo    [56] TIFINAGH LETTER YA..TIFINAGH LETTER YO
-	{runeRange{0x2D6F, 0x2D6F}, eawprN},     // Lm         TIFINAGH MODIFIER LETTER LABIALIZATION MARK
-	{runeRange{0x2D70, 0x2D70}, eawprN},     // Po         TIFINAGH SEPARATOR MARK
-	{runeRange{0x2D7F, 0x2D7F}, eawprN},     // Mn         TIFINAGH CONSONANT JOINER
-	{runeRange{0x2D80, 0x2D96}, eawprN},     // Lo    [23] ETHIOPIC SYLLABLE LOA..ETHIOPIC SYLLABLE GGWE
-	{runeRange{0x2DA0, 0x2DA6}, eawprN},     // Lo     [7] ETHIOPIC SYLLABLE SSA..ETHIOPIC SYLLABLE SSO
-	{runeRange{0x2DA8, 0x2DAE}, eawprN},     // Lo     [7] ETHIOPIC SYLLABLE CCA..ETHIOPIC SYLLABLE CCO
-	{runeRange{0x2DB0, 0x2DB6}, eawprN},     // Lo     [7] ETHIOPIC SYLLABLE ZZA..ETHIOPIC SYLLABLE ZZO
-	{runeRange{0x2DB8, 0x2DBE}, eawprN},     // Lo     [7] ETHIOPIC SYLLABLE CCHA..ETHIOPIC SYLLABLE CCHO
-	{runeRange{0x2DC0, 0x2DC6}, eawprN},     // Lo     [7] ETHIOPIC SYLLABLE QYA..ETHIOPIC SYLLABLE QYO
-	{runeRange{0x2DC8, 0x2DCE}, eawprN},     // Lo     [7] ETHIOPIC SYLLABLE KYA..ETHIOPIC SYLLABLE KYO
-	{runeRange{0x2DD0, 0x2DD6}, eawprN},     // Lo     [7] ETHIOPIC SYLLABLE XYA..ETHIOPIC SYLLABLE XYO
-	{runeRange{0x2DD8, 0x2DDE}, eawprN},     // Lo     [7] ETHIOPIC SYLLABLE GYA..ETHIOPIC SYLLABLE GYO
-	{runeRange{0x2DE0, 0x2DFF}, eawprN},     // Mn    [32] COMBINING CYRILLIC LETTER BE..COMBINING CYRILLIC LETTER IOTIFIED BIG YUS
-	{runeRange{0x2E00, 0x2E01}, eawprN},     // Po     [2] RIGHT ANGLE SUBSTITUTION MARKER..RIGHT ANGLE DOTTED SUBSTITUTION MARKER
-	{runeRange{0x2E02, 0x2E02}, eawprN},     // Pi         LEFT SUBSTITUTION BRACKET
-	{runeRange{0x2E03, 0x2E03}, eawprN},     // Pf         RIGHT SUBSTITUTION BRACKET
-	{runeRange{0x2E04, 0x2E04}, eawprN},     // Pi         LEFT DOTTED SUBSTITUTION BRACKET
-	{runeRange{0x2E05, 0x2E05}, eawprN},     // Pf         RIGHT DOTTED SUBSTITUTION BRACKET
-	{runeRange{0x2E06, 0x2E08}, eawprN},     // Po     [3] RAISED INTERPOLATION MARKER..DOTTED TRANSPOSITION MARKER
-	{runeRange{0x2E09, 0x2E09}, eawprN},     // Pi         LEFT TRANSPOSITION BRACKET
-	{runeRange{0x2E0A, 0x2E0A}, eawprN},     // Pf         RIGHT TRANSPOSITION BRACKET
-	{runeRange{0x2E0B, 0x2E0B}, eawprN},     // Po         RAISED SQUARE
-	{runeRange{0x2E0C, 0x2E0C}, eawprN},     // Pi         LEFT RAISED OMISSION BRACKET
-	{runeRange{0x2E0D, 0x2E0D}, eawprN},     // Pf         RIGHT RAISED OMISSION BRACKET
-	{runeRange{0x2E0E, 0x2E16}, eawprN},     // Po     [9] EDITORIAL CORONIS..DOTTED RIGHT-POINTING ANGLE
-	{runeRange{0x2E17, 0x2E17}, eawprN},     // Pd         DOUBLE OBLIQUE HYPHEN
-	{runeRange{0x2E18, 0x2E19}, eawprN},     // Po     [2] INVERTED INTERROBANG..PALM BRANCH
-	{runeRange{0x2E1A, 0x2E1A}, eawprN},     // Pd         HYPHEN WITH DIAERESIS
-	{runeRange{0x2E1B, 0x2E1B}, eawprN},     // Po         TILDE WITH RING ABOVE
-	{runeRange{0x2E1C, 0x2E1C}, eawprN},     // Pi         LEFT LOW PARAPHRASE BRACKET
-	{runeRange{0x2E1D, 0x2E1D}, eawprN},     // Pf         RIGHT LOW PARAPHRASE BRACKET
-	{runeRange{0x2E1E, 0x2E1F}, eawprN},     // Po     [2] TILDE WITH DOT ABOVE..TILDE WITH DOT BELOW
-	{runeRange{0x2E20, 0x2E20}, eawprN},     // Pi         LEFT VERTICAL BAR WITH QUILL
-	{runeRange{0x2E21, 0x2E21}, eawprN},     // Pf         RIGHT VERTICAL BAR WITH QUILL
-	{runeRange{0x2E22, 0x2E22}, eawprN},     // Ps         TOP LEFT HALF BRACKET
-	{runeRange{0x2E23, 0x2E23}, eawprN},     // Pe         TOP RIGHT HALF BRACKET
-	{runeRange{0x2E24, 0x2E24}, eawprN},     // Ps         BOTTOM LEFT HALF BRACKET
-	{runeRange{0x2E25, 0x2E25}, eawprN},     // Pe         BOTTOM RIGHT HALF BRACKET
-	{runeRange{0x2E26, 0x2E26}, eawprN},     // Ps         LEFT SIDEWAYS U BRACKET
-	{runeRange{0x2E27, 0x2E27}, eawprN},     // Pe         RIGHT SIDEWAYS U BRACKET
-	{runeRange{0x2E28, 0x2E28}, eawprN},     // Ps         LEFT DOUBLE PARENTHESIS
-	{runeRange{0x2E29, 0x2E29}, eawprN},     // Pe         RIGHT DOUBLE PARENTHESIS
-	{runeRange{0x2E2A, 0x2E2E}, eawprN},     // Po     [5] TWO DOTS OVER ONE DOT PUNCTUATION..REVERSED QUESTION MARK
-	{runeRange{0x2E2F, 0x2E2F}, eawprN},     // Lm         VERTICAL TILDE
-	{runeRange{0x2E30, 0x2E39}, eawprN},     // Po    [10] RING POINT..TOP HALF SECTION SIGN
-	{runeRange{0x2E3A, 0x2E3B}, eawprN},     // Pd     [2] TWO-EM DASH..THREE-EM DASH
-	{runeRange{0x2E3C, 0x2E3F}, eawprN},     // Po     [4] STENOGRAPHIC FULL STOP..CAPITULUM
-	{runeRange{0x2E40, 0x2E40}, eawprN},     // Pd         DOUBLE HYPHEN
-	{runeRange{0x2E41, 0x2E41}, eawprN},     // Po         REVERSED COMMA
-	{runeRange{0x2E42, 0x2E42}, eawprN},     // Ps         DOUBLE LOW-REVERSED-9 QUOTATION MARK
-	{runeRange{0x2E43, 0x2E4F}, eawprN},     // Po    [13] DASH WITH LEFT UPTURN..CORNISH VERSE DIVIDER
-	{runeRange{0x2E50, 0x2E51}, eawprN},     // So     [2] CROSS PATTY WITH RIGHT CROSSBAR..CROSS PATTY WITH LEFT CROSSBAR
-	{runeRange{0x2E52, 0x2E54}, eawprN},     // Po     [3] TIRONIAN SIGN CAPITAL ET..MEDIEVAL QUESTION MARK
-	{runeRange{0x2E55, 0x2E55}, eawprN},     // Ps         LEFT SQUARE BRACKET WITH STROKE
-	{runeRange{0x2E56, 0x2E56}, eawprN},     // Pe         RIGHT SQUARE BRACKET WITH STROKE
-	{runeRange{0x2E57, 0x2E57}, eawprN},     // Ps         LEFT SQUARE BRACKET WITH DOUBLE STROKE
-	{runeRange{0x2E58, 0x2E58}, eawprN},     // Pe         RIGHT SQUARE BRACKET WITH DOUBLE STROKE
-	{runeRange{0x2E59, 0x2E59}, eawprN},     // Ps         TOP HALF LEFT PARENTHESIS
-	{runeRange{0x2E5A, 0x2E5A}, eawprN},     // Pe         TOP HALF RIGHT PARENTHESIS
-	{runeRange{0x2E5B, 0x2E5B}, eawprN},     // Ps         BOTTOM HALF LEFT PARENTHESIS
-	{runeRange{0x2E5C, 0x2E5C}, eawprN},     // Pe         BOTTOM HALF RIGHT PARENTHESIS
-	{runeRange{0x2E5D, 0x2E5D}, eawprN},     // Pd         OBLIQUE HYPHEN
-	{runeRange{0x2E80, 0x2E99}, eawprW},     // So    [26] CJK RADICAL REPEAT..CJK RADICAL RAP
-	{runeRange{0x2E9B, 0x2EF3}, eawprW},     // So    [89] CJK RADICAL CHOKE..CJK RADICAL C-SIMPLIFIED TURTLE
-	{runeRange{0x2F00, 0x2FD5}, eawprW},     // So   [214] KANGXI RADICAL ONE..KANGXI RADICAL FLUTE
-	{runeRange{0x2FF0, 0x2FFB}, eawprW},     // So    [12] IDEOGRAPHIC DESCRIPTION CHARACTER LEFT TO RIGHT..IDEOGRAPHIC DESCRIPTION CHARACTER OVERLAID
-	{runeRange{0x3000, 0x3000}, eawprF},     // Zs         IDEOGRAPHIC SPACE
-	{runeRange{0x3001, 0x3003}, eawprW},     // Po     [3] IDEOGRAPHIC COMMA..DITTO MARK
-	{runeRange{0x3004, 0x3004}, eawprW},     // So         JAPANESE INDUSTRIAL STANDARD SYMBOL
-	{runeRange{0x3005, 0x3005}, eawprW},     // Lm         IDEOGRAPHIC ITERATION MARK
-	{runeRange{0x3006, 0x3006}, eawprW},     // Lo         IDEOGRAPHIC CLOSING MARK
-	{runeRange{0x3007, 0x3007}, eawprW},     // Nl         IDEOGRAPHIC NUMBER ZERO
-	{runeRange{0x3008, 0x3008}, eawprW},     // Ps         LEFT ANGLE BRACKET
-	{runeRange{0x3009, 0x3009}, eawprW},     // Pe         RIGHT ANGLE BRACKET
-	{runeRange{0x300A, 0x300A}, eawprW},     // Ps         LEFT DOUBLE ANGLE BRACKET
-	{runeRange{0x300B, 0x300B}, eawprW},     // Pe         RIGHT DOUBLE ANGLE BRACKET
-	{runeRange{0x300C, 0x300C}, eawprW},     // Ps         LEFT CORNER BRACKET
-	{runeRange{0x300D, 0x300D}, eawprW},     // Pe         RIGHT CORNER BRACKET
-	{runeRange{0x300E, 0x300E}, eawprW},     // Ps         LEFT WHITE CORNER BRACKET
-	{runeRange{0x300F, 0x300F}, eawprW},     // Pe         RIGHT WHITE CORNER BRACKET
-	{runeRange{0x3010, 0x3010}, eawprW},     // Ps         LEFT BLACK LENTICULAR BRACKET
-	{runeRange{0x3011, 0x3011}, eawprW},     // Pe         RIGHT BLACK LENTICULAR BRACKET
-	{runeRange{0x3012, 0x3013}, eawprW},     // So     [2] POSTAL MARK..GETA MARK
-	{runeRange{0x3014, 0x3014}, eawprW},     // Ps         LEFT TORTOISE SHELL BRACKET
-	{runeRange{0x3015, 0x3015}, eawprW},     // Pe         RIGHT TORTOISE SHELL BRACKET
-	{runeRange{0x3016, 0x3016}, eawprW},     // Ps         LEFT WHITE LENTICULAR BRACKET
-	{runeRange{0x3017, 0x3017}, eawprW},     // Pe         RIGHT WHITE LENTICULAR BRACKET
-	{runeRange{0x3018, 0x3018}, eawprW},     // Ps         LEFT WHITE TORTOISE SHELL BRACKET
-	{runeRange{0x3019, 0x3019}, eawprW},     // Pe         RIGHT WHITE TORTOISE SHELL BRACKET
-	{runeRange{0x301A, 0x301A}, eawprW},     // Ps         LEFT WHITE SQUARE BRACKET
-	{runeRange{0x301B, 0x301B}, eawprW},     // Pe         RIGHT WHITE SQUARE BRACKET
-	{runeRange{0x301C, 0x301C}, eawprW},     // Pd         WAVE DASH
-	{runeRange{0x301D, 0x301D}, eawprW},     // Ps         REVERSED DOUBLE PRIME QUOTATION MARK
-	{runeRange{0x301E, 0x301F}, eawprW},     // Pe     [2] DOUBLE PRIME QUOTATION MARK..LOW DOUBLE PRIME QUOTATION MARK
-	{runeRange{0x3020, 0x3020}, eawprW},     // So         POSTAL MARK FACE
-	{runeRange{0x3021, 0x3029}, eawprW},     // Nl     [9] HANGZHOU NUMERAL ONE..HANGZHOU NUMERAL NINE
-	{runeRange{0x302A, 0x302D}, eawprW},     // Mn     [4] IDEOGRAPHIC LEVEL TONE MARK..IDEOGRAPHIC ENTERING TONE MARK
-	{runeRange{0x302E, 0x302F}, eawprW},     // Mc     [2] HANGUL SINGLE DOT TONE MARK..HANGUL DOUBLE DOT TONE MARK
-	{runeRange{0x3030, 0x3030}, eawprW},     // Pd         WAVY DASH
-	{runeRange{0x3031, 0x3035}, eawprW},     // Lm     [5] VERTICAL KANA REPEAT MARK..VERTICAL KANA REPEAT MARK LOWER HALF
-	{runeRange{0x3036, 0x3037}, eawprW},     // So     [2] CIRCLED POSTAL MARK..IDEOGRAPHIC TELEGRAPH LINE FEED SEPARATOR SYMBOL
-	{runeRange{0x3038, 0x303A}, eawprW},     // Nl     [3] HANGZHOU NUMERAL TEN..HANGZHOU NUMERAL THIRTY
-	{runeRange{0x303B, 0x303B}, eawprW},     // Lm         VERTICAL IDEOGRAPHIC ITERATION MARK
-	{runeRange{0x303C, 0x303C}, eawprW},     // Lo         MASU MARK
-	{runeRange{0x303D, 0x303D}, eawprW},     // Po         PART ALTERNATION MARK
-	{runeRange{0x303E, 0x303E}, eawprW},     // So         IDEOGRAPHIC VARIATION INDICATOR
-	{runeRange{0x303F, 0x303F}, eawprN},     // So         IDEOGRAPHIC HALF FILL SPACE
-	{runeRange{0x3041, 0x3096}, eawprW},     // Lo    [86] HIRAGANA LETTER SMALL A..HIRAGANA LETTER SMALL KE
-	{runeRange{0x3099, 0x309A}, eawprW},     // Mn     [2] COMBINING KATAKANA-HIRAGANA VOICED SOUND MARK..COMBINING KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK
-	{runeRange{0x309B, 0x309C}, eawprW},     // Sk     [2] KATAKANA-HIRAGANA VOICED SOUND MARK..KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK
-	{runeRange{0x309D, 0x309E}, eawprW},     // Lm     [2] HIRAGANA ITERATION MARK..HIRAGANA VOICED ITERATION MARK
-	{runeRange{0x309F, 0x309F}, eawprW},     // Lo         HIRAGANA DIGRAPH YORI
-	{runeRange{0x30A0, 0x30A0}, eawprW},     // Pd         KATAKANA-HIRAGANA DOUBLE HYPHEN
-	{runeRange{0x30A1, 0x30FA}, eawprW},     // Lo    [90] KATAKANA LETTER SMALL A..KATAKANA LETTER VO
-	{runeRange{0x30FB, 0x30FB}, eawprW},     // Po         KATAKANA MIDDLE DOT
-	{runeRange{0x30FC, 0x30FE}, eawprW},     // Lm     [3] KATAKANA-HIRAGANA PROLONGED SOUND MARK..KATAKANA VOICED ITERATION MARK
-	{runeRange{0x30FF, 0x30FF}, eawprW},     // Lo         KATAKANA DIGRAPH KOTO
-	{runeRange{0x3105, 0x312F}, eawprW},     // Lo    [43] BOPOMOFO LETTER B..BOPOMOFO LETTER NN
-	{runeRange{0x3131, 0x318E}, eawprW},     // Lo    [94] HANGUL LETTER KIYEOK..HANGUL LETTER ARAEAE
-	{runeRange{0x3190, 0x3191}, eawprW},     // So     [2] IDEOGRAPHIC ANNOTATION LINKING MARK..IDEOGRAPHIC ANNOTATION REVERSE MARK
-	{runeRange{0x3192, 0x3195}, eawprW},     // No     [4] IDEOGRAPHIC ANNOTATION ONE MARK..IDEOGRAPHIC ANNOTATION FOUR MARK
-	{runeRange{0x3196, 0x319F}, eawprW},     // So    [10] IDEOGRAPHIC ANNOTATION TOP MARK..IDEOGRAPHIC ANNOTATION MAN MARK
-	{runeRange{0x31A0, 0x31BF}, eawprW},     // Lo    [32] BOPOMOFO LETTER BU..BOPOMOFO LETTER AH
-	{runeRange{0x31C0, 0x31E3}, eawprW},     // So    [36] CJK STROKE T..CJK STROKE Q
-	{runeRange{0x31F0, 0x31FF}, eawprW},     // Lo    [16] KATAKANA LETTER SMALL KU..KATAKANA LETTER SMALL RO
-	{runeRange{0x3200, 0x321E}, eawprW},     // So    [31] PARENTHESIZED HANGUL KIYEOK..PARENTHESIZED KOREAN CHARACTER O HU
-	{runeRange{0x3220, 0x3229}, eawprW},     // No    [10] PARENTHESIZED IDEOGRAPH ONE..PARENTHESIZED IDEOGRAPH TEN
-	{runeRange{0x322A, 0x3247}, eawprW},     // So    [30] PARENTHESIZED IDEOGRAPH MOON..CIRCLED IDEOGRAPH KOTO
-	{runeRange{0x3248, 0x324F}, eawprA},     // No     [8] CIRCLED NUMBER TEN ON BLACK SQUARE..CIRCLED NUMBER EIGHTY ON BLACK SQUARE
-	{runeRange{0x3250, 0x3250}, eawprW},     // So         PARTNERSHIP SIGN
-	{runeRange{0x3251, 0x325F}, eawprW},     // No    [15] CIRCLED NUMBER TWENTY ONE..CIRCLED NUMBER THIRTY FIVE
-	{runeRange{0x3260, 0x327F}, eawprW},     // So    [32] CIRCLED HANGUL KIYEOK..KOREAN STANDARD SYMBOL
-	{runeRange{0x3280, 0x3289}, eawprW},     // No    [10] CIRCLED IDEOGRAPH ONE..CIRCLED IDEOGRAPH TEN
-	{runeRange{0x328A, 0x32B0}, eawprW},     // So    [39] CIRCLED IDEOGRAPH MOON..CIRCLED IDEOGRAPH NIGHT
-	{runeRange{0x32B1, 0x32BF}, eawprW},     // No    [15] CIRCLED NUMBER THIRTY SIX..CIRCLED NUMBER FIFTY
-	{runeRange{0x32C0, 0x32FF}, eawprW},     // So    [64] IDEOGRAPHIC TELEGRAPH SYMBOL FOR JANUARY..SQUARE ERA NAME REIWA
-	{runeRange{0x3300, 0x33FF}, eawprW},     // So   [256] SQUARE APAATO..SQUARE GAL
-	{runeRange{0x3400, 0x4DBF}, eawprW},     // Lo  [6592] CJK UNIFIED IDEOGRAPH-3400..CJK UNIFIED IDEOGRAPH-4DBF
-	{runeRange{0x4DC0, 0x4DFF}, eawprN},     // So    [64] HEXAGRAM FOR THE CREATIVE HEAVEN..HEXAGRAM FOR BEFORE COMPLETION
-	{runeRange{0x4E00, 0x9FFF}, eawprW},     // Lo [20992] CJK UNIFIED IDEOGRAPH-4E00..CJK UNIFIED IDEOGRAPH-9FFF
-	{runeRange{0xA000, 0xA014}, eawprW},     // Lo    [21] YI SYLLABLE IT..YI SYLLABLE E
-	{runeRange{0xA015, 0xA015}, eawprW},     // Lm         YI SYLLABLE WU
-	{runeRange{0xA016, 0xA48C}, eawprW},     // Lo  [1143] YI SYLLABLE BIT..YI SYLLABLE YYR
-	{runeRange{0xA490, 0xA4C6}, eawprW},     // So    [55] YI RADICAL QOT..YI RADICAL KE
-	{runeRange{0xA4D0, 0xA4F7}, eawprN},     // Lo    [40] LISU LETTER BA..LISU LETTER OE
-	{runeRange{0xA4F8, 0xA4FD}, eawprN},     // Lm     [6] LISU LETTER TONE MYA TI..LISU LETTER TONE MYA JEU
-	{runeRange{0xA4FE, 0xA4FF}, eawprN},     // Po     [2] LISU PUNCTUATION COMMA..LISU PUNCTUATION FULL STOP
-	{runeRange{0xA500, 0xA60B}, eawprN},     // Lo   [268] VAI SYLLABLE EE..VAI SYLLABLE NG
-	{runeRange{0xA60C, 0xA60C}, eawprN},     // Lm         VAI SYLLABLE LENGTHENER
-	{runeRange{0xA60D, 0xA60F}, eawprN},     // Po     [3] VAI COMMA..VAI QUESTION MARK
-	{runeRange{0xA610, 0xA61F}, eawprN},     // Lo    [16] VAI SYLLABLE NDOLE FA..VAI SYMBOL JONG
-	{runeRange{0xA620, 0xA629}, eawprN},     // Nd    [10] VAI DIGIT ZERO..VAI DIGIT NINE
-	{runeRange{0xA62A, 0xA62B}, eawprN},     // Lo     [2] VAI SYLLABLE NDOLE MA..VAI SYLLABLE NDOLE DO
-	{runeRange{0xA640, 0xA66D}, eawprN},     // L&    [46] CYRILLIC CAPITAL LETTER ZEMLYA..CYRILLIC SMALL LETTER DOUBLE MONOCULAR O
-	{runeRange{0xA66E, 0xA66E}, eawprN},     // Lo         CYRILLIC LETTER MULTIOCULAR O
-	{runeRange{0xA66F, 0xA66F}, eawprN},     // Mn         COMBINING CYRILLIC VZMET
-	{runeRange{0xA670, 0xA672}, eawprN},     // Me     [3] COMBINING CYRILLIC TEN MILLIONS SIGN..COMBINING CYRILLIC THOUSAND MILLIONS SIGN
-	{runeRange{0xA673, 0xA673}, eawprN},     // Po         SLAVONIC ASTERISK
-	{runeRange{0xA674, 0xA67D}, eawprN},     // Mn    [10] COMBINING CYRILLIC LETTER UKRAINIAN IE..COMBINING CYRILLIC PAYEROK
-	{runeRange{0xA67E, 0xA67E}, eawprN},     // Po         CYRILLIC KAVYKA
-	{runeRange{0xA67F, 0xA67F}, eawprN},     // Lm         CYRILLIC PAYEROK
-	{runeRange{0xA680, 0xA69B}, eawprN},     // L&    [28] CYRILLIC CAPITAL LETTER DWE..CYRILLIC SMALL LETTER CROSSED O
-	{runeRange{0xA69C, 0xA69D}, eawprN},     // Lm     [2] MODIFIER LETTER CYRILLIC HARD SIGN..MODIFIER LETTER CYRILLIC SOFT SIGN
-	{runeRange{0xA69E, 0xA69F}, eawprN},     // Mn     [2] COMBINING CYRILLIC LETTER EF..COMBINING CYRILLIC LETTER IOTIFIED E
-	{runeRange{0xA6A0, 0xA6E5}, eawprN},     // Lo    [70] BAMUM LETTER A..BAMUM LETTER KI
-	{runeRange{0xA6E6, 0xA6EF}, eawprN},     // Nl    [10] BAMUM LETTER MO..BAMUM LETTER KOGHOM
-	{runeRange{0xA6F0, 0xA6F1}, eawprN},     // Mn     [2] BAMUM COMBINING MARK KOQNDON..BAMUM COMBINING MARK TUKWENTIS
-	{runeRange{0xA6F2, 0xA6F7}, eawprN},     // Po     [6] BAMUM NJAEMLI..BAMUM QUESTION MARK
-	{runeRange{0xA700, 0xA716}, eawprN},     // Sk    [23] MODIFIER LETTER CHINESE TONE YIN PING..MODIFIER LETTER EXTRA-LOW LEFT-STEM TONE BAR
-	{runeRange{0xA717, 0xA71F}, eawprN},     // Lm     [9] MODIFIER LETTER DOT VERTICAL BAR..MODIFIER LETTER LOW INVERTED EXCLAMATION MARK
-	{runeRange{0xA720, 0xA721}, eawprN},     // Sk     [2] MODIFIER LETTER STRESS AND HIGH TONE..MODIFIER LETTER STRESS AND LOW TONE
-	{runeRange{0xA722, 0xA76F}, eawprN},     // L&    [78] LATIN CAPITAL LETTER EGYPTOLOGICAL ALEF..LATIN SMALL LETTER CON
-	{runeRange{0xA770, 0xA770}, eawprN},     // Lm         MODIFIER LETTER US
-	{runeRange{0xA771, 0xA787}, eawprN},     // L&    [23] LATIN SMALL LETTER DUM..LATIN SMALL LETTER INSULAR T
-	{runeRange{0xA788, 0xA788}, eawprN},     // Lm         MODIFIER LETTER LOW CIRCUMFLEX ACCENT
-	{runeRange{0xA789, 0xA78A}, eawprN},     // Sk     [2] MODIFIER LETTER COLON..MODIFIER LETTER SHORT EQUALS SIGN
-	{runeRange{0xA78B, 0xA78E}, eawprN},     // L&     [4] LATIN CAPITAL LETTER SALTILLO..LATIN SMALL LETTER L WITH RETROFLEX HOOK AND BELT
-	{runeRange{0xA78F, 0xA78F}, eawprN},     // Lo         LATIN LETTER SINOLOGICAL DOT
-	{runeRange{0xA790, 0xA7CA}, eawprN},     // L&    [59] LATIN CAPITAL LETTER N WITH DESCENDER..LATIN SMALL LETTER S WITH SHORT STROKE OVERLAY
-	{runeRange{0xA7D0, 0xA7D1}, eawprN},     // L&     [2] LATIN CAPITAL LETTER CLOSED INSULAR G..LATIN SMALL LETTER CLOSED INSULAR G
-	{runeRange{0xA7D3, 0xA7D3}, eawprN},     // Ll         LATIN SMALL LETTER DOUBLE THORN
-	{runeRange{0xA7D5, 0xA7D9}, eawprN},     // L&     [5] LATIN SMALL LETTER DOUBLE WYNN..LATIN SMALL LETTER SIGMOID S
-	{runeRange{0xA7F2, 0xA7F4}, eawprN},     // Lm     [3] MODIFIER LETTER CAPITAL C..MODIFIER LETTER CAPITAL Q
-	{runeRange{0xA7F5, 0xA7F6}, eawprN},     // L&     [2] LATIN CAPITAL LETTER REVERSED HALF H..LATIN SMALL LETTER REVERSED HALF H
-	{runeRange{0xA7F7, 0xA7F7}, eawprN},     // Lo         LATIN EPIGRAPHIC LETTER SIDEWAYS I
-	{runeRange{0xA7F8, 0xA7F9}, eawprN},     // Lm     [2] MODIFIER LETTER CAPITAL H WITH STROKE..MODIFIER LETTER SMALL LIGATURE OE
-	{runeRange{0xA7FA, 0xA7FA}, eawprN},     // Ll         LATIN LETTER SMALL CAPITAL TURNED M
-	{runeRange{0xA7FB, 0xA7FF}, eawprN},     // Lo     [5] LATIN EPIGRAPHIC LETTER REVERSED F..LATIN EPIGRAPHIC LETTER ARCHAIC M
-	{runeRange{0xA800, 0xA801}, eawprN},     // Lo     [2] SYLOTI NAGRI LETTER A..SYLOTI NAGRI LETTER I
-	{runeRange{0xA802, 0xA802}, eawprN},     // Mn         SYLOTI NAGRI SIGN DVISVARA
-	{runeRange{0xA803, 0xA805}, eawprN},     // Lo     [3] SYLOTI NAGRI LETTER U..SYLOTI NAGRI LETTER O
-	{runeRange{0xA806, 0xA806}, eawprN},     // Mn         SYLOTI NAGRI SIGN HASANTA
-	{runeRange{0xA807, 0xA80A}, eawprN},     // Lo     [4] SYLOTI NAGRI LETTER KO..SYLOTI NAGRI LETTER GHO
-	{runeRange{0xA80B, 0xA80B}, eawprN},     // Mn         SYLOTI NAGRI SIGN ANUSVARA
-	{runeRange{0xA80C, 0xA822}, eawprN},     // Lo    [23] SYLOTI NAGRI LETTER CO..SYLOTI NAGRI LETTER HO
-	{runeRange{0xA823, 0xA824}, eawprN},     // Mc     [2] SYLOTI NAGRI VOWEL SIGN A..SYLOTI NAGRI VOWEL SIGN I
-	{runeRange{0xA825, 0xA826}, eawprN},     // Mn     [2] SYLOTI NAGRI VOWEL SIGN U..SYLOTI NAGRI VOWEL SIGN E
-	{runeRange{0xA827, 0xA827}, eawprN},     // Mc         SYLOTI NAGRI VOWEL SIGN OO
-	{runeRange{0xA828, 0xA82B}, eawprN},     // So     [4] SYLOTI NAGRI POETRY MARK-1..SYLOTI NAGRI POETRY MARK-4
-	{runeRange{0xA82C, 0xA82C}, eawprN},     // Mn         SYLOTI NAGRI SIGN ALTERNATE HASANTA
-	{runeRange{0xA830, 0xA835}, eawprN},     // No     [6] NORTH INDIC FRACTION ONE QUARTER..NORTH INDIC FRACTION THREE SIXTEENTHS
-	{runeRange{0xA836, 0xA837}, eawprN},     // So     [2] NORTH INDIC QUARTER MARK..NORTH INDIC PLACEHOLDER MARK
-	{runeRange{0xA838, 0xA838}, eawprN},     // Sc         NORTH INDIC RUPEE MARK
-	{runeRange{0xA839, 0xA839}, eawprN},     // So         NORTH INDIC QUANTITY MARK
-	{runeRange{0xA840, 0xA873}, eawprN},     // Lo    [52] PHAGS-PA LETTER KA..PHAGS-PA LETTER CANDRABINDU
-	{runeRange{0xA874, 0xA877}, eawprN},     // Po     [4] PHAGS-PA SINGLE HEAD MARK..PHAGS-PA MARK DOUBLE SHAD
-	{runeRange{0xA880, 0xA881}, eawprN},     // Mc     [2] SAURASHTRA SIGN ANUSVARA..SAURASHTRA SIGN VISARGA
-	{runeRange{0xA882, 0xA8B3}, eawprN},     // Lo    [50] SAURASHTRA LETTER A..SAURASHTRA LETTER LLA
-	{runeRange{0xA8B4, 0xA8C3}, eawprN},     // Mc    [16] SAURASHTRA CONSONANT SIGN HAARU..SAURASHTRA VOWEL SIGN AU
-	{runeRange{0xA8C4, 0xA8C5}, eawprN},     // Mn     [2] SAURASHTRA SIGN VIRAMA..SAURASHTRA SIGN CANDRABINDU
-	{runeRange{0xA8CE, 0xA8CF}, eawprN},     // Po     [2] SAURASHTRA DANDA..SAURASHTRA DOUBLE DANDA
-	{runeRange{0xA8D0, 0xA8D9}, eawprN},     // Nd    [10] SAURASHTRA DIGIT ZERO..SAURASHTRA DIGIT NINE
-	{runeRange{0xA8E0, 0xA8F1}, eawprN},     // Mn    [18] COMBINING DEVANAGARI DIGIT ZERO..COMBINING DEVANAGARI SIGN AVAGRAHA
-	{runeRange{0xA8F2, 0xA8F7}, eawprN},     // Lo     [6] DEVANAGARI SIGN SPACING CANDRABINDU..DEVANAGARI SIGN CANDRABINDU AVAGRAHA
-	{runeRange{0xA8F8, 0xA8FA}, eawprN},     // Po     [3] DEVANAGARI SIGN PUSHPIKA..DEVANAGARI CARET
-	{runeRange{0xA8FB, 0xA8FB}, eawprN},     // Lo         DEVANAGARI HEADSTROKE
-	{runeRange{0xA8FC, 0xA8FC}, eawprN},     // Po         DEVANAGARI SIGN SIDDHAM
-	{runeRange{0xA8FD, 0xA8FE}, eawprN},     // Lo     [2] DEVANAGARI JAIN OM..DEVANAGARI LETTER AY
-	{runeRange{0xA8FF, 0xA8FF}, eawprN},     // Mn         DEVANAGARI VOWEL SIGN AY
-	{runeRange{0xA900, 0xA909}, eawprN},     // Nd    [10] KAYAH LI DIGIT ZERO..KAYAH LI DIGIT NINE
-	{runeRange{0xA90A, 0xA925}, eawprN},     // Lo    [28] KAYAH LI LETTER KA..KAYAH LI LETTER OO
-	{runeRange{0xA926, 0xA92D}, eawprN},     // Mn     [8] KAYAH LI VOWEL UE..KAYAH LI TONE CALYA PLOPHU
-	{runeRange{0xA92E, 0xA92F}, eawprN},     // Po     [2] KAYAH LI SIGN CWI..KAYAH LI SIGN SHYA
-	{runeRange{0xA930, 0xA946}, eawprN},     // Lo    [23] REJANG LETTER KA..REJANG LETTER A
-	{runeRange{0xA947, 0xA951}, eawprN},     // Mn    [11] REJANG VOWEL SIGN I..REJANG CONSONANT SIGN R
-	{runeRange{0xA952, 0xA953}, eawprN},     // Mc     [2] REJANG CONSONANT SIGN H..REJANG VIRAMA
 	{runeRange{0xA95F, 0xA95F}, eawprN},     // Po         REJANG SECTION MARK
-	{runeRange{0xA960, 0xA97C}, eawprW},     // Lo    [29] HANGUL CHOSEONG TIKEUT-MIEUM..HANGUL CHOSEONG SSANGYEORINHIEUH
-	{runeRange{0xA980, 0xA982}, eawprN},     // Mn     [3] JAVANESE SIGN PANYANGGA..JAVANESE SIGN LAYAR
-	{runeRange{0xA983, 0xA983}, eawprN},     // Mc         JAVANESE SIGN WIGNYAN
-	{runeRange{0xA984, 0xA9B2}, eawprN},     // Lo    [47] JAVANESE LETTER A..JAVANESE LETTER HA
-	{runeRange{0xA9B3, 0xA9B3}, eawprN},     // Mn         JAVANESE SIGN CECAK TELU
-	{runeRange{0xA9B4, 0xA9B5}, eawprN},     // Mc     [2] JAVANESE VOWEL SIGN TARUNG..JAVANESE VOWEL SIGN TOLONG
-	{runeRange{0xA9B6, 0xA9B9}, eawprN},     // Mn     [4] JAVANESE VOWEL SIGN WULU..JAVANESE VOWEL SIGN SUKU MENDUT
-	{runeRange{0xA9BA, 0xA9BB}, eawprN},     // Mc     [2] JAVANESE VOWEL SIGN TALING..JAVANESE VOWEL SIGN DIRGA MURE
-	{runeRange{0xA9BC, 0xA9BD}, eawprN},     // Mn     [2] JAVANESE VOWEL SIGN PEPET..JAVANESE CONSONANT SIGN KERET
-	{runeRange{0xA9BE, 0xA9C0}, eawprN},     // Mc     [3] JAVANESE CONSONANT SIGN PENGKAL..JAVANESE PANGKON
-	{runeRange{0xA9C1, 0xA9CD}, eawprN},     // Po    [13] JAVANESE LEFT RERENGGAN..JAVANESE TURNED PADA PISELEH
-	{runeRange{0xA9CF, 0xA9CF}, eawprN},     // Lm         JAVANESE PANGRANGKEP
-	{runeRange{0xA9D0, 0xA9D9}, eawprN},     // Nd    [10] JAVANESE DIGIT ZERO..JAVANESE DIGIT NINE
-	{runeRange{0xA9DE, 0xA9DF}, eawprN},     // Po     [2] JAVANESE PADA TIRTA TUMETES..JAVANESE PADA ISEN-ISEN
-	{runeRange{0xA9E0, 0xA9E4}, eawprN},     // Lo     [5] MYANMAR LETTER SHAN GHA..MYANMAR LETTER SHAN BHA
-	{runeRange{0xA9E5, 0xA9E5}, eawprN},     // Mn         MYANMAR SIGN SHAN SAW
-	{runeRange{0xA9E6, 0xA9E6}, eawprN},     // Lm         MYANMAR MODIFIER LETTER SHAN REDUPLICATION
-	{runeRange{0xA9E7, 0xA9EF}, eawprN},     // Lo     [9] MYANMAR LETTER TAI LAING NYA..MYANMAR LETTER TAI LAING NNA
-	{runeRange{0xA9F0, 0xA9F9}, eawprN},     // Nd    [10] MYANMAR TAI LAING DIGIT ZERO..MYANMAR TAI LAING DIGIT NINE
-	{runeRange{0xA9FA, 0xA9FE}, eawprN},     // Lo     [5] MYANMAR LETTER TAI LAING LLA..MYANMAR LETTER TAI LAING BHA
-	{runeRange{0xAA00, 0xAA28}, eawprN},     // Lo    [41] CHAM LETTER A..CHAM LETTER HA
-	{runeRange{0xAA29, 0xAA2E}, eawprN},     // Mn     [6] CHAM VOWEL SIGN AA..CHAM VOWEL SIGN OE
-	{runeRange{0xAA2F, 0xAA30}, eawprN},     // Mc     [2] CHAM VOWEL SIGN O..CHAM VOWEL SIGN AI
-	{runeRange{0xAA31, 0xAA32}, eawprN},     // Mn     [2] CHAM VOWEL SIGN AU..CHAM VOWEL SIGN UE
-	{runeRange{0xAA33, 0xAA34}, eawprN},     // Mc     [2] CHAM CONSONANT SIGN YA..CHAM CONSONANT SIGN RA
-	{runeRange{0xAA35, 0xAA36}, eawprN},     // Mn     [2] CHAM CONSONANT SIGN LA..CHAM CONSONANT SIGN WA
-	{runeRange{0xAA40, 0xAA42}, eawprN},     // Lo     [3] CHAM LETTER FINAL K..CHAM LETTER FINAL NG
-	{runeRange{0xAA43, 0xAA43}, eawprN},     // Mn         CHAM CONSONANT SIGN FINAL NG
-	{runeRange{0xAA44, 0xAA4B}, eawprN},     // Lo     [8] CHAM LETTER FINAL CH..CHAM LETTER FINAL SS
-	{runeRange{0xAA4C, 0xAA4C}, eawprN},     // Mn         CHAM CONSONANT SIGN FINAL M
-	{runeRange{0xAA4D, 0xAA4D}, eawprN},     // Mc         CHAM CONSONANT SIGN FINAL H
-	{runeRange{0xAA50, 0xAA59}, eawprN},     // Nd    [10] CHAM DIGIT ZERO..CHAM DIGIT NINE
-	{runeRange{0xAA5C, 0xAA5F}, eawprN},     // Po     [4] CHAM PUNCTUATION SPIRAL..CHAM PUNCTUATION TRIPLE DANDA
-	{runeRange{0xAA60, 0xAA6F}, eawprN},     // Lo    [16] MYANMAR LETTER KHAMTI GA..MYANMAR LETTER KHAMTI FA
-	{runeRange{0xAA70, 0xAA70}, eawprN},     // Lm         MYANMAR MODIFIER LETTER KHAMTI REDUPLICATION
-	{runeRange{0xAA71, 0xAA76}, eawprN},     // Lo     [6] MYANMAR LETTER KHAMTI XA..MYANMAR LOGOGRAM KHAMTI HM
-	{runeRange{0xAA77, 0xAA79}, eawprN},     // So     [3] MYANMAR SYMBOL AITON EXCLAMATION..MYANMAR SYMBOL AITON TWO
-	{runeRange{0xAA7A, 0xAA7A}, eawprN},     // Lo         MYANMAR LETTER AITON RA
-	{runeRange{0xAA7B, 0xAA7B}, eawprN},     // Mc         MYANMAR SIGN PAO KAREN TONE
-	{runeRange{0xAA7C, 0xAA7C}, eawprN},     // Mn         MYANMAR SIGN TAI LAING TONE-2
-	{runeRange{0xAA7D, 0xAA7D}, eawprN},     // Mc         MYANMAR SIGN TAI LAING TONE-5
-	{runeRange{0xAA7E, 0xAA7F}, eawprN},     // Lo     [2] MYANMAR LETTER SHWE PALAUNG CHA..MYANMAR LETTER SHWE PALAUNG SHA
-	{runeRange{0xAA80, 0xAAAF}, eawprN},     // Lo    [48] TAI VIET LETTER LOW KO..TAI VIET LETTER HIGH O
-	{runeRange{0xAAB0, 0xAAB0}, eawprN},     // Mn         TAI VIET MAI KANG
-	{runeRange{0xAAB1, 0xAAB1}, eawprN},     // Lo         TAI VIET VOWEL AA
-	{runeRange{0xAAB2, 0xAAB4}, eawprN},     // Mn     [3] TAI VIET VOWEL I..TAI VIET VOWEL U
-	{runeRange{0xAAB5, 0xAAB6}, eawprN},     // Lo     [2] TAI VIET VOWEL E..TAI VIET VOWEL O
-	{runeRange{0xAAB7, 0xAAB8}, eawprN},     // Mn     [2] TAI VIET MAI KHIT..TAI VIET VOWEL IA
-	{runeRange{0xAAB9, 0xAABD}, eawprN},     // Lo     [5] TAI VIET VOWEL UEA..TAI VIET VOWEL AN
-	{runeRange{0xAABE, 0xAABF}, eawprN},     // Mn     [2] TAI VIET VOWEL AM..TAI VIET TONE MAI EK
-	{runeRange{0xAAC0, 0xAAC0}, eawprN},     // Lo         TAI VIET TONE MAI NUENG
-	{runeRange{0xAAC1, 0xAAC1}, eawprN},     // Mn         TAI VIET TONE MAI THO
-	{runeRange{0xAAC2, 0xAAC2}, eawprN},     // Lo         TAI VIET TONE MAI SONG
-	{runeRange{0xAADB, 0xAADC}, eawprN},     // Lo     [2] TAI VIET SYMBOL KON..TAI VIET SYMBOL NUENG
-	{runeRange{0xAADD, 0xAADD}, eawprN},     // Lm         TAI VIET SYMBOL SAM
-	{runeRange{0xAADE, 0xAADF}, eawprN},     // Po     [2] TAI VIET SYMBOL HO HOI..TAI VIET SYMBOL KOI KOI
-	{runeRange{0xAAE0, 0xAAEA}, eawprN},     // Lo    [11] MEETEI MAYEK LETTER E..MEETEI MAYEK LETTER SSA
-	{runeRange{0xAAEB, 0xAAEB}, eawprN},     // Mc         MEETEI MAYEK VOWEL SIGN II
-	{runeRange{0xAAEC, 0xAAED}, eawprN},     // Mn     [2] MEETEI MAYEK VOWEL SIGN UU..MEETEI MAYEK VOWEL SIGN AAI
-	{runeRange{0xAAEE, 0xAAEF}, eawprN},     // Mc     [2] MEETEI MAYEK VOWEL SIGN AU..MEETEI MAYEK VOWEL SIGN AAU
-	{runeRange{0xAAF0, 0xAAF1}, eawprN},     // Po     [2] MEETEI MAYEK CHEIKHAN..MEETEI MAYEK AHANG KHUDAM
-	{runeRange{0xAAF2, 0xAAF2}, eawprN},     // Lo         MEETEI MAYEK ANJI
-	{runeRange{0xAAF3, 0xAAF4}, eawprN},     // Lm     [2] MEETEI MAYEK SYLLABLE REPETITION MARK..MEETEI MAYEK WORD REPETITION MARK
-	{runeRange{0xAAF5, 0xAAF5}, eawprN},     // Mc         MEETEI MAYEK VOWEL SIGN VISARGA
-	{runeRange{0xAAF6, 0xAAF6}, eawprN},     // Mn         MEETEI MAYEK VIRAMA
-	{runeRange{0xAB01, 0xAB06}, eawprN},     // Lo     [6] ETHIOPIC SYLLABLE TTHU..ETHIOPIC SYLLABLE TTHO
-	{runeRange{0xAB09, 0xAB0E}, eawprN},     // Lo     [6] ETHIOPIC SYLLABLE DDHU..ETHIOPIC SYLLABLE DDHO
-	{runeRange{0xAB11, 0xAB16}, eawprN},     // Lo     [6] ETHIOPIC SYLLABLE DZU..ETHIOPIC SYLLABLE DZO
-	{runeRange{0xAB20, 0xAB26}, eawprN},     // Lo     [7] ETHIOPIC SYLLABLE CCHHA..ETHIOPIC SYLLABLE CCHHO
-	{runeRange{0xAB28, 0xAB2E}, eawprN},     // Lo     [7] ETHIOPIC SYLLABLE BBA..ETHIOPIC SYLLABLE BBO
-	{runeRange{0xAB30, 0xAB5A}, eawprN},     // Ll    [43] LATIN SMALL LETTER BARRED ALPHA..LATIN SMALL LETTER Y WITH SHORT RIGHT LEG
-	{runeRange{0xAB5B, 0xAB5B}, eawprN},     // Sk         MODIFIER BREVE WITH INVERTED BREVE
-	{runeRange{0xAB5C, 0xAB5F}, eawprN},     // Lm     [4] MODIFIER LETTER SMALL HENG..MODIFIER LETTER SMALL U WITH LEFT HOOK
-	{runeRange{0xAB60, 0xAB68}, eawprN},     // Ll     [9] LATIN SMALL LETTER SAKHA YAT..LATIN SMALL LETTER TURNED R WITH MIDDLE TILDE
-	{runeRange{0xAB69, 0xAB69}, eawprN},     // Lm         MODIFIER LETTER SMALL TURNED W
-	{runeRange{0xAB6A, 0xAB6B}, eawprN},     // Sk     [2] MODIFIER LETTER LEFT TACK..MODIFIER LETTER RIGHT TACK
-	{runeRange{0xAB70, 0xABBF}, eawprN},     // Ll    [80] CHEROKEE SMALL LETTER A..CHEROKEE SMALL LETTER YA
-	{runeRange{0xABC0, 0xABE2}, eawprN},     // Lo    [35] MEETEI MAYEK LETTER KOK..MEETEI MAYEK LETTER I LONSUM
-	{runeRange{0xABE3, 0xABE4}, eawprN},     // Mc     [2] MEETEI MAYEK VOWEL SIGN ONAP..MEETEI MAYEK VOWEL SIGN INAP
-	{runeRange{0xABE5, 0xABE5}, eawprN},     // Mn         MEETEI MAYEK VOWEL SIGN ANAP
-	{runeRange{0xABE6, 0xABE7}, eawprN},     // Mc     [2] MEETEI MAYEK VOWEL SIGN YENAP..MEETEI MAYEK VOWEL SIGN SOUNAP
-	{runeRange{0xABE8, 0xABE8}, eawprN},     // Mn         MEETEI MAYEK VOWEL SIGN UNAP
-	{runeRange{0xABE9, 0xABEA}, eawprN},     // Mc     [2] MEETEI MAYEK VOWEL SIGN CHEINAP..MEETEI MAYEK VOWEL SIGN NUNG
-	{runeRange{0xABEB, 0xABEB}, eawprN},     // Po         MEETEI MAYEK CHEIKHEI
-	{runeRange{0xABEC, 0xABEC}, eawprN},     // Mc         MEETEI MAYEK LUM IYEK
-	{runeRange{0xABED, 0xABED}, eawprN},     // Mn         MEETEI MAYEK APUN IYEK
-	{runeRange{0xABF0, 0xABF9}, eawprN},     // Nd    [10] MEETEI MAYEK DIGIT ZERO..MEETEI MAYEK DIGIT NINE
-	{runeRange{0xAC00, 0xD7A3}, eawprW},     // Lo [11172] HANGUL SYLLABLE GA..HANGUL SYLLABLE HIH
-	{runeRange{0xD7B0, 0xD7C6}, eawprN},     // Lo    [23] HANGUL JUNGSEONG O-YEO..HANGUL JUNGSEONG ARAEA-E
-	{runeRange{0xD7CB, 0xD7FB}, eawprN},     // Lo    [49] HANGUL JONGSEONG NIEUN-RIEUL..HANGUL JONGSEONG PHIEUPH-THIEUTH
-	{runeRange{0xD800, 0xDB7F}, eawprN},     // Cs   [896] <surrogate-D800>..<surrogate-DB7F>
-	{runeRange{0xDB80, 0xDBFF}, eawprN},     // Cs   [128] <surrogate-DB80>..<surrogate-DBFF>
-	{runeRange{0xDC00, 0xDFFF}, eawprN},     // Cs  [1024] <surrogate-DC00>..<surrogate-DFFF>
-	{runeRange{0xE000, 0xF8FF}, eawprA},     // Co  [6400] <private-use-E000>..<private-use-F8FF>
-	{runeRange{0xF900, 0xFA6D}, eawprW},     // Lo   [366] CJK COMPATIBILITY IDEOGRAPH-F900..CJK COMPATIBILITY IDEOGRAPH-FA6D
-	{runeRange{0xFA6E, 0xFA6F}, eawprW},     // Cn     [2] <reserved-FA6E>..<reserved-FA6F>
-	{runeRange{0xFA70, 0xFAD9}, eawprW},     // Lo   [106] CJK COMPATIBILITY IDEOGRAPH-FA70..CJK COMPATIBILITY IDEOGRAPH-FAD9
-	{runeRange{0xFADA, 0xFAFF}, eawprW},     // Cn    [38] <reserved-FADA>..<reserved-FAFF>
-	{runeRange{0xFB00, 0xFB06}, eawprN},     // Ll     [7] LATIN SMALL LIGATURE FF..LATIN SMALL LIGATURE ST
-	{runeRange{0xFB13, 0xFB17}, eawprN},     // Ll     [5] ARMENIAN SMALL LIGATURE MEN NOW..ARMENIAN SMALL LIGATURE MEN XEH
-	{runeRange{0xFB1D, 0xFB1D}, eawprN},     // Lo         HEBREW LETTER YOD WITH HIRIQ
-	{runeRange{0xFB1E, 0xFB1E}, eawprN},     // Mn         HEBREW POINT JUDEO-SPANISH VARIKA
-	{runeRange{0xFB1F, 0xFB28}, eawprN},     // Lo    [10] HEBREW LIGATURE YIDDISH YOD YOD PATAH..HEBREW LETTER WIDE TAV
-	{runeRange{0xFB29, 0xFB29}, eawprN},     // Sm         HEBREW LETTER ALTERNATIVE PLUS SIGN
-	{runeRange{0xFB2A, 0xFB36}, eawprN},     // Lo    [13] HEBREW LETTER SHIN WITH SHIN DOT..HEBREW LETTER ZAYIN WITH DAGESH
-	{runeRange{0xFB38, 0xFB3C}, eawprN},     // Lo     [5] HEBREW LETTER TET WITH DAGESH..HEBREW LETTER LAMED WITH DAGESH
-	{runeRange{0xFB3E, 0xFB3E}, eawprN},     // Lo         HEBREW LETTER MEM WITH DAGESH
-	{runeRange{0xFB40, 0xFB41}, eawprN},     // Lo     [2] HEBREW LETTER NUN WITH DAGESH..HEBREW LETTER SAMEKH WITH DAGESH
-	{runeRange{0xFB43, 0xFB44}, eawprN},     // Lo     [2] HEBREW LETTER FINAL PE WITH DAGESH..HEBREW LETTER PE WITH DAGESH
-	{runeRange{0xFB46, 0xFB4F}, eawprN},     // Lo    [10] HEBREW LETTER TSADI WITH DAGESH..HEBREW LIGATURE ALEF LAMED
-	{runeRange{0xFB50, 0xFBB1}, eawprN},     // Lo    [98] ARABIC LETTER ALEF WASLA ISOLATED FORM..ARABIC LETTER YEH BARREE WITH HAMZA ABOVE FINAL FORM
-	{runeRange{0xFBB2, 0xFBC2}, eawprN},     // Sk    [17] ARABIC SYMBOL DOT ABOVE..ARABIC SYMBOL WASLA ABOVE
-	{runeRange{0xFBD3, 0xFD3D}, eawprN},     // Lo   [363] ARABIC LETTER NG ISOLATED FORM..ARABIC LIGATURE ALEF WITH FATHATAN ISOLATED FORM
-	{runeRange{0xFD3E, 0xFD3E}, eawprN},     // Pe         ORNATE LEFT PARENTHESIS
-	{runeRange{0xFD3F, 0xFD3F}, eawprN},     // Ps         ORNATE RIGHT PARENTHESIS
-	{runeRange{0xFD40, 0xFD4F}, eawprN},     // So    [16] ARABIC LIGATURE RAHIMAHU ALLAAH..ARABIC LIGATURE RAHIMAHUM ALLAAH
-	{runeRange{0xFD50, 0xFD8F}, eawprN},     // Lo    [64] ARABIC LIGATURE TEH WITH JEEM WITH MEEM INITIAL FORM..ARABIC LIGATURE MEEM WITH KHAH WITH MEEM INITIAL FORM
-	{runeRange{0xFD92, 0xFDC7}, eawprN},     // Lo    [54] ARABIC LIGATURE MEEM WITH JEEM WITH KHAH INITIAL FORM..ARABIC LIGATURE NOON WITH JEEM WITH YEH FINAL FORM
-	{runeRange{0xFDCF, 0xFDCF}, eawprN},     // So         ARABIC LIGATURE SALAAMUHU ALAYNAA
-	{runeRange{0xFDF0, 0xFDFB}, eawprN},     // Lo    [12] ARABIC LIGATURE SALLA USED AS KORANIC STOP SIGN ISOLATED FORM..ARABIC LIGATURE JALLAJALALOUHOU
-	{runeRange{0xFDFC, 0xFDFC}, eawprN},     // Sc         RIAL SIGN
-	{runeRange{0xFDFD, 0xFDFF}, eawprN},     // So     [3] ARABIC LIGATURE BISMILLAH AR-RAHMAN AR-RAHEEM..ARABIC LIGATURE AZZA WA JALL
-	{runeRange{0xFE00, 0xFE0F}, eawprA},     // Mn    [16] VARIATION SELECTOR-1..VARIATION SELECTOR-16
-	{runeRange{0xFE10, 0xFE16}, eawprW},     // Po     [7] PRESENTATION FORM FOR VERTICAL COMMA..PRESENTATION FORM FOR VERTICAL QUESTION MARK
-	{runeRange{0xFE17, 0xFE17}, eawprW},     // Ps         PRESENTATION FORM FOR VERTICAL LEFT WHITE LENTICULAR BRACKET
-	{runeRange{0xFE18, 0xFE18}, eawprW},     // Pe         PRESENTATION FORM FOR VERTICAL RIGHT WHITE LENTICULAR BRAKCET
-	{runeRange{0xFE19, 0xFE19}, eawprW},     // Po         PRESENTATION FORM FOR VERTICAL HORIZONTAL ELLIPSIS
-	{runeRange{0xFE20, 0xFE2F}, eawprN},     // Mn    [16] COMBINING LIGATURE LEFT HALF..COMBINING CYRILLIC TITLO RIGHT HALF
-	{runeRange{0xFE30, 0xFE30}, eawprW},     // Po         PRESENTATION FORM FOR VERTICAL TWO DOT LEADER
-	{runeRange{0xFE31, 0xFE32}, eawprW},     // Pd     [2] PRESENTATION FORM FOR VERTICAL EM DASH..PRESENTATION FORM FOR VERTICAL EN DASH
-	{runeRange{0xFE33, 0xFE34}, eawprW},     // Pc     [2] PRESENTATION FORM FOR VERTICAL LOW LINE..PRESENTATION FORM FOR VERTICAL WAVY LOW LINE
-	{runeRange{0xFE35, 0xFE35}, eawprW},     // Ps         PRESENTATION FORM FOR VERTICAL LEFT PARENTHESIS
-	{runeRange{0xFE36, 0xFE36}, eawprW},     // Pe         PRESENTATION FORM FOR VERTICAL RIGHT PARENTHESIS
-	{runeRange{0xFE37, 0xFE37}, eawprW},     // Ps         PRESENTATION FORM FOR VERTICAL LEFT CURLY BRACKET
-	{runeRange{0xFE38, 0xFE38}, eawprW},     // Pe         PRESENTATION FORM FOR VERTICAL RIGHT CURLY BRACKET
-	{runeRange{0xFE39, 0xFE39}, eawprW},     // Ps         PRESENTATION FORM FOR VERTICAL LEFT TORTOISE SHELL BRACKET
-	{runeRange{0xFE3A, 0xFE3A}, eawprW},     // Pe         PRESENTATION FORM FOR VERTICAL RIGHT TORTOISE SHELL BRACKET
-	{runeRange{0xFE3B, 0xFE3B}, eawprW},     // Ps         PRESENTATION FORM FOR VERTICAL LEFT BLACK LENTICULAR BRACKET
-	{runeRange{0xFE3C, 0xFE3C}, eawprW},     // Pe         PRESENTATION FORM FOR VERTICAL RIGHT BLACK LENTICULAR BRACKET
-	{runeRange{0xFE3D, 0xFE3D}, eawprW},     // Ps         PRESENTATION FORM FOR VERTICAL LEFT DOUBLE ANGLE BRACKET
-	{runeRange{0xFE3E, 0xFE3E}, eawprW},     // Pe         PRESENTATION FORM FOR VERTICAL RIGHT DOUBLE ANGLE BRACKET
-	{runeRange{0xFE3F, 0xFE3F}, eawprW},     // Ps         PRESENTATION FORM FOR VERTICAL LEFT ANGLE BRACKET
-	{runeRange{0xFE40, 0xFE40}, eawprW},     // Pe         PRESENTATION FORM FOR VERTICAL RIGHT ANGLE BRACKET
-	{runeRange{0xFE41, 0xFE41}, eawprW},     // Ps         PRESENTATION FORM FOR VERTICAL LEFT CORNER BRACKET
-	{runeRange{0xFE42, 0xFE42}, eawprW},     // Pe         PRESENTATION FORM FOR VERTICAL RIGHT CORNER BRACKET
-	{runeRange{0xFE43, 0xFE43}, eawprW},     // Ps         PRESENTATION FORM FOR VERTICAL LEFT WHITE CORNER BRACKET
-	{runeRange{0xFE44, 0xFE44}, eawprW},     // Pe         PRESENTATION FORM FOR VERTICAL RIGHT WHITE CORNER BRACKET
-	{runeRange{0xFE45, 0xFE46}, eawprW},     // Po     [2] SESAME DOT..WHITE SESAME DOT
-	{runeRange{0xFE47, 0xFE47}, eawprW},     // Ps         PRESENTATION FORM FOR VERTICAL LEFT SQUARE BRACKET
-	{runeRange{0xFE48, 0xFE48}, eawprW},     // Pe         PRESENTATION FORM FOR VERTICAL RIGHT SQUARE BRACKET
-	{runeRange{0xFE49, 0xFE4C}, eawprW},     // Po     [4] DASHED OVERLINE..DOUBLE WAVY OVERLINE
-	{runeRange{0xFE4D, 0xFE4F}, eawprW},     // Pc     [3] DASHED LOW LINE..WAVY LOW LINE
-	{runeRange{0xFE50, 0xFE52}, eawprW},     // Po     [3] SMALL COMMA..SMALL FULL STOP
-	{runeRange{0xFE54, 0xFE57}, eawprW},     // Po     [4] SMALL SEMICOLON..SMALL EXCLAMATION MARK
-	{runeRange{0xFE58, 0xFE58}, eawprW},     // Pd         SMALL EM DASH
-	{runeRange{0xFE59, 0xFE59}, eawprW},     // Ps         SMALL LEFT PARENTHESIS
-	{runeRange{0xFE5A, 0xFE5A}, eawprW},     // Pe         SMALL RIGHT PARENTHESIS
-	{runeRange{0xFE5B, 0xFE5B}, eawprW},     // Ps         SMALL LEFT CURLY BRACKET
-	{runeRange{0xFE5C, 0xFE5C}, eawprW},     // Pe         SMALL RIGHT CURLY BRACKET
-	{runeRange{0xFE5D, 0xFE5D}, eawprW},     // Ps         SMALL LEFT TORTOISE SHELL BRACKET
-	{runeRange{0xFE5E, 0xFE5E}, eawprW},     // Pe         SMALL RIGHT TORTOISE SHELL BRACKET
-	{runeRange{0xFE5F, 0xFE61}, eawprW},     // Po     [3] SMALL NUMBER SIGN..SMALL ASTERISK
-	{runeRange{0xFE62, 0xFE62}, eawprW},     // Sm         SMALL PLUS SIGN
-	{runeRange{0xFE63, 0xFE63}, eawprW},     // Pd         SMALL HYPHEN-MINUS
-	{runeRange{0xFE64, 0xFE66}, eawprW},     // Sm     [3] SMALL LESS-THAN SIGN..SMALL EQUALS SIGN
-	{runeRange{0xFE68, 0xFE68}, eawprW},     // Po         SMALL REVERSE SOLIDUS
-	{runeRange{0xFE69, 0xFE69}, eawprW},     // Sc         SMALL DOLLAR SIGN
-	{runeRange{0xFE6A, 0xFE6B}, eawprW},     // Po     [2] SMALL PERCENT SIGN..SMALL COMMERCIAL AT
-	{runeRange{0xFE70, 0xFE74}, eawprN},     // Lo     [5] ARABIC FATHATAN ISOLATED FORM..ARABIC KASRATAN ISOLATED FORM
-	{runeRange{0xFE76, 0xFEFC}, eawprN},     // Lo   [135] ARABIC FATHA ISOLATED FORM..ARABIC LIGATURE LAM WITH ALEF FINAL FORM
-	{runeRange{0xFEFF, 0xFEFF}, eawprN},     // Cf         ZERO WIDTH NO-BREAK SPACE
-	{runeRange{0xFF01, 0xFF03}, eawprF},     // Po     [3] FULLWIDTH EXCLAMATION MARK..FULLWIDTH NUMBER SIGN
-	{runeRange{0xFF04, 0xFF04}, eawprF},     // Sc         FULLWIDTH DOLLAR SIGN
-	{runeRange{0xFF05, 0xFF07}, eawprF},     // Po     [3] FULLWIDTH PERCENT SIGN..FULLWIDTH APOSTROPHE
-	{runeRange{0xFF08, 0xFF08}, eawprF},     // Ps         FULLWIDTH LEFT PARENTHESIS
-	{runeRange{0xFF09, 0xFF09}, eawprF},     // Pe         FULLWIDTH RIGHT PARENTHESIS
-	{runeRange{0xFF0A, 0xFF0A}, eawprF},     // Po         FULLWIDTH ASTERISK
-	{runeRange{0xFF0B, 0xFF0B}, eawprF},     // Sm         FULLWIDTH PLUS SIGN
-	{runeRange{0xFF0C, 0xFF0C}, eawprF},     // Po         FULLWIDTH COMMA
-	{runeRange{0xFF0D, 0xFF0D}, eawprF},     // Pd         FULLWIDTH HYPHEN-MINUS
-	{runeRange{0xFF0E, 0xFF0F}, eawprF},     // Po     [2] FULLWIDTH FULL STOP..FULLWIDTH SOLIDUS
-	{runeRange{0xFF10, 0xFF19}, eawprF},     // Nd    [10] FULLWIDTH DIGIT ZERO..FULLWIDTH DIGIT NINE
-	{runeRange{0xFF1A, 0xFF1B}, eawprF},     // Po     [2] FULLWIDTH COLON..FULLWIDTH SEMICOLON
-	{runeRange{0xFF1C, 0xFF1E}, eawprF},     // Sm     [3] FULLWIDTH LESS-THAN SIGN..FULLWIDTH GREATER-THAN SIGN
-	{runeRange{0xFF1F, 0xFF20}, eawprF},     // Po     [2] FULLWIDTH QUESTION MARK..FULLWIDTH COMMERCIAL AT
-	{runeRange{0xFF21, 0xFF3A}, eawprF},     // Lu    [26] FULLWIDTH LATIN CAPITAL LETTER A..FULLWIDTH LATIN CAPITAL LETTER Z
-	{runeRange{0xFF3B, 0xFF3B}, eawprF},     // Ps         FULLWIDTH LEFT SQUARE BRACKET
-	{runeRange{0xFF3C, 0xFF3C}, eawprF},     // Po         FULLWIDTH REVERSE SOLIDUS
-	{runeRange{0xFF3D, 0xFF3D}, eawprF},     // Pe         FULLWIDTH RIGHT SQUARE BRACKET
-	{runeRange{0xFF3E, 0xFF3E}, eawprF},     // Sk         FULLWIDTH CIRCUMFLEX ACCENT
-	{runeRange{0xFF3F, 0xFF3F}, eawprF},     // Pc         FULLWIDTH LOW LINE
-	{runeRange{0xFF40, 0xFF40}, eawprF},     // Sk         FULLWIDTH GRAVE ACCENT
-	{runeRange{0xFF41, 0xFF5A}, eawprF},     // Ll    [26] FULLWIDTH LATIN SMALL LETTER A..FULLWIDTH LATIN SMALL LETTER Z
-	{runeRange{0xFF5B, 0xFF5B}, eawprF},     // Ps         FULLWIDTH LEFT CURLY BRACKET
-	{runeRange{0xFF5C, 0xFF5C}, eawprF},     // Sm         FULLWIDTH VERTICAL LINE
-	{runeRange{0xFF5D, 0xFF5D}, eawprF},     // Pe         FULLWIDTH RIGHT CURLY BRACKET
-	{runeRange{0xFF5E, 0xFF5E}, eawprF},     // Sm         FULLWIDTH TILDE
-	{runeRange{0xFF5F, 0xFF5F}, eawprF},     // Ps         FULLWIDTH LEFT WHITE PARENTHESIS
-	{runeRange{0xFF60, 0xFF60}, eawprF},     // Pe         FULLWIDTH RIGHT WHITE PARENTHESIS
-	{runeRange{0xFF61, 0xFF61}, eawprH},     // Po         HALFWIDTH IDEOGRAPHIC FULL STOP
-	{runeRange{0xFF62, 0xFF62}, eawprH},     // Ps         HALFWIDTH LEFT CORNER BRACKET
-	{runeRange{0xFF63, 0xFF63}, eawprH},     // Pe         HALFWIDTH RIGHT CORNER BRACKET
-	{runeRange{0xFF64, 0xFF65}, eawprH},     // Po     [2] HALFWIDTH IDEOGRAPHIC COMMA..HALFWIDTH KATAKANA MIDDLE DOT
-	{runeRange{0xFF66, 0xFF6F}, eawprH},     // Lo    [10] HALFWIDTH KATAKANA LETTER WO..HALFWIDTH KATAKANA LETTER SMALL TU
-	{runeRange{0xFF70, 0xFF70}, eawprH},     // Lm         HALFWIDTH KATAKANA-HIRAGANA PROLONGED SOUND MARK
-	{runeRange{0xFF71, 0xFF9D}, eawprH},     // Lo    [45] HALFWIDTH KATAKANA LETTER A..HALFWIDTH KATAKANA LETTER N
-	{runeRange{0xFF9E, 0xFF9F}, eawprH},     // Lm     [2] HALFWIDTH KATAKANA VOICED SOUND MARK..HALFWIDTH KATAKANA SEMI-VOICED SOUND MARK
-	{runeRange{0xFFA0, 0xFFBE}, eawprH},     // Lo    [31] HALFWIDTH HANGUL FILLER..HALFWIDTH HANGUL LETTER HIEUH
-	{runeRange{0xFFC2, 0xFFC7}, eawprH},     // Lo     [6] HALFWIDTH HANGUL LETTER A..HALFWIDTH HANGUL LETTER E
-	{runeRange{0xFFCA, 0xFFCF}, eawprH},     // Lo     [6] HALFWIDTH HANGUL LETTER YEO..HALFWIDTH HANGUL LETTER OE
-	{runeRange{0xFFD2, 0xFFD7}, eawprH},     // Lo     [6] HALFWIDTH HANGUL LETTER YO..HALFWIDTH HANGUL LETTER YU
-	{runeRange{0xFFDA, 0xFFDC}, eawprH},     // Lo     [3] HALFWIDTH HANGUL LETTER EU..HALFWIDTH HANGUL LETTER I
-	{runeRange{0xFFE0, 0xFFE1}, eawprF},     // Sc     [2] FULLWIDTH CENT SIGN..FULLWIDTH POUND SIGN
-	{runeRange{0xFFE2, 0xFFE2}, eawprF},     // Sm         FULLWIDTH NOT SIGN
-	{runeRange{0xFFE3, 0xFFE3}, eawprF},     // Sk         FULLWIDTH MACRON
-	{runeRange{0xFFE4, 0xFFE4}, eawprF},     // So         FULLWIDTH BROKEN BAR
-	{runeRange{0xFFE5, 0xFFE6}, eawprF},     // Sc     [2] FULLWIDTH YEN SIGN..FULLWIDTH WON SIGN
-	{runeRange{0xFFE8, 0xFFE8}, eawprH},     // So         HALFWIDTH FORMS LIGHT VERTICAL
-	{runeRange{0xFFE9, 0xFFEC}, eawprH},     // Sm     [4] HALFWIDTH LEFTWARDS ARROW..HALFWIDTH DOWNWARDS ARROW
-	{runeRange{0xFFED, 0xFFEE}, eawprH},     // So     [2] HALFWIDTH BLACK SQUARE..HALFWIDTH WHITE CIRCLE
-	{runeRange{0xFFF9, 0xFFFB}, eawprN},     // Cf     [3] INTERLINEAR ANNOTATION ANCHOR..INTERLINEAR ANNOTATION TERMINATOR
-	{runeRange{0xFFFC, 0xFFFC}, eawprN},     // So         OBJECT REPLACEMENT CHARACTER
-	{runeRange{0xFFFD, 0xFFFD}, eawprA},     // So         REPLACEMENT CHARACTER
-	{runeRange{0x10000, 0x1000B}, eawprN},   // Lo    [12] LINEAR B SYLLABLE B008 A..LINEAR B SYLLABLE B046 JE
-	{runeRange{0x1000D, 0x10026}, eawprN},   // Lo    [26] LINEAR B SYLLABLE B036 JO..LINEAR B SYLLABLE B032 QO
-	{runeRange{0x10028, 0x1003A}, eawprN},   // Lo    [19] LINEAR B SYLLABLE B060 RA..LINEAR B SYLLABLE B042 WO
-	{runeRange{0x1003C, 0x1003D}, eawprN},   // Lo     [2] LINEAR B SYLLABLE B017 ZA..LINEAR B SYLLABLE B074 ZE
-	{runeRange{0x1003F, 0x1004D}, eawprN},   // Lo    [15] LINEAR B SYLLABLE B020 ZO..LINEAR B SYLLABLE B091 TWO
-	{runeRange{0x10050, 0x1005D}, eawprN},   // Lo    [14] LINEAR B SYMBOL B018..LINEAR B SYMBOL B089
-	{runeRange{0x10080, 0x100FA}, eawprN},   // Lo   [123] LINEAR B IDEOGRAM B100 MAN..LINEAR B IDEOGRAM VESSEL B305
-	{runeRange{0x10100, 0x10102}, eawprN},   // Po     [3] AEGEAN WORD SEPARATOR LINE..AEGEAN CHECK MARK
-	{runeRange{0x10107, 0x10133}, eawprN},   // No    [45] AEGEAN NUMBER ONE..AEGEAN NUMBER NINETY THOUSAND
-	{runeRange{0x10137, 0x1013F}, eawprN},   // So     [9] AEGEAN WEIGHT BASE UNIT..AEGEAN MEASURE THIRD SUBUNIT
-	{runeRange{0x10140, 0x10174}, eawprN},   // Nl    [53] GREEK ACROPHONIC ATTIC ONE QUARTER..GREEK ACROPHONIC STRATIAN FIFTY MNAS
-	{runeRange{0x10175, 0x10178}, eawprN},   // No     [4] GREEK ONE HALF SIGN..GREEK THREE QUARTERS SIGN
-	{runeRange{0x10179, 0x10189}, eawprN},   // So    [17] GREEK YEAR SIGN..GREEK TRYBLION BASE SIGN
-	{runeRange{0x1018A, 0x1018B}, eawprN},   // No     [2] GREEK ZERO SIGN..GREEK ONE QUARTER SIGN
-	{runeRange{0x1018C, 0x1018E}, eawprN},   // So     [3] GREEK SINUSOID SIGN..NOMISMA SIGN
-	{runeRange{0x10190, 0x1019C}, eawprN},   // So    [13] ROMAN SEXTANS SIGN..ASCIA SYMBOL
-	{runeRange{0x101A0, 0x101A0}, eawprN},   // So         GREEK SYMBOL TAU RHO
-	{runeRange{0x101D0, 0x101FC}, eawprN},   // So    [45] PHAISTOS DISC SIGN PEDESTRIAN..PHAISTOS DISC SIGN WAVY BAND
-	{runeRange{0x101FD, 0x101FD}, eawprN},   // Mn         PHAISTOS DISC SIGN COMBINING OBLIQUE STROKE
-	{runeRange{0x10280, 0x1029C}, eawprN},   // Lo    [29] LYCIAN LETTER A..LYCIAN LETTER X
-	{runeRange{0x102A0, 0x102D0}, eawprN},   // Lo    [49] CARIAN LETTER A..CARIAN LETTER UUU3
-	{runeRange{0x102E0, 0x102E0}, eawprN},   // Mn         COPTIC EPACT THOUSANDS MARK
-	{runeRange{0x102E1, 0x102FB}, eawprN},   // No    [27] COPTIC EPACT DIGIT ONE..COPTIC EPACT NUMBER NINE HUNDRED
-	{runeRange{0x10300, 0x1031F}, eawprN},   // Lo    [32] OLD ITALIC LETTER A..OLD ITALIC LETTER ESS
-	{runeRange{0x10320, 0x10323}, eawprN},   // No     [4] OLD ITALIC NUMERAL ONE..OLD ITALIC NUMERAL FIFTY
-	{runeRange{0x1032D, 0x1032F}, eawprN},   // Lo     [3] OLD ITALIC LETTER YE..OLD ITALIC LETTER SOUTHERN TSE
-	{runeRange{0x10330, 0x10340}, eawprN},   // Lo    [17] GOTHIC LETTER AHSA..GOTHIC LETTER PAIRTHRA
-	{runeRange{0x10341, 0x10341}, eawprN},   // Nl         GOTHIC LETTER NINETY
-	{runeRange{0x10342, 0x10349}, eawprN},   // Lo     [8] GOTHIC LETTER RAIDA..GOTHIC LETTER OTHAL
-	{runeRange{0x1034A, 0x1034A}, eawprN},   // Nl         GOTHIC LETTER NINE HUNDRED
-	{runeRange{0x10350, 0x10375}, eawprN},   // Lo    [38] OLD PERMIC LETTER AN..OLD PERMIC LETTER IA
-	{runeRange{0x10376, 0x1037A}, eawprN},   // Mn     [5] COMBINING OLD PERMIC LETTER AN..COMBINING OLD PERMIC LETTER SII
-	{runeRange{0x10380, 0x1039D}, eawprN},   // Lo    [30] UGARITIC LETTER ALPA..UGARITIC LETTER SSU
-	{runeRange{0x1039F, 0x1039F}, eawprN},   // Po         UGARITIC WORD DIVIDER
-	{runeRange{0x103A0, 0x103C3}, eawprN},   // Lo    [36] OLD PERSIAN SIGN A..OLD PERSIAN SIGN HA
-	{runeRange{0x103C8, 0x103CF}, eawprN},   // Lo     [8] OLD PERSIAN SIGN AURAMAZDAA..OLD PERSIAN SIGN BUUMISH
-	{runeRange{0x103D0, 0x103D0}, eawprN},   // Po         OLD PERSIAN WORD DIVIDER
-	{runeRange{0x103D1, 0x103D5}, eawprN},   // Nl     [5] OLD PERSIAN NUMBER ONE..OLD PERSIAN NUMBER HUNDRED
-	{runeRange{0x10400, 0x1044F}, eawprN},   // L&    [80] DESERET CAPITAL LETTER LONG I..DESERET SMALL LETTER EW
-	{runeRange{0x10450, 0x1047F}, eawprN},   // Lo    [48] SHAVIAN LETTER PEEP..SHAVIAN LETTER YEW
-	{runeRange{0x10480, 0x1049D}, eawprN},   // Lo    [30] OSMANYA LETTER ALEF..OSMANYA LETTER OO
-	{runeRange{0x104A0, 0x104A9}, eawprN},   // Nd    [10] OSMANYA DIGIT ZERO..OSMANYA DIGIT NINE
-	{runeRange{0x104B0, 0x104D3}, eawprN},   // Lu    [36] OSAGE CAPITAL LETTER A..OSAGE CAPITAL LETTER ZHA
-	{runeRange{0x104D8, 0x104FB}, eawprN},   // Ll    [36] OSAGE SMALL LETTER A..OSAGE SMALL LETTER ZHA
-	{runeRange{0x10500, 0x10527}, eawprN},   // Lo    [40] ELBASAN LETTER A..ELBASAN LETTER KHE
-	{runeRange{0x10530, 0x10563}, eawprN},   // Lo    [52] CAUCASIAN ALBANIAN LETTER ALT..CAUCASIAN ALBANIAN LETTER KIW
-	{runeRange{0x1056F, 0x1056F}, eawprN},   // Po         CAUCASIAN ALBANIAN CITATION MARK
-	{runeRange{0x10570, 0x1057A}, eawprN},   // Lu    [11] VITHKUQI CAPITAL LETTER A..VITHKUQI CAPITAL LETTER GA
-	{runeRange{0x1057C, 0x1058A}, eawprN},   // Lu    [15] VITHKUQI CAPITAL LETTER HA..VITHKUQI CAPITAL LETTER RE
-	{runeRange{0x1058C, 0x10592}, eawprN},   // Lu     [7] VITHKUQI CAPITAL LETTER SE..VITHKUQI CAPITAL LETTER XE
-	{runeRange{0x10594, 0x10595}, eawprN},   // Lu     [2] VITHKUQI CAPITAL LETTER Y..VITHKUQI CAPITAL LETTER ZE
-	{runeRange{0x10597, 0x105A1}, eawprN},   // Ll    [11] VITHKUQI SMALL LETTER A..VITHKUQI SMALL LETTER GA
-	{runeRange{0x105A3, 0x105B1}, eawprN},   // Ll    [15] VITHKUQI SMALL LETTER HA..VITHKUQI SMALL LETTER RE
-	{runeRange{0x105B3, 0x105B9}, eawprN},   // Ll     [7] VITHKUQI SMALL LETTER SE..VITHKUQI SMALL LETTER XE
-	{runeRange{0x105BB, 0x105BC}, eawprN},   // Ll     [2] VITHKUQI SMALL LETTER Y..VITHKUQI SMALL LETTER ZE
-	{runeRange{0x10600, 0x10736}, eawprN},   // Lo   [311] LINEAR A SIGN AB001..LINEAR A SIGN A664
-	{runeRange{0x10740, 0x10755}, eawprN},   // Lo    [22] LINEAR A SIGN A701 A..LINEAR A SIGN A732 JE
-	{runeRange{0x10760, 0x10767}, eawprN},   // Lo     [8] LINEAR A SIGN A800..LINEAR A SIGN A807
-	{runeRange{0x10780, 0x10785}, eawprN},   // Lm     [6] MODIFIER LETTER SMALL CAPITAL AA..MODIFIER LETTER SMALL B WITH HOOK
-	{runeRange{0x10787, 0x107B0}, eawprN},   // Lm    [42] MODIFIER LETTER SMALL DZ DIGRAPH..MODIFIER LETTER SMALL V WITH RIGHT HOOK
-	{runeRange{0x107B2, 0x107BA}, eawprN},   // Lm     [9] MODIFIER LETTER SMALL CAPITAL Y..MODIFIER LETTER SMALL S WITH CURL
-	{runeRange{0x10800, 0x10805}, eawprN},   // Lo     [6] CYPRIOT SYLLABLE A..CYPRIOT SYLLABLE JA
-	{runeRange{0x10808, 0x10808}, eawprN},   // Lo         CYPRIOT SYLLABLE JO
-	{runeRange{0x1080A, 0x10835}, eawprN},   // Lo    [44] CYPRIOT SYLLABLE KA..CYPRIOT SYLLABLE WO
-	{runeRange{0x10837, 0x10838}, eawprN},   // Lo     [2] CYPRIOT SYLLABLE XA..CYPRIOT SYLLABLE XE
-	{runeRange{0x1083C, 0x1083C}, eawprN},   // Lo         CYPRIOT SYLLABLE ZA
-	{runeRange{0x1083F, 0x1083F}, eawprN},   // Lo         CYPRIOT SYLLABLE ZO
-	{runeRange{0x10840, 0x10855}, eawprN},   // Lo    [22] IMPERIAL ARAMAIC LETTER ALEPH..IMPERIAL ARAMAIC LETTER TAW
-	{runeRange{0x10857, 0x10857}, eawprN},   // Po         IMPERIAL ARAMAIC SECTION SIGN
-	{runeRange{0x10858, 0x1085F}, eawprN},   // No     [8] IMPERIAL ARAMAIC NUMBER ONE..IMPERIAL ARAMAIC NUMBER TEN THOUSAND
-	{runeRange{0x10860, 0x10876}, eawprN},   // Lo    [23] PALMYRENE LETTER ALEPH..PALMYRENE LETTER TAW
-	{runeRange{0x10877, 0x10878}, eawprN},   // So     [2] PALMYRENE LEFT-POINTING FLEURON..PALMYRENE RIGHT-POINTING FLEURON
-	{runeRange{0x10879, 0x1087F}, eawprN},   // No     [7] PALMYRENE NUMBER ONE..PALMYRENE NUMBER TWENTY
-	{runeRange{0x10880, 0x1089E}, eawprN},   // Lo    [31] NABATAEAN LETTER FINAL ALEPH..NABATAEAN LETTER TAW
-	{runeRange{0x108A7, 0x108AF}, eawprN},   // No     [9] NABATAEAN NUMBER ONE..NABATAEAN NUMBER ONE HUNDRED
-	{runeRange{0x108E0, 0x108F2}, eawprN},   // Lo    [19] HATRAN LETTER ALEPH..HATRAN LETTER QOPH
-	{runeRange{0x108F4, 0x108F5}, eawprN},   // Lo     [2] HATRAN LETTER SHIN..HATRAN LETTER TAW
-	{runeRange{0x108FB, 0x108FF}, eawprN},   // No     [5] HATRAN NUMBER ONE..HATRAN NUMBER ONE HUNDRED
-	{runeRange{0x10900, 0x10915}, eawprN},   // Lo    [22] PHOENICIAN LETTER ALF..PHOENICIAN LETTER TAU
-	{runeRange{0x10916, 0x1091B}, eawprN},   // No     [6] PHOENICIAN NUMBER ONE..PHOENICIAN NUMBER THREE
-	{runeRange{0x1091F, 0x1091F}, eawprN},   // Po         PHOENICIAN WORD SEPARATOR
-	{runeRange{0x10920, 0x10939}, eawprN},   // Lo    [26] LYDIAN LETTER A..LYDIAN LETTER C
-	{runeRange{0x1093F, 0x1093F}, eawprN},   // Po         LYDIAN TRIANGULAR MARK
-	{runeRange{0x10980, 0x1099F}, eawprN},   // Lo    [32] MEROITIC HIEROGLYPHIC LETTER A..MEROITIC HIEROGLYPHIC SYMBOL VIDJ-2
-	{runeRange{0x109A0, 0x109B7}, eawprN},   // Lo    [24] MEROITIC CURSIVE LETTER A..MEROITIC CURSIVE LETTER DA
-	{runeRange{0x109BC, 0x109BD}, eawprN},   // No     [2] MEROITIC CURSIVE FRACTION ELEVEN TWELFTHS..MEROITIC CURSIVE FRACTION ONE HALF
-	{runeRange{0x109BE, 0x109BF}, eawprN},   // Lo     [2] MEROITIC CURSIVE LOGOGRAM RMT..MEROITIC CURSIVE LOGOGRAM IMN
-	{runeRange{0x109C0, 0x109CF}, eawprN},   // No    [16] MEROITIC CURSIVE NUMBER ONE..MEROITIC CURSIVE NUMBER SEVENTY
-	{runeRange{0x109D2, 0x109FF}, eawprN},   // No    [46] MEROITIC CURSIVE NUMBER ONE HUNDRED..MEROITIC CURSIVE FRACTION TEN TWELFTHS
-	{runeRange{0x10A00, 0x10A00}, eawprN},   // Lo         KHAROSHTHI LETTER A
-	{runeRange{0x10A01, 0x10A03}, eawprN},   // Mn     [3] KHAROSHTHI VOWEL SIGN I..KHAROSHTHI VOWEL SIGN VOCALIC R
-	{runeRange{0x10A05, 0x10A06}, eawprN},   // Mn     [2] KHAROSHTHI VOWEL SIGN E..KHAROSHTHI VOWEL SIGN O
-	{runeRange{0x10A0C, 0x10A0F}, eawprN},   // Mn     [4] KHAROSHTHI VOWEL LENGTH MARK..KHAROSHTHI SIGN VISARGA
-	{runeRange{0x10A10, 0x10A13}, eawprN},   // Lo     [4] KHAROSHTHI LETTER KA..KHAROSHTHI LETTER GHA
-	{runeRange{0x10A15, 0x10A17}, eawprN},   // Lo     [3] KHAROSHTHI LETTER CA..KHAROSHTHI LETTER JA
-	{runeRange{0x10A19, 0x10A35}, eawprN},   // Lo    [29] KHAROSHTHI LETTER NYA..KHAROSHTHI LETTER VHA
-	{runeRange{0x10A38, 0x10A3A}, eawprN},   // Mn     [3] KHAROSHTHI SIGN BAR ABOVE..KHAROSHTHI SIGN DOT BELOW
-	{runeRange{0x10A3F, 0x10A3F}, eawprN},   // Mn         KHAROSHTHI VIRAMA
-	{runeRange{0x10A40, 0x10A48}, eawprN},   // No     [9] KHAROSHTHI DIGIT ONE..KHAROSHTHI FRACTION ONE HALF
-	{runeRange{0x10A50, 0x10A58}, eawprN},   // Po     [9] KHAROSHTHI PUNCTUATION DOT..KHAROSHTHI PUNCTUATION LINES
-	{runeRange{0x10A60, 0x10A7C}, eawprN},   // Lo    [29] OLD SOUTH ARABIAN LETTER HE..OLD SOUTH ARABIAN LETTER THETH
-	{runeRange{0x10A7D, 0x10A7E}, eawprN},   // No     [2] OLD SOUTH ARABIAN NUMBER ONE..OLD SOUTH ARABIAN NUMBER FIFTY
-	{runeRange{0x10A7F, 0x10A7F}, eawprN},   // Po         OLD SOUTH ARABIAN NUMERIC INDICATOR
-	{runeRange{0x10A80, 0x10A9C}, eawprN},   // Lo    [29] OLD NORTH ARABIAN LETTER HEH..OLD NORTH ARABIAN LETTER ZAH
-	{runeRange{0x10A9D, 0x10A9F}, eawprN},   // No     [3] OLD NORTH ARABIAN NUMBER ONE..OLD NORTH ARABIAN NUMBER TWENTY
-	{runeRange{0x10AC0, 0x10AC7}, eawprN},   // Lo     [8] MANICHAEAN LETTER ALEPH..MANICHAEAN LETTER WAW
-	{runeRange{0x10AC8, 0x10AC8}, eawprN},   // So         MANICHAEAN SIGN UD
-	{runeRange{0x10AC9, 0x10AE4}, eawprN},   // Lo    [28] MANICHAEAN LETTER ZAYIN..MANICHAEAN LETTER TAW
-	{runeRange{0x10AE5, 0x10AE6}, eawprN},   // Mn     [2] MANICHAEAN ABBREVIATION MARK ABOVE..MANICHAEAN ABBREVIATION MARK BELOW
-	{runeRange{0x10AEB, 0x10AEF}, eawprN},   // No     [5] MANICHAEAN NUMBER ONE..MANICHAEAN NUMBER ONE HUNDRED
-	{runeRange{0x10AF0, 0x10AF6}, eawprN},   // Po     [7] MANICHAEAN PUNCTUATION STAR..MANICHAEAN PUNCTUATION LINE FILLER
-	{runeRange{0x10B00, 0x10B35}, eawprN},   // Lo    [54] AVESTAN LETTER A..AVESTAN LETTER HE
-	{runeRange{0x10B39, 0x10B3F}, eawprN},   // Po     [7] AVESTAN ABBREVIATION MARK..LARGE ONE RING OVER TWO RINGS PUNCTUATION
-	{runeRange{0x10B40, 0x10B55}, eawprN},   // Lo    [22] INSCRIPTIONAL PARTHIAN LETTER ALEPH..INSCRIPTIONAL PARTHIAN LETTER TAW
-	{runeRange{0x10B58, 0x10B5F}, eawprN},   // No     [8] INSCRIPTIONAL PARTHIAN NUMBER ONE..INSCRIPTIONAL PARTHIAN NUMBER ONE THOUSAND
-	{runeRange{0x10B60, 0x10B72}, eawprN},   // Lo    [19] INSCRIPTIONAL PAHLAVI LETTER ALEPH..INSCRIPTIONAL PAHLAVI LETTER TAW
-	{runeRange{0x10B78, 0x10B7F}, eawprN},   // No     [8] INSCRIPTIONAL PAHLAVI NUMBER ONE..INSCRIPTIONAL PAHLAVI NUMBER ONE THOUSAND
-	{runeRange{0x10B80, 0x10B91}, eawprN},   // Lo    [18] PSALTER PAHLAVI LETTER ALEPH..PSALTER PAHLAVI LETTER TAW
-	{runeRange{0x10B99, 0x10B9C}, eawprN},   // Po     [4] PSALTER PAHLAVI SECTION MARK..PSALTER PAHLAVI FOUR DOTS WITH DOT
-	{runeRange{0x10BA9, 0x10BAF}, eawprN},   // No     [7] PSALTER PAHLAVI NUMBER ONE..PSALTER PAHLAVI NUMBER ONE HUNDRED
-	{runeRange{0x10C00, 0x10C48}, eawprN},   // Lo    [73] OLD TURKIC LETTER ORKHON A..OLD TURKIC LETTER ORKHON BASH
-	{runeRange{0x10C80, 0x10CB2}, eawprN},   // Lu    [51] OLD HUNGARIAN CAPITAL LETTER A..OLD HUNGARIAN CAPITAL LETTER US
-	{runeRange{0x10CC0, 0x10CF2}, eawprN},   // Ll    [51] OLD HUNGARIAN SMALL LETTER A..OLD HUNGARIAN SMALL LETTER US
-	{runeRange{0x10CFA, 0x10CFF}, eawprN},   // No     [6] OLD HUNGARIAN NUMBER ONE..OLD HUNGARIAN NUMBER ONE THOUSAND
-	{runeRange{0x10D00, 0x10D23}, eawprN},   // Lo    [36] HANIFI ROHINGYA LETTER A..HANIFI ROHINGYA MARK NA KHONNA
-	{runeRange{0x10D24, 0x10D27}, eawprN},   // Mn     [4] HANIFI ROHINGYA SIGN HARBAHAY..HANIFI ROHINGYA SIGN TASSI
-	{runeRange{0x10D30, 0x10D39}, eawprN},   // Nd    [10] HANIFI ROHINGYA DIGIT ZERO..HANIFI ROHINGYA DIGIT NINE
-	{runeRange{0x10E60, 0x10E7E}, eawprN},   // No    [31] RUMI DIGIT ONE..RUMI FRACTION TWO THIRDS
-	{runeRange{0x10E80, 0x10EA9}, eawprN},   // Lo    [42] YEZIDI LETTER ELIF..YEZIDI LETTER ET
-	{runeRange{0x10EAB, 0x10EAC}, eawprN},   // Mn     [2] YEZIDI COMBINING HAMZA MARK..YEZIDI COMBINING MADDA MARK
-	{runeRange{0x10EAD, 0x10EAD}, eawprN},   // Pd         YEZIDI HYPHENATION MARK
-	{runeRange{0x10EB0, 0x10EB1}, eawprN},   // Lo     [2] YEZIDI LETTER LAM WITH DOT ABOVE..YEZIDI LETTER YOT WITH CIRCUMFLEX ABOVE
-	{runeRange{0x10EFD, 0x10EFF}, eawprN},   // Mn     [3] ARABIC SMALL LOW WORD SAKTA..ARABIC SMALL LOW WORD MADDA
-	{runeRange{0x10F00, 0x10F1C}, eawprN},   // Lo    [29] OLD SOGDIAN LETTER ALEPH..OLD SOGDIAN LETTER FINAL TAW WITH VERTICAL TAIL
-	{runeRange{0x10F1D, 0x10F26}, eawprN},   // No    [10] OLD SOGDIAN NUMBER ONE..OLD SOGDIAN FRACTION ONE HALF
-	{runeRange{0x10F27, 0x10F27}, eawprN},   // Lo         OLD SOGDIAN LIGATURE AYIN-DALETH
-	{runeRange{0x10F30, 0x10F45}, eawprN},   // Lo    [22] SOGDIAN LETTER ALEPH..SOGDIAN INDEPENDENT SHIN
-	{runeRange{0x10F46, 0x10F50}, eawprN},   // Mn    [11] SOGDIAN COMBINING DOT BELOW..SOGDIAN COMBINING STROKE BELOW
-	{runeRange{0x10F51, 0x10F54}, eawprN},   // No     [4] SOGDIAN NUMBER ONE..SOGDIAN NUMBER ONE HUNDRED
-	{runeRange{0x10F55, 0x10F59}, eawprN},   // Po     [5] SOGDIAN PUNCTUATION TWO VERTICAL BARS..SOGDIAN PUNCTUATION HALF CIRCLE WITH DOT
-	{runeRange{0x10F70, 0x10F81}, eawprN},   // Lo    [18] OLD UYGHUR LETTER ALEPH..OLD UYGHUR LETTER LESH
-	{runeRange{0x10F82, 0x10F85}, eawprN},   // Mn     [4] OLD UYGHUR COMBINING DOT ABOVE..OLD UYGHUR COMBINING TWO DOTS BELOW
-	{runeRange{0x10F86, 0x10F89}, eawprN},   // Po     [4] OLD UYGHUR PUNCTUATION BAR..OLD UYGHUR PUNCTUATION FOUR DOTS
-	{runeRange{0x10FB0, 0x10FC4}, eawprN},   // Lo    [21] CHORASMIAN LETTER ALEPH..CHORASMIAN LETTER TAW
-	{runeRange{0x10FC5, 0x10FCB}, eawprN},   // No     [7] CHORASMIAN NUMBER ONE..CHORASMIAN NUMBER ONE HUNDRED
-	{runeRange{0x10FE0, 0x10FF6}, eawprN},   // Lo    [23] ELYMAIC LETTER ALEPH..ELYMAIC LIGATURE ZAYIN-YODH
-	{runeRange{0x11000, 0x11000}, eawprN},   // Mc         BRAHMI SIGN CANDRABINDU
-	{runeRange{0x11001, 0x11001}, eawprN},   // Mn         BRAHMI SIGN ANUSVARA
-	{runeRange{0x11002, 0x11002}, eawprN},   // Mc         BRAHMI SIGN VISARGA
-	{runeRange{0x11003, 0x11037}, eawprN},   // Lo    [53] BRAHMI SIGN JIHVAMULIYA..BRAHMI LETTER OLD TAMIL NNNA
-	{runeRange{0x11038, 0x11046}, eawprN},   // Mn    [15] BRAHMI VOWEL SIGN AA..BRAHMI VIRAMA
-	{runeRange{0x11047, 0x1104D}, eawprN},   // Po     [7] BRAHMI DANDA..BRAHMI PUNCTUATION LOTUS
-	{runeRange{0x11052, 0x11065}, eawprN},   // No    [20] BRAHMI NUMBER ONE..BRAHMI NUMBER ONE THOUSAND
-	{runeRange{0x11066, 0x1106F}, eawprN},   // Nd    [10] BRAHMI DIGIT ZERO..BRAHMI DIGIT NINE
-	{runeRange{0x11070, 0x11070}, eawprN},   // Mn         BRAHMI SIGN OLD TAMIL VIRAMA
-	{runeRange{0x11071, 0x11072}, eawprN},   // Lo     [2] BRAHMI LETTER OLD TAMIL SHORT E..BRAHMI LETTER OLD TAMIL SHORT O
-	{runeRange{0x11073, 0x11074}, eawprN},   // Mn     [2] BRAHMI VOWEL SIGN OLD TAMIL SHORT E..BRAHMI VOWEL SIGN OLD TAMIL SHORT O
-	{runeRange{0x11075, 0x11075}, eawprN},   // Lo         BRAHMI LETTER OLD TAMIL LLA
-	{runeRange{0x1107F, 0x1107F}, eawprN},   // Mn         BRAHMI NUMBER JOINER
-	{runeRange{0x11080, 0x11081}, eawprN},   // Mn     [2] KAITHI SIGN CANDRABINDU..KAITHI SIGN ANUSVARA
-	{runeRange{0x11082, 0x11082}, eawprN},   // Mc         KAITHI SIGN VISARGA
-	{runeRange{0x11083, 0x110AF}, eawprN},   // Lo    [45] KAITHI LETTER A..KAITHI LETTER HA
-	{runeRange{0x110B0, 0x110B2}, eawprN},   // Mc     [3] KAITHI VOWEL SIGN AA..KAITHI VOWEL SIGN II
-	{runeRange{0x110B3, 0x110B6}, eawprN},   // Mn     [4] KAITHI VOWEL SIGN U..KAITHI VOWEL SIGN AI
-	{runeRange{0x110B7, 0x110B8}, eawprN},   // Mc     [2] KAITHI VOWEL SIGN O..KAITHI VOWEL SIGN AU
-	{runeRange{0x110B9, 0x110BA}, eawprN},   // Mn     [2] KAITHI SIGN VIRAMA..KAITHI SIGN NUKTA
-	{runeRange{0x110BB, 0x110BC}, eawprN},   // Po     [2] KAITHI ABBREVIATION SIGN..KAITHI ENUMERATION SIGN
-	{runeRange{0x110BD, 0x110BD}, eawprN},   // Cf         KAITHI NUMBER SIGN
-	{runeRange{0x110BE, 0x110C1}, eawprN},   // Po     [4] KAITHI SECTION MARK..KAITHI DOUBLE DANDA
-	{runeRange{0x110C2, 0x110C2}, eawprN},   // Mn         KAITHI VOWEL SIGN VOCALIC R
-	{runeRange{0x110CD, 0x110CD}, eawprN},   // Cf         KAITHI NUMBER SIGN ABOVE
-	{runeRange{0x110D0, 0x110E8}, eawprN},   // Lo    [25] SORA SOMPENG LETTER SAH..SORA SOMPENG LETTER MAE
-	{runeRange{0x110F0, 0x110F9}, eawprN},   // Nd    [10] SORA SOMPENG DIGIT ZERO..SORA SOMPENG DIGIT NINE
-	{runeRange{0x11100, 0x11102}, eawprN},   // Mn     [3] CHAKMA SIGN CANDRABINDU..CHAKMA SIGN VISARGA
-	{runeRange{0x11103, 0x11126}, eawprN},   // Lo    [36] CHAKMA LETTER AA..CHAKMA LETTER HAA
-	{runeRange{0x11127, 0x1112B}, eawprN},   // Mn     [5] CHAKMA VOWEL SIGN A..CHAKMA VOWEL SIGN UU
-	{runeRange{0x1112C, 0x1112C}, eawprN},   // Mc         CHAKMA VOWEL SIGN E
-	{runeRange{0x1112D, 0x11134}, eawprN},   // Mn     [8] CHAKMA VOWEL SIGN AI..CHAKMA MAAYYAA
-	{runeRange{0x11136, 0x1113F}, eawprN},   // Nd    [10] CHAKMA DIGIT ZERO..CHAKMA DIGIT NINE
-	{runeRange{0x11140, 0x11143}, eawprN},   // Po     [4] CHAKMA SECTION MARK..CHAKMA QUESTION MARK
-	{runeRange{0x11144, 0x11144}, eawprN},   // Lo         CHAKMA LETTER LHAA
-	{runeRange{0x11145, 0x11146}, eawprN},   // Mc     [2] CHAKMA VOWEL SIGN AA..CHAKMA VOWEL SIGN EI
-	{runeRange{0x11147, 0x11147}, eawprN},   // Lo         CHAKMA LETTER VAA
-	{runeRange{0x11150, 0x11172}, eawprN},   // Lo    [35] MAHAJANI LETTER A..MAHAJANI LETTER RRA
-	{runeRange{0x11173, 0x11173}, eawprN},   // Mn         MAHAJANI SIGN NUKTA
-	{runeRange{0x11174, 0x11175}, eawprN},   // Po     [2] MAHAJANI ABBREVIATION SIGN..MAHAJANI SECTION MARK
-	{runeRange{0x11176, 0x11176}, eawprN},   // Lo         MAHAJANI LIGATURE SHRI
-	{runeRange{0x11180, 0x11181}, eawprN},   // Mn     [2] SHARADA SIGN CANDRABINDU..SHARADA SIGN ANUSVARA
-	{runeRange{0x11182, 0x11182}, eawprN},   // Mc         SHARADA SIGN VISARGA
-	{runeRange{0x11183, 0x111B2}, eawprN},   // Lo    [48] SHARADA LETTER A..SHARADA LETTER HA
-	{runeRange{0x111B3, 0x111B5}, eawprN},   // Mc     [3] SHARADA VOWEL SIGN AA..SHARADA VOWEL SIGN II
-	{runeRange{0x111B6, 0x111BE}, eawprN},   // Mn     [9] SHARADA VOWEL SIGN U..SHARADA VOWEL SIGN O
-	{runeRange{0x111BF, 0x111C0}, eawprN},   // Mc     [2] SHARADA VOWEL SIGN AU..SHARADA SIGN VIRAMA
-	{runeRange{0x111C1, 0x111C4}, eawprN},   // Lo     [4] SHARADA SIGN AVAGRAHA..SHARADA OM
-	{runeRange{0x111C5, 0x111C8}, eawprN},   // Po     [4] SHARADA DANDA..SHARADA SEPARATOR
-	{runeRange{0x111C9, 0x111CC}, eawprN},   // Mn     [4] SHARADA SANDHI MARK..SHARADA EXTRA SHORT VOWEL MARK
-	{runeRange{0x111CD, 0x111CD}, eawprN},   // Po         SHARADA SUTRA MARK
-	{runeRange{0x111CE, 0x111CE}, eawprN},   // Mc         SHARADA VOWEL SIGN PRISHTHAMATRA E
-	{runeRange{0x111CF, 0x111CF}, eawprN},   // Mn         SHARADA SIGN INVERTED CANDRABINDU
-	{runeRange{0x111D0, 0x111D9}, eawprN},   // Nd    [10] SHARADA DIGIT ZERO..SHARADA DIGIT NINE
-	{runeRange{0x111DA, 0x111DA}, eawprN},   // Lo         SHARADA EKAM
-	{runeRange{0x111DB, 0x111DB}, eawprN},   // Po         SHARADA SIGN SIDDHAM
-	{runeRange{0x111DC, 0x111DC}, eawprN},   // Lo         SHARADA HEADSTROKE
-	{runeRange{0x111DD, 0x111DF}, eawprN},   // Po     [3] SHARADA CONTINUATION SIGN..SHARADA SECTION MARK-2
-	{runeRange{0x111E1, 0x111F4}, eawprN},   // No    [20] SINHALA ARCHAIC DIGIT ONE..SINHALA ARCHAIC NUMBER ONE THOUSAND
-	{runeRange{0x11200, 0x11211}, eawprN},   // Lo    [18] KHOJKI LETTER A..KHOJKI LETTER JJA
-	{runeRange{0x11213, 0x1122B}, eawprN},   // Lo    [25] KHOJKI LETTER NYA..KHOJKI LETTER LLA
-	{runeRange{0x1122C, 0x1122E}, eawprN},   // Mc     [3] KHOJKI VOWEL SIGN AA..KHOJKI VOWEL SIGN II
-	{runeRange{0x1122F, 0x11231}, eawprN},   // Mn     [3] KHOJKI VOWEL SIGN U..KHOJKI VOWEL SIGN AI
-	{runeRange{0x11232, 0x11233}, eawprN},   // Mc     [2] KHOJKI VOWEL SIGN O..KHOJKI VOWEL SIGN AU
-	{runeRange{0x11234, 0x11234}, eawprN},   // Mn         KHOJKI SIGN ANUSVARA
-	{runeRange{0x11235, 0x11235}, eawprN},   // Mc         KHOJKI SIGN VIRAMA
-	{runeRange{0x11236, 0x11237}, eawprN},   // Mn     [2] KHOJKI SIGN NUKTA..KHOJKI SIGN SHADDA
-	{runeRange{0x11238, 0x1123D}, eawprN},   // Po     [6] KHOJKI DANDA..KHOJKI ABBREVIATION SIGN
-	{runeRange{0x1123E, 0x1123E}, eawprN},   // Mn         KHOJKI SIGN SUKUN
-	{runeRange{0x1123F, 0x11240}, eawprN},   // Lo     [2] KHOJKI LETTER QA..KHOJKI LETTER SHORT I
-	{runeRange{0x11241, 0x11241}, eawprN},   // Mn         KHOJKI VOWEL SIGN VOCALIC R
-	{runeRange{0x11280, 0x11286}, eawprN},   // Lo     [7] MULTANI LETTER A..MULTANI LETTER GA
-	{runeRange{0x11288, 0x11288}, eawprN},   // Lo         MULTANI LETTER GHA
-	{runeRange{0x1128A, 0x1128D}, eawprN},   // Lo     [4] MULTANI LETTER CA..MULTANI LETTER JJA
-	{runeRange{0x1128F, 0x1129D}, eawprN},   // Lo    [15] MULTANI LETTER NYA..MULTANI LETTER BA
-	{runeRange{0x1129F, 0x112A8}, eawprN},   // Lo    [10] MULTANI LETTER BHA..MULTANI LETTER RHA
-	{runeRange{0x112A9, 0x112A9}, eawprN},   // Po         MULTANI SECTION MARK
-	{runeRange{0x112B0, 0x112DE}, eawprN},   // Lo    [47] KHUDAWADI LETTER A..KHUDAWADI LETTER HA
-	{runeRange{0x112DF, 0x112DF}, eawprN},   // Mn         KHUDAWADI SIGN ANUSVARA
-	{runeRange{0x112E0, 0x112E2}, eawprN},   // Mc     [3] KHUDAWADI VOWEL SIGN AA..KHUDAWADI VOWEL SIGN II
-	{runeRange{0x112E3, 0x112EA}, eawprN},   // Mn     [8] KHUDAWADI VOWEL SIGN U..KHUDAWADI SIGN VIRAMA
-	{runeRange{0x112F0, 0x112F9}, eawprN},   // Nd    [10] KHUDAWADI DIGIT ZERO..KHUDAWADI DIGIT NINE
-	{runeRange{0x11300, 0x11301}, eawprN},   // Mn     [2] GRANTHA SIGN COMBINING ANUSVARA ABOVE..GRANTHA SIGN CANDRABINDU
-	{runeRange{0x11302, 0x11303}, eawprN},   // Mc     [2] GRANTHA SIGN ANUSVARA..GRANTHA SIGN VISARGA
-	{runeRange{0x11305, 0x1130C}, eawprN},   // Lo     [8] GRANTHA LETTER A..GRANTHA LETTER VOCALIC L
-	{runeRange{0x1130F, 0x11310}, eawprN},   // Lo     [2] GRANTHA LETTER EE..GRANTHA LETTER AI
-	{runeRange{0x11313, 0x11328}, eawprN},   // Lo    [22] GRANTHA LETTER OO..GRANTHA LETTER NA
-	{runeRange{0x1132A, 0x11330}, eawprN},   // Lo     [7] GRANTHA LETTER PA..GRANTHA LETTER RA
-	{runeRange{0x11332, 0x11333}, eawprN},   // Lo     [2] GRANTHA LETTER LA..GRANTHA LETTER LLA
-	{runeRange{0x11335, 0x11339}, eawprN},   // Lo     [5] GRANTHA LETTER VA..GRANTHA LETTER HA
-	{runeRange{0x1133B, 0x1133C}, eawprN},   // Mn     [2] COMBINING BINDU BELOW..GRANTHA SIGN NUKTA
-	{runeRange{0x1133D, 0x1133D}, eawprN},   // Lo         GRANTHA SIGN AVAGRAHA
-	{runeRange{0x1133E, 0x1133F}, eawprN},   // Mc     [2] GRANTHA VOWEL SIGN AA..GRANTHA VOWEL SIGN I
-	{runeRange{0x11340, 0x11340}, eawprN},   // Mn         GRANTHA VOWEL SIGN II
-	{runeRange{0x11341, 0x11344}, eawprN},   // Mc     [4] GRANTHA VOWEL SIGN U..GRANTHA VOWEL SIGN VOCALIC RR
-	{runeRange{0x11347, 0x11348}, eawprN},   // Mc     [2] GRANTHA VOWEL SIGN EE..GRANTHA VOWEL SIGN AI
-	{runeRange{0x1134B, 0x1134D}, eawprN},   // Mc     [3] GRANTHA VOWEL SIGN OO..GRANTHA SIGN VIRAMA
-	{runeRange{0x11350, 0x11350}, eawprN},   // Lo         GRANTHA OM
-	{runeRange{0x11357, 0x11357}, eawprN},   // Mc         GRANTHA AU LENGTH MARK
-	{runeRange{0x1135D, 0x11361}, eawprN},   // Lo     [5] GRANTHA SIGN PLUTA..GRANTHA LETTER VOCALIC LL
-	{runeRange{0x11362, 0x11363}, eawprN},   // Mc     [2] GRANTHA VOWEL SIGN VOCALIC L..GRANTHA VOWEL SIGN VOCALIC LL
-	{runeRange{0x11366, 0x1136C}, eawprN},   // Mn     [7] COMBINING GRANTHA DIGIT ZERO..COMBINING GRANTHA DIGIT SIX
-	{runeRange{0x11370, 0x11374}, eawprN},   // Mn     [5] COMBINING GRANTHA LETTER A..COMBINING GRANTHA LETTER PA
-	{runeRange{0x11400, 0x11434}, eawprN},   // Lo    [53] NEWA LETTER A..NEWA LETTER HA
-	{runeRange{0x11435, 0x11437}, eawprN},   // Mc     [3] NEWA VOWEL SIGN AA..NEWA VOWEL SIGN II
-	{runeRange{0x11438, 0x1143F}, eawprN},   // Mn     [8] NEWA VOWEL SIGN U..NEWA VOWEL SIGN AI
-	{runeRange{0x11440, 0x11441}, eawprN},   // Mc     [2] NEWA VOWEL SIGN O..NEWA VOWEL SIGN AU
-	{runeRange{0x11442, 0x11444}, eawprN},   // Mn     [3] NEWA SIGN VIRAMA..NEWA SIGN ANUSVARA
-	{runeRange{0x11445, 0x11445}, eawprN},   // Mc         NEWA SIGN VISARGA
-	{runeRange{0x11446, 0x11446}, eawprN},   // Mn         NEWA SIGN NUKTA
-	{runeRange{0x11447, 0x1144A}, eawprN},   // Lo     [4] NEWA SIGN AVAGRAHA..NEWA SIDDHI
-	{runeRange{0x1144B, 0x1144F}, eawprN},   // Po     [5] NEWA DANDA..NEWA ABBREVIATION SIGN
-	{runeRange{0x11450, 0x11459}, eawprN},   // Nd    [10] NEWA DIGIT ZERO..NEWA DIGIT NINE
-	{runeRange{0x1145A, 0x1145B}, eawprN},   // Po     [2] NEWA DOUBLE COMMA..NEWA PLACEHOLDER MARK
-	{runeRange{0x1145D, 0x1145D}, eawprN},   // Po         NEWA INSERTION SIGN
-	{runeRange{0x1145E, 0x1145E}, eawprN},   // Mn         NEWA SANDHI MARK
-	{runeRange{0x1145F, 0x11461}, eawprN},   // Lo     [3] NEWA LETTER VEDIC ANUSVARA..NEWA SIGN UPADHMANIYA
-	{runeRange{0x11480, 0x114AF}, eawprN},   // Lo    [48] TIRHUTA ANJI..TIRHUTA LETTER HA
-	{runeRange{0x114B0, 0x114B2}, eawprN},   // Mc     [3] TIRHUTA VOWEL SIGN AA..TIRHUTA VOWEL SIGN II
-	{runeRange{0x114B3, 0x114B8}, eawprN},   // Mn     [6] TIRHUTA VOWEL SIGN U..TIRHUTA VOWEL SIGN VOCALIC LL
-	{runeRange{0x114B9, 0x114B9}, eawprN},   // Mc         TIRHUTA VOWEL SIGN E
-	{runeRange{0x114BA, 0x114BA}, eawprN},   // Mn         TIRHUTA VOWEL SIGN SHORT E
-	{runeRange{0x114BB, 0x114BE}, eawprN},   // Mc     [4] TIRHUTA VOWEL SIGN AI..TIRHUTA VOWEL SIGN AU
-	{runeRange{0x114BF, 0x114C0}, eawprN},   // Mn     [2] TIRHUTA SIGN CANDRABINDU..TIRHUTA SIGN ANUSVARA
-	{runeRange{0x114C1, 0x114C1}, eawprN},   // Mc         TIRHUTA SIGN VISARGA
-	{runeRange{0x114C2, 0x114C3}, eawprN},   // Mn     [2] TIRHUTA SIGN VIRAMA..TIRHUTA SIGN NUKTA
-	{runeRange{0x114C4, 0x114C5}, eawprN},   // Lo     [2] TIRHUTA SIGN AVAGRAHA..TIRHUTA GVANG
-	{runeRange{0x114C6, 0x114C6}, eawprN},   // Po         TIRHUTA ABBREVIATION SIGN
-	{runeRange{0x114C7, 0x114C7}, eawprN},   // Lo         TIRHUTA OM
-	{runeRange{0x114D0, 0x114D9}, eawprN},   // Nd    [10] TIRHUTA DIGIT ZERO..TIRHUTA DIGIT NINE
-	{runeRange{0x11580, 0x115AE}, eawprN},   // Lo    [47] SIDDHAM LETTER A..SIDDHAM LETTER HA
-	{runeRange{0x115AF, 0x115B1}, eawprN},   // Mc     [3] SIDDHAM VOWEL SIGN AA..SIDDHAM VOWEL SIGN II
-	{runeRange{0x115B2, 0x115B5}, eawprN},   // Mn     [4] SIDDHAM VOWEL SIGN U..SIDDHAM VOWEL SIGN VOCALIC RR
-	{runeRange{0x115B8, 0x115BB}, eawprN},   // Mc     [4] SIDDHAM VOWEL SIGN E..SIDDHAM VOWEL SIGN AU
-	{runeRange{0x115BC, 0x115BD}, eawprN},   // Mn     [2] SIDDHAM SIGN CANDRABINDU..SIDDHAM SIGN ANUSVARA
-	{runeRange{0x115BE, 0x115BE}, eawprN},   // Mc         SIDDHAM SIGN VISARGA
-	{runeRange{0x115BF, 0x115C0}, eawprN},   // Mn     [2] SIDDHAM SIGN VIRAMA..SIDDHAM SIGN NUKTA
-	{runeRange{0x115C1, 0x115D7}, eawprN},   // Po    [23] SIDDHAM SIGN SIDDHAM..SIDDHAM SECTION MARK WITH CIRCLES AND FOUR ENCLOSURES
-	{runeRange{0x115D8, 0x115DB}, eawprN},   // Lo     [4] SIDDHAM LETTER THREE-CIRCLE ALTERNATE I..SIDDHAM LETTER ALTERNATE U
-	{runeRange{0x115DC, 0x115DD}, eawprN},   // Mn     [2] SIDDHAM VOWEL SIGN ALTERNATE U..SIDDHAM VOWEL SIGN ALTERNATE UU
-	{runeRange{0x11600, 0x1162F}, eawprN},   // Lo    [48] MODI LETTER A..MODI LETTER LLA
-	{runeRange{0x11630, 0x11632}, eawprN},   // Mc     [3] MODI VOWEL SIGN AA..MODI VOWEL SIGN II
+	{runeRange{0x2204, 0x2206}, eawprN},     // Sm     [3] THERE DOES NOT EXIST..INCREMENT
 	{runeRange{0x11633, 0x1163A}, eawprN},   // Mn     [8] MODI VOWEL SIGN U..MODI VOWEL SIGN AI
-	{runeRange{0x1163B, 0x1163C}, eawprN},   // Mc     [2] MODI VOWEL SIGN O..MODI VOWEL SIGN AU
-	{runeRange{0x1163D, 0x1163D}, eawprN},   // Mn         MODI SIGN ANUSVARA
-	{runeRange{0x1163E, 0x1163E}, eawprN},   // Mc         MODI SIGN VISARGA
-	{runeRange{0x1163F, 0x11640}, eawprN},   // Mn     [2] MODI SIGN VIRAMA..MODI SIGN ARDHACANDRA
-	{runeRange{0x11641, 0x11643}, eawprN},   // Po     [3] MODI DANDA..MODI ABBREVIATION SIGN
-	{runeRange{0x11644, 0x11644}, eawprN},   // Lo         MODI SIGN HUVA
-	{runeRange{0x11650, 0x11659}, eawprN},   // Nd    [10] MODI DIGIT ZERO..MODI DIGIT NINE
-	{runeRange{0x11660, 0x1166C}, eawprN},   // Po    [13] MONGOLIAN BIRGA WITH ORNAMENT..MONGOLIAN TURNED SWIRL BIRGA WITH DOUBLE ORNAMENT
-	{runeRange{0x11680, 0x116AA}, eawprN},   // Lo    [43] TAKRI LETTER A..TAKRI LETTER RRA
-	{runeRange{0x116AB, 0x116AB}, eawprN},   // Mn         TAKRI SIGN ANUSVARA
-	{runeRange{0x116AC, 0x116AC}, eawprN},   // Mc         TAKRI SIGN VISARGA
-	{runeRange{0x116AD, 0x116AD}, eawprN},   // Mn         TAKRI VOWEL SIGN AA
-	{runeRange{0x116AE, 0x116AF}, eawprN},   // Mc     [2] TAKRI VOWEL SIGN I..TAKRI VOWEL SIGN II
-	{runeRange{0x116B0, 0x116B5}, eawprN},   // Mn     [6] TAKRI VOWEL SIGN U..TAKRI VOWEL SIGN AU
-	{runeRange{0x116B6, 0x116B6}, eawprN},   // Mc         TAKRI SIGN VIRAMA
-	{runeRange{0x116B7, 0x116B7}, eawprN},   // Mn         TAKRI SIGN NUKTA
-	{runeRange{0x116B8, 0x116B8}, eawprN},   // Lo         TAKRI LETTER ARCHAIC KHA
-	{runeRange{0x116B9, 0x116B9}, eawprN},   // Po         TAKRI ABBREVIATION SIGN
-	{runeRange{0x116C0, 0x116C9}, eawprN},   // Nd    [10] TAKRI DIGIT ZERO..TAKRI DIGIT NINE
-	{runeRange{0x11700, 0x1171A}, eawprN},   // Lo    [27] AHOM LETTER KA..AHOM LETTER ALTERNATE BA
-	{runeRange{0x1171D, 0x1171F}, eawprN},   // Mn     [3] AHOM CONSONANT SIGN MEDIAL LA..AHOM CONSONANT SIGN MEDIAL LIGATING RA
-	{runeRange{0x11720, 0x11721}, eawprN},   // Mc     [2] AHOM VOWEL SIGN A..AHOM VOWEL SIGN AA
-	{runeRange{0x11722, 0x11725}, eawprN},   // Mn     [4] AHOM VOWEL SIGN I..AHOM VOWEL SIGN UU
-	{runeRange{0x11726, 0x11726}, eawprN},   // Mc         AHOM VOWEL SIGN E
-	{runeRange{0x11727, 0x1172B}, eawprN},   // Mn     [5] AHOM VOWEL SIGN AW..AHOM SIGN KILLER
-	{runeRange{0x11730, 0x11739}, eawprN},   // Nd    [10] AHOM DIGIT ZERO..AHOM DIGIT NINE
-	{runeRange{0x1173A, 0x1173B}, eawprN},   // No     [2] AHOM NUMBER TEN..AHOM NUMBER TWENTY
-	{runeRange{0x1173C, 0x1173E}, eawprN},   // Po     [3] AHOM SIGN SMALL SECTION..AHOM SIGN RULAI
-	{runeRange{0x1173F, 0x1173F}, eawprN},   // So         AHOM SYMBOL VI
-	{runeRange{0x11740, 0x11746}, eawprN},   // Lo     [7] AHOM LETTER CA..AHOM LETTER LLA
-	{runeRange{0x11800, 0x1182B}, eawprN},   // Lo    [44] DOGRA LETTER A..DOGRA LETTER RRA
-	{runeRange{0x1182C, 0x1182E}, eawprN},   // Mc     [3] DOGRA VOWEL SIGN AA..DOGRA VOWEL SIGN II
-	{runeRange{0x1182F, 0x11837}, eawprN},   // Mn     [9] DOGRA VOWEL SIGN U..DOGRA SIGN ANUSVARA
-	{runeRange{0x11838, 0x11838}, eawprN},   // Mc         DOGRA SIGN VISARGA
-	{runeRange{0x11839, 0x1183A}, eawprN},   // Mn     [2] DOGRA SIGN VIRAMA..DOGRA SIGN NUKTA
-	{runeRange{0x1183B, 0x1183B}, eawprN},   // Po         DOGRA ABBREVIATION SIGN
-	{runeRange{0x118A0, 0x118DF}, eawprN},   // L&    [64] WARANG CITI CAPITAL LETTER NGAA..WARANG CITI SMALL LETTER VIYO
-	{runeRange{0x118E0, 0x118E9}, eawprN},   // Nd    [10] WARANG CITI DIGIT ZERO..WARANG CITI DIGIT NINE
-	{runeRange{0x118EA, 0x118F2}, eawprN},   // No     [9] WARANG CITI NUMBER TEN..WARANG CITI NUMBER NINETY
-	{runeRange{0x118FF, 0x118FF}, eawprN},   // Lo         WARANG CITI OM
-	{runeRange{0x11900, 0x11906}, eawprN},   // Lo     [7] DIVES AKURU LETTER A..DIVES AKURU LETTER E
-	{runeRange{0x11909, 0x11909}, eawprN},   // Lo         DIVES AKURU LETTER O
-	{runeRange{0x1190C, 0x11913}, eawprN},   // Lo     [8] DIVES AKURU LETTER KA..DIVES AKURU LETTER JA
-	{runeRange{0x11915, 0x11916}, eawprN},   // Lo     [2] DIVES AKURU LETTER NYA..DIVES AKURU LETTER TTA
-	{runeRange{0x11918, 0x1192F}, eawprN},   // Lo    [24] DIVES AKURU LETTER DDA..DIVES AKURU LETTER ZA
-	{runeRange{0x11930, 0x11935}, eawprN},   // Mc     [6] DIVES AKURU VOWEL SIGN AA..DIVES AKURU VOWEL SIGN E
-	{runeRange{0x11937, 0x11938}, eawprN},   // Mc     [2] DIVES AKURU VOWEL SIGN AI..DIVES AKURU VOWEL SIGN O
-	{runeRange{0x1193B, 0x1193C}, eawprN},   // Mn     [2] DIVES AKURU SIGN ANUSVARA..DIVES AKURU SIGN CANDRABINDU
-	{runeRange{0x1193D, 0x1193D}, eawprN},   // Mc         DIVES AKURU SIGN HALANTA
-	{runeRange{0x1193E, 0x1193E}, eawprN},   // Mn         DIVES AKURU VIRAMA
-	{runeRange{0x1193F, 0x1193F}, eawprN},   // Lo         DIVES AKURU PREFIXED NASAL SIGN
-	{runeRange{0x11940, 0x11940}, eawprN},   // Mc         DIVES AKURU MEDIAL YA
-	{runeRange{0x11941, 0x11941}, eawprN},   // Lo         DIVES AKURU INITIAL RA
-	{runeRange{0x11942, 0x11942}, eawprN},   // Mc         DIVES AKURU MEDIAL RA
-	{runeRange{0x11943, 0x11943}, eawprN},   // Mn         DIVES AKURU SIGN NUKTA
-	{runeRange{0x11944, 0x11946}, eawprN},   // Po     [3] DIVES AKURU DOUBLE DANDA..DIVES AKURU END OF TEXT MARK
-	{runeRange{0x11950, 0x11959}, eawprN},   // Nd    [10] DIVES AKURU DIGIT ZERO..DIVES AKURU DIGIT NINE
-	{runeRange{0x119A0, 0x119A7}, eawprN},   // Lo     [8] NANDINAGARI LETTER A..NANDINAGARI LETTER VOCALIC RR
-	{runeRange{0x119AA, 0x119D0}, eawprN},   // Lo    [39] NANDINAGARI LETTER E..NANDINAGARI LETTER RRA
-	{runeRange{0x119D1, 0x119D3}, eawprN},   // Mc     [3] NANDINAGARI VOWEL SIGN AA..NANDINAGARI VOWEL SIGN II
-	{runeRange{0x119D4, 0x119D7}, eawprN},   // Mn     [4] NANDINAGARI VOWEL SIGN U..NANDINAGARI VOWEL SIGN VOCALIC RR
-	{runeRange{0x119DA, 0x119DB}, eawprN},   // Mn     [2] NANDINAGARI VOWEL SIGN E..NANDINAGARI VOWEL SIGN AI
-	{runeRange{0x119DC, 0x119DF}, eawprN},   // Mc     [4] NANDINAGARI VOWEL SIGN O..NANDINAGARI SIGN VISARGA
-	{runeRange{0x119E0, 0x119E0}, eawprN},   // Mn         NANDINAGARI SIGN VIRAMA
-	{runeRange{0x119E1, 0x119E1}, eawprN},   // Lo         NANDINAGARI SIGN AVAGRAHA
-	{runeRange{0x119E2, 0x119E2}, eawprN},   // Po         NANDINAGARI SIGN SIDDHAM
-	{runeRange{0x119E3, 0x119E3}, eawprN},   // Lo         NANDINAGARI HEADSTROKE
-	{runeRange{0x119E4, 0x119E4}, eawprN},   // Mc         NANDINAGARI VOWEL SIGN PRISHTHAMATRA E
-	{runeRange{0x11A00, 0x11A00}, eawprN},   // Lo         ZANABAZAR SQUARE LETTER A
-	{runeRange{0x11A01, 0x11A0A}, eawprN},   // Mn    [10] ZANABAZAR SQUARE VOWEL SIGN I..ZANABAZAR SQUARE VOWEL LENGTH MARK
-	{runeRange{0x11A0B, 0x11A32}, eawprN},   // Lo    [40] ZANABAZAR SQUARE LETTER KA..ZANABAZAR SQUARE LETTER KSSA
-	{runeRange{0x11A33, 0x11A38}, eawprN},   // Mn     [6] ZANABAZAR SQUARE FINAL CONSONANT MARK..ZANABAZAR SQUARE SIGN ANUSVARA
-	{runeRange{0x11A39, 0x11A39}, eawprN},   // Mc         ZANABAZAR SQUARE SIGN VISARGA
-	{runeRange{0x11A3A, 0x11A3A}, eawprN},   // Lo         ZANABAZAR SQUARE CLUSTER-INITIAL LETTER RA
-	{runeRange{0x11A3B, 0x11A3E}, eawprN},   // Mn     [4] ZANABAZAR SQUARE CLUSTER-FINAL LETTER YA..ZANABAZAR SQUARE CLUSTER-FINAL LETTER VA
-	{runeRange{0x11A3F, 0x11A46}, eawprN},   // Po     [8] ZANABAZAR SQUARE INITIAL HEAD MARK..ZANABAZAR SQUARE CLOSING DOUBLE-LINED HEAD MARK
-	{runeRange{0x11A47, 0x11A47}, eawprN},   // Mn         ZANABAZAR SQUARE SUBJOINER
-	{runeRange{0x11A50, 0x11A50}, eawprN},   // Lo         SOYOMBO LETTER A
-	{runeRange{0x11A51, 0x11A56}, eawprN},   // Mn     [6] SOYOMBO VOWEL SIGN I..SOYOMBO VOWEL SIGN OE
-	{runeRange{0x11A57, 0x11A58}, eawprN},   // Mc     [2] SOYOMBO VOWEL SIGN AI..SOYOMBO VOWEL SIGN AU
-	{runeRange{0x11A59, 0x11A5B}, eawprN},   // Mn     [3] SOYOMBO VOWEL SIGN VOCALIC R..SOYOMBO VOWEL LENGTH MARK
-	{runeRange{0x11A5C, 0x11A89}, eawprN},   // Lo    [46] SOYOMBO LETTER KA..SOYOMBO CLUSTER-INITIAL LETTER SA
-	{runeRange{0x11A8A, 0x11A96}, eawprN},   // Mn    [13] SOYOMBO FINAL CONSONANT SIGN G..SOYOMBO SIGN ANUSVARA
-	{runeRange{0x11A97, 0x11A97}, eawprN},   // Mc         SOYOMBO SIGN VISARGA
-	{runeRange{0x11A98, 0x11A99}, eawprN},   // Mn     [2] SOYOMBO GEMINATION MARK..SOYOMBO SUBJOINER
-	{runeRange{0x11A9A, 0x11A9C}, eawprN},   // Po     [3] SOYOMBO MARK TSHEG..SOYOMBO MARK DOUBLE SHAD
-	{runeRange{0x11A9D, 0x11A9D}, eawprN},   // Lo         SOYOMBO MARK PLUTA
-	{runeRange{0x11A9E, 0x11AA2}, eawprN},   // Po     [5] SOYOMBO HEAD MARK WITH MOON AND SUN AND TRIPLE FLAME..SOYOMBO TERMINAL MARK-2
-	{runeRange{0x11AB0, 0x11ABF}, eawprN},   // Lo    [16] CANADIAN SYLLABICS NATTILIK HI..CANADIAN SYLLABICS SPA
-	{runeRange{0x11AC0, 0x11AF8}, eawprN},   // Lo    [57] PAU CIN HAU LETTER PA..PAU CIN HAU GLOTTAL STOP FINAL
-	{runeRange{0x11B00, 0x11B09}, eawprN},   // Po    [10] DEVANAGARI HEAD MARK..DEVANAGARI SIGN MINDU
-	{runeRange{0x11C00, 0x11C08}, eawprN},   // Lo     [9] BHAIKSUKI LETTER A..BHAIKSUKI LETTER VOCALIC L
-	{runeRange{0x11C0A, 0x11C2E}, eawprN},   // Lo    [37] BHAIKSUKI LETTER E..BHAIKSUKI LETTER HA
-	{runeRange{0x11C2F, 0x11C2F}, eawprN},   // Mc         BHAIKSUKI VOWEL SIGN AA
-	{runeRange{0x11C30, 0x11C36}, eawprN},   // Mn     [7] BHAIKSUKI VOWEL SIGN I..BHAIKSUKI VOWEL SIGN VOCALIC L
-	{runeRange{0x11C38, 0x11C3D}, eawprN},   // Mn     [6] BHAIKSUKI VOWEL SIGN E..BHAIKSUKI SIGN ANUSVARA
-	{runeRange{0x11C3E, 0x11C3E}, eawprN},   // Mc         BHAIKSUKI SIGN VISARGA
-	{runeRange{0x11C3F, 0x11C3F}, eawprN},   // Mn         BHAIKSUKI SIGN VIRAMA
-	{runeRange{0x11C40, 0x11C40}, eawprN},   // Lo         BHAIKSUKI SIGN AVAGRAHA
-	{runeRange{0x11C41, 0x11C45}, eawprN},   // Po     [5] BHAIKSUKI DANDA..BHAIKSUKI GAP FILLER-2
-	{runeRange{0x11C50, 0x11C59}, eawprN},   // Nd    [10] BHAIKSUKI DIGIT ZERO..BHAIKSUKI DIGIT NINE
-	{runeRange{0x11C5A, 0x11C6C}, eawprN},   // No    [19] BHAIKSUKI NUMBER ONE..BHAIKSUKI HUNDREDS UNIT MARK
-	{runeRange{0x11C70, 0x11C71}, eawprN},   // Po     [2] MARCHEN HEAD MARK..MARCHEN MARK SHAD
-	{runeRange{0x11C72, 0x11C8F}, eawprN},   // Lo    [30] MARCHEN LETTER KA..MARCHEN LETTER A
-	{runeRange{0x11C92, 0x11CA7}, eawprN},   // Mn    [22] MARCHEN SUBJOINED LETTER KA..MARCHEN SUBJOINED LETTER ZA
-	{runeRange{0x11CA9, 0x11CA9}, eawprN},   // Mc         MARCHEN SUBJOINED LETTER YA
-	{runeRange{0x11CAA, 0x11CB0}, eawprN},   // Mn     [7] MARCHEN SUBJOINED LETTER RA..MARCHEN VOWEL SIGN AA
-	{runeRange{0x11CB1, 0x11CB1}, eawprN},   // Mc         MARCHEN VOWEL SIGN I
-	{runeRange{0x11CB2, 0x11CB3}, eawprN},   // Mn     [2] MARCHEN VOWEL SIGN U..MARCHEN VOWEL SIGN E
-	{runeRange{0x11CB4, 0x11CB4}, eawprN},   // Mc         MARCHEN VOWEL SIGN O
-	{runeRange{0x11CB5, 0x11CB6}, eawprN},   // Mn     [2] MARCHEN SIGN ANUSVARA..MARCHEN SIGN CANDRABINDU
-	{runeRange{0x11D00, 0x11D06}, eawprN},   // Lo     [7] MASARAM GONDI LETTER A..MASARAM GONDI LETTER E
-	{runeRange{0x11D08, 0x11D09}, eawprN},   // Lo     [2] MASARAM GONDI LETTER AI..MASARAM GONDI LETTER O
-	{runeRange{0x11D0B, 0x11D30}, eawprN},   // Lo    [38] MASARAM GONDI LETTER AU..MASARAM GONDI LETTER TRA
-	{runeRange{0x11D31, 0x11D36}, eawprN},   // Mn     [6] MASARAM GONDI VOWEL SIGN AA..MASARAM GONDI VOWEL SIGN VOCALIC R
-	{runeRange{0x11D3A, 0x11D3A}, eawprN},   // Mn         MASARAM GONDI VOWEL SIGN E
-	{runeRange{0x11D3C, 0x11D3D}, eawprN},   // Mn     [2] MASARAM GONDI VOWEL SIGN AI..MASARAM GONDI VOWEL SIGN O
-	{runeRange{0x11D3F, 0x11D45}, eawprN},   // Mn     [7] MASARAM GONDI VOWEL SIGN AU..MASARAM GONDI VIRAMA
-	{runeRange{0x11D46, 0x11D46}, eawprN},   // Lo         MASARAM GONDI REPHA
-	{runeRange{0x11D47, 0x11D47}, eawprN},   // Mn         MASARAM GONDI RA-KARA
-	{runeRange{0x11D50, 0x11D59}, eawprN},   // Nd    [10] MASARAM GONDI DIGIT ZERO..MASARAM GONDI DIGIT NINE
-	{runeRange{0x11D60, 0x11D65}, eawprN},   // Lo     [6] GUNJALA GONDI LETTER A..GUNJALA GONDI LETTER UU
-	{runeRange{0x11D67, 0x11D68}, eawprN},   // Lo     [2] GUNJALA GONDI LETTER EE..GUNJALA GONDI LETTER AI
-	{runeRange{0x11D6A, 0x11D89}, eawprN},   // Lo    [32] GUNJALA GONDI LETTER OO..GUNJALA GONDI LETTER SA
-	{runeRange{0x11D8A, 0x11D8E}, eawprN},   // Mc     [5] GUNJALA GONDI VOWEL SIGN AA..GUNJALA GONDI VOWEL SIGN UU
-	{runeRange{0x11D90, 0x11D91}, eawprN},   // Mn     [2] GUNJALA GONDI VOWEL SIGN EE..GUNJALA GONDI VOWEL SIGN AI
-	{runeRange{0x11D93, 0x11D94}, eawprN},   // Mc     [2] GUNJALA GONDI VOWEL SIGN OO..GUNJALA GONDI VOWEL SIGN AU
-	{runeRange{0x11D95, 0x11D95}, eawprN},   // Mn         GUNJALA GONDI SIGN ANUSVARA
-	{runeRange{0x11D96, 0x11D96}, eawprN},   // Mc         GUNJALA GONDI SIGN VISARGA
-	{runeRange{0x11D97, 0x11D97}, eawprN},   // Mn         GUNJALA GONDI VIRAMA
-	{runeRange{0x11D98, 0x11D98}, eawprN},   // Lo         GUNJALA GONDI OM
-	{runeRange{0x11DA0, 0x11DA9}, eawprN},   // Nd    [10] GUNJALA GONDI DIGIT ZERO..GUNJALA GONDI DIGIT NINE
-	{runeRange{0x11EE0, 0x11EF2}, eawprN},   // Lo    [19] MAKASAR LETTER KA..MAKASAR ANGKA
-	{runeRange{0x11EF3, 0x11EF4}, eawprN},   // Mn     [2] MAKASAR VOWEL SIGN I..MAKASAR VOWEL SIGN U
-	{runeRange{0x11EF5, 0x11EF6}, eawprN},   // Mc     [2] MAKASAR VOWEL SIGN E..MAKASAR VOWEL SIGN O
-	{runeRange{0x11EF7, 0x11EF8}, eawprN},   // Po     [2] MAKASAR PASSIMBANG..MAKASAR END OF SECTION
-	{runeRange{0x11F00, 0x11F01}, eawprN},   // Mn     [2] KAWI SIGN CANDRABINDU..KAWI SIGN ANUSVARA
-	{runeRange{0x11F02, 0x11F02}, eawprN},   // Lo         KAWI SIGN REPHA
-	{runeRange{0x11F03, 0x11F03}, eawprN},   // Mc         KAWI SIGN VISARGA
-	{runeRange{0x11F04, 0x11F10}, eawprN},   // Lo    [13] KAWI LETTER A..KAWI LETTER O
-	{runeRange{0x11F12, 0x11F33}, eawprN},   // Lo    [34] KAWI LETTER KA..KAWI LETTER JNYA
-	{runeRange{0x11F34, 0x11F35}, eawprN},   // Mc     [2] KAWI VOWEL SIGN AA..KAWI VOWEL SIGN ALTERNATE AA
-	{runeRange{0x11F36, 0x11F3A}, eawprN},   // Mn     [5] KAWI VOWEL SIGN I..KAWI VOWEL SIGN VOCALIC R
-	{runeRange{0x11F3E, 0x11F3F}, eawprN},   // Mc     [2] KAWI VOWEL SIGN E..KAWI VOWEL SIGN AI
-	{runeRange{0x11F40, 0x11F40}, eawprN},   // Mn         KAWI VOWEL SIGN EU
-	{runeRange{0x11F41, 0x11F41}, eawprN},   // Mc         KAWI SIGN KILLER
-	{runeRange{0x11F42, 0x11F42}, eawprN},   // Mn         KAWI CONJOINER
-	{runeRange{0x11F43, 0x11F4F}, eawprN},   // Po    [13] KAWI DANDA..KAWI PUNCTUATION CLOSING SPIRAL
-	{runeRange{0x11F50, 0x11F59}, eawprN},   // Nd    [10] KAWI DIGIT ZERO..KAWI DIGIT NINE
-	{runeRange{0x11FB0, 0x11FB0}, eawprN},   // Lo         LISU LETTER YHA
-	{runeRange{0x11FC0, 0x11FD4}, eawprN},   // No    [21] TAMIL FRACTION ONE THREE-HUNDRED-AND-TWENTIETH..TAMIL FRACTION DOWNSCALING FACTOR KIIZH
-	{runeRange{0x11FD5, 0x11FDC}, eawprN},   // So     [8] TAMIL SIGN NEL..TAMIL SIGN MUKKURUNI
-	{runeRange{0x11FDD, 0x11FE0}, eawprN},   // Sc     [4] TAMIL SIGN KAACU..TAMIL SIGN VARAAKAN
-	{runeRange{0x11FE1, 0x11FF1}, eawprN},   // So    [17] TAMIL SIGN PAARAM..TAMIL SIGN VAKAIYARAA
-	{runeRange{0x11FFF, 0x11FFF}, eawprN},   // Po         TAMIL PUNCTUATION END OF TEXT
-	{runeRange{0x12000, 0x12399}, eawprN},   // Lo   [922] CUNEIFORM SIGN A..CUNEIFORM SIGN U U
-	{runeRange{0x12400, 0x1246E}, eawprN},   // Nl   [111] CUNEIFORM NUMERIC SIGN TWO ASH..CUNEIFORM NUMERIC SIGN NINE U VARIANT FORM
-	{runeRange{0x12470, 0x12474}, eawprN},   // Po     [5] CUNEIFORM PUNCTUATION SIGN OLD ASSYRIAN WORD DIVIDER..CUNEIFORM PUNCTUATION SIGN DIAGONAL QUADCOLON
-	{runeRange{0x12480, 0x12543}, eawprN},   // Lo   [196] CUNEIFORM SIGN AB TIMES NUN TENU..CUNEIFORM SIGN ZU5 TIMES THREE DISH TENU
-	{runeRange{0x12F90, 0x12FF0}, eawprN},   // Lo    [97] CYPRO-MINOAN SIGN CM001..CYPRO-MINOAN SIGN CM114
-	{runeRange{0x12FF1, 0x12FF2}, eawprN},   // Po     [2] CYPRO-MINOAN SIGN CM301..CYPRO-MINOAN SIGN CM302
-	{runeRange{0x13000, 0x1342F}, eawprN},   // Lo  [1072] EGYPTIAN HIEROGLYPH A001..EGYPTIAN HIEROGLYPH V011D
-	{runeRange{0x13430, 0x1343F}, eawprN},   // Cf    [16] EGYPTIAN HIEROGLYPH VERTICAL JOINER..EGYPTIAN HIEROGLYPH END WALLED ENCLOSURE
-	{runeRange{0x13440, 0x13440}, eawprN},   // Mn         EGYPTIAN HIEROGLYPH MIRROR HORIZONTALLY
-	{runeRange{0x13441, 0x13446}, eawprN},   // Lo     [6] EGYPTIAN HIEROGLYPH FULL BLANK..EGYPTIAN HIEROGLYPH WIDE LOST SIGN
-	{runeRange{0x13447, 0x13455}, eawprN},   // Mn    [15] EGYPTIAN HIEROGLYPH MODIFIER DAMAGED AT TOP START..EGYPTIAN HIEROGLYPH MODIFIER DAMAGED
-	{runeRange{0x14400, 0x14646}, eawprN},   // Lo   [583] ANATOLIAN HIEROGLYPH A001..ANATOLIAN HIEROGLYPH A530
-	{runeRange{0x16800, 0x16A38}, eawprN},   // Lo   [569] BAMUM LETTER PHASE-A NGKUE MFON..BAMUM LETTER PHASE-F VUEQ
-	{runeRange{0x16A40, 0x16A5E}, eawprN},   // Lo    [31] MRO LETTER TA..MRO LETTER TEK
-	{runeRange{0x16A60, 0x16A69}, eawprN},   // Nd    [10] MRO DIGIT ZERO..MRO DIGIT NINE
-	{runeRange{0x16A6E, 0x16A6F}, eawprN},   // Po     [2] MRO DANDA..MRO DOUBLE DANDA
-	{runeRange{0x16A70, 0x16ABE}, eawprN},   // Lo    [79] TANGSA LETTER OZ..TANGSA LETTER ZA
-	{runeRange{0x16AC0, 0x16AC9}, eawprN},   // Nd    [10] TANGSA DIGIT ZERO..TANGSA DIGIT NINE
-	{runeRange{0x16AD0, 0x16AED}, eawprN},   // Lo    [30] BASSA VAH LETTER ENNI..BASSA VAH LETTER I
-	{runeRange{0x16AF0, 0x16AF4}, eawprN},   // Mn     [5] BASSA VAH COMBINING HIGH TONE..BASSA VAH COMBINING HIGH-LOW TONE
-	{runeRange{0x16AF5, 0x16AF5}, eawprN},   // Po         BASSA VAH FULL STOP
-	{runeRange{0x16B00, 0x16B2F}, eawprN},   // Lo    [48] PAHAWH HMONG VOWEL KEEB..PAHAWH HMONG CONSONANT CAU
-	{runeRange{0x16B30, 0x16B36}, eawprN},   // Mn     [7] PAHAWH HMONG MARK CIM TUB..PAHAWH HMONG MARK CIM TAUM
-	{runeRange{0x16B37, 0x16B3B}, eawprN},   // Po     [5] PAHAWH HMONG SIGN VOS THOM..PAHAWH HMONG SIGN VOS FEEM
-	{runeRange{0x16B3C, 0x16B3F}, eawprN},   // So     [4] PAHAWH HMONG SIGN XYEEM NTXIV..PAHAWH HMONG SIGN XYEEM FAIB
-	{runeRange{0x16B40, 0x16B43}, eawprN},   // Lm     [4] PAHAWH HMONG SIGN VOS SEEV..PAHAWH HMONG SIGN IB YAM
-	{runeRange{0x16B44, 0x16B44}, eawprN},   // Po         PAHAWH HMONG SIGN XAUS
-	{runeRange{0x16B45, 0x16B45}, eawprN},   // So         PAHAWH HMONG SIGN CIM TSOV ROG
-	{runeRange{0x16B50, 0x16B59}, eawprN},   // Nd    [10] PAHAWH HMONG DIGIT ZERO..PAHAWH HMONG DIGIT NINE
-	{runeRange{0x16B5B, 0x16B61}, eawprN},   // No     [7] PAHAWH HMONG NUMBER TENS..PAHAWH HMONG NUMBER TRILLIONS
-	{runeRange{0x16B63, 0x16B77}, eawprN},   // Lo    [21] PAHAWH HMONG SIGN VOS LUB..PAHAWH HMONG SIGN CIM NRES TOS
-	{runeRange{0x16B7D, 0x16B8F}, eawprN},   // Lo    [19] PAHAWH HMONG CLAN SIGN TSHEEJ..PAHAWH HMONG CLAN SIGN VWJ
-	{runeRange{0x16E40, 0x16E7F}, eawprN},   // L&    [64] MEDEFAIDRIN CAPITAL LETTER M..MEDEFAIDRIN SMALL LETTER Y
-	{runeRange{0x16E80, 0x16E96}, eawprN},   // No    [23] MEDEFAIDRIN DIGIT ZERO..MEDEFAIDRIN DIGIT THREE ALTERNATE FORM
-	{runeRange{0x16E97, 0x16E9A}, eawprN},   // Po     [4] MEDEFAIDRIN COMMA..MEDEFAIDRIN EXCLAMATION OH
-	{runeRange{0x16F00, 0x16F4A}, eawprN},   // Lo    [75] MIAO LETTER PA..MIAO LETTER RTE
-	{runeRange{0x16F4F, 0x16F4F}, eawprN},   // Mn         MIAO SIGN CONSONANT MODIFIER BAR
-	{runeRange{0x16F50, 0x16F50}, eawprN},   // Lo         MIAO LETTER NASALIZATION
-	{runeRange{0x16F51, 0x16F87}, eawprN},   // Mc    [55] MIAO SIGN ASPIRATION..MIAO VOWEL SIGN UI
-	{runeRange{0x16F8F, 0x16F92}, eawprN},   // Mn     [4] MIAO TONE RIGHT..MIAO TONE BELOW
-	{runeRange{0x16F93, 0x16F9F}, eawprN},   // Lm    [13] MIAO LETTER TONE-2..MIAO LETTER REFORMED TONE-8
-	{runeRange{0x16FE0, 0x16FE1}, eawprW},   // Lm     [2] TANGUT ITERATION MARK..NUSHU ITERATION MARK
-	{runeRange{0x16FE2, 0x16FE2}, eawprW},   // Po         OLD CHINESE HOOK MARK
-	{runeRange{0x16FE3, 0x16FE3}, eawprW},   // Lm         OLD CHINESE ITERATION MARK
-	{runeRange{0x16FE4, 0x16FE4}, eawprW},   // Mn         KHITAN SMALL SCRIPT FILLER
-	{runeRange{0x16FF0, 0x16FF1}, eawprW},   // Mc     [2] VIETNAMESE ALTERNATE READING MARK CA..VIETNAMESE ALTERNATE READING MARK NHAY
-	{runeRange{0x17000, 0x187F7}, eawprW},   // Lo  [6136] TANGUT IDEOGRAPH-17000..TANGUT IDEOGRAPH-187F7
-	{runeRange{0x18800, 0x18AFF}, eawprW},   // Lo   [768] TANGUT COMPONENT-001..TANGUT COMPONENT-768
-	{runeRange{0x18B00, 0x18CD5}, eawprW},   // Lo   [470] KHITAN SMALL SCRIPT CHARACTER-18B00..KHITAN SMALL SCRIPT CHARACTER-18CD5
-	{runeRange{0x18D00, 0x18D08}, eawprW},   // Lo     [9] TANGUT IDEOGRAPH-18D00..TANGUT IDEOGRAPH-18D08
-	{runeRange{0x1AFF0, 0x1AFF3}, eawprW},   // Lm     [4] KATAKANA LETTER MINNAN TONE-2..KATAKANA LETTER MINNAN TONE-5
-	{runeRange{0x1AFF5, 0x1AFFB}, eawprW},   // Lm     [7] KATAKANA LETTER MINNAN TONE-7..KATAKANA LETTER MINNAN NASALIZED TONE-5
-	{runeRange{0x1AFFD, 0x1AFFE}, eawprW},   // Lm     [2] KATAKANA LETTER MINNAN NASALIZED TONE-7..KATAKANA LETTER MINNAN NASALIZED TONE-8
-	{runeRange{0x1B000, 0x1B0FF}, eawprW},   // Lo   [256] KATAKANA LETTER ARCHAIC E..HENTAIGANA LETTER RE-2
-	{runeRange{0x1B100, 0x1B122}, eawprW},   // Lo    [35] HENTAIGANA LETTER RE-3..KATAKANA LETTER ARCHAIC WU
-	{runeRange{0x1B132, 0x1B132}, eawprW},   // Lo         HIRAGANA LETTER SMALL KO
-	{runeRange{0x1B150, 0x1B152}, eawprW},   // Lo     [3] HIRAGANA LETTER SMALL WI..HIRAGANA LETTER SMALL WO
-	{runeRange{0x1B155, 0x1B155}, eawprW},   // Lo         KATAKANA LETTER SMALL KO
-	{runeRange{0x1B164, 0x1B167}, eawprW},   // Lo     [4] KATAKANA LETTER SMALL WI..KATAKANA LETTER SMALL N
-	{runeRange{0x1B170, 0x1B2FB}, eawprW},   // Lo   [396] NUSHU CHARACTER-1B170..NUSHU CHARACTER-1B2FB
-	{runeRange{0x1BC00, 0x1BC6A}, eawprN},   // Lo   [107] DUPLOYAN LETTER H..DUPLOYAN LETTER VOCALIC M
-	{runeRange{0x1BC70, 0x1BC7C}, eawprN},   // Lo    [13] DUPLOYAN AFFIX LEFT HORIZONTAL SECANT..DUPLOYAN AFFIX ATTACHED TANGENT HOOK
-	{runeRange{0x1BC80, 0x1BC88}, eawprN},   // Lo     [9] DUPLOYAN AFFIX HIGH ACUTE..DUPLOYAN AFFIX HIGH VERTICAL
-	{runeRange{0x1BC90, 0x1BC99}, eawprN},   // Lo    [10] DUPLOYAN AFFIX LOW ACUTE..DUPLOYAN AFFIX LOW ARROW
-	{runeRange{0x1BC9C, 0x1BC9C}, eawprN},   // So         DUPLOYAN SIGN O WITH CROSS
-	{runeRange{0x1BC9D, 0x1BC9E}, eawprN},   // Mn     [2] DUPLOYAN THICK LETTER SELECTOR..DUPLOYAN DOUBLE MARK
-	{runeRange{0x1BC9F, 0x1BC9F}, eawprN},   // Po         DUPLOYAN PUNCTUATION CHINOOK FULL STOP
-	{runeRange{0x1BCA0, 0x1BCA3}, eawprN},   // Cf     [4] SHORTHAND FORMAT LETTER OVERLAP..SHORTHAND FORMAT UP STEP
-	{runeRange{0x1CF00, 0x1CF2D}, eawprN},   // Mn    [46] ZNAMENNY COMBINING MARK GORAZDO NIZKO S KRYZHEM ON LEFT..ZNAMENNY COMBINING MARK KRYZH ON LEFT
-	{runeRange{0x1CF30, 0x1CF46}, eawprN},   // Mn    [23] ZNAMENNY COMBINING TONAL RANGE MARK MRACHNO..ZNAMENNY PRIZNAK MODIFIER ROG
-	{runeRange{0x1CF50, 0x1CFC3}, eawprN},   // So   [116] ZNAMENNY NEUME KRYUK..ZNAMENNY NEUME PAUK
-	{runeRange{0x1D000, 0x1D0F5}, eawprN},   // So   [246] BYZANTINE MUSICAL SYMBOL PSILI..BYZANTINE MUSICAL SYMBOL GORGON NEO KATO
-	{runeRange{0x1D100, 0x1D126}, eawprN},   // So    [39] MUSICAL SYMBOL SINGLE BARLINE..MUSICAL SYMBOL DRUM CLEF-2
-	{runeRange{0x1D129, 0x1D164}, eawprN},   // So    [60] MUSICAL SYMBOL MULTIPLE MEASURE REST..MUSICAL SYMBOL ONE HUNDRED TWENTY-EIGHTH NOTE
-	{runeRange{0x1D165, 0x1D166}, eawprN},   // Mc     [2] MUSICAL SYMBOL COMBINING STEM..MUSICAL SYMBOL COMBINING SPRECHGESANG STEM
-	{runeRange{0x1D167, 0x1D169}, eawprN},   // Mn     [3] MUSICAL SYMBOL COMBINING TREMOLO-1..MUSICAL SYMBOL COMBINING TREMOLO-3
-	{runeRange{0x1D16A, 0x1D16C}, eawprN},   // So     [3] MUSICAL SYMBOL FINGERED TREMOLO-1..MUSICAL SYMBOL FINGERED TREMOLO-3
-	{runeRange{0x1D16D, 0x1D172}, eawprN},   // Mc     [6] MUSICAL SYMBOL COMBINING AUGMENTATION DOT..MUSICAL SYMBOL COMBINING FLAG-5
-	{runeRange{0x1D173, 0x1D17A}, eawprN},   // Cf     [8] MUSICAL SYMBOL BEGIN BEAM..MUSICAL SYMBOL END PHRASE
-	{runeRange{0x1D17B, 0x1D182}, eawprN},   // Mn     [8] MUSICAL SYMBOL COMBINING ACCENT..MUSICAL SYMBOL COMBINING LOURE
-	{runeRange{0x1D183, 0x1D184}, eawprN},   // So     [2] MUSICAL SYMBOL ARPEGGIATO UP..MUSICAL SYMBOL ARPEGGIATO DOWN
-	{runeRange{0x1D185, 0x1D18B}, eawprN},   // Mn     [7] MUSICAL SYMBOL COMBINING DOIT..MUSICAL SYMBOL COMBINING TRIPLE TONGUE
-	{runeRange{0x1D18C, 0x1D1A9}, eawprN},   // So    [30] MUSICAL SYMBOL RINFORZANDO..MUSICAL SYMBOL DEGREE SLASH
-	{runeRange{0x1D1AA, 0x1D1AD}, eawprN},   // Mn     [4] MUSICAL SYMBOL COMBINING DOWN BOW..MUSICAL SYMBOL COMBINING SNAP PIZZICATO
-	{runeRange{0x1D1AE, 0x1D1EA}, eawprN},   // So    [61] MUSICAL SYMBOL PEDAL MARK..MUSICAL SYMBOL KORON
-	{runeRange{0x1D200, 0x1D241}, eawprN},   // So    [66] GREEK VOCAL NOTATION SYMBOL-1..GREEK INSTRUMENTAL NOTATION SYMBOL-54
-	{runeRange{0x1D242, 0x1D244}, eawprN},   // Mn     [3] COMBINING GREEK MUSICAL TRISEME..COMBINING GREEK MUSICAL PENTASEME
-	{runeRange{0x1D245, 0x1D245}, eawprN},   // So         GREEK MUSICAL LEIMMA
-	{runeRange{0x1D2C0, 0x1D2D3}, eawprN},   // No    [20] KAKTOVIK NUMERAL ZERO..KAKTOVIK NUMERAL NINETEEN
-	{runeRange{0x1D2E0, 0x1D2F3}, eawprN},   // No    [20] MAYAN NUMERAL ZERO..MAYAN NUMERAL NINETEEN
-	{runeRange{0x1D300, 0x1D356}, eawprN},   // So    [87] MONOGRAM FOR EARTH..TETRAGRAM FOR FOSTERING
-	{runeRange{0x1D360, 0x1D378}, eawprN},   // No    [25] COUNTING ROD UNIT DIGIT ONE..TALLY MARK FIVE
-	{runeRange{0x1D400, 0x1D454}, eawprN},   // L&    [85] MATHEMATICAL BOLD CAPITAL A..MATHEMATICAL ITALIC SMALL G
-	{runeRange{0x1D456, 0x1D49C}, eawprN},   // L&    [71] MATHEMATICAL ITALIC SMALL I..MATHEMATICAL SCRIPT CAPITAL A
-	{runeRange{0x1D49E, 0x1D49F}, eawprN},   // Lu     [2] MATHEMATICAL SCRIPT CAPITAL C..MATHEMATICAL SCRIPT CAPITAL D
-	{runeRange{0x1D4A2, 0x1D4A2}, eawprN},   // Lu         MATHEMATICAL SCRIPT CAPITAL G
-	{runeRange{0x1D4A5, 0x1D4A6}, eawprN},   // Lu     [2] MATHEMATICAL SCRIPT CAPITAL J..MATHEMATICAL SCRIPT CAPITAL K
-	{runeRange{0x1D4A9, 0x1D4AC}, eawprN},   // Lu     [4] MATHEMATICAL SCRIPT CAPITAL N..MATHEMATICAL SCRIPT CAPITAL Q
-	{runeRange{0x1D4AE, 0x1D4B9}, eawprN},   // L&    [12] MATHEMATICAL SCRIPT CAPITAL S..MATHEMATICAL SCRIPT SMALL D
-	{runeRange{0x1D4BB, 0x1D4BB}, eawprN},   // Ll         MATHEMATICAL SCRIPT SMALL F
+	{runeRange{0x0D58, 0x0D5E}, eawprN},     // No     [7] MALAYALAM FRACTION ONE ONE-HUNDRED-AND-SIXTIETH..MALAYALAM FRACTION ONE FIFTH
+	{runeRange{0x2B00, 0x2B1A}, eawprN},     // So    [27] NORTH EAST WHITE ARROW..DOTTED SQUARE
+	{runeRange{0x10380, 0x1039D}, eawprN},   // Lo    [30] UGARITIC LETTER ALPA..UGARITIC LETTER SSU
 	{runeRange{0x1D4BD, 0x1D4C3}, eawprN},   // Ll     [7] MATHEMATICAL SCRIPT SMALL H..MATHEMATICAL SCRIPT SMALL N
-	{runeRange{0x1D4C5, 0x1D505}, eawprN},   // L&    [65] MATHEMATICAL SCRIPT SMALL P..MATHEMATICAL FRAKTUR CAPITAL B
-	{runeRange{0x1D507, 0x1D50A}, eawprN},   // Lu     [4] MATHEMATICAL FRAKTUR CAPITAL D..MATHEMATICAL FRAKTUR CAPITAL G
-	{runeRange{0x1D50D, 0x1D514}, eawprN},   // Lu     [8] MATHEMATICAL FRAKTUR CAPITAL J..MATHEMATICAL FRAKTUR CAPITAL Q
-	{runeRange{0x1D516, 0x1D51C}, eawprN},   // Lu     [7] MATHEMATICAL FRAKTUR CAPITAL S..MATHEMATICAL FRAKTUR CAPITAL Y
-	{runeRange{0x1D51E, 0x1D539}, eawprN},   // L&    [28] MATHEMATICAL FRAKTUR SMALL A..MATHEMATICAL DOUBLE-STRUCK CAPITAL B
-	{runeRange{0x1D53B, 0x1D53E}, eawprN},   // Lu     [4] MATHEMATICAL DOUBLE-STRUCK CAPITAL D..MATHEMATICAL DOUBLE-STRUCK CAPITAL G
-	{runeRange{0x1D540, 0x1D544}, eawprN},   // Lu     [5] MATHEMATICAL DOUBLE-STRUCK CAPITAL I..MATHEMATICAL DOUBLE-STRUCK CAPITAL M
-	{runeRange{0x1D546, 0x1D546}, eawprN},   // Lu         MATHEMATICAL DOUBLE-STRUCK CAPITAL O
-	{runeRange{0x1D54A, 0x1D550}, eawprN},   // Lu     [7] MATHEMATICAL DOUBLE-STRUCK CAPITAL S..MATHEMATICAL DOUBLE-STRUCK CAPITAL Y
-	{runeRange{0x1D552, 0x1D6A5}, eawprN},   // L&   [340] MATHEMATICAL DOUBLE-STRUCK SMALL A..MATHEMATICAL ITALIC SMALL DOTLESS J
-	{runeRange{0x1D6A8, 0x1D6C0}, eawprN},   // Lu    [25] MATHEMATICAL BOLD CAPITAL ALPHA..MATHEMATICAL BOLD CAPITAL OMEGA
-	{runeRange{0x1D6C1, 0x1D6C1}, eawprN},   // Sm         MATHEMATICAL BOLD NABLA
-	{runeRange{0x1D6C2, 0x1D6DA}, eawprN},   // Ll    [25] MATHEMATICAL BOLD SMALL ALPHA..MATHEMATICAL BOLD SMALL OMEGA
-	{runeRange{0x1D6DB, 0x1D6DB}, eawprN},   // Sm         MATHEMATICAL BOLD PARTIAL DIFFERENTIAL
-	{runeRange{0x1D6DC, 0x1D6FA}, eawprN},   // L&    [31] MATHEMATICAL BOLD EPSILON SYMBOL..MATHEMATICAL ITALIC CAPITAL OMEGA
-	{runeRange{0x1D6FB, 0x1D6FB}, eawprN},   // Sm         MATHEMATICAL ITALIC NABLA
-	{runeRange{0x1D6FC, 0x1D714}, eawprN},   // Ll    [25] MATHEMATICAL ITALIC SMALL ALPHA..MATHEMATICAL ITALIC SMALL OMEGA
-	{runeRange{0x1D715, 0x1D715}, eawprN},   // Sm         MATHEMATICAL ITALIC PARTIAL DIFFERENTIAL
-	{runeRange{0x1D716, 0x1D734}, eawprN},   // L&    [31] MATHEMATICAL ITALIC EPSILON SYMBOL..MATHEMATICAL BOLD ITALIC CAPITAL OMEGA
-	{runeRange{0x1D735, 0x1D735}, eawprN},   // Sm         MATHEMATICAL BOLD ITALIC NABLA
-	{runeRange{0x1D736, 0x1D74E}, eawprN},   // Ll    [25] MATHEMATICAL BOLD ITALIC SMALL ALPHA..MATHEMATICAL BOLD ITALIC SMALL OMEGA
-	{runeRange{0x1D74F, 0x1D74F}, eawprN},   // Sm         MATHEMATICAL BOLD ITALIC PARTIAL DIFFERENTIAL
-	{runeRange{0x1D750, 0x1D76E}, eawprN},   // L&    [31] MATHEMATICAL BOLD ITALIC EPSILON SYMBOL..MATHEMATICAL SANS-SERIF BOLD CAPITAL OMEGA
-	{runeRange{0x1D76F, 0x1D76F}, eawprN},   // Sm         MATHEMATICAL SANS-SERIF BOLD NABLA
-	{runeRange{0x1D770, 0x1D788}, eawprN},   // Ll    [25] MATHEMATICAL SANS-SERIF BOLD SMALL ALPHA..MATHEMATICAL SANS-SERIF BOLD SMALL OMEGA
-	{runeRange{0x1D789, 0x1D789}, eawprN},   // Sm         MATHEMATICAL SANS-SERIF BOLD PARTIAL DIFFERENTIAL
-	{runeRange{0x1D78A, 0x1D7A8}, eawprN},   // L&    [31] MATHEMATICAL SANS-SERIF BOLD EPSILON SYMBOL..MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL OMEGA
-	{runeRange{0x1D7A9, 0x1D7A9}, eawprN},   // Sm         MATHEMATICAL SANS-SERIF BOLD ITALIC NABLA
-	{runeRange{0x1D7AA, 0x1D7C2}, eawprN},   // Ll    [25] MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL ALPHA..MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL OMEGA
-	{runeRange{0x1D7C3, 0x1D7C3}, eawprN},   // Sm         MATHEMATICAL SANS-SERIF BOLD ITALIC PARTIAL DIFFERENTIAL
-	{runeRange{0x1D7C4, 0x1D7CB}, eawprN},   // L&     [8] MATHEMATICAL SANS-SERIF BOLD ITALIC EPSILON SYMBOL..MATHEMATICAL BOLD SMALL DIGAMMA
-	{runeRange{0x1D7CE, 0x1D7FF}, eawprN},   // Nd    [50] MATHEMATICAL BOLD DIGIT ZERO..MATHEMATICAL MONOSPACE DIGIT NINE
-	{runeRange{0x1D800, 0x1D9FF}, eawprN},   // So   [512] SIGNWRITING HAND-FIST INDEX..SIGNWRITING HEAD
-	{runeRange{0x1DA00, 0x1DA36}, eawprN},   // Mn    [55] SIGNWRITING HEAD RIM..SIGNWRITING AIR SUCKING IN
-	{runeRange{0x1DA37, 0x1DA3A}, eawprN},   // So     [4] SIGNWRITING AIR BLOW SMALL ROTATIONS..SIGNWRITING BREATH EXHALE
-	{runeRange{0x1DA3B, 0x1DA6C}, eawprN},   // Mn    [50] SIGNWRITING MOUTH CLOSED NEUTRAL..SIGNWRITING EXCITEMENT
-	{runeRange{0x1DA6D, 0x1DA74}, eawprN},   // So     [8] SIGNWRITING SHOULDER HIP SPINE..SIGNWRITING TORSO-FLOORPLANE TWISTING
-	{runeRange{0x1DA75, 0x1DA75}, eawprN},   // Mn         SIGNWRITING UPPER BODY TILTING FROM HIP JOINTS
-	{runeRange{0x1DA76, 0x1DA83}, eawprN},   // So    [14] SIGNWRITING LIMB COMBINATION..SIGNWRITING LOCATION DEPTH
-	{runeRange{0x1DA84, 0x1DA84}, eawprN},   // Mn         SIGNWRITING LOCATION HEAD NECK
-	{runeRange{0x1DA85, 0x1DA86}, eawprN},   // So     [2] SIGNWRITING LOCATION TORSO..SIGNWRITING LOCATION LIMBS DIGITS
-	{runeRange{0x1DA87, 0x1DA8B}, eawprN},   // Po     [5] SIGNWRITING COMMA..SIGNWRITING PARENTHESIS
-	{runeRange{0x1DA9B, 0x1DA9F}, eawprN},   // Mn     [5] SIGNWRITING FILL MODIFIER-2..SIGNWRITING FILL MODIFIER-6
-	{runeRange{0x1DAA1, 0x1DAAF}, eawprN},   // Mn    [15] SIGNWRITING ROTATION MODIFIER-2..SIGNWRITING ROTATION MODIFIER-16
-	{runeRange{0x1DF00, 0x1DF09}, eawprN},   // Ll    [10] LATIN SMALL LETTER FENG DIGRAPH WITH TRILL..LATIN SMALL LETTER T WITH HOOK AND RETROFLEX HOOK
-	{runeRange{0x1DF0A, 0x1DF0A}, eawprN},   // Lo         LATIN LETTER RETROFLEX CLICK WITH RETROFLEX HOOK
-	{runeRange{0x1DF0B, 0x1DF1E}, eawprN},   // Ll    [20] LATIN SMALL LETTER ESH WITH DOUBLE BAR..LATIN SMALL LETTER S WITH CURL
-	{runeRange{0x1DF25, 0x1DF2A}, eawprN},   // Ll     [6] LATIN SMALL LETTER D WITH MID-HEIGHT LEFT HOOK..LATIN SMALL LETTER T WITH MID-HEIGHT LEFT HOOK
-	{runeRange{0x1E000, 0x1E006}, eawprN},   // Mn     [7] COMBINING GLAGOLITIC LETTER AZU..COMBINING GLAGOLITIC LETTER ZHIVETE
-	{runeRange{0x1E008, 0x1E018}, eawprN},   // Mn    [17] COMBINING GLAGOLITIC LETTER ZEMLJA..COMBINING GLAGOLITIC LETTER HERU
-	{runeRange{0x1E01B, 0x1E021}, eawprN},   // Mn     [7] COMBINING GLAGOLITIC LETTER SHTA..COMBINING GLAGOLITIC LETTER YATI
-	{runeRange{0x1E023, 0x1E024}, eawprN},   // Mn     [2] COMBINING GLAGOLITIC LETTER YU..COMBINING GLAGOLITIC LETTER SMALL YUS
-	{runeRange{0x1E026, 0x1E02A}, eawprN},   // Mn     [5] COMBINING GLAGOLITIC LETTER YO..COMBINING GLAGOLITIC LETTER FITA
-	{runeRange{0x1E030, 0x1E06D}, eawprN},   // Lm    [62] MODIFIER LETTER CYRILLIC SMALL A..MODIFIER LETTER CYRILLIC SMALL STRAIGHT U WITH STROKE
-	{runeRange{0x1E08F, 0x1E08F}, eawprN},   // Mn         COMBINING CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I
-	{runeRange{0x1E100, 0x1E12C}, eawprN},   // Lo    [45] NYIAKENG PUACHUE HMONG LETTER MA..NYIAKENG PUACHUE HMONG LETTER W
-	{runeRange{0x1E130, 0x1E136}, eawprN},   // Mn     [7] NYIAKENG PUACHUE HMONG TONE-B..NYIAKENG PUACHUE HMONG TONE-D
-	{runeRange{0x1E137, 0x1E13D}, eawprN},   // Lm     [7] NYIAKENG PUACHUE HMONG SIGN FOR PERSON..NYIAKENG PUACHUE HMONG SYLLABLE LENGTHENER
-	{runeRange{0x1E140, 0x1E149}, eawprN},   // Nd    [10] NYIAKENG PUACHUE HMONG DIGIT ZERO..NYIAKENG PUACHUE HMONG DIGIT NINE
-	{runeRange{0x1E14E, 0x1E14E}, eawprN},   // Lo         NYIAKENG PUACHUE HMONG LOGOGRAM NYAJ
-	{runeRange{0x1E14F, 0x1E14F}, eawprN},   // So         NYIAKENG PUACHUE HMONG CIRCLED CA
-	{runeRange{0x1E290, 0x1E2AD}, eawprN},   // Lo    [30] TOTO LETTER PA..TOTO LETTER A
-	{runeRange{0x1E2AE, 0x1E2AE}, eawprN},   // Mn         TOTO SIGN RISING TONE
-	{runeRange{0x1E2C0, 0x1E2EB}, eawprN},   // Lo    [44] WANCHO LETTER AA..WANCHO LETTER YIH
-	{runeRange{0x1E2EC, 0x1E2EF}, eawprN},   // Mn     [4] WANCHO TONE TUP..WANCHO TONE KOINI
-	{runeRange{0x1E2F0, 0x1E2F9}, eawprN},   // Nd    [10] WANCHO DIGIT ZERO..WANCHO DIGIT NINE
-	{runeRange{0x1E2FF, 0x1E2FF}, eawprN},   // Sc         WANCHO NGUN SIGN
-	{runeRange{0x1E4D0, 0x1E4EA}, eawprN},   // Lo    [27] NAG MUNDARI LETTER O..NAG MUNDARI LETTER ELL
-	{runeRange{0x1E4EB, 0x1E4EB}, eawprN},   // Lm         NAG MUNDARI SIGN OJOD
-	{runeRange{0x1E4EC, 0x1E4EF}, eawprN},   // Mn     [4] NAG MUNDARI SIGN MUHOR..NAG MUNDARI SIGN SUTUH
-	{runeRange{0x1E4F0, 0x1E4F9}, eawprN},   // Nd    [10] NAG MUNDARI DIGIT ZERO..NAG MUNDARI DIGIT NINE
-	{runeRange{0x1E7E0, 0x1E7E6}, eawprN},   // Lo     [7] ETHIOPIC SYLLABLE HHYA..ETHIOPIC SYLLABLE HHYO
-	{runeRange{0x1E7E8, 0x1E7EB}, eawprN},   // Lo     [4] ETHIOPIC SYLLABLE GURAGE HHWA..ETHIOPIC SYLLABLE HHWE
-	{runeRange{0x1E7ED, 0x1E7EE}, eawprN},   // Lo     [2] ETHIOPIC SYLLABLE GURAGE MWI..ETHIOPIC SYLLABLE GURAGE MWEE
-	{runeRange{0x1E7F0, 0x1E7FE}, eawprN},   // Lo    [15] ETHIOPIC SYLLABLE GURAGE QWI..ETHIOPIC SYLLABLE GURAGE PWEE
-	{runeRange{0x1E800, 0x1E8C4}, eawprN},   // Lo   [197] MENDE KIKAKUI SYLLABLE M001 KI..MENDE KIKAKUI SYLLABLE M060 NYON
-	{runeRange{0x1E8C7, 0x1E8CF}, eawprN},   // No     [9] MENDE KIKAKUI DIGIT ONE..MENDE KIKAKUI DIGIT NINE
-	{runeRange{0x1E8D0, 0x1E8D6}, eawprN},   // Mn     [7] MENDE KIKAKUI COMBINING NUMBER TEENS..MENDE KIKAKUI COMBINING NUMBER MILLIONS
-	{runeRange{0x1E900, 0x1E943}, eawprN},   // L&    [68] ADLAM CAPITAL LETTER ALIF..ADLAM SMALL LETTER SHA
-	{runeRange{0x1E944, 0x1E94A}, eawprN},   // Mn     [7] ADLAM ALIF LENGTHENER..ADLAM NUKTA
-	{runeRange{0x1E94B, 0x1E94B}, eawprN},   // Lm         ADLAM NASALIZATION MARK
-	{runeRange{0x1E950, 0x1E959}, eawprN},   // Nd    [10] ADLAM DIGIT ZERO..ADLAM DIGIT NINE
-	{runeRange{0x1E95E, 0x1E95F}, eawprN},   // Po     [2] ADLAM INITIAL EXCLAMATION MARK..ADLAM INITIAL QUESTION MARK
-	{runeRange{0x1EC71, 0x1ECAB}, eawprN},   // No    [59] INDIC SIYAQ NUMBER ONE..INDIC SIYAQ NUMBER PREFIXED NINE
-	{runeRange{0x1ECAC, 0x1ECAC}, eawprN},   // So         INDIC SIYAQ PLACEHOLDER
-	{runeRange{0x1ECAD, 0x1ECAF}, eawprN},   // No     [3] INDIC SIYAQ FRACTION ONE QUARTER..INDIC SIYAQ FRACTION THREE QUARTERS
-	{runeRange{0x1ECB0, 0x1ECB0}, eawprN},   // Sc         INDIC SIYAQ RUPEE MARK
-	{runeRange{0x1ECB1, 0x1ECB4}, eawprN},   // No     [4] INDIC SIYAQ NUMBER ALTERNATE ONE..INDIC SIYAQ ALTERNATE LAKH MARK
-	{runeRange{0x1ED01, 0x1ED2D}, eawprN},   // No    [45] OTTOMAN SIYAQ NUMBER ONE..OTTOMAN SIYAQ NUMBER NINETY THOUSAND
-	{runeRange{0x1ED2E, 0x1ED2E}, eawprN},   // So         OTTOMAN SIYAQ MARRATAN
-	{runeRange{0x1ED2F, 0x1ED3D}, eawprN},   // No    [15] OTTOMAN SIYAQ ALTERNATE NUMBER TWO..OTTOMAN SIYAQ FRACTION ONE SIXTH
-	{runeRange{0x1EE00, 0x1EE03}, eawprN},   // Lo     [4] ARABIC MATHEMATICAL ALEF..ARABIC MATHEMATICAL DAL
-	{runeRange{0x1EE05, 0x1EE1F}, eawprN},   // Lo    [27] ARABIC MATHEMATICAL WAW..ARABIC MATHEMATICAL DOTLESS QAF
-	{runeRange{0x1EE21, 0x1EE22}, eawprN},   // Lo     [2] ARABIC MATHEMATICAL INITIAL BEH..ARABIC MATHEMATICAL INITIAL JEEM
-	{runeRange{0x1EE24, 0x1EE24}, eawprN},   // Lo         ARABIC MATHEMATICAL INITIAL HEH
-	{runeRange{0x1EE27, 0x1EE27}, eawprN},   // Lo         ARABIC MATHEMATICAL INITIAL HAH
-	{runeRange{0x1EE29, 0x1EE32}, eawprN},   // Lo    [10] ARABIC MATHEMATICAL INITIAL YEH..ARABIC MATHEMATICAL INITIAL QAF
-	{runeRange{0x1EE34, 0x1EE37}, eawprN},   // Lo     [4] ARABIC MATHEMATICAL INITIAL SHEEN..ARABIC MATHEMATICAL INITIAL KHAH
-	{runeRange{0x1EE39, 0x1EE39}, eawprN},   // Lo         ARABIC MATHEMATICAL INITIAL DAD
-	{runeRange{0x1EE3B, 0x1EE3B}, eawprN},   // Lo         ARABIC MATHEMATICAL INITIAL GHAIN
-	{runeRange{0x1EE42, 0x1EE42}, eawprN},   // Lo         ARABIC MATHEMATICAL TAILED JEEM
-	{runeRange{0x1EE47, 0x1EE47}, eawprN},   // Lo         ARABIC MATHEMATICAL TAILED HAH
-	{runeRange{0x1EE49, 0x1EE49}, eawprN},   // Lo         ARABIC MATHEMATICAL TAILED YEH
-	{runeRange{0x1EE4B, 0x1EE4B}, eawprN},   // Lo         ARABIC MATHEMATICAL TAILED LAM
-	{runeRange{0x1EE4D, 0x1EE4F}, eawprN},   // Lo     [3] ARABIC MATHEMATICAL TAILED NOON..ARABIC MATHEMATICAL TAILED AIN
-	{runeRange{0x1EE51, 0x1EE52}, eawprN},   // Lo     [2] ARABIC MATHEMATICAL TAILED SAD..ARABIC MATHEMATICAL TAILED QAF
-	{runeRange{0x1EE54, 0x1EE54}, eawprN},   // Lo         ARABIC MATHEMATICAL TAILED SHEEN
-	{runeRange{0x1EE57, 0x1EE57}, eawprN},   // Lo         ARABIC MATHEMATICAL TAILED KHAH
-	{runeRange{0x1EE59, 0x1EE59}, eawprN},   // Lo         ARABIC MATHEMATICAL TAILED DAD
-	{runeRange{0x1EE5B, 0x1EE5B}, eawprN},   // Lo         ARABIC MATHEMATICAL TAILED GHAIN
-	{runeRange{0x1EE5D, 0x1EE5D}, eawprN},   // Lo         ARABIC MATHEMATICAL TAILED DOTLESS NOON
-	{runeRange{0x1EE5F, 0x1EE5F}, eawprN},   // Lo         ARABIC MATHEMATICAL TAILED DOTLESS QAF
-	{runeRange{0x1EE61, 0x1EE62}, eawprN},   // Lo     [2] ARABIC MATHEMATICAL STRETCHED BEH..ARABIC MATHEMATICAL STRETCHED JEEM
-	{runeRange{0x1EE64, 0x1EE64}, eawprN},   // Lo         ARABIC MATHEMATICAL STRETCHED HEH
-	{runeRange{0x1EE67, 0x1EE6A}, eawprN},   // Lo     [4] ARABIC MATHEMATICAL STRETCHED HAH..ARABIC MATHEMATICAL STRETCHED KAF
-	{runeRange{0x1EE6C, 0x1EE72}, eawprN},   // Lo     [7] ARABIC MATHEMATICAL STRETCHED MEEM..ARABIC MATHEMATICAL STRETCHED QAF
-	{runeRange{0x1EE74, 0x1EE77}, eawprN},   // Lo     [4] ARABIC MATHEMATICAL STRETCHED SHEEN..ARABIC MATHEMATICAL STRETCHED KHAH
-	{runeRange{0x1EE79, 0x1EE7C}, eawprN},   // Lo     [4] ARABIC MATHEMATICAL STRETCHED DAD..ARABIC MATHEMATICAL STRETCHED DOTLESS BEH
-	{runeRange{0x1EE7E, 0x1EE7E}, eawprN},   // Lo         ARABIC MATHEMATICAL STRETCHED DOTLESS FEH
-	{runeRange{0x1EE80, 0x1EE89}, eawprN},   // Lo    [10] ARABIC MATHEMATICAL LOOPED ALEF..ARABIC MATHEMATICAL LOOPED YEH
-	{runeRange{0x1EE8B, 0x1EE9B}, eawprN},   // Lo    [17] ARABIC MATHEMATICAL LOOPED LAM..ARABIC MATHEMATICAL LOOPED GHAIN
-	{runeRange{0x1EEA1, 0x1EEA3}, eawprN},   // Lo     [3] ARABIC MATHEMATICAL DOUBLE-STRUCK BEH..ARABIC MATHEMATICAL DOUBLE-STRUCK DAL
-	{runeRange{0x1EEA5, 0x1EEA9}, eawprN},   // Lo     [5] ARABIC MATHEMATICAL DOUBLE-STRUCK WAW..ARABIC MATHEMATICAL DOUBLE-STRUCK YEH
-	{runeRange{0x1EEAB, 0x1EEBB}, eawprN},   // Lo    [17] ARABIC MATHEMATICAL DOUBLE-STRUCK LAM..ARABIC MATHEMATICAL DOUBLE-STRUCK GHAIN
-	{runeRange{0x1EEF0, 0x1EEF1}, eawprN},   // Sm     [2] ARABIC MATHEMATICAL OPERATOR MEEM WITH HAH WITH TATWEEL..ARABIC MATHEMATICAL OPERATOR HAH WITH DAL
-	{runeRange{0x1F000, 0x1F003}, eawprN},   // So     [4] MAHJONG TILE EAST WIND..MAHJONG TILE NORTH WIND
-	{runeRange{0x1F004, 0x1F004}, eawprW},   // So         MAHJONG TILE RED DRAGON
+	{runeRange{0x06FA, 0x06FC}, eawprN},     // Lo     [3] ARABIC LETTER SHEEN WITH DOT BELOW..ARABIC LETTER GHAIN WITH DOT BELOW
+	{runeRange{0x1ABF, 0x1ACE}, eawprN},     // Mn    [16] COMBINING LATIN SMALL LETTER W BELOW..COMBINING LATIN SMALL LETTER INSULAR T
+	{runeRange{0x2667, 0x266A}, eawprA},     // So     [4] WHITE CLUB SUIT..EIGHTH NOTE
+	{runeRange{0x3030, 0x3030}, eawprW},     // Pd         WAVY DASH
+	{runeRange{0xFE20, 0xFE2F}, eawprN},     // Mn    [16] COMBINING LIGATURE LEFT HALF..COMBINING CYRILLIC TITLO RIGHT HALF
+	{runeRange{0x11082, 0x11082}, eawprN},   // Mc         KAITHI SIGN VISARGA
+	{runeRange{0x11D95, 0x11D95}, eawprN},   // Mn         GUNJALA GONDI SIGN ANUSVARA
 	{runeRange{0x1F005, 0x1F02B}, eawprN},   // So    [39] MAHJONG TILE GREEN DRAGON..MAHJONG TILE BACK
-	{runeRange{0x1F030, 0x1F093}, eawprN},   // So   [100] DOMINO TILE HORIZONTAL BACK..DOMINO TILE VERTICAL-06-06
-	{runeRange{0x1F0A0, 0x1F0AE}, eawprN},   // So    [15] PLAYING CARD BACK..PLAYING CARD KING OF SPADES
-	{runeRange{0x1F0B1, 0x1F0BF}, eawprN},   // So    [15] PLAYING CARD ACE OF HEARTS..PLAYING CARD RED JOKER
-	{runeRange{0x1F0C1, 0x1F0CE}, eawprN},   // So    [14] PLAYING CARD ACE OF DIAMONDS..PLAYING CARD KING OF DIAMONDS
-	{runeRange{0x1F0CF, 0x1F0CF}, eawprW},   // So         PLAYING CARD BLACK JOKER
-	{runeRange{0x1F0D1, 0x1F0F5}, eawprN},   // So    [37] PLAYING CARD ACE OF CLUBS..PLAYING CARD TRUMP-21
-	{runeRange{0x1F100, 0x1F10A}, eawprA},   // No    [11] DIGIT ZERO FULL STOP..DIGIT NINE COMMA
-	{runeRange{0x1F10B, 0x1F10C}, eawprN},   // No     [2] DINGBAT CIRCLED SANS-SERIF DIGIT ZERO..DINGBAT NEGATIVE CIRCLED SANS-SERIF DIGIT ZERO
-	{runeRange{0x1F10D, 0x1F10F}, eawprN},   // So     [3] CIRCLED ZERO WITH SLASH..CIRCLED DOLLAR SIGN WITH OVERLAID BACKSLASH
-	{runeRange{0x1F110, 0x1F12D}, eawprA},   // So    [30] PARENTHESIZED LATIN CAPITAL LETTER A..CIRCLED CD
-	{runeRange{0x1F12E, 0x1F12F}, eawprN},   // So     [2] CIRCLED WZ..COPYLEFT SYMBOL
-	{runeRange{0x1F130, 0x1F169}, eawprA},   // So    [58] SQUARED LATIN CAPITAL LETTER A..NEGATIVE CIRCLED LATIN CAPITAL LETTER Z
-	{runeRange{0x1F16A, 0x1F16F}, eawprN},   // So     [6] RAISED MC SIGN..CIRCLED HUMAN FIGURE
-	{runeRange{0x1F170, 0x1F18D}, eawprA},   // So    [30] NEGATIVE SQUARED LATIN CAPITAL LETTER A..NEGATIVE SQUARED SA
-	{runeRange{0x1F18E, 0x1F18E}, eawprW},   // So         NEGATIVE SQUARED AB
-	{runeRange{0x1F18F, 0x1F190}, eawprA},   // So     [2] NEGATIVE SQUARED WC..SQUARE DJ
-	{runeRange{0x1F191, 0x1F19A}, eawprW},   // So    [10] SQUARED CL..SQUARED VS
-	{runeRange{0x1F19B, 0x1F1AC}, eawprA},   // So    [18] SQUARED THREE D..SQUARED VOD
-	{runeRange{0x1F1AD, 0x1F1AD}, eawprN},   // So         MASK WORK SYMBOL
-	{runeRange{0x1F1E6, 0x1F1FF}, eawprN},   // So    [26] REGIONAL INDICATOR SYMBOL LETTER A..REGIONAL INDICATOR SYMBOL LETTER Z
-	{runeRange{0x1F200, 0x1F202}, eawprW},   // So     [3] SQUARE HIRAGANA HOKA..SQUARED KATAKANA SA
-	{runeRange{0x1F210, 0x1F23B}, eawprW},   // So    [44] SQUARED CJK UNIFIED IDEOGRAPH-624B..SQUARED CJK UNIFIED IDEOGRAPH-914D
-	{runeRange{0x1F240, 0x1F248}, eawprW},   // So     [9] TORTOISE SHELL BRACKETED CJK UNIFIED IDEOGRAPH-672C..TORTOISE SHELL BRACKETED CJK UNIFIED IDEOGRAPH-6557
-	{runeRange{0x1F250, 0x1F251}, eawprW},   // So     [2] CIRCLED IDEOGRAPH ADVANTAGE..CIRCLED IDEOGRAPH ACCEPT
-	{runeRange{0x1F260, 0x1F265}, eawprW},   // So     [6] ROUNDED SYMBOL FOR FU..ROUNDED SYMBOL FOR CAI
-	{runeRange{0x1F300, 0x1F320}, eawprW},   // So    [33] CYCLONE..SHOOTING STAR
-	{runeRange{0x1F321, 0x1F32C}, eawprN},   // So    [12] THERMOMETER..WIND BLOWING FACE
-	{runeRange{0x1F32D, 0x1F335}, eawprW},   // So     [9] HOT DOG..CACTUS
-	{runeRange{0x1F336, 0x1F336}, eawprN},   // So         HOT PEPPER
-	{runeRange{0x1F337, 0x1F37C}, eawprW},   // So    [70] TULIP..BABY BOTTLE
-	{runeRange{0x1F37D, 0x1F37D}, eawprN},   // So         FORK AND KNIFE WITH PLATE
-	{runeRange{0x1F37E, 0x1F393}, eawprW},   // So    [22] BOTTLE WITH POPPING CORK..GRADUATION CAP
-	{runeRange{0x1F394, 0x1F39F}, eawprN},   // So    [12] HEART WITH TIP ON THE LEFT..ADMISSION TICKETS
-	{runeRange{0x1F3A0, 0x1F3CA}, eawprW},   // So    [43] CAROUSEL HORSE..SWIMMER
-	{runeRange{0x1F3CB, 0x1F3CE}, eawprN},   // So     [4] WEIGHT LIFTER..RACING CAR
-	{runeRange{0x1F3CF, 0x1F3D3}, eawprW},   // So     [5] CRICKET BAT AND BALL..TABLE TENNIS PADDLE AND BALL
-	{runeRange{0x1F3D4, 0x1F3DF}, eawprN},   // So    [12] SNOW CAPPED MOUNTAIN..STADIUM
-	{runeRange{0x1F3E0, 0x1F3F0}, eawprW},   // So    [17] HOUSE BUILDING..EUROPEAN CASTLE
-	{runeRange{0x1F3F1, 0x1F3F3}, eawprN},   // So     [3] WHITE PENNANT..WAVING WHITE FLAG
-	{runeRange{0x1F3F4, 0x1F3F4}, eawprW},   // So         WAVING BLACK FLAG
-	{runeRange{0x1F3F5, 0x1F3F7}, eawprN},   // So     [3] ROSETTE..LABEL
-	{runeRange{0x1F3F8, 0x1F3FA}, eawprW},   // So     [3] BADMINTON RACQUET AND SHUTTLECOCK..AMPHORA
-	{runeRange{0x1F3FB, 0x1F3FF}, eawprW},   // Sk     [5] EMOJI MODIFIER FITZPATRICK TYPE-1-2..EMOJI MODIFIER FITZPATRICK TYPE-6
-	{runeRange{0x1F400, 0x1F43E}, eawprW},   // So    [63] RAT..PAW PRINTS
-	{runeRange{0x1F43F, 0x1F43F}, eawprN},   // So         CHIPMUNK
-	{runeRange{0x1F440, 0x1F440}, eawprW},   // So         EYES
-	{runeRange{0x1F441, 0x1F441}, eawprN},   // So         EYE
-	{runeRange{0x1F442, 0x1F4FC}, eawprW},   // So   [187] EAR..VIDEOCASSETTE
-	{runeRange{0x1F4FD, 0x1F4FE}, eawprN},   // So     [2] FILM PROJECTOR..PORTABLE STEREO
-	{runeRange{0x1F4FF, 0x1F53D}, eawprW},   // So    [63] PRAYER BEADS..DOWN-POINTING SMALL RED TRIANGLE
-	{runeRange{0x1F53E, 0x1F54A}, eawprN},   // So    [13] LOWER RIGHT SHADOWED WHITE CIRCLE..DOVE OF PEACE
-	{runeRange{0x1F54B, 0x1F54E}, eawprW},   // So     [4] KAABA..MENORAH WITH NINE BRANCHES
-	{runeRange{0x1F54F, 0x1F54F}, eawprN},   // So         BOWL OF HYGIEIA
-	{runeRange{0x1F550, 0x1F567}, eawprW},   // So    [24] CLOCK FACE ONE OCLOCK..CLOCK FACE TWELVE-THIRTY
-	{runeRange{0x1F568, 0x1F579}, eawprN},   // So    [18] RIGHT SPEAKER..JOYSTICK
-	{runeRange{0x1F57A, 0x1F57A}, eawprW},   // So         MAN DANCING
-	{runeRange{0x1F57B, 0x1F594}, eawprN},   // So    [26] LEFT HAND TELEPHONE RECEIVER..REVERSED VICTORY HAND
-	{runeRange{0x1F595, 0x1F596}, eawprW},   // So     [2] REVERSED HAND WITH MIDDLE FINGER EXTENDED..RAISED HAND WITH PART BETWEEN MIDDLE AND RING FINGERS
-	{runeRange{0x1F597, 0x1F5A3}, eawprN},   // So    [13] WHITE DOWN POINTING LEFT HAND INDEX..BLACK DOWN POINTING BACKHAND INDEX
-	{runeRange{0x1F5A4, 0x1F5A4}, eawprW},   // So         BLACK HEART
-	{runeRange{0x1F5A5, 0x1F5FA}, eawprN},   // So    [86] DESKTOP COMPUTER..WORLD MAP
-	{runeRange{0x1F5FB, 0x1F5FF}, eawprW},   // So     [5] MOUNT FUJI..MOYAI
-	{runeRange{0x1F600, 0x1F64F}, eawprW},   // So    [80] GRINNING FACE..PERSON WITH FOLDED HANDS
+	{runeRange{0x01D5, 0x01D5}, eawprN},     // Lu         LATIN CAPITAL LETTER U WITH DIAERESIS AND MACRON
+	{runeRange{0x0ABD, 0x0ABD}, eawprN},     // Lo         GUJARATI SIGN AVAGRAHA
+	{runeRange{0x1100, 0x115F}, eawprW},     // Lo    [96] HANGUL CHOSEONG KIYEOK..HANGUL CHOSEONG FILLER
+	{runeRange{0x2032, 0x2033}, eawprA},     // Po     [2] PRIME..DOUBLE PRIME
+	{runeRange{0x2400, 0x2426}, eawprN},     // So    [39] SYMBOL FOR NULL..SYMBOL FOR SUBSTITUTE FORM TWO
+	{runeRange{0x2770, 0x2770}, eawprN},     // Ps         HEAVY LEFT-POINTING ANGLE BRACKET ORNAMENT
+	{runeRange{0x2E22, 0x2E22}, eawprN},     // Ps         TOP LEFT HALF BRACKET
+	{runeRange{0xA69C, 0xA69D}, eawprN},     // Lm     [2] MODIFIER LETTER CYRILLIC HARD SIGN..MODIFIER LETTER CYRILLIC SOFT SIGN
+	{runeRange{0xAAF5, 0xAAF5}, eawprN},     // Mc         MEETEI MAYEK VOWEL SIGN VISARGA
+	{runeRange{0xFF40, 0xFF40}, eawprF},     // Sk         FULLWIDTH GRAVE ACCENT
+	{runeRange{0x10A38, 0x10A3A}, eawprN},   // Mn     [3] KHAROSHTHI SIGN BAR ABOVE..KHAROSHTHI SIGN DOT BELOW
+	{runeRange{0x112DF, 0x112DF}, eawprN},   // Mn         KHUDAWADI SIGN ANUSVARA
+	{runeRange{0x119E0, 0x119E0}, eawprN},   // Mn         NANDINAGARI SIGN VIRAMA
+	{runeRange{0x16F4F, 0x16F4F}, eawprN},   // Mn         MIAO SIGN CONSONANT MODIFIER BAR
+	{runeRange{0x1E2C0, 0x1E2EB}, eawprN},   // Lo    [44] WANCHO LETTER AA..WANCHO LETTER YIH
 	{runeRange{0x1F650, 0x1F67F}, eawprN},   // So    [48] NORTH WEST POINTING LEAF..REVERSE CHECKER BOARD
-	{runeRange{0x1F680, 0x1F6C5}, eawprW},   // So    [70] ROCKET..LEFT LUGGAGE
-	{runeRange{0x1F6C6, 0x1F6CB}, eawprN},   // So     [6] TRIANGLE WITH ROUNDED CORNERS..COUCH AND LAMP
-	{runeRange{0x1F6CC, 0x1F6CC}, eawprW},   // So         SLEEPING ACCOMMODATION
-	{runeRange{0x1F6CD, 0x1F6CF}, eawprN},   // So     [3] SHOPPING BAGS..BED
-	{runeRange{0x1F6D0, 0x1F6D2}, eawprW},   // So     [3] PLACE OF WORSHIP..SHOPPING TROLLEY
-	{runeRange{0x1F6D3, 0x1F6D4}, eawprN},   // So     [2] STUPA..PAGODA
-	{runeRange{0x1F6D5, 0x1F6D7}, eawprW},   // So     [3] HINDU TEMPLE..ELEVATOR
-	{runeRange{0x1F6DC, 0x1F6DF}, eawprW},   // So     [4] WIRELESS..RING BUOY
-	{runeRange{0x1F6E0, 0x1F6EA}, eawprN},   // So    [11] HAMMER AND WRENCH..NORTHEAST-POINTING AIRPLANE
-	{runeRange{0x1F6EB, 0x1F6EC}, eawprW},   // So     [2] AIRPLANE DEPARTURE..AIRPLANE ARRIVING
-	{runeRange{0x1F6F0, 0x1F6F3}, eawprN},   // So     [4] SATELLITE..PASSENGER SHIP
-	{runeRange{0x1F6F4, 0x1F6FC}, eawprW},   // So     [9] SCOOTER..ROLLER SKATE
-	{runeRange{0x1F700, 0x1F776}, eawprN},   // So   [119] ALCHEMICAL SYMBOL FOR QUINTESSENCE..LUNAR ECLIPSE
-	{runeRange{0x1F77B, 0x1F77F}, eawprN},   // So     [5] HAUMEA..ORCUS
-	{runeRange{0x1F780, 0x1F7D9}, eawprN},   // So    [90] BLACK LEFT-POINTING ISOSCELES RIGHT TRIANGLE..NINE POINTED WHITE STAR
-	{runeRange{0x1F7E0, 0x1F7EB}, eawprW},   // So    [12] LARGE ORANGE CIRCLE..LARGE BROWN SQUARE
-	{runeRange{0x1F7F0, 0x1F7F0}, eawprW},   // So         HEAVY EQUALS SIGN
-	{runeRange{0x1F800, 0x1F80B}, eawprN},   // So    [12] LEFTWARDS ARROW WITH SMALL TRIANGLE ARROWHEAD..DOWNWARDS ARROW WITH LARGE TRIANGLE ARROWHEAD
-	{runeRange{0x1F810, 0x1F847}, eawprN},   // So    [56] LEFTWARDS ARROW WITH SMALL EQUILATERAL ARROWHEAD..DOWNWARDS HEAVY ARROW
-	{runeRange{0x1F850, 0x1F859}, eawprN},   // So    [10] LEFTWARDS SANS-SERIF ARROW..UP DOWN SANS-SERIF ARROW
-	{runeRange{0x1F860, 0x1F887}, eawprN},   // So    [40] WIDE-HEADED LEFTWARDS LIGHT BARB ARROW..WIDE-HEADED SOUTH WEST VERY HEAVY BARB ARROW
-	{runeRange{0x1F890, 0x1F8AD}, eawprN},   // So    [30] LEFTWARDS TRIANGLE ARROWHEAD..WHITE ARROW SHAFT WIDTH TWO THIRDS
-	{runeRange{0x1F8B0, 0x1F8B1}, eawprN},   // So     [2] ARROW POINTING UPWARDS THEN NORTH WEST..ARROW POINTING RIGHTWARDS THEN CURVING SOUTH WEST
-	{runeRange{0x1F900, 0x1F90B}, eawprN},   // So    [12] CIRCLED CROSS FORMEE WITH FOUR DOTS..DOWNWARD FACING NOTCHED HOOK WITH DOT
-	{runeRange{0x1F90C, 0x1F93A}, eawprW},   // So    [47] PINCHED FINGERS..FENCER
-	{runeRange{0x1F93B, 0x1F93B}, eawprN},   // So         MODERN PENTATHLON
-	{runeRange{0x1F93C, 0x1F945}, eawprW},   // So    [10] WRESTLERS..GOAL NET
-	{runeRange{0x1F946, 0x1F946}, eawprN},   // So         RIFLE
-	{runeRange{0x1F947, 0x1F9FF}, eawprW},   // So   [185] FIRST PLACE MEDAL..NAZAR AMULET
-	{runeRange{0x1FA00, 0x1FA53}, eawprN},   // So    [84] NEUTRAL CHESS KING..BLACK CHESS KNIGHT-BISHOP
-	{runeRange{0x1FA60, 0x1FA6D}, eawprN},   // So    [14] XIANGQI RED GENERAL..XIANGQI BLACK SOLDIER
+	{runeRange{0x00D8, 0x00D8}, eawprA},     // Lu         LATIN CAPITAL LETTER O WITH STROKE
+	{runeRange{0x03F7, 0x03FF}, eawprN},     // L&     [9] GREEK CAPITAL LETTER SHO..GREEK CAPITAL REVERSED DOTTED LUNATE SIGMA SYMBOL
+	{runeRange{0x0970, 0x0970}, eawprN},     // Po         DEVANAGARI ABBREVIATION SIGN
+	{runeRange{0x0BFA, 0x0BFA}, eawprN},     // So         TAMIL NUMBER SIGN
+	{runeRange{0x0F3A, 0x0F3A}, eawprN},     // Ps         TIBETAN MARK GUG RTAGS GYON
+	{runeRange{0x17DD, 0x17DD}, eawprN},     // Mn         KHMER SIGN ATTHACAN
+	{runeRange{0x1CEE, 0x1CF3}, eawprN},     // Lo     [6] VEDIC SIGN HEXIFORM LONG ANUSVARA..VEDIC SIGN ROTATED ARDHAVISARGA
+	{runeRange{0x211E, 0x2120}, eawprN},     // So     [3] PRESCRIPTION TAKE..SERVICE MARK
+	{runeRange{0x229A, 0x22A4}, eawprN},     // Sm    [11] CIRCLED RING OPERATOR..DOWN TACK
+	{runeRange{0x25CE, 0x25D1}, eawprA},     // So     [4] BULLSEYE..CIRCLE WITH RIGHT HALF BLACK
+	{runeRange{0x26F4, 0x26F4}, eawprA},     // So         FERRY
+	{runeRange{0x2983, 0x2983}, eawprN},     // Ps         LEFT WHITE CURLY BRACKET
+	{runeRange{0x2D7F, 0x2D7F}, eawprN},     // Mn         TIFINAGH CONSONANT JOINER
+	{runeRange{0x3000, 0x3000}, eawprF},     // Zs         IDEOGRAPHIC SPACE
+	{runeRange{0x3251, 0x325F}, eawprW},     // No    [15] CIRCLED NUMBER TWENTY ONE..CIRCLED NUMBER THIRTY FIVE
+	{runeRange{0xA80C, 0xA822}, eawprN},     // Lo    [23] SYLOTI NAGRI LETTER CO..SYLOTI NAGRI LETTER HO
+	{runeRange{0xAA50, 0xAA59}, eawprN},     // Nd    [10] CHAM DIGIT ZERO..CHAM DIGIT NINE
+	{runeRange{0xFA6E, 0xFA6F}, eawprW},     // Cn     [2] <reserved-FA6E>..<reserved-FA6F>
+	{runeRange{0xFE5D, 0xFE5D}, eawprW},     // Ps         SMALL LEFT TORTOISE SHELL BRACKET
+	{runeRange{0x10000, 0x1000B}, eawprN},   // Lo    [12] LINEAR B SYLLABLE B008 A..LINEAR B SYLLABLE B046 JE
+	{runeRange{0x10837, 0x10838}, eawprN},   // Lo     [2] CYPRIOT SYLLABLE XA..CYPRIOT SYLLABLE XE
+	{runeRange{0x10E80, 0x10EA9}, eawprN},   // Lo    [42] YEZIDI LETTER ELIF..YEZIDI LETTER ET
+	{runeRange{0x111BF, 0x111C0}, eawprN},   // Mc     [2] SHARADA VOWEL SIGN AU..SHARADA SIGN VIRAMA
+	{runeRange{0x11447, 0x1144A}, eawprN},   // Lo     [4] NEWA SIGN AVAGRAHA..NEWA SIDDHI
+	{runeRange{0x1182C, 0x1182E}, eawprN},   // Mc     [3] DOGRA VOWEL SIGN AA..DOGRA VOWEL SIGN II
+	{runeRange{0x11C38, 0x11C3D}, eawprN},   // Mn     [6] BHAIKSUKI VOWEL SIGN E..BHAIKSUKI SIGN ANUSVARA
+	{runeRange{0x12F90, 0x12FF0}, eawprN},   // Lo    [97] CYPRO-MINOAN SIGN CM001..CYPRO-MINOAN SIGN CM114
+	{runeRange{0x1CF00, 0x1CF2D}, eawprN},   // Mn    [46] ZNAMENNY COMBINING MARK GORAZDO NIZKO S KRYZHEM ON LEFT..ZNAMENNY COMBINING MARK KRYZH ON LEFT
+	{runeRange{0x1D7CE, 0x1D7FF}, eawprN},   // Nd    [50] MATHEMATICAL BOLD DIGIT ZERO..MATHEMATICAL MONOSPACE DIGIT NINE
+	{runeRange{0x1EE27, 0x1EE27}, eawprN},   // Lo         ARABIC MATHEMATICAL INITIAL HAH
+	{runeRange{0x1F37E, 0x1F393}, eawprW},   // So    [22] BOTTLE WITH POPPING CORK..GRADUATION CAP
 	{runeRange{0x1FA70, 0x1FA7C}, eawprW},   // So    [13] BALLET SHOES..CRUTCH
-	{runeRange{0x1FA80, 0x1FA88}, eawprW},   // So     [9] YO-YO..FLUTE
-	{runeRange{0x1FA90, 0x1FABD}, eawprW},   // So    [46] RINGED PLANET..WING
-	{runeRange{0x1FABF, 0x1FAC5}, eawprW},   // So     [7] GOOSE..PERSON WITH CROWN
-	{runeRange{0x1FACE, 0x1FADB}, eawprW},   // So    [14] MOOSE..PEA POD
-	{runeRange{0x1FAE0, 0x1FAE8}, eawprW},   // So     [9] MELTING FACE..SHAKING FACE
-	{runeRange{0x1FAF0, 0x1FAF8}, eawprW},   // So     [9] HAND WITH INDEX FINGER AND THUMB CROSSED..RIGHTWARDS PUSHING HAND
-	{runeRange{0x1FB00, 0x1FB92}, eawprN},   // So   [147] BLOCK SEXTANT-1..UPPER HALF INVERSE MEDIUM SHADE AND LOWER HALF BLOCK
-	{runeRange{0x1FB94, 0x1FBCA}, eawprN},   // So    [55] LEFT HALF INVERSE MEDIUM SHADE AND RIGHT HALF BLOCK..WHITE UP-POINTING CHEVRON
-	{runeRange{0x1FBF0, 0x1FBF9}, eawprN},   // Nd    [10] SEGMENTED DIGIT ZERO..SEGMENTED DIGIT NINE
-	{runeRange{0x20000, 0x2A6DF}, eawprW},   // Lo [42720] CJK UNIFIED IDEOGRAPH-20000..CJK UNIFIED IDEOGRAPH-2A6DF
-	{runeRange{0x2A6E0, 0x2A6FF}, eawprW},   // Cn    [32] <reserved-2A6E0>..<reserved-2A6FF>
-	{runeRange{0x2A700, 0x2B739}, eawprW},   // Lo  [4154] CJK UNIFIED IDEOGRAPH-2A700..CJK UNIFIED IDEOGRAPH-2B739
-	{runeRange{0x2B73A, 0x2B73F}, eawprW},   // Cn     [6] <reserved-2B73A>..<reserved-2B73F>
-	{runeRange{0x2B740, 0x2B81D}, eawprW},   // Lo   [222] CJK UNIFIED IDEOGRAPH-2B740..CJK UNIFIED IDEOGRAPH-2B81D
-	{runeRange{0x2B81E, 0x2B81F}, eawprW},   // Cn     [2] <reserved-2B81E>..<reserved-2B81F>
+	{runeRange{0x00A1, 0x00A1}, eawprA},     // Po         INVERTED EXCLAMATION MARK
+	{runeRange{0x012B, 0x012B}, eawprA},     // Ll         LATIN SMALL LETTER I WITH MACRON
+	{runeRange{0x02DD, 0x02DD}, eawprA},     // Sk         DOUBLE ACUTE ACCENT
+	{runeRange{0x05F3, 0x05F4}, eawprN},     // Po     [2] HEBREW PUNCTUATION GERESH..HEBREW PUNCTUATION GERSHAYIM
+	{runeRange{0x0840, 0x0858}, eawprN},     // Lo    [25] MANDAIC LETTER HALQA..MANDAIC LETTER AIN
+	{runeRange{0x09FE, 0x09FE}, eawprN},     // Mn         BENGALI SANDHI MARK
+	{runeRange{0x0B55, 0x0B56}, eawprN},     // Mn     [2] ORIYA SIGN OVERLINE..ORIYA AI LENGTH MARK
+	{runeRange{0x0CBC, 0x0CBC}, eawprN},     // Mn         KANNADA SIGN NUKTA
+	{runeRange{0x0E5A, 0x0E5B}, eawprN},     // Po     [2] THAI CHARACTER ANGKHANKHU..THAI CHARACTER KHOMUT
+	{runeRange{0x1040, 0x1049}, eawprN},     // Nd    [10] MYANMAR DIGIT ZERO..MYANMAR DIGIT NINE
+	{runeRange{0x169B, 0x169B}, eawprN},     // Ps         OGHAM FEATHER MARK
+	{runeRange{0x1970, 0x1974}, eawprN},     // Lo     [5] TAI LE LETTER TONE-2..TAI LE LETTER TONE-6
+	{runeRange{0x1BE6, 0x1BE6}, eawprN},     // Mn         BATAK SIGN TOMPI
+	{runeRange{0x1FD0, 0x1FD3}, eawprN},     // Ll     [4] GREEK SMALL LETTER IOTA WITH VRACHY..GREEK SMALL LETTER IOTA WITH DIALYTIKA AND OXIA
+	{runeRange{0x2085, 0x2089}, eawprN},     // No     [5] SUBSCRIPT FIVE..SUBSCRIPT NINE
+	{runeRange{0x2170, 0x2179}, eawprA},     // Nl    [10] SMALL ROMAN NUMERAL ONE..SMALL ROMAN NUMERAL TEN
+	{runeRange{0x2253, 0x225F}, eawprN},     // Sm    [13] IMAGE OF OR APPROXIMATELY EQUAL TO..QUESTIONED EQUAL TO
+	{runeRange{0x2322, 0x2328}, eawprN},     // So     [7] FROWN..KEYBOARD
+	{runeRange{0x25A3, 0x25A9}, eawprA},     // So     [7] WHITE SQUARE CONTAINING BLACK SMALL SQUARE..SQUARE WITH DIAGONAL CROSSHATCH FILL
+	{runeRange{0x2614, 0x2615}, eawprW},     // So     [2] UMBRELLA WITH RAIN DROPS..HOT BEVERAGE
+	{runeRange{0x26BD, 0x26BE}, eawprW},     // So     [2] SOCCER BALL..BASEBALL
+	{runeRange{0x274C, 0x274C}, eawprW},     // So         CROSS MARK
+	{runeRange{0x27C6, 0x27C6}, eawprN},     // Pe         RIGHT S-SHAPED BAG DELIMITER
+	{runeRange{0x2993, 0x2993}, eawprN},     // Ps         LEFT ARC LESS-THAN BRACKET
+	{runeRange{0x2C7C, 0x2C7D}, eawprN},     // Lm     [2] LATIN SUBSCRIPT SMALL LETTER J..MODIFIER LETTER CAPITAL V
+	{runeRange{0x2E06, 0x2E08}, eawprN},     // Po     [3] RAISED INTERPOLATION MARKER..DOTTED TRANSPOSITION MARKER
+	{runeRange{0x2E43, 0x2E4F}, eawprN},     // Po    [13] DASH WITH LEFT UPTURN..CORNISH VERSE DIVIDER
+	{runeRange{0x3012, 0x3013}, eawprW},     // So     [2] POSTAL MARK..GETA MARK
+	{runeRange{0x30FB, 0x30FB}, eawprW},     // Po         KATAKANA MIDDLE DOT
+	{runeRange{0xA4FE, 0xA4FF}, eawprN},     // Po     [2] LISU PUNCTUATION COMMA..LISU PUNCTUATION FULL STOP
+	{runeRange{0xA790, 0xA7CA}, eawprN},     // L&    [59] LATIN CAPITAL LETTER N WITH DESCENDER..LATIN SMALL LETTER S WITH SHORT STROKE OVERLAY
+	{runeRange{0xA8CE, 0xA8CF}, eawprN},     // Po     [2] SAURASHTRA DANDA..SAURASHTRA DOUBLE DANDA
+	{runeRange{0xA9E5, 0xA9E5}, eawprN},     // Mn         MYANMAR SIGN SHAN SAW
+	{runeRange{0xAAB7, 0xAAB8}, eawprN},     // Mn     [2] TAI VIET MAI KHIT..TAI VIET VOWEL IA
+	{runeRange{0xABE5, 0xABE5}, eawprN},     // Mn         MEETEI MAYEK VOWEL SIGN ANAP
+	{runeRange{0xFBB2, 0xFBC2}, eawprN},     // Sk    [17] ARABIC SYMBOL DOT ABOVE..ARABIC SYMBOL WASLA ABOVE
+	{runeRange{0xFE41, 0xFE41}, eawprW},     // Ps         PRESENTATION FORM FOR VERTICAL LEFT CORNER BRACKET
+	{runeRange{0xFF09, 0xFF09}, eawprF},     // Pe         FULLWIDTH RIGHT PARENTHESIS
+	{runeRange{0xFFA0, 0xFFBE}, eawprH},     // Lo    [31] HALFWIDTH HANGUL FILLER..HALFWIDTH HANGUL LETTER HIEUH
+	{runeRange{0x101A0, 0x101A0}, eawprN},   // So         GREEK SYMBOL TAU RHO
+	{runeRange{0x1057C, 0x1058A}, eawprN},   // Lu    [15] VITHKUQI CAPITAL LETTER HA..VITHKUQI CAPITAL LETTER RE
+	{runeRange{0x1091F, 0x1091F}, eawprN},   // Po         PHOENICIAN WORD SEPARATOR
+	{runeRange{0x10B39, 0x10B3F}, eawprN},   // Po     [7] AVESTAN ABBREVIATION MARK..LARGE ONE RING OVER TWO RINGS PUNCTUATION
+	{runeRange{0x10FC5, 0x10FCB}, eawprN},   // No     [7] CHORASMIAN NUMBER ONE..CHORASMIAN NUMBER ONE HUNDRED
+	{runeRange{0x1112C, 0x1112C}, eawprN},   // Mc         CHAKMA VOWEL SIGN E
+	{runeRange{0x1122F, 0x11231}, eawprN},   // Mn     [3] KHOJKI VOWEL SIGN U..KHOJKI VOWEL SIGN AI
+	{runeRange{0x11341, 0x11344}, eawprN},   // Mc     [4] GRANTHA VOWEL SIGN U..GRANTHA VOWEL SIGN VOCALIC RR
+	{runeRange{0x114C4, 0x114C5}, eawprN},   // Lo     [2] TIRHUTA SIGN AVAGRAHA..TIRHUTA GVANG
+	{runeRange{0x116B7, 0x116B7}, eawprN},   // Mn         TAKRI SIGN NUKTA
+	{runeRange{0x1193B, 0x1193C}, eawprN},   // Mn     [2] DIVES AKURU SIGN ANUSVARA..DIVES AKURU SIGN CANDRABINDU
+	{runeRange{0x11A57, 0x11A58}, eawprN},   // Mc     [2] SOYOMBO VOWEL SIGN AI..SOYOMBO VOWEL SIGN AU
+	{runeRange{0x11D00, 0x11D06}, eawprN},   // Lo     [7] MASARAM GONDI LETTER A..MASARAM GONDI LETTER E
+	{runeRange{0x11F3E, 0x11F3F}, eawprN},   // Mc     [2] KAWI VOWEL SIGN E..KAWI VOWEL SIGN AI
+	{runeRange{0x16AF5, 0x16AF5}, eawprN},   // Po         BASSA VAH FULL STOP
+	{runeRange{0x1AFFD, 0x1AFFE}, eawprW},   // Lm     [2] KATAKANA LETTER MINNAN NASALIZED TONE-7..KATAKANA LETTER MINNAN NASALIZED TONE-8
+	{runeRange{0x1D1AE, 0x1D1EA}, eawprN},   // So    [61] MUSICAL SYMBOL PEDAL MARK..MUSICAL SYMBOL KORON
+	{runeRange{0x1D6FB, 0x1D6FB}, eawprN},   // Sm         MATHEMATICAL ITALIC NABLA
+	{runeRange{0x1DF25, 0x1DF2A}, eawprN},   // Ll     [6] LATIN SMALL LETTER D WITH MID-HEIGHT LEFT HOOK..LATIN SMALL LETTER T WITH MID-HEIGHT LEFT HOOK
+	{runeRange{0x1E944, 0x1E94A}, eawprN},   // Mn     [7] ADLAM ALIF LENGTHENER..ADLAM NUKTA
+	{runeRange{0x1EE5F, 0x1EE5F}, eawprN},   // Lo         ARABIC MATHEMATICAL TAILED DOTLESS QAF
+	{runeRange{0x1F18F, 0x1F190}, eawprA},   // So     [2] NEGATIVE SQUARED WC..SQUARE DJ
+	{runeRange{0x1F442, 0x1F4FC}, eawprW},   // So   [187] EAR..VIDEOCASSETTE
+	{runeRange{0x1F7E0, 0x1F7EB}, eawprW},   // So    [12] LARGE ORANGE CIRCLE..LARGE BROWN SQUARE
 	{runeRange{0x2B820, 0x2CEA1}, eawprW},   // Lo  [5762] CJK UNIFIED IDEOGRAPH-2B820..CJK UNIFIED IDEOGRAPH-2CEA1
-	{runeRange{0x2CEA2, 0x2CEAF}, eawprW},   // Cn    [14] <reserved-2CEA2>..<reserved-2CEAF>
-	{runeRange{0x2CEB0, 0x2EBE0}, eawprW},   // Lo  [7473] CJK UNIFIED IDEOGRAPH-2CEB0..CJK UNIFIED IDEOGRAPH-2EBE0
-	{runeRange{0x2EBE1, 0x2F7FF}, eawprW},   // Cn  [3103] <reserved-2EBE1>..<reserved-2F7FF>
-	{runeRange{0x2F800, 0x2FA1D}, eawprW},   // Lo   [542] CJK COMPATIBILITY IDEOGRAPH-2F800..CJK COMPATIBILITY IDEOGRAPH-2FA1D
-	{runeRange{0x2FA1E, 0x2FA1F}, eawprW},   // Cn     [2] <reserved-2FA1E>..<reserved-2FA1F>
-	{runeRange{0x2FA20, 0x2FFFD}, eawprW},   // Cn  [1502] <reserved-2FA20>..<reserved-2FFFD>
-	{runeRange{0x30000, 0x3134A}, eawprW},   // Lo  [4939] CJK UNIFIED IDEOGRAPH-30000..CJK UNIFIED IDEOGRAPH-3134A
+	{runeRange{0x003F, 0x0040}, eawprNa},    // Po     [2] QUESTION MARK..COMMERCIAL AT
+	{runeRange{0x00B2, 0x00B3}, eawprA},     // No     [2] SUPERSCRIPT TWO..SUPERSCRIPT THREE
+	{runeRange{0x00FB, 0x00FB}, eawprN},     // Ll         LATIN SMALL LETTER U WITH CIRCUMFLEX
+	{runeRange{0x0166, 0x0167}, eawprA},     // L&     [2] LATIN CAPITAL LETTER T WITH STROKE..LATIN SMALL LETTER T WITH STROKE
+	{runeRange{0x02B0, 0x02C1}, eawprN},     // Lm    [18] MODIFIER LETTER SMALL H..MODIFIER LETTER REVERSED GLOTTAL STOP
+	{runeRange{0x037E, 0x037E}, eawprN},     // Po         GREEK QUESTION MARK
+	{runeRange{0x0560, 0x0588}, eawprN},     // Ll    [41] ARMENIAN SMALL LETTER TURNED AYB..ARMENIAN SMALL LETTER YI WITH STROKE
+	{runeRange{0x066A, 0x066D}, eawprN},     // Po     [4] ARABIC PERCENT SIGN..ARABIC FIVE POINTED STAR
+	{runeRange{0x07EB, 0x07F3}, eawprN},     // Mn     [9] NKO COMBINING SHORT HIGH TONE..NKO COMBINING DOUBLE DOT ABOVE
+	{runeRange{0x0904, 0x0939}, eawprN},     // Lo    [54] DEVANAGARI LETTER SHORT A..DEVANAGARI LETTER HA
+	{runeRange{0x09C7, 0x09C8}, eawprN},     // Mc     [2] BENGALI VOWEL SIGN E..BENGALI VOWEL SIGN AI
+	{runeRange{0x0A59, 0x0A5C}, eawprN},     // Lo     [4] GURMUKHI LETTER KHHA..GURMUKHI LETTER RRA
+	{runeRange{0x0B02, 0x0B03}, eawprN},     // Mc     [2] ORIYA SIGN ANUSVARA..ORIYA SIGN VISARGA
+	{runeRange{0x0B9E, 0x0B9F}, eawprN},     // Lo     [2] TAMIL LETTER NYA..TAMIL LETTER TTA
+	{runeRange{0x0C5D, 0x0C5D}, eawprN},     // Lo         TELUGU LETTER NAKAARA POLLU
+	{runeRange{0x0D00, 0x0D01}, eawprN},     // Mn     [2] MALAYALAM SIGN COMBINING ANUSVARA ABOVE..MALAYALAM SIGN CANDRABINDU
+	{runeRange{0x0DD2, 0x0DD4}, eawprN},     // Mn     [3] SINHALA VOWEL SIGN KETTI IS-PILLA..SINHALA VOWEL SIGN KETTI PAA-PILLA
+	{runeRange{0x0F00, 0x0F00}, eawprN},     // Lo         TIBETAN SYLLABLE OM
+	{runeRange{0x0FC6, 0x0FC6}, eawprN},     // Mn         TIBETAN SYMBOL PADMA GDAN
+	{runeRange{0x1085, 0x1086}, eawprN},     // Mn     [2] MYANMAR VOWEL SIGN SHAN E ABOVE..MYANMAR VOWEL SIGN SHAN FINAL Y
+	{runeRange{0x1312, 0x1315}, eawprN},     // Lo     [4] ETHIOPIC SYLLABLE GWI..ETHIOPIC SYLLABLE GWE
+	{runeRange{0x1760, 0x176C}, eawprN},     // Lo    [13] TAGBANWA LETTER A..TAGBANWA LETTER YA
+	{runeRange{0x18A9, 0x18A9}, eawprN},     // Mn         MONGOLIAN LETTER ALI GALI DAGALGA
+	{runeRange{0x1A58, 0x1A5E}, eawprN},     // Mn     [7] TAI THAM SIGN MAI KANG LAI..TAI THAM CONSONANT SIGN SA
+	{runeRange{0x1B6B, 0x1B73}, eawprN},     // Mn     [9] BALINESE MUSICAL SYMBOL COMBINING TEGEH..BALINESE MUSICAL SYMBOL COMBINING GONG
+	{runeRange{0x1C4D, 0x1C4F}, eawprN},     // Lo     [3] LEPCHA LETTER TTA..LEPCHA LETTER DDA
+	{runeRange{0x1F18, 0x1F1D}, eawprN},     // Lu     [6] GREEK CAPITAL LETTER EPSILON WITH PSILI..GREEK CAPITAL LETTER EPSILON WITH DASIA AND OXIA
+	{runeRange{0x2019, 0x2019}, eawprA},     // Pf         RIGHT SINGLE QUOTATION MARK
+	{runeRange{0x2053, 0x2053}, eawprN},     // Po         SWUNG DASH
+	{runeRange{0x2102, 0x2102}, eawprN},     // Lu         DOUBLE-STRUCK CAPITAL C
+	{runeRange{0x213A, 0x213B}, eawprN},     // So     [2] ROTATED CAPITAL Q..FACSIMILE SIGN
+	{runeRange{0x21AE, 0x21AE}, eawprN},     // Sm         LEFT RIGHT ARROW WITH STROKE
+	{runeRange{0x2224, 0x2224}, eawprN},     // Sm         DOES NOT DIVIDE
+	{runeRange{0x2270, 0x2281}, eawprN},     // Sm    [18] NEITHER LESS-THAN NOR EQUAL TO..DOES NOT SUCCEED
+	{runeRange{0x230A, 0x230A}, eawprN},     // Ps         LEFT FLOOR
+	{runeRange{0x23DC, 0x23E1}, eawprN},     // Sm     [6] TOP PARENTHESIS..BOTTOM TORTOISE SHELL BRACKET
+	{runeRange{0x2550, 0x2573}, eawprA},     // So    [36] BOX DRAWINGS DOUBLE HORIZONTAL..BOX DRAWINGS LIGHT DIAGONAL CROSS
+	{runeRange{0x25BE, 0x25BF}, eawprN},     // So     [2] BLACK DOWN-POINTING SMALL TRIANGLE..WHITE DOWN-POINTING SMALL TRIANGLE
+	{runeRange{0x25FF, 0x25FF}, eawprN},     // Sm         LOWER RIGHT TRIANGLE
+	{runeRange{0x2642, 0x2642}, eawprA},     // So         MALE SIGN
+	{runeRange{0x2693, 0x2693}, eawprW},     // So         ANCHOR
+	{runeRange{0x26D5, 0x26E1}, eawprA},     // So    [13] ALTERNATE ONE-WAY LEFT WAY TRAFFIC..RESTRICTED LEFT ENTRY-2
+	{runeRange{0x2705, 0x2705}, eawprW},     // So         WHITE HEAVY CHECK MARK
+	{runeRange{0x2768, 0x2768}, eawprN},     // Ps         MEDIUM LEFT PARENTHESIS ORNAMENT
+	{runeRange{0x2794, 0x2794}, eawprN},     // So         HEAVY WIDE-HEADED RIGHTWARDS ARROW
+	{runeRange{0x27EC, 0x27EC}, eawprNa},    // Ps         MATHEMATICAL LEFT WHITE TORTOISE SHELL BRACKET
+	{runeRange{0x298B, 0x298B}, eawprN},     // Ps         LEFT SQUARE BRACKET WITH UNDERBAR
+	{runeRange{0x29D9, 0x29D9}, eawprN},     // Pe         RIGHT WIGGLY FENCE
+	{runeRange{0x2B51, 0x2B54}, eawprN},     // So     [4] BLACK SMALL STAR..WHITE RIGHT-POINTING PENTAGON
+	{runeRange{0x2CFD, 0x2CFD}, eawprN},     // No         COPTIC FRACTION ONE HALF
+	{runeRange{0x2DD0, 0x2DD6}, eawprN},     // Lo     [7] ETHIOPIC SYLLABLE XYA..ETHIOPIC SYLLABLE XYO
+	{runeRange{0x2E18, 0x2E19}, eawprN},     // Po     [2] INVERTED INTERROBANG..PALM BRANCH
+	{runeRange{0x2E2A, 0x2E2E}, eawprN},     // Po     [5] TWO DOTS OVER ONE DOT PUNCTUATION..REVERSED QUESTION MARK
+	{runeRange{0x2E5A, 0x2E5A}, eawprN},     // Pe         TOP HALF RIGHT PARENTHESIS
+	{runeRange{0x300A, 0x300A}, eawprW},     // Ps         LEFT DOUBLE ANGLE BRACKET
+	{runeRange{0x301B, 0x301B}, eawprW},     // Pe         RIGHT WHITE SQUARE BRACKET
+	{runeRange{0x303F, 0x303F}, eawprN},     // So         IDEOGRAPHIC HALF FILL SPACE
+	{runeRange{0x31A0, 0x31BF}, eawprW},     // Lo    [32] BOPOMOFO LETTER BU..BOPOMOFO LETTER AH
+	{runeRange{0x4DC0, 0x4DFF}, eawprN},     // So    [64] HEXAGRAM FOR THE CREATIVE HEAVEN..HEXAGRAM FOR BEFORE COMPLETION
+	{runeRange{0xA66E, 0xA66E}, eawprN},     // Lo         CYRILLIC LETTER MULTIOCULAR O
+	{runeRange{0xA720, 0xA721}, eawprN},     // Sk     [2] MODIFIER LETTER STRESS AND HIGH TONE..MODIFIER LETTER STRESS AND LOW TONE
+	{runeRange{0xA7FA, 0xA7FA}, eawprN},     // Ll         LATIN LETTER SMALL CAPITAL TURNED M
+	{runeRange{0xA838, 0xA838}, eawprN},     // Sc         NORTH INDIC RUPEE MARK
+	{runeRange{0xA8FF, 0xA8FF}, eawprN},     // Mn         DEVANAGARI VOWEL SIGN AY
+	{runeRange{0xA9BA, 0xA9BB}, eawprN},     // Mc     [2] JAVANESE VOWEL SIGN TALING..JAVANESE VOWEL SIGN DIRGA MURE
+	{runeRange{0xAA31, 0xAA32}, eawprN},     // Mn     [2] CHAM VOWEL SIGN AU..CHAM VOWEL SIGN UE
+	{runeRange{0xAA7C, 0xAA7C}, eawprN},     // Mn         MYANMAR SIGN TAI LAING TONE-2
+	{runeRange{0xAADE, 0xAADF}, eawprN},     // Po     [2] TAI VIET SYMBOL HO HOI..TAI VIET SYMBOL KOI KOI
+	{runeRange{0xAB5B, 0xAB5B}, eawprN},     // Sk         MODIFIER BREVE WITH INVERTED BREVE
+	{runeRange{0xAC00, 0xD7A3}, eawprW},     // Lo [11172] HANGUL SYLLABLE GA..HANGUL SYLLABLE HIH
+	{runeRange{0xFB29, 0xFB29}, eawprN},     // Sm         HEBREW LETTER ALTERNATIVE PLUS SIGN
+	{runeRange{0xFDF0, 0xFDFB}, eawprN},     // Lo    [12] ARABIC LIGATURE SALLA USED AS KORANIC STOP SIGN ISOLATED FORM..ARABIC LIGATURE JALLAJALALOUHOU
+	{runeRange{0xFE39, 0xFE39}, eawprW},     // Ps         PRESENTATION FORM FOR VERTICAL LEFT TORTOISE SHELL BRACKET
+	{runeRange{0xFE4D, 0xFE4F}, eawprW},     // Pc     [3] DASHED LOW LINE..WAVY LOW LINE
+	{runeRange{0xFE6A, 0xFE6B}, eawprW},     // Po     [2] SMALL PERCENT SIGN..SMALL COMMERCIAL AT
+	{runeRange{0xFF1C, 0xFF1E}, eawprF},     // Sm     [3] FULLWIDTH LESS-THAN SIGN..FULLWIDTH GREATER-THAN SIGN
+	{runeRange{0xFF61, 0xFF61}, eawprH},     // Po         HALFWIDTH IDEOGRAPHIC FULL STOP
+	{runeRange{0xFFE4, 0xFFE4}, eawprF},     // So         FULLWIDTH BROKEN BAR
+	{runeRange{0x10107, 0x10133}, eawprN},   // No    [45] AEGEAN NUMBER ONE..AEGEAN NUMBER NINETY THOUSAND
+	{runeRange{0x10320, 0x10323}, eawprN},   // No     [4] OLD ITALIC NUMERAL ONE..OLD ITALIC NUMERAL FIFTY
+	{runeRange{0x10480, 0x1049D}, eawprN},   // Lo    [30] OSMANYA LETTER ALEF..OSMANYA LETTER OO
+	{runeRange{0x10740, 0x10755}, eawprN},   // Lo    [22] LINEAR A SIGN A701 A..LINEAR A SIGN A732 JE
+	{runeRange{0x10879, 0x1087F}, eawprN},   // No     [7] PALMYRENE NUMBER ONE..PALMYRENE NUMBER TWENTY
+	{runeRange{0x109D2, 0x109FF}, eawprN},   // No    [46] MEROITIC CURSIVE NUMBER ONE HUNDRED..MEROITIC CURSIVE FRACTION TEN TWELFTHS
+	{runeRange{0x10A9D, 0x10A9F}, eawprN},   // No     [3] OLD NORTH ARABIAN NUMBER ONE..OLD NORTH ARABIAN NUMBER TWENTY
+	{runeRange{0x10C00, 0x10C48}, eawprN},   // Lo    [73] OLD TURKIC LETTER ORKHON A..OLD TURKIC LETTER ORKHON BASH
+	{runeRange{0x10F30, 0x10F45}, eawprN},   // Lo    [22] SOGDIAN LETTER ALEPH..SOGDIAN INDEPENDENT SHIN
+	{runeRange{0x11052, 0x11065}, eawprN},   // No    [20] BRAHMI NUMBER ONE..BRAHMI NUMBER ONE THOUSAND
+	{runeRange{0x110BE, 0x110C1}, eawprN},   // Po     [4] KAITHI SECTION MARK..KAITHI DOUBLE DANDA
+	{runeRange{0x11173, 0x11173}, eawprN},   // Mn         MAHAJANI SIGN NUKTA
+	{runeRange{0x111DA, 0x111DA}, eawprN},   // Lo         SHARADA EKAM
+	{runeRange{0x11241, 0x11241}, eawprN},   // Mn         KHOJKI VOWEL SIGN VOCALIC R
+	{runeRange{0x11313, 0x11328}, eawprN},   // Lo    [22] GRANTHA LETTER OO..GRANTHA LETTER NA
+	{runeRange{0x11370, 0x11374}, eawprN},   // Mn     [5] COMBINING GRANTHA LETTER A..COMBINING GRANTHA LETTER PA
+	{runeRange{0x114B0, 0x114B2}, eawprN},   // Mc     [3] TIRHUTA VOWEL SIGN AA..TIRHUTA VOWEL SIGN II
+	{runeRange{0x115BC, 0x115BD}, eawprN},   // Mn     [2] SIDDHAM SIGN CANDRABINDU..SIDDHAM SIGN ANUSVARA
+	{runeRange{0x11660, 0x1166C}, eawprN},   // Po    [13] MONGOLIAN BIRGA WITH ORNAMENT..MONGOLIAN TURNED SWIRL BIRGA WITH DOUBLE ORNAMENT
+	{runeRange{0x11726, 0x11726}, eawprN},   // Mc         AHOM VOWEL SIGN E
+	{runeRange{0x118FF, 0x118FF}, eawprN},   // Lo         WARANG CITI OM
+	{runeRange{0x11944, 0x11946}, eawprN},   // Po     [3] DIVES AKURU DOUBLE DANDA..DIVES AKURU END OF TEXT MARK
+	{runeRange{0x11A33, 0x11A38}, eawprN},   // Mn     [6] ZANABAZAR SQUARE FINAL CONSONANT MARK..ZANABAZAR SQUARE SIGN ANUSVARA
+	{runeRange{0x11A9E, 0x11AA2}, eawprN},   // Po     [5] SOYOMBO HEAD MARK WITH MOON AND SUN AND TRIPLE FLAME..SOYOMBO TERMINAL MARK-2
+	{runeRange{0x11C72, 0x11C8F}, eawprN},   // Lo    [30] MARCHEN LETTER KA..MARCHEN LETTER A
+	{runeRange{0x11D47, 0x11D47}, eawprN},   // Mn         MASARAM GONDI RA-KARA
+	{runeRange{0x11EF7, 0x11EF8}, eawprN},   // Po     [2] MAKASAR PASSIMBANG..MAKASAR END OF SECTION
+	{runeRange{0x11FD5, 0x11FDC}, eawprN},   // So     [8] TAMIL SIGN NEL..TAMIL SIGN MUKKURUNI
+	{runeRange{0x16800, 0x16A38}, eawprN},   // Lo   [569] BAMUM LETTER PHASE-A NGKUE MFON..BAMUM LETTER PHASE-F VUEQ
+	{runeRange{0x16B50, 0x16B59}, eawprN},   // Nd    [10] PAHAWH HMONG DIGIT ZERO..PAHAWH HMONG DIGIT NINE
+	{runeRange{0x16FE4, 0x16FE4}, eawprW},   // Mn         KHITAN SMALL SCRIPT FILLER
+	{runeRange{0x1BC00, 0x1BC6A}, eawprN},   // Lo   [107] DUPLOYAN LETTER H..DUPLOYAN LETTER VOCALIC M
+	{runeRange{0x1D16A, 0x1D16C}, eawprN},   // So     [3] MUSICAL SYMBOL FINGERED TREMOLO-1..MUSICAL SYMBOL FINGERED TREMOLO-3
+	{runeRange{0x1D400, 0x1D454}, eawprN},   // L&    [85] MATHEMATICAL BOLD CAPITAL A..MATHEMATICAL ITALIC SMALL G
+	{runeRange{0x1D546, 0x1D546}, eawprN},   // Lu         MATHEMATICAL DOUBLE-STRUCK CAPITAL O
+	{runeRange{0x1D76F, 0x1D76F}, eawprN},   // Sm         MATHEMATICAL SANS-SERIF BOLD NABLA
+	{runeRange{0x1DA84, 0x1DA84}, eawprN},   // Mn         SIGNWRITING LOCATION HEAD NECK
+	{runeRange{0x1E100, 0x1E12C}, eawprN},   // Lo    [45] NYIAKENG PUACHUE HMONG LETTER MA..NYIAKENG PUACHUE HMONG LETTER W
+	{runeRange{0x1E7E0, 0x1E7E6}, eawprN},   // Lo     [7] ETHIOPIC SYLLABLE HHYA..ETHIOPIC SYLLABLE HHYO
+	{runeRange{0x1ECB1, 0x1ECB4}, eawprN},   // No     [4] INDIC SIYAQ NUMBER ALTERNATE ONE..INDIC SIYAQ ALTERNATE LAKH MARK
+	{runeRange{0x1EE4B, 0x1EE4B}, eawprN},   // Lo         ARABIC MATHEMATICAL TAILED LAM
+	{runeRange{0x1EE80, 0x1EE89}, eawprN},   // Lo    [10] ARABIC MATHEMATICAL LOOPED ALEF..ARABIC MATHEMATICAL LOOPED YEH
+	{runeRange{0x1F10B, 0x1F10C}, eawprN},   // No     [2] DINGBAT CIRCLED SANS-SERIF DIGIT ZERO..DINGBAT NEGATIVE CIRCLED SANS-SERIF DIGIT ZERO
+	{runeRange{0x1F250, 0x1F251}, eawprW},   // So     [2] CIRCLED IDEOGRAPH ADVANTAGE..CIRCLED IDEOGRAPH ACCEPT
+	{runeRange{0x1F3F4, 0x1F3F4}, eawprW},   // So         WAVING BLACK FLAG
+	{runeRange{0x1F57A, 0x1F57A}, eawprW},   // So         MAN DANCING
+	{runeRange{0x1F6DC, 0x1F6DF}, eawprW},   // So     [4] WIRELESS..RING BUOY
+	{runeRange{0x1F900, 0x1F90B}, eawprN},   // So    [12] CIRCLED CROSS FORMEE WITH FOUR DOTS..DOWNWARD FACING NOTCHED HOOK WITH DOT
+	{runeRange{0x1FB94, 0x1FBCA}, eawprN},   // So    [55] LEFT HALF INVERSE MEDIUM SHADE AND RIGHT HALF BLOCK..WHITE UP-POINTING CHEVRON
 	{runeRange{0x3134B, 0x3134F}, eawprW},   // Cn     [5] <reserved-3134B>..<reserved-3134F>
-	{runeRange{0x31350, 0x323AF}, eawprW},   // Lo  [4192] CJK UNIFIED IDEOGRAPH-31350..CJK UNIFIED IDEOGRAPH-323AF
-	{runeRange{0x323B0, 0x3FFFD}, eawprW},   // Cn [56398] <reserved-323B0>..<reserved-3FFFD>
-	{runeRange{0xE0001, 0xE0001}, eawprN},   // Cf         LANGUAGE TAG
+	{runeRange{0x002A, 0x002A}, eawprNa},    // Po         ASTERISK
+	{runeRange{0x0061, 0x007A}, eawprNa},    // Ll    [26] LATIN SMALL LETTER A..LATIN SMALL LETTER Z
+	{runeRange{0x00AA, 0x00AA}, eawprA},     // Lo         FEMININE ORDINAL INDICATOR
+	{runeRange{0x00BC, 0x00BE}, eawprA},     // No     [3] VULGAR FRACTION ONE QUARTER..VULGAR FRACTION THREE QUARTERS
+	{runeRange{0x00EC, 0x00ED}, eawprA},     // Ll     [2] LATIN SMALL LETTER I WITH GRAVE..LATIN SMALL LETTER I WITH ACUTE
+	{runeRange{0x0111, 0x0111}, eawprA},     // Ll         LATIN SMALL LETTER D WITH STROKE
+	{runeRange{0x0144, 0x0144}, eawprA},     // Ll         LATIN SMALL LETTER N WITH ACUTE
+	{runeRange{0x01C4, 0x01CD}, eawprN},     // L&    [10] LATIN CAPITAL LETTER DZ WITH CARON..LATIN CAPITAL LETTER A WITH CARON
+	{runeRange{0x01DD, 0x024F}, eawprN},     // L&   [115] LATIN SMALL LETTER TURNED E..LATIN SMALL LETTER Y WITH STROKE
+	{runeRange{0x02CC, 0x02CC}, eawprN},     // Lm         MODIFIER LETTER LOW VERTICAL LINE
+	{runeRange{0x02EF, 0x02FF}, eawprN},     // Sk    [17] MODIFIER LETTER LOW DOWN ARROWHEAD..MODIFIER LETTER LOW LEFT ARROW
+	{runeRange{0x0391, 0x03A1}, eawprA},     // Lu    [17] GREEK CAPITAL LETTER ALPHA..GREEK CAPITAL LETTER RHO
+	{runeRange{0x0482, 0x0482}, eawprN},     // So         CYRILLIC THOUSANDS SIGN
+	{runeRange{0x05C0, 0x05C0}, eawprN},     // Po         HEBREW PUNCTUATION PASEQ
+	{runeRange{0x061B, 0x061B}, eawprN},     // Po         ARABIC SEMICOLON
+	{runeRange{0x06DE, 0x06DE}, eawprN},     // So         ARABIC START OF RUB EL HIZB
+	{runeRange{0x0730, 0x074A}, eawprN},     // Mn    [27] SYRIAC PTHAHA ABOVE..SYRIAC BARREKH
+	{runeRange{0x0816, 0x0819}, eawprN},     // Mn     [4] SAMARITAN MARK IN..SAMARITAN MARK DAGESH
+	{runeRange{0x0898, 0x089F}, eawprN},     // Mn     [8] ARABIC SMALL HIGH WORD AL-JUZ..ARABIC HALF MADDA OVER MADDA
+	{runeRange{0x094D, 0x094D}, eawprN},     // Mn         DEVANAGARI SIGN VIRAMA
+	{runeRange{0x0993, 0x09A8}, eawprN},     // Lo    [22] BENGALI LETTER O..BENGALI LETTER NA
+	{runeRange{0x09E6, 0x09EF}, eawprN},     // Nd    [10] BENGALI DIGIT ZERO..BENGALI DIGIT NINE
+	{runeRange{0x0A35, 0x0A36}, eawprN},     // Lo     [2] GURMUKHI LETTER VA..GURMUKHI LETTER SHA
+	{runeRange{0x0A83, 0x0A83}, eawprN},     // Mc         GUJARATI SIGN VISARGA
+	{runeRange{0x0AE0, 0x0AE1}, eawprN},     // Lo     [2] GUJARATI LETTER VOCALIC RR..GUJARATI LETTER VOCALIC LL
+	{runeRange{0x0B3D, 0x0B3D}, eawprN},     // Lo         ORIYA SIGN AVAGRAHA
+	{runeRange{0x0B72, 0x0B77}, eawprN},     // No     [6] ORIYA FRACTION ONE QUARTER..ORIYA FRACTION THREE SIXTEENTHS
+	{runeRange{0x0BCA, 0x0BCC}, eawprN},     // Mc     [3] TAMIL VOWEL SIGN O..TAMIL VOWEL SIGN AU
+	{runeRange{0x0C3C, 0x0C3C}, eawprN},     // Mn         TELUGU SIGN NUKTA
+	{runeRange{0x0C81, 0x0C81}, eawprN},     // Mn         KANNADA SIGN CANDRABINDU
+	{runeRange{0x0CCC, 0x0CCD}, eawprN},     // Mn     [2] KANNADA VOWEL SIGN AU..KANNADA SIGN VIRAMA
+	{runeRange{0x0D41, 0x0D44}, eawprN},     // Mn     [4] MALAYALAM VOWEL SIGN U..MALAYALAM VOWEL SIGN VOCALIC RR
+	{runeRange{0x0D82, 0x0D83}, eawprN},     // Mc     [2] SINHALA SIGN ANUSVARAYA..SINHALA SIGN VISARGAYA
+	{runeRange{0x0E32, 0x0E33}, eawprN},     // Lo     [2] THAI CHARACTER SARA AA..THAI CHARACTER SARA AM
+	{runeRange{0x0EB2, 0x0EB3}, eawprN},     // Lo     [2] LAO VOWEL SIGN AA..LAO VOWEL SIGN AM
+	{runeRange{0x0F20, 0x0F29}, eawprN},     // Nd    [10] TIBETAN DIGIT ZERO..TIBETAN DIGIT NINE
+	{runeRange{0x0F7F, 0x0F7F}, eawprN},     // Mc         TIBETAN SIGN RNAM BCAD
+	{runeRange{0x102D, 0x1030}, eawprN},     // Mn     [4] MYANMAR VOWEL SIGN I..MYANMAR VOWEL SIGN UU
+	{runeRange{0x1062, 0x1064}, eawprN},     // Mc     [3] MYANMAR VOWEL SIGN SGAW KAREN EU..MYANMAR TONE MARK SGAW KAREN KE PHO
+	{runeRange{0x109E, 0x109F}, eawprN},     // So     [2] MYANMAR SYMBOL SHAN ONE..MYANMAR SYMBOL SHAN EXCLAMATION
+	{runeRange{0x128A, 0x128D}, eawprN},     // Lo     [4] ETHIOPIC SYLLABLE XWI..ETHIOPIC SYLLABLE XWE
+	{runeRange{0x13F8, 0x13FD}, eawprN},     // Ll     [6] CHEROKEE SMALL LETTER YE..CHEROKEE SMALL LETTER MV
+	{runeRange{0x1715, 0x1715}, eawprN},     // Mc         TAGALOG SIGN PAMUDPOD
+	{runeRange{0x17C6, 0x17C6}, eawprN},     // Mn         KHMER SIGN NIKAHIT
+	{runeRange{0x180F, 0x180F}, eawprN},     // Mn         MONGOLIAN FREE VARIATION SELECTOR FOUR
+	{runeRange{0x1930, 0x1931}, eawprN},     // Mc     [2] LIMBU SMALL LETTER KA..LIMBU SMALL LETTER NGA
+	{runeRange{0x1A17, 0x1A18}, eawprN},     // Mn     [2] BUGINESE VOWEL SIGN I..BUGINESE VOWEL SIGN U
+	{runeRange{0x1A7F, 0x1A7F}, eawprN},     // Mn         TAI THAM COMBINING CRYPTOGRAMMIC DOT
+	{runeRange{0x1B3C, 0x1B3C}, eawprN},     // Mn         BALINESE VOWEL SIGN LA LENGA
+	{runeRange{0x1BA6, 0x1BA7}, eawprN},     // Mc     [2] SUNDANESE VOWEL SIGN PANAELAENG..SUNDANESE VOWEL SIGN PANOLONG
+	{runeRange{0x1BFC, 0x1BFF}, eawprN},     // Po     [4] BATAK SYMBOL BINDU NA METEK..BATAK SYMBOL BINDU PANGOLAT
+	{runeRange{0x1CC0, 0x1CC7}, eawprN},     // Po     [8] SUNDANESE PUNCTUATION BINDU SURYA..SUNDANESE PUNCTUATION BINDU BA SATANGA
+	{runeRange{0x1D6B, 0x1D77}, eawprN},     // Ll    [13] LATIN SMALL LETTER UE..LATIN SMALL LETTER TURNED G
+	{runeRange{0x1F80, 0x1FB4}, eawprN},     // L&    [53] GREEK SMALL LETTER ALPHA WITH PSILI AND YPOGEGRAMMENI..GREEK SMALL LETTER ALPHA WITH OXIA AND YPOGEGRAMMENI
+	{runeRange{0x2000, 0x200A}, eawprN},     // Zs    [11] EN QUAD..HAIR SPACE
+	{runeRange{0x2023, 0x2023}, eawprN},     // Po         TRIANGULAR BULLET
+	{runeRange{0x203E, 0x203E}, eawprA},     // Po         OVERLINE
+	{runeRange{0x2074, 0x2074}, eawprA},     // No         SUPERSCRIPT FOUR
+	{runeRange{0x20AC, 0x20AC}, eawprA},     // Sc         EURO SIGN
+	{runeRange{0x210A, 0x2112}, eawprN},     // L&     [9] SCRIPT SMALL G..SCRIPT CAPITAL L
+	{runeRange{0x2129, 0x2129}, eawprN},     // So         TURNED GREEK SMALL LETTER IOTA
+	{runeRange{0x214F, 0x214F}, eawprN},     // So         SYMBOL FOR SAMARITAN SOURCE
+	{runeRange{0x219A, 0x219B}, eawprN},     // Sm     [2] LEFTWARDS ARROW WITH STROKE..RIGHTWARDS ARROW WITH STROKE
+	{runeRange{0x21D4, 0x21D4}, eawprA},     // Sm         LEFT RIGHT DOUBLE ARROW
+	{runeRange{0x2212, 0x2214}, eawprN},     // Sm     [3] MINUS SIGN..DOT PLUS
+	{runeRange{0x2238, 0x223B}, eawprN},     // Sm     [4] DOT MINUS..HOMOTHETIC
+	{runeRange{0x2268, 0x2269}, eawprN},     // Sm     [2] LESS-THAN BUT NOT EQUAL TO..GREATER-THAN BUT NOT EQUAL TO
+	{runeRange{0x2288, 0x2294}, eawprN},     // Sm    [13] NEITHER A SUBSET OF NOR EQUAL TO..SQUARE CUP
+	{runeRange{0x22C0, 0x22FF}, eawprN},     // Sm    [64] N-ARY LOGICAL AND..Z NOTATION BAG MEMBERSHIP
+	{runeRange{0x2313, 0x2319}, eawprN},     // So     [7] SEGMENT..TURNED NOT SIGN
+	{runeRange{0x237C, 0x237C}, eawprN},     // Sm         RIGHT ANGLE WITH DOWNWARDS ZIGZAG ARROW
+	{runeRange{0x23F0, 0x23F0}, eawprW},     // So         ALARM CLOCK
+	{runeRange{0x24EA, 0x24EA}, eawprN},     // No         CIRCLED DIGIT ZERO
+	{runeRange{0x2592, 0x2595}, eawprA},     // So     [4] MEDIUM SHADE..RIGHT ONE EIGHTH BLOCK
+	{runeRange{0x25B6, 0x25B6}, eawprA},     // So         BLACK RIGHT-POINTING TRIANGLE
+	{runeRange{0x25C6, 0x25C8}, eawprA},     // So     [3] BLACK DIAMOND..WHITE DIAMOND CONTAINING BLACK SMALL DIAMOND
+	{runeRange{0x25EF, 0x25EF}, eawprA},     // So         LARGE CIRCLE
+	{runeRange{0x2609, 0x2609}, eawprA},     // So         SUN
+	{runeRange{0x261E, 0x261E}, eawprA},     // So         WHITE RIGHT POINTING INDEX
+	{runeRange{0x2660, 0x2661}, eawprA},     // So     [2] BLACK SPADE SUIT..WHITE HEART SUIT
+	{runeRange{0x266F, 0x266F}, eawprA},     // Sm         MUSIC SHARP SIGN
+	{runeRange{0x26A1, 0x26A1}, eawprW},     // So         HIGH VOLTAGE SIGN
+	{runeRange{0x26C6, 0x26CD}, eawprA},     // So     [8] RAIN..DISABLED CAR
+	{runeRange{0x26E8, 0x26E9}, eawprA},     // So     [2] BLACK CROSS ON SHIELD..SHINTO SHRINE
+	{runeRange{0x26FB, 0x26FC}, eawprA},     // So     [2] JAPANESE BANK SYMBOL..HEADSTONE GRAVEYARD SYMBOL
+	{runeRange{0x2728, 0x2728}, eawprW},     // So         SPARKLES
+	{runeRange{0x2753, 0x2755}, eawprW},     // So     [3] BLACK QUESTION MARK ORNAMENT..WHITE EXCLAMATION MARK ORNAMENT
+	{runeRange{0x276C, 0x276C}, eawprN},     // Ps         MEDIUM LEFT-POINTING ANGLE BRACKET ORNAMENT
+	{runeRange{0x2774, 0x2774}, eawprN},     // Ps         MEDIUM LEFT CURLY BRACKET ORNAMENT
+	{runeRange{0x27B1, 0x27BE}, eawprN},     // So    [14] NOTCHED UPPER RIGHT-SHADOWED WHITE RIGHTWARDS ARROW..OPEN-OUTLINED RIGHTWARDS ARROW
+	{runeRange{0x27E8, 0x27E8}, eawprNa},    // Ps         MATHEMATICAL LEFT ANGLE BRACKET
+	{runeRange{0x27F0, 0x27FF}, eawprN},     // Sm    [16] UPWARDS QUADRUPLE ARROW..LONG RIGHTWARDS SQUIGGLE ARROW
+	{runeRange{0x2987, 0x2987}, eawprN},     // Ps         Z NOTATION LEFT IMAGE BRACKET
+	{runeRange{0x298F, 0x298F}, eawprN},     // Ps         LEFT SQUARE BRACKET WITH TICK IN BOTTOM CORNER
+	{runeRange{0x2997, 0x2997}, eawprN},     // Ps         LEFT BLACK TORTOISE SHELL BRACKET
+	{runeRange{0x29FC, 0x29FC}, eawprN},     // Ps         LEFT-POINTING CURVED ANGLE BRACKET
+	{runeRange{0x2B45, 0x2B46}, eawprN},     // So     [2] LEFTWARDS QUADRUPLE ARROW..RIGHTWARDS QUADRUPLE ARROW
+	{runeRange{0x2B76, 0x2B95}, eawprN},     // So    [32] NORTH WEST TRIANGLE-HEADED ARROW TO BAR..RIGHTWARDS BLACK ARROW
+	{runeRange{0x2CEB, 0x2CEE}, eawprN},     // L&     [4] COPTIC CAPITAL LETTER CRYPTOGRAMMIC SHEI..COPTIC SMALL LETTER CRYPTOGRAMMIC GANGIA
+	{runeRange{0x2D2D, 0x2D2D}, eawprN},     // Ll         GEORGIAN SMALL LETTER AEN
+	{runeRange{0x2DB0, 0x2DB6}, eawprN},     // Lo     [7] ETHIOPIC SYLLABLE ZZA..ETHIOPIC SYLLABLE ZZO
+	{runeRange{0x2E02, 0x2E02}, eawprN},     // Pi         LEFT SUBSTITUTION BRACKET
+	{runeRange{0x2E0C, 0x2E0C}, eawprN},     // Pi         LEFT RAISED OMISSION BRACKET
+	{runeRange{0x2E1D, 0x2E1D}, eawprN},     // Pf         RIGHT LOW PARAPHRASE BRACKET
+	{runeRange{0x2E26, 0x2E26}, eawprN},     // Ps         LEFT SIDEWAYS U BRACKET
+	{runeRange{0x2E3C, 0x2E3F}, eawprN},     // Po     [4] STENOGRAPHIC FULL STOP..CAPITULUM
+	{runeRange{0x2E56, 0x2E56}, eawprN},     // Pe         RIGHT SQUARE BRACKET WITH STROKE
+	{runeRange{0x2E80, 0x2E99}, eawprW},     // So    [26] CJK RADICAL REPEAT..CJK RADICAL RAP
+	{runeRange{0x3006, 0x3006}, eawprW},     // Lo         IDEOGRAPHIC CLOSING MARK
+	{runeRange{0x300E, 0x300E}, eawprW},     // Ps         LEFT WHITE CORNER BRACKET
+	{runeRange{0x3017, 0x3017}, eawprW},     // Pe         RIGHT WHITE LENTICULAR BRACKET
+	{runeRange{0x3020, 0x3020}, eawprW},     // So         POSTAL MARK FACE
+	{runeRange{0x303B, 0x303B}, eawprW},     // Lm         VERTICAL IDEOGRAPHIC ITERATION MARK
+	{runeRange{0x309D, 0x309E}, eawprW},     // Lm     [2] HIRAGANA ITERATION MARK..HIRAGANA VOICED ITERATION MARK
+	{runeRange{0x3131, 0x318E}, eawprW},     // Lo    [94] HANGUL LETTER KIYEOK..HANGUL LETTER ARAEAE
+	{runeRange{0x3220, 0x3229}, eawprW},     // No    [10] PARENTHESIZED IDEOGRAPH ONE..PARENTHESIZED IDEOGRAPH TEN
+	{runeRange{0x32B1, 0x32BF}, eawprW},     // No    [15] CIRCLED NUMBER THIRTY SIX..CIRCLED NUMBER FIFTY
+	{runeRange{0xA016, 0xA48C}, eawprW},     // Lo  [1143] YI SYLLABLE BIT..YI SYLLABLE YYR
+	{runeRange{0xA610, 0xA61F}, eawprN},     // Lo    [16] VAI SYLLABLE NDOLE FA..VAI SYMBOL JONG
+	{runeRange{0xA674, 0xA67D}, eawprN},     // Mn    [10] COMBINING CYRILLIC LETTER UKRAINIAN IE..COMBINING CYRILLIC PAYEROK
+	{runeRange{0xA6F0, 0xA6F1}, eawprN},     // Mn     [2] BAMUM COMBINING MARK KOQNDON..BAMUM COMBINING MARK TUKWENTIS
+	{runeRange{0xA788, 0xA788}, eawprN},     // Lm         MODIFIER LETTER LOW CIRCUMFLEX ACCENT
+	{runeRange{0xA7F2, 0xA7F4}, eawprN},     // Lm     [3] MODIFIER LETTER CAPITAL C..MODIFIER LETTER CAPITAL Q
+	{runeRange{0xA803, 0xA805}, eawprN},     // Lo     [3] SYLOTI NAGRI LETTER U..SYLOTI NAGRI LETTER O
+	{runeRange{0xA828, 0xA82B}, eawprN},     // So     [4] SYLOTI NAGRI POETRY MARK-1..SYLOTI NAGRI POETRY MARK-4
+	{runeRange{0xA880, 0xA881}, eawprN},     // Mc     [2] SAURASHTRA SIGN ANUSVARA..SAURASHTRA SIGN VISARGA
+	{runeRange{0xA8F8, 0xA8FA}, eawprN},     // Po     [3] DEVANAGARI SIGN PUSHPIKA..DEVANAGARI CARET
+	{runeRange{0xA92E, 0xA92F}, eawprN},     // Po     [2] KAYAH LI SIGN CWI..KAYAH LI SIGN SHYA
+	{runeRange{0xA984, 0xA9B2}, eawprN},     // Lo    [47] JAVANESE LETTER A..JAVANESE LETTER HA
+	{runeRange{0xA9CF, 0xA9CF}, eawprN},     // Lm         JAVANESE PANGRANGKEP
+	{runeRange{0xA9FA, 0xA9FE}, eawprN},     // Lo     [5] MYANMAR LETTER TAI LAING LLA..MYANMAR LETTER TAI LAING BHA
+	{runeRange{0xAA43, 0xAA43}, eawprN},     // Mn         CHAM CONSONANT SIGN FINAL NG
+	{runeRange{0xAA71, 0xAA76}, eawprN},     // Lo     [6] MYANMAR LETTER KHAMTI XA..MYANMAR LOGOGRAM KHAMTI HM
+	{runeRange{0xAAB0, 0xAAB0}, eawprN},     // Mn         TAI VIET MAI KANG
+	{runeRange{0xAAC1, 0xAAC1}, eawprN},     // Mn         TAI VIET TONE MAI THO
+	{runeRange{0xAAEE, 0xAAEF}, eawprN},     // Mc     [2] MEETEI MAYEK VOWEL SIGN AU..MEETEI MAYEK VOWEL SIGN AAU
+	{runeRange{0xAB11, 0xAB16}, eawprN},     // Lo     [6] ETHIOPIC SYLLABLE DZU..ETHIOPIC SYLLABLE DZO
+	{runeRange{0xAB6A, 0xAB6B}, eawprN},     // Sk     [2] MODIFIER LETTER LEFT TACK..MODIFIER LETTER RIGHT TACK
+	{runeRange{0xABEB, 0xABEB}, eawprN},     // Po         MEETEI MAYEK CHEIKHEI
+	{runeRange{0xDB80, 0xDBFF}, eawprN},     // Cs   [128] <surrogate-DB80>..<surrogate-DBFF>
+	{runeRange{0xFB13, 0xFB17}, eawprN},     // Ll     [5] ARMENIAN SMALL LIGATURE MEN NOW..ARMENIAN SMALL LIGATURE MEN XEH
+	{runeRange{0xFB40, 0xFB41}, eawprN},     // Lo     [2] HEBREW LETTER NUN WITH DAGESH..HEBREW LETTER SAMEKH WITH DAGESH
+	{runeRange{0xFD40, 0xFD4F}, eawprN},     // So    [16] ARABIC LIGATURE RAHIMAHU ALLAAH..ARABIC LIGATURE RAHIMAHUM ALLAAH
+	{runeRange{0xFE10, 0xFE16}, eawprW},     // Po     [7] PRESENTATION FORM FOR VERTICAL COMMA..PRESENTATION FORM FOR VERTICAL QUESTION MARK
+	{runeRange{0xFE35, 0xFE35}, eawprW},     // Ps         PRESENTATION FORM FOR VERTICAL LEFT PARENTHESIS
+	{runeRange{0xFE3D, 0xFE3D}, eawprW},     // Ps         PRESENTATION FORM FOR VERTICAL LEFT DOUBLE ANGLE BRACKET
+	{runeRange{0xFE45, 0xFE46}, eawprW},     // Po     [2] SESAME DOT..WHITE SESAME DOT
+	{runeRange{0xFE59, 0xFE59}, eawprW},     // Ps         SMALL LEFT PARENTHESIS
+	{runeRange{0xFE63, 0xFE63}, eawprW},     // Pd         SMALL HYPHEN-MINUS
+	{runeRange{0xFF01, 0xFF03}, eawprF},     // Po     [3] FULLWIDTH EXCLAMATION MARK..FULLWIDTH NUMBER SIGN
+	{runeRange{0xFF0D, 0xFF0D}, eawprF},     // Pd         FULLWIDTH HYPHEN-MINUS
+	{runeRange{0xFF3C, 0xFF3C}, eawprF},     // Po         FULLWIDTH REVERSE SOLIDUS
+	{runeRange{0xFF5D, 0xFF5D}, eawprF},     // Pe         FULLWIDTH RIGHT CURLY BRACKET
+	{runeRange{0xFF66, 0xFF6F}, eawprH},     // Lo    [10] HALFWIDTH KATAKANA LETTER WO..HALFWIDTH KATAKANA LETTER SMALL TU
+	{runeRange{0xFFDA, 0xFFDC}, eawprH},     // Lo     [3] HALFWIDTH HANGUL LETTER EU..HALFWIDTH HANGUL LETTER I
+	{runeRange{0xFFED, 0xFFEE}, eawprH},     // So     [2] HALFWIDTH BLACK SQUARE..HALFWIDTH WHITE CIRCLE
+	{runeRange{0x1003F, 0x1004D}, eawprN},   // Lo    [15] LINEAR B SYLLABLE B020 ZO..LINEAR B SYLLABLE B091 TWO
+	{runeRange{0x10179, 0x10189}, eawprN},   // So    [17] GREEK YEAR SIGN..GREEK TRYBLION BASE SIGN
+	{runeRange{0x102A0, 0x102D0}, eawprN},   // Lo    [49] CARIAN LETTER A..CARIAN LETTER UUU3
+	{runeRange{0x10342, 0x10349}, eawprN},   // Lo     [8] GOTHIC LETTER RAIDA..GOTHIC LETTER OTHAL
+	{runeRange{0x103D0, 0x103D0}, eawprN},   // Po         OLD PERSIAN WORD DIVIDER
+	{runeRange{0x10500, 0x10527}, eawprN},   // Lo    [40] ELBASAN LETTER A..ELBASAN LETTER KHE
+	{runeRange{0x105A3, 0x105B1}, eawprN},   // Ll    [15] VITHKUQI SMALL LETTER HA..VITHKUQI SMALL LETTER RE
+	{runeRange{0x107B2, 0x107BA}, eawprN},   // Lm     [9] MODIFIER LETTER SMALL CAPITAL Y..MODIFIER LETTER SMALL S WITH CURL
+	{runeRange{0x10857, 0x10857}, eawprN},   // Po         IMPERIAL ARAMAIC SECTION SIGN
+	{runeRange{0x108F4, 0x108F5}, eawprN},   // Lo     [2] HATRAN LETTER SHIN..HATRAN LETTER TAW
+	{runeRange{0x109A0, 0x109B7}, eawprN},   // Lo    [24] MEROITIC CURSIVE LETTER A..MEROITIC CURSIVE LETTER DA
+	{runeRange{0x10A0C, 0x10A0F}, eawprN},   // Mn     [4] KHAROSHTHI VOWEL LENGTH MARK..KHAROSHTHI SIGN VISARGA
+	{runeRange{0x10A60, 0x10A7C}, eawprN},   // Lo    [29] OLD SOUTH ARABIAN LETTER HE..OLD SOUTH ARABIAN LETTER THETH
+	{runeRange{0x10AE5, 0x10AE6}, eawprN},   // Mn     [2] MANICHAEAN ABBREVIATION MARK ABOVE..MANICHAEAN ABBREVIATION MARK BELOW
+	{runeRange{0x10B78, 0x10B7F}, eawprN},   // No     [8] INSCRIPTIONAL PAHLAVI NUMBER ONE..INSCRIPTIONAL PAHLAVI NUMBER ONE THOUSAND
+	{runeRange{0x10D00, 0x10D23}, eawprN},   // Lo    [36] HANIFI ROHINGYA LETTER A..HANIFI ROHINGYA MARK NA KHONNA
+	{runeRange{0x10EFD, 0x10EFF}, eawprN},   // Mn     [3] ARABIC SMALL LOW WORD SAKTA..ARABIC SMALL LOW WORD MADDA
+	{runeRange{0x10F70, 0x10F81}, eawprN},   // Lo    [18] OLD UYGHUR LETTER ALEPH..OLD UYGHUR LETTER LESH
+	{runeRange{0x11002, 0x11002}, eawprN},   // Mc         BRAHMI SIGN VISARGA
+	{runeRange{0x11073, 0x11074}, eawprN},   // Mn     [2] BRAHMI VOWEL SIGN OLD TAMIL SHORT E..BRAHMI VOWEL SIGN OLD TAMIL SHORT O
+	{runeRange{0x110B7, 0x110B8}, eawprN},   // Mc     [2] KAITHI VOWEL SIGN O..KAITHI VOWEL SIGN AU
+	{runeRange{0x110F0, 0x110F9}, eawprN},   // Nd    [10] SORA SOMPENG DIGIT ZERO..SORA SOMPENG DIGIT NINE
+	{runeRange{0x11144, 0x11144}, eawprN},   // Lo         CHAKMA LETTER LHAA
+	{runeRange{0x11182, 0x11182}, eawprN},   // Mc         SHARADA SIGN VISARGA
+	{runeRange{0x111CD, 0x111CD}, eawprN},   // Po         SHARADA SUTRA MARK
+	{runeRange{0x111E1, 0x111F4}, eawprN},   // No    [20] SINHALA ARCHAIC DIGIT ONE..SINHALA ARCHAIC NUMBER ONE THOUSAND
+	{runeRange{0x11236, 0x11237}, eawprN},   // Mn     [2] KHOJKI SIGN NUKTA..KHOJKI SIGN SHADDA
+	{runeRange{0x1128F, 0x1129D}, eawprN},   // Lo    [15] MULTANI LETTER NYA..MULTANI LETTER BA
+	{runeRange{0x11300, 0x11301}, eawprN},   // Mn     [2] GRANTHA SIGN COMBINING ANUSVARA ABOVE..GRANTHA SIGN CANDRABINDU
+	{runeRange{0x1133B, 0x1133C}, eawprN},   // Mn     [2] COMBINING BINDU BELOW..GRANTHA SIGN NUKTA
+	{runeRange{0x11357, 0x11357}, eawprN},   // Mc         GRANTHA AU LENGTH MARK
+	{runeRange{0x11440, 0x11441}, eawprN},   // Mc     [2] NEWA VOWEL SIGN O..NEWA VOWEL SIGN AU
+	{runeRange{0x1145D, 0x1145D}, eawprN},   // Po         NEWA INSERTION SIGN
+	{runeRange{0x114BB, 0x114BE}, eawprN},   // Mc     [4] TIRHUTA VOWEL SIGN AI..TIRHUTA VOWEL SIGN AU
+	{runeRange{0x11580, 0x115AE}, eawprN},   // Lo    [47] SIDDHAM LETTER A..SIDDHAM LETTER HA
+	{runeRange{0x115D8, 0x115DB}, eawprN},   // Lo     [4] SIDDHAM LETTER THREE-CIRCLE ALTERNATE I..SIDDHAM LETTER ALTERNATE U
+	{runeRange{0x1163F, 0x11640}, eawprN},   // Mn     [2] MODI SIGN VIRAMA..MODI SIGN ARDHACANDRA
+	{runeRange{0x116AD, 0x116AD}, eawprN},   // Mn         TAKRI VOWEL SIGN AA
+	{runeRange{0x11700, 0x1171A}, eawprN},   // Lo    [27] AHOM LETTER KA..AHOM LETTER ALTERNATE BA
+	{runeRange{0x1173C, 0x1173E}, eawprN},   // Po     [3] AHOM SIGN SMALL SECTION..AHOM SIGN RULAI
+	{runeRange{0x1183B, 0x1183B}, eawprN},   // Po         DOGRA ABBREVIATION SIGN
+	{runeRange{0x11915, 0x11916}, eawprN},   // Lo     [2] DIVES AKURU LETTER NYA..DIVES AKURU LETTER TTA
+	{runeRange{0x11940, 0x11940}, eawprN},   // Mc         DIVES AKURU MEDIAL YA
+	{runeRange{0x119D1, 0x119D3}, eawprN},   // Mc     [3] NANDINAGARI VOWEL SIGN AA..NANDINAGARI VOWEL SIGN II
+	{runeRange{0x119E4, 0x119E4}, eawprN},   // Mc         NANDINAGARI VOWEL SIGN PRISHTHAMATRA E
+	{runeRange{0x11A3F, 0x11A46}, eawprN},   // Po     [8] ZANABAZAR SQUARE INITIAL HEAD MARK..ZANABAZAR SQUARE CLOSING DOUBLE-LINED HEAD MARK
+	{runeRange{0x11A97, 0x11A97}, eawprN},   // Mc         SOYOMBO SIGN VISARGA
+	{runeRange{0x11C00, 0x11C08}, eawprN},   // Lo     [9] BHAIKSUKI LETTER A..BHAIKSUKI LETTER VOCALIC L
+	{runeRange{0x11C41, 0x11C45}, eawprN},   // Po     [5] BHAIKSUKI DANDA..BHAIKSUKI GAP FILLER-2
+	{runeRange{0x11CB1, 0x11CB1}, eawprN},   // Mc         MARCHEN VOWEL SIGN I
+	{runeRange{0x11D3A, 0x11D3A}, eawprN},   // Mn         MASARAM GONDI VOWEL SIGN E
+	{runeRange{0x11D6A, 0x11D89}, eawprN},   // Lo    [32] GUNJALA GONDI LETTER OO..GUNJALA GONDI LETTER SA
+	{runeRange{0x11DA0, 0x11DA9}, eawprN},   // Nd    [10] GUNJALA GONDI DIGIT ZERO..GUNJALA GONDI DIGIT NINE
+	{runeRange{0x11F04, 0x11F10}, eawprN},   // Lo    [13] KAWI LETTER A..KAWI LETTER O
+	{runeRange{0x11F43, 0x11F4F}, eawprN},   // Po    [13] KAWI DANDA..KAWI PUNCTUATION CLOSING SPIRAL
+	{runeRange{0x12000, 0x12399}, eawprN},   // Lo   [922] CUNEIFORM SIGN A..CUNEIFORM SIGN U U
+	{runeRange{0x13440, 0x13440}, eawprN},   // Mn         EGYPTIAN HIEROGLYPH MIRROR HORIZONTALLY
+	{runeRange{0x16A70, 0x16ABE}, eawprN},   // Lo    [79] TANGSA LETTER OZ..TANGSA LETTER ZA
+	{runeRange{0x16B3C, 0x16B3F}, eawprN},   // So     [4] PAHAWH HMONG SIGN XYEEM NTXIV..PAHAWH HMONG SIGN XYEEM FAIB
+	{runeRange{0x16E40, 0x16E7F}, eawprN},   // L&    [64] MEDEFAIDRIN CAPITAL LETTER M..MEDEFAIDRIN SMALL LETTER Y
+	{runeRange{0x16F93, 0x16F9F}, eawprN},   // Lm    [13] MIAO LETTER TONE-2..MIAO LETTER REFORMED TONE-8
+	{runeRange{0x18B00, 0x18CD5}, eawprW},   // Lo   [470] KHITAN SMALL SCRIPT CHARACTER-18B00..KHITAN SMALL SCRIPT CHARACTER-18CD5
+	{runeRange{0x1B150, 0x1B152}, eawprW},   // Lo     [3] HIRAGANA LETTER SMALL WI..HIRAGANA LETTER SMALL WO
+	{runeRange{0x1BC9C, 0x1BC9C}, eawprN},   // So         DUPLOYAN SIGN O WITH CROSS
+	{runeRange{0x1D100, 0x1D126}, eawprN},   // So    [39] MUSICAL SYMBOL SINGLE BARLINE..MUSICAL SYMBOL DRUM CLEF-2
+	{runeRange{0x1D183, 0x1D184}, eawprN},   // So     [2] MUSICAL SYMBOL ARPEGGIATO UP..MUSICAL SYMBOL ARPEGGIATO DOWN
+	{runeRange{0x1D2C0, 0x1D2D3}, eawprN},   // No    [20] KAKTOVIK NUMERAL ZERO..KAKTOVIK NUMERAL NINETEEN
+	{runeRange{0x1D4A5, 0x1D4A6}, eawprN},   // Lu     [2] MATHEMATICAL SCRIPT CAPITAL J..MATHEMATICAL SCRIPT CAPITAL K
+	{runeRange{0x1D516, 0x1D51C}, eawprN},   // Lu     [7] MATHEMATICAL FRAKTUR CAPITAL S..MATHEMATICAL FRAKTUR CAPITAL Y
+	{runeRange{0x1D6C1, 0x1D6C1}, eawprN},   // Sm         MATHEMATICAL BOLD NABLA
+	{runeRange{0x1D735, 0x1D735}, eawprN},   // Sm         MATHEMATICAL BOLD ITALIC NABLA
+	{runeRange{0x1D7A9, 0x1D7A9}, eawprN},   // Sm         MATHEMATICAL SANS-SERIF BOLD ITALIC NABLA
+	{runeRange{0x1DA3B, 0x1DA6C}, eawprN},   // Mn    [50] SIGNWRITING MOUTH CLOSED NEUTRAL..SIGNWRITING EXCITEMENT
+	{runeRange{0x1DAA1, 0x1DAAF}, eawprN},   // Mn    [15] SIGNWRITING ROTATION MODIFIER-2..SIGNWRITING ROTATION MODIFIER-16
+	{runeRange{0x1E023, 0x1E024}, eawprN},   // Mn     [2] COMBINING GLAGOLITIC LETTER YU..COMBINING GLAGOLITIC LETTER SMALL YUS
+	{runeRange{0x1E14E, 0x1E14E}, eawprN},   // Lo         NYIAKENG PUACHUE HMONG LOGOGRAM NYAJ
+	{runeRange{0x1E4D0, 0x1E4EA}, eawprN},   // Lo    [27] NAG MUNDARI LETTER O..NAG MUNDARI LETTER ELL
+	{runeRange{0x1E800, 0x1E8C4}, eawprN},   // Lo   [197] MENDE KIKAKUI SYLLABLE M001 KI..MENDE KIKAKUI SYLLABLE M060 NYON
+	{runeRange{0x1EC71, 0x1ECAB}, eawprN},   // No    [59] INDIC SIYAQ NUMBER ONE..INDIC SIYAQ NUMBER PREFIXED NINE
+	{runeRange{0x1EE00, 0x1EE03}, eawprN},   // Lo     [4] ARABIC MATHEMATICAL ALEF..ARABIC MATHEMATICAL DAL
+	{runeRange{0x1EE3B, 0x1EE3B}, eawprN},   // Lo         ARABIC MATHEMATICAL INITIAL GHAIN
+	{runeRange{0x1EE57, 0x1EE57}, eawprN},   // Lo         ARABIC MATHEMATICAL TAILED KHAH
+	{runeRange{0x1EE6C, 0x1EE72}, eawprN},   // Lo     [7] ARABIC MATHEMATICAL STRETCHED MEEM..ARABIC MATHEMATICAL STRETCHED QAF
+	{runeRange{0x1EEAB, 0x1EEBB}, eawprN},   // Lo    [17] ARABIC MATHEMATICAL DOUBLE-STRUCK LAM..ARABIC MATHEMATICAL DOUBLE-STRUCK GHAIN
+	{runeRange{0x1F0C1, 0x1F0CE}, eawprN},   // So    [14] PLAYING CARD ACE OF DIAMONDS..PLAYING CARD KING OF DIAMONDS
+	{runeRange{0x1F130, 0x1F169}, eawprA},   // So    [58] SQUARED LATIN CAPITAL LETTER A..NEGATIVE CIRCLED LATIN CAPITAL LETTER Z
+	{runeRange{0x1F1E6, 0x1F1FF}, eawprN},   // So    [26] REGIONAL INDICATOR SYMBOL LETTER A..REGIONAL INDICATOR SYMBOL LETTER Z
+	{runeRange{0x1F32D, 0x1F335}, eawprW},   // So     [9] HOT DOG..CACTUS
+	{runeRange{0x1F3CF, 0x1F3D3}, eawprW},   // So     [5] CRICKET BAT AND BALL..TABLE TENNIS PADDLE AND BALL
+	{runeRange{0x1F400, 0x1F43E}, eawprW},   // So    [63] RAT..PAW PRINTS
+	{runeRange{0x1F54B, 0x1F54E}, eawprW},   // So     [4] KAABA..MENORAH WITH NINE BRANCHES
+	{runeRange{0x1F5A4, 0x1F5A4}, eawprW},   // So         BLACK HEART
+	{runeRange{0x1F6CD, 0x1F6CF}, eawprN},   // So     [3] SHOPPING BAGS..BED
+	{runeRange{0x1F6F4, 0x1F6FC}, eawprW},   // So     [9] SCOOTER..ROLLER SKATE
+	{runeRange{0x1F850, 0x1F859}, eawprN},   // So    [10] LEFTWARDS SANS-SERIF ARROW..UP DOWN SANS-SERIF ARROW
+	{runeRange{0x1F946, 0x1F946}, eawprN},   // So         RIFLE
+	{runeRange{0x1FACE, 0x1FADB}, eawprW},   // So    [14] MOOSE..PEA POD
+	{runeRange{0x2A700, 0x2B739}, eawprW},   // Lo  [4154] CJK UNIFIED IDEOGRAPH-2A700..CJK UNIFIED IDEOGRAPH-2B739
+	{runeRange{0x2F800, 0x2FA1D}, eawprW},   // Lo   [542] CJK COMPATIBILITY IDEOGRAPH-2F800..CJK COMPATIBILITY IDEOGRAPH-2FA1D
 	{runeRange{0xE0020, 0xE007F}, eawprN},   // Cf    [96] TAG SPACE..CANCEL TAG
-	{runeRange{0xE0100, 0xE01EF}, eawprA},   // Mn   [240] VARIATION SELECTOR-17..VARIATION SELECTOR-256
+	{runeRange{0x0024, 0x0024}, eawprNa},    // Sc         DOLLAR SIGN
+	{runeRange{0x002E, 0x002F}, eawprNa},    // Po     [2] FULL STOP..SOLIDUS
+	{runeRange{0x005D, 0x005D}, eawprNa},    // Pe         RIGHT SQUARE BRACKET
+	{runeRange{0x007E, 0x007E}, eawprNa},    // Sm         TILDE
+	{runeRange{0x00A6, 0x00A6}, eawprNa},    // So         BROKEN BAR
+	{runeRange{0x00AE, 0x00AE}, eawprA},     // So         REGISTERED SIGN
+	{runeRange{0x00B8, 0x00B8}, eawprA},     // Sk         CEDILLA
+	{runeRange{0x00C7, 0x00CF}, eawprN},     // Lu     [9] LATIN CAPITAL LETTER C WITH CEDILLA..LATIN CAPITAL LETTER I WITH DIAERESIS
+	{runeRange{0x00E6, 0x00E6}, eawprA},     // Ll         LATIN SMALL LETTER AE
+	{runeRange{0x00F2, 0x00F3}, eawprA},     // Ll     [2] LATIN SMALL LETTER O WITH GRAVE..LATIN SMALL LETTER O WITH ACUTE
+	{runeRange{0x00FF, 0x00FF}, eawprN},     // Ll         LATIN SMALL LETTER Y WITH DIAERESIS
+	{runeRange{0x011B, 0x011B}, eawprA},     // Ll         LATIN SMALL LETTER E WITH CARON
+	{runeRange{0x0138, 0x0138}, eawprA},     // Ll         LATIN SMALL LETTER KRA
+	{runeRange{0x014D, 0x014D}, eawprA},     // Ll         LATIN SMALL LETTER O WITH MACRON
+	{runeRange{0x0180, 0x01BA}, eawprN},     // L&    [59] LATIN SMALL LETTER B WITH STROKE..LATIN SMALL LETTER EZH WITH TAIL
+	{runeRange{0x01D1, 0x01D1}, eawprN},     // Lu         LATIN CAPITAL LETTER O WITH CARON
+	{runeRange{0x01D9, 0x01D9}, eawprN},     // Lu         LATIN CAPITAL LETTER U WITH DIAERESIS AND CARON
+	{runeRange{0x0261, 0x0261}, eawprA},     // Ll         LATIN SMALL LETTER SCRIPT G
+	{runeRange{0x02C6, 0x02C6}, eawprN},     // Lm         MODIFIER LETTER CIRCUMFLEX ACCENT
+	{runeRange{0x02D1, 0x02D1}, eawprN},     // Lm         MODIFIER LETTER HALF TRIANGULAR COLON
+	{runeRange{0x02E5, 0x02EB}, eawprN},     // Sk     [7] MODIFIER LETTER EXTRA-HIGH TONE BAR..MODIFIER LETTER YANG DEPARTING TONE MARK
+	{runeRange{0x0375, 0x0375}, eawprN},     // Sk         GREEK LOWER NUMERAL SIGN
+	{runeRange{0x0387, 0x0387}, eawprN},     // Po         GREEK ANO TELEIA
+	{runeRange{0x03C2, 0x03C2}, eawprN},     // Ll         GREEK SMALL LETTER FINAL SIGMA
+	{runeRange{0x0410, 0x044F}, eawprA},     // L&    [64] CYRILLIC CAPITAL LETTER A..CYRILLIC SMALL LETTER YA
+	{runeRange{0x0500, 0x052F}, eawprN},     // L&    [48] CYRILLIC CAPITAL LETTER KOMI DE..CYRILLIC SMALL LETTER EL WITH DESCENDER
+	{runeRange{0x058F, 0x058F}, eawprN},     // Sc         ARMENIAN DRAM SIGN
+	{runeRange{0x05C6, 0x05C6}, eawprN},     // Po         HEBREW PUNCTUATION NUN HAFUKHA
+	{runeRange{0x060B, 0x060B}, eawprN},     // Sc         AFGHANI SIGN
+	{runeRange{0x0640, 0x0640}, eawprN},     // Lm         ARABIC TATWEEL
+	{runeRange{0x06D4, 0x06D4}, eawprN},     // Po         ARABIC FULL STOP
+	{runeRange{0x06E9, 0x06E9}, eawprN},     // So         ARABIC PLACE OF SAJDAH
+	{runeRange{0x070F, 0x070F}, eawprN},     // Cf         SYRIAC ABBREVIATION MARK
+	{runeRange{0x07A6, 0x07B0}, eawprN},     // Mn    [11] THAANA ABAFILI..THAANA SUKUN
+	{runeRange{0x07FA, 0x07FA}, eawprN},     // Lm         NKO LAJANYALAN
+	{runeRange{0x0825, 0x0827}, eawprN},     // Mn     [3] SAMARITAN VOWEL SIGN SHORT A..SAMARITAN VOWEL SIGN U
+	{runeRange{0x0870, 0x0887}, eawprN},     // Lo    [24] ARABIC LETTER ALEF WITH ATTACHED FATHA..ARABIC BASELINE ROUND DOT
+	{runeRange{0x08E2, 0x08E2}, eawprN},     // Cf         ARABIC DISPUTED END OF AYAH
+	{runeRange{0x093D, 0x093D}, eawprN},     // Lo         DEVANAGARI SIGN AVAGRAHA
+	{runeRange{0x0958, 0x0961}, eawprN},     // Lo    [10] DEVANAGARI LETTER QA..DEVANAGARI LETTER VOCALIC LL
+	{runeRange{0x0981, 0x0981}, eawprN},     // Mn         BENGALI SIGN CANDRABINDU
+	{runeRange{0x09BC, 0x09BC}, eawprN},     // Mn         BENGALI SIGN NUKTA
+	{runeRange{0x09D7, 0x09D7}, eawprN},     // Mc         BENGALI AU LENGTH MARK
+	{runeRange{0x09FA, 0x09FA}, eawprN},     // So         BENGALI ISSHAR
+	{runeRange{0x0A0F, 0x0A10}, eawprN},     // Lo     [2] GURMUKHI LETTER EE..GURMUKHI LETTER AI
+	{runeRange{0x0A41, 0x0A42}, eawprN},     // Mn     [2] GURMUKHI VOWEL SIGN U..GURMUKHI VOWEL SIGN UU
+	{runeRange{0x0A72, 0x0A74}, eawprN},     // Lo     [3] GURMUKHI IRI..GURMUKHI EK ONKAR
+	{runeRange{0x0AAA, 0x0AB0}, eawprN},     // Lo     [7] GUJARATI LETTER PA..GUJARATI LETTER RA
+	{runeRange{0x0AC9, 0x0AC9}, eawprN},     // Mc         GUJARATI VOWEL SIGN CANDRA O
+	{runeRange{0x0AF1, 0x0AF1}, eawprN},     // Sc         GUJARATI RUPEE SIGN
+	{runeRange{0x0B2A, 0x0B30}, eawprN},     // Lo     [7] ORIYA LETTER PA..ORIYA LETTER RA
+	{runeRange{0x0B41, 0x0B44}, eawprN},     // Mn     [4] ORIYA VOWEL SIGN U..ORIYA VOWEL SIGN VOCALIC RR
+	{runeRange{0x0B62, 0x0B63}, eawprN},     // Mn     [2] ORIYA VOWEL SIGN VOCALIC L..ORIYA VOWEL SIGN VOCALIC LL
+	{runeRange{0x0B8E, 0x0B90}, eawprN},     // Lo     [3] TAMIL LETTER E..TAMIL LETTER AI
+	{runeRange{0x0BBE, 0x0BBF}, eawprN},     // Mc     [2] TAMIL VOWEL SIGN AA..TAMIL VOWEL SIGN I
+	{runeRange{0x0BE6, 0x0BEF}, eawprN},     // Nd    [10] TAMIL DIGIT ZERO..TAMIL DIGIT NINE
+	{runeRange{0x0C05, 0x0C0C}, eawprN},     // Lo     [8] TELUGU LETTER A..TELUGU LETTER VOCALIC L
+	{runeRange{0x0C46, 0x0C48}, eawprN},     // Mn     [3] TELUGU VOWEL SIGN E..TELUGU VOWEL SIGN AI
+	{runeRange{0x0C77, 0x0C77}, eawprN},     // Po         TELUGU SIGN SIDDHAM
+	{runeRange{0x0C8E, 0x0C90}, eawprN},     // Lo     [3] KANNADA LETTER E..KANNADA LETTER AI
+	{runeRange{0x0CC0, 0x0CC4}, eawprN},     // Mc     [5] KANNADA VOWEL SIGN II..KANNADA VOWEL SIGN VOCALIC RR
+	{runeRange{0x0CE2, 0x0CE3}, eawprN},     // Mn     [2] KANNADA VOWEL SIGN VOCALIC L..KANNADA VOWEL SIGN VOCALIC LL
+	{runeRange{0x0D12, 0x0D3A}, eawprN},     // Lo    [41] MALAYALAM LETTER O..MALAYALAM LETTER TTTA
+	{runeRange{0x0D4E, 0x0D4E}, eawprN},     // Lo         MALAYALAM LETTER DOT REPH
+	{runeRange{0x0D70, 0x0D78}, eawprN},     // No     [9] MALAYALAM NUMBER TEN..MALAYALAM FRACTION THREE SIXTEENTHS
+	{runeRange{0x0DBD, 0x0DBD}, eawprN},     // Lo         SINHALA LETTER DANTAJA LAYANNA
+	{runeRange{0x0DF2, 0x0DF3}, eawprN},     // Mc     [2] SINHALA VOWEL SIGN DIGA GAETTA-PILLA..SINHALA VOWEL SIGN DIGA GAYANUKITTA
+	{runeRange{0x0E46, 0x0E46}, eawprN},     // Lm         THAI CHARACTER MAIYAMOK
+	{runeRange{0x0E8C, 0x0EA3}, eawprN},     // Lo    [24] LAO LETTER PALI JHA..LAO LETTER LO LING
+	{runeRange{0x0EC6, 0x0EC6}, eawprN},     // Lm         LAO KO LA
+	{runeRange{0x0F14, 0x0F14}, eawprN},     // Po         TIBETAN MARK GTER TSHEG
+	{runeRange{0x0F36, 0x0F36}, eawprN},     // So         TIBETAN MARK CARET -DZUD RTAGS BZHI MIG CAN
+	{runeRange{0x0F3E, 0x0F3F}, eawprN},     // Mc     [2] TIBETAN SIGN YAR TSHES..TIBETAN SIGN MAR TSHES
+	{runeRange{0x0F88, 0x0F8C}, eawprN},     // Lo     [5] TIBETAN SIGN LCE TSA CAN..TIBETAN SIGN INVERTED MCHU CAN
+	{runeRange{0x0FD5, 0x0FD8}, eawprN},     // So     [4] RIGHT-FACING SVASTI SIGN..LEFT-FACING SVASTI SIGN WITH DOTS
+	{runeRange{0x1039, 0x103A}, eawprN},     // Mn     [2] MYANMAR SIGN VIRAMA..MYANMAR SIGN ASAT
+	{runeRange{0x1058, 0x1059}, eawprN},     // Mn     [2] MYANMAR VOWEL SIGN VOCALIC L..MYANMAR VOWEL SIGN VOCALIC LL
+	{runeRange{0x1071, 0x1074}, eawprN},     // Mn     [4] MYANMAR VOWEL SIGN GEBA KAREN I..MYANMAR VOWEL SIGN KAYAH EE
+	{runeRange{0x108F, 0x108F}, eawprN},     // Mc         MYANMAR SIGN RUMAI PALAUNG TONE-5
+	{runeRange{0x10D0, 0x10FA}, eawprN},     // Ll    [43] GEORGIAN LETTER AN..GEORGIAN LETTER AIN
+	{runeRange{0x1250, 0x1256}, eawprN},     // Lo     [7] ETHIOPIC SYLLABLE QHA..ETHIOPIC SYLLABLE QHO
+	{runeRange{0x12C0, 0x12C0}, eawprN},     // Lo         ETHIOPIC SYLLABLE KXWA
+	{runeRange{0x1369, 0x137C}, eawprN},     // No    [20] ETHIOPIC DIGIT ONE..ETHIOPIC NUMBER TEN THOUSAND
+	{runeRange{0x166E, 0x166E}, eawprN},     // Po         CANADIAN SYLLABICS FULL STOP
+	{runeRange{0x16EE, 0x16F0}, eawprN},     // Nl     [3] RUNIC ARLAUG SYMBOL..RUNIC BELGTHOR SYMBOL
+	{runeRange{0x1734, 0x1734}, eawprN},     // Mc         HANUNOO SIGN PAMUDPOD
+	{runeRange{0x17B4, 0x17B5}, eawprN},     // Mn     [2] KHMER VOWEL INHERENT AQ..KHMER VOWEL INHERENT AA
+	{runeRange{0x17D7, 0x17D7}, eawprN},     // Lm         KHMER SIGN LEK TOO
+	{runeRange{0x1806, 0x1806}, eawprN},     // Pd         MONGOLIAN TODO SOFT HYPHEN
+	{runeRange{0x1844, 0x1878}, eawprN},     // Lo    [53] MONGOLIAN LETTER TODO E..MONGOLIAN LETTER CHA WITH TWO DOTS
+	{runeRange{0x1920, 0x1922}, eawprN},     // Mn     [3] LIMBU VOWEL SIGN A..LIMBU VOWEL SIGN U
+	{runeRange{0x1940, 0x1940}, eawprN},     // So         LIMBU SIGN LOO
+	{runeRange{0x19DA, 0x19DA}, eawprN},     // No         NEW TAI LUE THAM DIGIT ONE
+	{runeRange{0x1A20, 0x1A54}, eawprN},     // Lo    [53] TAI THAM LETTER HIGH KA..TAI THAM LETTER GREAT SA
+	{runeRange{0x1A63, 0x1A64}, eawprN},     // Mc     [2] TAI THAM VOWEL SIGN AA..TAI THAM VOWEL SIGN TALL AA
+	{runeRange{0x1AA7, 0x1AA7}, eawprN},     // Lm         TAI THAM SIGN MAI YAMOK
+	{runeRange{0x1B34, 0x1B34}, eawprN},     // Mn         BALINESE SIGN REREKAN
+	{runeRange{0x1B45, 0x1B4C}, eawprN},     // Lo     [8] BALINESE LETTER KAF SASAK..BALINESE LETTER ARCHAIC JNYA
+	{runeRange{0x1B82, 0x1B82}, eawprN},     // Mc         SUNDANESE SIGN PANGWISAD
+	{runeRange{0x1BAE, 0x1BAF}, eawprN},     // Lo     [2] SUNDANESE LETTER KHA..SUNDANESE LETTER SYA
+	{runeRange{0x1BED, 0x1BED}, eawprN},     // Mn         BATAK VOWEL SIGN KARO O
+	{runeRange{0x1C34, 0x1C35}, eawprN},     // Mc     [2] LEPCHA CONSONANT SIGN NYIN-DO..LEPCHA CONSONANT SIGN KANG
+	{runeRange{0x1C7E, 0x1C7F}, eawprN},     // Po     [2] OL CHIKI PUNCTUATION MUCAAD..OL CHIKI PUNCTUATION DOUBLE MUCAAD
+	{runeRange{0x1CE1, 0x1CE1}, eawprN},     // Mc         VEDIC TONE ATHARVAVEDIC INDEPENDENT SVARITA
+	{runeRange{0x1CF8, 0x1CF9}, eawprN},     // Mn     [2] VEDIC TONE RING ABOVE..VEDIC TONE DOUBLE RING ABOVE
+	{runeRange{0x1D9B, 0x1DBF}, eawprN},     // Lm    [37] MODIFIER LETTER SMALL TURNED ALPHA..MODIFIER LETTER SMALL THETA
+	{runeRange{0x1F59, 0x1F59}, eawprN},     // Lu         GREEK CAPITAL LETTER UPSILON WITH DASIA
+	{runeRange{0x1FBF, 0x1FC1}, eawprN},     // Sk     [3] GREEK PSILI..GREEK DIALYTIKA AND PERISPOMENI
+	{runeRange{0x1FED, 0x1FEF}, eawprN},     // Sk     [3] GREEK DIALYTIKA AND VARIA..GREEK VARIA
+	{runeRange{0x2013, 0x2015}, eawprA},     // Pd     [3] EN DASH..HORIZONTAL BAR
+	{runeRange{0x201D, 0x201D}, eawprA},     // Pf         RIGHT DOUBLE QUOTATION MARK
+	{runeRange{0x202A, 0x202E}, eawprN},     // Cf     [5] LEFT-TO-RIGHT EMBEDDING..RIGHT-TO-LEFT OVERRIDE
+	{runeRange{0x2039, 0x2039}, eawprN},     // Pi         SINGLE LEFT-POINTING ANGLE QUOTATION MARK
+	{runeRange{0x2045, 0x2045}, eawprN},     // Ps         LEFT SQUARE BRACKET WITH QUILL
+	{runeRange{0x2060, 0x2064}, eawprN},     // Cf     [5] WORD JOINER..INVISIBLE PLUS
+	{runeRange{0x207E, 0x207E}, eawprN},     // Pe         SUPERSCRIPT RIGHT PARENTHESIS
+	{runeRange{0x2090, 0x209C}, eawprN},     // Lm    [13] LATIN SUBSCRIPT SMALL LETTER A..LATIN SUBSCRIPT SMALL LETTER T
+	{runeRange{0x20E1, 0x20E1}, eawprN},     // Mn         COMBINING LEFT RIGHT ARROW ABOVE
+	{runeRange{0x2106, 0x2106}, eawprN},     // So         CADA UNA
+	{runeRange{0x2116, 0x2116}, eawprA},     // So         NUMERO SIGN
+	{runeRange{0x2125, 0x2125}, eawprN},     // So         OUNCE SIGN
+	{runeRange{0x212E, 0x212E}, eawprN},     // So         ESTIMATED SYMBOL
+	{runeRange{0x214A, 0x214A}, eawprN},     // So         PROPERTY LINE
+	{runeRange{0x215B, 0x215E}, eawprA},     // No     [4] VULGAR FRACTION ONE EIGHTH..VULGAR FRACTION SEVEN EIGHTHS
+	{runeRange{0x2189, 0x2189}, eawprA},     // No         VULGAR FRACTION ZERO THIRDS
+	{runeRange{0x21A3, 0x21A3}, eawprN},     // Sm         RIGHTWARDS ARROW WITH TAIL
+	{runeRange{0x21CE, 0x21CF}, eawprN},     // Sm     [2] LEFT RIGHT DOUBLE ARROW WITH STROKE..RIGHTWARDS DOUBLE ARROW WITH STROKE
+	{runeRange{0x21F4, 0x21FF}, eawprN},     // Sm    [12] RIGHT ARROW WITH SMALL CIRCLE..LEFT RIGHT OPEN-HEADED ARROW
+	{runeRange{0x220C, 0x220E}, eawprN},     // Sm     [3] DOES NOT CONTAIN AS MEMBER..END OF PROOF
+	{runeRange{0x221B, 0x221C}, eawprN},     // Sm     [2] CUBE ROOT..FOURTH ROOT
+	{runeRange{0x222D, 0x222D}, eawprN},     // Sm         TRIPLE INTEGRAL
+	{runeRange{0x2249, 0x224B}, eawprN},     // Sm     [3] NOT ALMOST EQUAL TO..TRIPLE TILDE
+	{runeRange{0x2262, 0x2263}, eawprN},     // Sm     [2] NOT IDENTICAL TO..STRICTLY EQUIVALENT TO
+	{runeRange{0x226C, 0x226D}, eawprN},     // Sm     [2] BETWEEN..NOT EQUIVALENT TO
+	{runeRange{0x2284, 0x2285}, eawprN},     // Sm     [2] NOT A SUBSET OF..NOT A SUPERSET OF
+	{runeRange{0x2296, 0x2298}, eawprN},     // Sm     [3] CIRCLED MINUS..CIRCLED DIVISION SLASH
+	{runeRange{0x22A6, 0x22BE}, eawprN},     // Sm    [25] ASSERTION..RIGHT ANGLE WITH ARC
+	{runeRange{0x2308, 0x2308}, eawprN},     // Ps         LEFT CEILING
+	{runeRange{0x230C, 0x2311}, eawprN},     // So     [6] BOTTOM RIGHT CROP..SQUARE LOZENGE
+	{runeRange{0x231C, 0x231F}, eawprN},     // So     [4] TOP LEFT CORNER..BOTTOM RIGHT CORNER
+	{runeRange{0x232A, 0x232A}, eawprW},     // Pe         RIGHT-POINTING ANGLE BRACKET
+	{runeRange{0x239B, 0x23B3}, eawprN},     // Sm    [25] LEFT PARENTHESIS UPPER HOOK..SUMMATION BOTTOM
+	{runeRange{0x23E9, 0x23EC}, eawprW},     // So     [4] BLACK RIGHT-POINTING DOUBLE TRIANGLE..BLACK DOWN-POINTING DOUBLE TRIANGLE
+	{runeRange{0x23F3, 0x23F3}, eawprW},     // So         HOURGLASS WITH FLOWING SAND
+	{runeRange{0x2460, 0x249B}, eawprA},     // No    [60] CIRCLED DIGIT ONE..NUMBER TWENTY FULL STOP
+	{runeRange{0x2500, 0x254B}, eawprA},     // So    [76] BOX DRAWINGS LIGHT HORIZONTAL..BOX DRAWINGS HEAVY VERTICAL AND HORIZONTAL
+	{runeRange{0x2580, 0x258F}, eawprA},     // So    [16] UPPER HALF BLOCK..LEFT ONE EIGHTH BLOCK
+	{runeRange{0x25A0, 0x25A1}, eawprA},     // So     [2] BLACK SQUARE..WHITE SQUARE
+	{runeRange{0x25B2, 0x25B3}, eawprA},     // So     [2] BLACK UP-POINTING TRIANGLE..WHITE UP-POINTING TRIANGLE
+	{runeRange{0x25B8, 0x25BB}, eawprN},     // So     [4] BLACK RIGHT-POINTING SMALL TRIANGLE..WHITE RIGHT-POINTING POINTER
+	{runeRange{0x25C1, 0x25C1}, eawprA},     // Sm         WHITE LEFT-POINTING TRIANGLE
+	{runeRange{0x25CB, 0x25CB}, eawprA},     // So         WHITE CIRCLE
+	{runeRange{0x25E2, 0x25E5}, eawprA},     // So     [4] BLACK LOWER RIGHT TRIANGLE..BLACK UPPER RIGHT TRIANGLE
+	{runeRange{0x25F8, 0x25FC}, eawprN},     // Sm     [5] UPPER LEFT TRIANGLE..BLACK MEDIUM SQUARE
+	{runeRange{0x2605, 0x2606}, eawprA},     // So     [2] BLACK STAR..WHITE STAR
+	{runeRange{0x260E, 0x260F}, eawprA},     // So     [2] BLACK TELEPHONE..WHITE TELEPHONE
+	{runeRange{0x261C, 0x261C}, eawprA},     // So         WHITE LEFT POINTING INDEX
+	{runeRange{0x2640, 0x2640}, eawprA},     // So         FEMALE SIGN
+	{runeRange{0x2648, 0x2653}, eawprW},     // So    [12] ARIES..PISCES
+	{runeRange{0x2663, 0x2665}, eawprA},     // So     [3] BLACK CLUB SUIT..BLACK HEART SUIT
+	{runeRange{0x266C, 0x266D}, eawprA},     // So     [2] BEAMED SIXTEENTH NOTES..MUSIC FLAT SIGN
+	{runeRange{0x267F, 0x267F}, eawprW},     // So         WHEELCHAIR SYMBOL
+	{runeRange{0x269E, 0x269F}, eawprA},     // So     [2] THREE LINES CONVERGING RIGHT..THREE LINES CONVERGING LEFT
+	{runeRange{0x26AA, 0x26AB}, eawprW},     // So     [2] MEDIUM WHITE CIRCLE..MEDIUM BLACK CIRCLE
+	{runeRange{0x26C0, 0x26C3}, eawprN},     // So     [4] WHITE DRAUGHTS MAN..BLACK DRAUGHTS KING
+	{runeRange{0x26CF, 0x26D3}, eawprA},     // So     [5] PICK..CHAINS
+	{runeRange{0x26E3, 0x26E3}, eawprA},     // So         HEAVY CIRCLE WITH STROKE AND TWO DOTS ABOVE
+	{runeRange{0x26EB, 0x26F1}, eawprA},     // So     [7] CASTLE..UMBRELLA ON GROUND
+	{runeRange{0x26F6, 0x26F9}, eawprA},     // So     [4] SQUARE FOUR CORNERS..PERSON WITH BALL
+	{runeRange{0x26FE, 0x26FF}, eawprA},     // So     [2] CUP ON BLACK SQUARE..WHITE FLAG WITH HORIZONTAL MIDDLE BLACK STRIPE
+	{runeRange{0x270A, 0x270B}, eawprW},     // So     [2] RAISED FIST..RAISED HAND
+	{runeRange{0x273D, 0x273D}, eawprA},     // So         HEAVY TEARDROP-SPOKED ASTERISK
+	{runeRange{0x274E, 0x274E}, eawprW},     // So         NEGATIVE SQUARED CROSS MARK
+	{runeRange{0x2757, 0x2757}, eawprW},     // So         HEAVY EXCLAMATION MARK SYMBOL
+	{runeRange{0x276A, 0x276A}, eawprN},     // Ps         MEDIUM FLATTENED LEFT PARENTHESIS ORNAMENT
+	{runeRange{0x276E, 0x276E}, eawprN},     // Ps         HEAVY LEFT-POINTING ANGLE QUOTATION MARK ORNAMENT
+	{runeRange{0x2772, 0x2772}, eawprN},     // Ps         LIGHT LEFT TORTOISE SHELL BRACKET ORNAMENT
+	{runeRange{0x2776, 0x277F}, eawprA},     // No    [10] DINGBAT NEGATIVE CIRCLED DIGIT ONE..DINGBAT NEGATIVE CIRCLED NUMBER TEN
+	{runeRange{0x2798, 0x27AF}, eawprN},     // So    [24] HEAVY SOUTH EAST ARROW..NOTCHED LOWER RIGHT-SHADOWED WHITE RIGHTWARDS ARROW
+	{runeRange{0x27C0, 0x27C4}, eawprN},     // Sm     [5] THREE DIMENSIONAL ANGLE..OPEN SUPERSET
+	{runeRange{0x27E6, 0x27E6}, eawprNa},    // Ps         MATHEMATICAL LEFT WHITE SQUARE BRACKET
+	{runeRange{0x27EA, 0x27EA}, eawprNa},    // Ps         MATHEMATICAL LEFT DOUBLE ANGLE BRACKET
+	{runeRange{0x27EE, 0x27EE}, eawprN},     // Ps         MATHEMATICAL LEFT FLATTENED PARENTHESIS
+	{runeRange{0x2900, 0x297F}, eawprN},     // Sm   [128] RIGHTWARDS TWO-HEADED ARROW WITH VERTICAL STROKE..DOWN FISH TAIL
+	{runeRange{0x2985, 0x2985}, eawprNa},    // Ps         LEFT WHITE PARENTHESIS
+	{runeRange{0x2989, 0x2989}, eawprN},     // Ps         Z NOTATION LEFT BINDING BRACKET
+	{runeRange{0x298D, 0x298D}, eawprN},     // Ps         LEFT SQUARE BRACKET WITH TICK IN TOP CORNER
+	{runeRange{0x2991, 0x2991}, eawprN},     // Ps         LEFT ANGLE BRACKET WITH DOT
+	{runeRange{0x2995, 0x2995}, eawprN},     // Ps         DOUBLE LEFT ARC GREATER-THAN BRACKET
+	{runeRange{0x2999, 0x29D7}, eawprN},     // Sm    [63] DOTTED FENCE..BLACK HOURGLASS
+	{runeRange{0x29DB, 0x29DB}, eawprN},     // Pe         RIGHT DOUBLE WIGGLY FENCE
+	{runeRange{0x29FE, 0x29FF}, eawprN},     // Sm     [2] TINY..MINY
+	{runeRange{0x2B1D, 0x2B2F}, eawprN},     // So    [19] BLACK VERY SMALL SQUARE..WHITE VERTICAL ELLIPSE
+	{runeRange{0x2B4D, 0x2B4F}, eawprN},     // So     [3] DOWNWARDS TRIANGLE-HEADED ZIGZAG ARROW..SHORT BACKSLANTED SOUTH ARROW
+	{runeRange{0x2B56, 0x2B59}, eawprA},     // So     [4] HEAVY OVAL WITH OVAL INSIDE..HEAVY CIRCLED SALTIRE
+	{runeRange{0x2C00, 0x2C5F}, eawprN},     // L&    [96] GLAGOLITIC CAPITAL LETTER AZU..GLAGOLITIC SMALL LETTER CAUDATE CHRIVI
+	{runeRange{0x2C80, 0x2CE4}, eawprN},     // L&   [101] COPTIC CAPITAL LETTER ALFA..COPTIC SYMBOL KAI
+	{runeRange{0x2CF2, 0x2CF3}, eawprN},     // L&     [2] COPTIC CAPITAL LETTER BOHAIRIC KHEI..COPTIC SMALL LETTER BOHAIRIC KHEI
+	{runeRange{0x2D00, 0x2D25}, eawprN},     // Ll    [38] GEORGIAN SMALL LETTER AN..GEORGIAN SMALL LETTER HOE
+	{runeRange{0x2D6F, 0x2D6F}, eawprN},     // Lm         TIFINAGH MODIFIER LETTER LABIALIZATION MARK
+	{runeRange{0x2DA0, 0x2DA6}, eawprN},     // Lo     [7] ETHIOPIC SYLLABLE SSA..ETHIOPIC SYLLABLE SSO
+	{runeRange{0x2DC0, 0x2DC6}, eawprN},     // Lo     [7] ETHIOPIC SYLLABLE QYA..ETHIOPIC SYLLABLE QYO
+	{runeRange{0x2DE0, 0x2DFF}, eawprN},     // Mn    [32] COMBINING CYRILLIC LETTER BE..COMBINING CYRILLIC LETTER IOTIFIED BIG YUS
+	{runeRange{0x2E04, 0x2E04}, eawprN},     // Pi         LEFT DOTTED SUBSTITUTION BRACKET
+	{runeRange{0x2E0A, 0x2E0A}, eawprN},     // Pf         RIGHT TRANSPOSITION BRACKET
+	{runeRange{0x2E0E, 0x2E16}, eawprN},     // Po     [9] EDITORIAL CORONIS..DOTTED RIGHT-POINTING ANGLE
+	{runeRange{0x2E1B, 0x2E1B}, eawprN},     // Po         TILDE WITH RING ABOVE
+	{runeRange{0x2E20, 0x2E20}, eawprN},     // Pi         LEFT VERTICAL BAR WITH QUILL
+	{runeRange{0x2E24, 0x2E24}, eawprN},     // Ps         BOTTOM LEFT HALF BRACKET
+	{runeRange{0x2E28, 0x2E28}, eawprN},     // Ps         LEFT DOUBLE PARENTHESIS
+	{runeRange{0x2E30, 0x2E39}, eawprN},     // Po    [10] RING POINT..TOP HALF SECTION SIGN
+	{runeRange{0x2E41, 0x2E41}, eawprN},     // Po         REVERSED COMMA
+	{runeRange{0x2E52, 0x2E54}, eawprN},     // Po     [3] TIRONIAN SIGN CAPITAL ET..MEDIEVAL QUESTION MARK
+	{runeRange{0x2E58, 0x2E58}, eawprN},     // Pe         RIGHT SQUARE BRACKET WITH DOUBLE STROKE
+	{runeRange{0x2E5C, 0x2E5C}, eawprN},     // Pe         BOTTOM HALF RIGHT PARENTHESIS
+	{runeRange{0x2F00, 0x2FD5}, eawprW},     // So   [214] KANGXI RADICAL ONE..KANGXI RADICAL FLUTE
+	{runeRange{0x3004, 0x3004}, eawprW},     // So         JAPANESE INDUSTRIAL STANDARD SYMBOL
+	{runeRange{0x3008, 0x3008}, eawprW},     // Ps         LEFT ANGLE BRACKET
+	{runeRange{0x300C, 0x300C}, eawprW},     // Ps         LEFT CORNER BRACKET
+	{runeRange{0x3010, 0x3010}, eawprW},     // Ps         LEFT BLACK LENTICULAR BRACKET
+	{runeRange{0x3015, 0x3015}, eawprW},     // Pe         RIGHT TORTOISE SHELL BRACKET
+	{runeRange{0x3019, 0x3019}, eawprW},     // Pe         RIGHT WHITE TORTOISE SHELL BRACKET
+	{runeRange{0x301D, 0x301D}, eawprW},     // Ps         REVERSED DOUBLE PRIME QUOTATION MARK
+	{runeRange{0x302A, 0x302D}, eawprW},     // Mn     [4] IDEOGRAPHIC LEVEL TONE MARK..IDEOGRAPHIC ENTERING TONE MARK
+	{runeRange{0x3036, 0x3037}, eawprW},     // So     [2] CIRCLED POSTAL MARK..IDEOGRAPHIC TELEGRAPH LINE FEED SEPARATOR SYMBOL
+	{runeRange{0x303D, 0x303D}, eawprW},     // Po         PART ALTERNATION MARK
+	{runeRange{0x3099, 0x309A}, eawprW},     // Mn     [2] COMBINING KATAKANA-HIRAGANA VOICED SOUND MARK..COMBINING KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK
+	{runeRange{0x30A0, 0x30A0}, eawprW},     // Pd         KATAKANA-HIRAGANA DOUBLE HYPHEN
+	{runeRange{0x30FF, 0x30FF}, eawprW},     // Lo         KATAKANA DIGRAPH KOTO
+	{runeRange{0x3192, 0x3195}, eawprW},     // No     [4] IDEOGRAPHIC ANNOTATION ONE MARK..IDEOGRAPHIC ANNOTATION FOUR MARK
+	{runeRange{0x31F0, 0x31FF}, eawprW},     // Lo    [16] KATAKANA LETTER SMALL KU..KATAKANA LETTER SMALL RO
+	{runeRange{0x3248, 0x324F}, eawprA},     // No     [8] CIRCLED NUMBER TEN ON BLACK SQUARE..CIRCLED NUMBER EIGHTY ON BLACK SQUARE
+	{runeRange{0x3280, 0x3289}, eawprW},     // No    [10] CIRCLED IDEOGRAPH ONE..CIRCLED IDEOGRAPH TEN
+	{runeRange{0x3300, 0x33FF}, eawprW},     // So   [256] SQUARE APAATO..SQUARE GAL
+	{runeRange{0xA000, 0xA014}, eawprW},     // Lo    [21] YI SYLLABLE IT..YI SYLLABLE E
+	{runeRange{0xA4D0, 0xA4F7}, eawprN},     // Lo    [40] LISU LETTER BA..LISU LETTER OE
+	{runeRange{0xA60C, 0xA60C}, eawprN},     // Lm         VAI SYLLABLE LENGTHENER
+	{runeRange{0xA62A, 0xA62B}, eawprN},     // Lo     [2] VAI SYLLABLE NDOLE MA..VAI SYLLABLE NDOLE DO
+	{runeRange{0xA670, 0xA672}, eawprN},     // Me     [3] COMBINING CYRILLIC TEN MILLIONS SIGN..COMBINING CYRILLIC THOUSAND MILLIONS SIGN
+	{runeRange{0xA67F, 0xA67F}, eawprN},     // Lm         CYRILLIC PAYEROK
+	{runeRange{0xA6A0, 0xA6E5}, eawprN},     // Lo    [70] BAMUM LETTER A..BAMUM LETTER KI
+	{runeRange{0xA700, 0xA716}, eawprN},     // Sk    [23] MODIFIER LETTER CHINESE TONE YIN PING..MODIFIER LETTER EXTRA-LOW LEFT-STEM TONE BAR
+	{runeRange{0xA770, 0xA770}, eawprN},     // Lm         MODIFIER LETTER US
+	{runeRange{0xA78B, 0xA78E}, eawprN},     // L&     [4] LATIN CAPITAL LETTER SALTILLO..LATIN SMALL LETTER L WITH RETROFLEX HOOK AND BELT
+	{runeRange{0xA7D3, 0xA7D3}, eawprN},     // Ll         LATIN SMALL LETTER DOUBLE THORN
+	{runeRange{0xA7F7, 0xA7F7}, eawprN},     // Lo         LATIN EPIGRAPHIC LETTER SIDEWAYS I
+	{runeRange{0xA800, 0xA801}, eawprN},     // Lo     [2] SYLOTI NAGRI LETTER A..SYLOTI NAGRI LETTER I
+	{runeRange{0xA807, 0xA80A}, eawprN},     // Lo     [4] SYLOTI NAGRI LETTER KO..SYLOTI NAGRI LETTER GHO
+	{runeRange{0xA825, 0xA826}, eawprN},     // Mn     [2] SYLOTI NAGRI VOWEL SIGN U..SYLOTI NAGRI VOWEL SIGN E
+	{runeRange{0xA830, 0xA835}, eawprN},     // No     [6] NORTH INDIC FRACTION ONE QUARTER..NORTH INDIC FRACTION THREE SIXTEENTHS
+	{runeRange{0xA840, 0xA873}, eawprN},     // Lo    [52] PHAGS-PA LETTER KA..PHAGS-PA LETTER CANDRABINDU
+	{runeRange{0xA8B4, 0xA8C3}, eawprN},     // Mc    [16] SAURASHTRA CONSONANT SIGN HAARU..SAURASHTRA VOWEL SIGN AU
+	{runeRange{0xA8E0, 0xA8F1}, eawprN},     // Mn    [18] COMBINING DEVANAGARI DIGIT ZERO..COMBINING DEVANAGARI SIGN AVAGRAHA
+	{runeRange{0xA8FC, 0xA8FC}, eawprN},     // Po         DEVANAGARI SIGN SIDDHAM
+	{runeRange{0xA90A, 0xA925}, eawprN},     // Lo    [28] KAYAH LI LETTER KA..KAYAH LI LETTER OO
+	{runeRange{0xA947, 0xA951}, eawprN},     // Mn    [11] REJANG VOWEL SIGN I..REJANG CONSONANT SIGN R
+	{runeRange{0xA980, 0xA982}, eawprN},     // Mn     [3] JAVANESE SIGN PANYANGGA..JAVANESE SIGN LAYAR
+	{runeRange{0xA9B4, 0xA9B5}, eawprN},     // Mc     [2] JAVANESE VOWEL SIGN TARUNG..JAVANESE VOWEL SIGN TOLONG
+	{runeRange{0xA9BE, 0xA9C0}, eawprN},     // Mc     [3] JAVANESE CONSONANT SIGN PENGKAL..JAVANESE PANGKON
+	{runeRange{0xA9DE, 0xA9DF}, eawprN},     // Po     [2] JAVANESE PADA TIRTA TUMETES..JAVANESE PADA ISEN-ISEN
+	{runeRange{0xA9E7, 0xA9EF}, eawprN},     // Lo     [9] MYANMAR LETTER TAI LAING NYA..MYANMAR LETTER TAI LAING NNA
+	{runeRange{0xAA29, 0xAA2E}, eawprN},     // Mn     [6] CHAM VOWEL SIGN AA..CHAM VOWEL SIGN OE
+	{runeRange{0xAA35, 0xAA36}, eawprN},     // Mn     [2] CHAM CONSONANT SIGN LA..CHAM CONSONANT SIGN WA
+	{runeRange{0xAA4C, 0xAA4C}, eawprN},     // Mn         CHAM CONSONANT SIGN FINAL M
+	{runeRange{0xAA60, 0xAA6F}, eawprN},     // Lo    [16] MYANMAR LETTER KHAMTI GA..MYANMAR LETTER KHAMTI FA
+	{runeRange{0xAA7A, 0xAA7A}, eawprN},     // Lo         MYANMAR LETTER AITON RA
+	{runeRange{0xAA7E, 0xAA7F}, eawprN},     // Lo     [2] MYANMAR LETTER SHWE PALAUNG CHA..MYANMAR LETTER SHWE PALAUNG SHA
+	{runeRange{0xAAB2, 0xAAB4}, eawprN},     // Mn     [3] TAI VIET VOWEL I..TAI VIET VOWEL U
+	{runeRange{0xAABE, 0xAABF}, eawprN},     // Mn     [2] TAI VIET VOWEL AM..TAI VIET TONE MAI EK
+	{runeRange{0xAADB, 0xAADC}, eawprN},     // Lo     [2] TAI VIET SYMBOL KON..TAI VIET SYMBOL NUENG
+	{runeRange{0xAAEB, 0xAAEB}, eawprN},     // Mc         MEETEI MAYEK VOWEL SIGN II
+	{runeRange{0xAAF2, 0xAAF2}, eawprN},     // Lo         MEETEI MAYEK ANJI
+	{runeRange{0xAB01, 0xAB06}, eawprN},     // Lo     [6] ETHIOPIC SYLLABLE TTHU..ETHIOPIC SYLLABLE TTHO
+	{runeRange{0xAB28, 0xAB2E}, eawprN},     // Lo     [7] ETHIOPIC SYLLABLE BBA..ETHIOPIC SYLLABLE BBO
+	{runeRange{0xAB60, 0xAB68}, eawprN},     // Ll     [9] LATIN SMALL LETTER SAKHA YAT..LATIN SMALL LETTER TURNED R WITH MIDDLE TILDE
+	{runeRange{0xABC0, 0xABE2}, eawprN},     // Lo    [35] MEETEI MAYEK LETTER KOK..MEETEI MAYEK LETTER I LONSUM
+	{runeRange{0xABE8, 0xABE8}, eawprN},     // Mn         MEETEI MAYEK VOWEL SIGN UNAP
+	{runeRange{0xABED, 0xABED}, eawprN},     // Mn         MEETEI MAYEK APUN IYEK
+	{runeRange{0xD7CB, 0xD7FB}, eawprN},     // Lo    [49] HANGUL JONGSEONG NIEUN-RIEUL..HANGUL JONGSEONG PHIEUPH-THIEUTH
+	{runeRange{0xE000, 0xF8FF}, eawprA},     // Co  [6400] <private-use-E000>..<private-use-F8FF>
+	{runeRange{0xFADA, 0xFAFF}, eawprW},     // Cn    [38] <reserved-FADA>..<reserved-FAFF>
+	{runeRange{0xFB1E, 0xFB1E}, eawprN},     // Mn         HEBREW POINT JUDEO-SPANISH VARIKA
+	{runeRange{0xFB38, 0xFB3C}, eawprN},     // Lo     [5] HEBREW LETTER TET WITH DAGESH..HEBREW LETTER LAMED WITH DAGESH
+	{runeRange{0xFB46, 0xFB4F}, eawprN},     // Lo    [10] HEBREW LETTER TSADI WITH DAGESH..HEBREW LIGATURE ALEF LAMED
+	{runeRange{0xFD3E, 0xFD3E}, eawprN},     // Pe         ORNATE LEFT PARENTHESIS
+	{runeRange{0xFD92, 0xFDC7}, eawprN},     // Lo    [54] ARABIC LIGATURE MEEM WITH JEEM WITH KHAH INITIAL FORM..ARABIC LIGATURE NOON WITH JEEM WITH YEH FINAL FORM
+	{runeRange{0xFDFD, 0xFDFF}, eawprN},     // So     [3] ARABIC LIGATURE BISMILLAH AR-RAHMAN AR-RAHEEM..ARABIC LIGATURE AZZA WA JALL
+	{runeRange{0xFE18, 0xFE18}, eawprW},     // Pe         PRESENTATION FORM FOR VERTICAL RIGHT WHITE LENTICULAR BRAKCET
+	{runeRange{0xFE31, 0xFE32}, eawprW},     // Pd     [2] PRESENTATION FORM FOR VERTICAL EM DASH..PRESENTATION FORM FOR VERTICAL EN DASH
+	{runeRange{0xFE37, 0xFE37}, eawprW},     // Ps         PRESENTATION FORM FOR VERTICAL LEFT CURLY BRACKET
+	{runeRange{0xFE3B, 0xFE3B}, eawprW},     // Ps         PRESENTATION FORM FOR VERTICAL LEFT BLACK LENTICULAR BRACKET
+	{runeRange{0xFE3F, 0xFE3F}, eawprW},     // Ps         PRESENTATION FORM FOR VERTICAL LEFT ANGLE BRACKET
+	{runeRange{0xFE43, 0xFE43}, eawprW},     // Ps         PRESENTATION FORM FOR VERTICAL LEFT WHITE CORNER BRACKET
+	{runeRange{0xFE48, 0xFE48}, eawprW},     // Pe         PRESENTATION FORM FOR VERTICAL RIGHT SQUARE BRACKET
+	{runeRange{0xFE54, 0xFE57}, eawprW},     // Po     [4] SMALL SEMICOLON..SMALL EXCLAMATION MARK
+	{runeRange{0xFE5B, 0xFE5B}, eawprW},     // Ps         SMALL LEFT CURLY BRACKET
+	{runeRange{0xFE5F, 0xFE61}, eawprW},     // Po     [3] SMALL NUMBER SIGN..SMALL ASTERISK
+	{runeRange{0xFE68, 0xFE68}, eawprW},     // Po         SMALL REVERSE SOLIDUS
+	{runeRange{0xFE76, 0xFEFC}, eawprN},     // Lo   [135] ARABIC FATHA ISOLATED FORM..ARABIC LIGATURE LAM WITH ALEF FINAL FORM
+	{runeRange{0xFF05, 0xFF07}, eawprF},     // Po     [3] FULLWIDTH PERCENT SIGN..FULLWIDTH APOSTROPHE
+	{runeRange{0xFF0B, 0xFF0B}, eawprF},     // Sm         FULLWIDTH PLUS SIGN
+	{runeRange{0xFF10, 0xFF19}, eawprF},     // Nd    [10] FULLWIDTH DIGIT ZERO..FULLWIDTH DIGIT NINE
+	{runeRange{0xFF21, 0xFF3A}, eawprF},     // Lu    [26] FULLWIDTH LATIN CAPITAL LETTER A..FULLWIDTH LATIN CAPITAL LETTER Z
+	{runeRange{0xFF3E, 0xFF3E}, eawprF},     // Sk         FULLWIDTH CIRCUMFLEX ACCENT
+	{runeRange{0xFF5B, 0xFF5B}, eawprF},     // Ps         FULLWIDTH LEFT CURLY BRACKET
+	{runeRange{0xFF5F, 0xFF5F}, eawprF},     // Ps         FULLWIDTH LEFT WHITE PARENTHESIS
+	{runeRange{0xFF63, 0xFF63}, eawprH},     // Pe         HALFWIDTH RIGHT CORNER BRACKET
+	{runeRange{0xFF71, 0xFF9D}, eawprH},     // Lo    [45] HALFWIDTH KATAKANA LETTER A..HALFWIDTH KATAKANA LETTER N
+	{runeRange{0xFFCA, 0xFFCF}, eawprH},     // Lo     [6] HALFWIDTH HANGUL LETTER YEO..HALFWIDTH HANGUL LETTER OE
+	{runeRange{0xFFE2, 0xFFE2}, eawprF},     // Sm         FULLWIDTH NOT SIGN
+	{runeRange{0xFFE8, 0xFFE8}, eawprH},     // So         HALFWIDTH FORMS LIGHT VERTICAL
+	{runeRange{0xFFFC, 0xFFFC}, eawprN},     // So         OBJECT REPLACEMENT CHARACTER
+	{runeRange{0x10028, 0x1003A}, eawprN},   // Lo    [19] LINEAR B SYLLABLE B060 RA..LINEAR B SYLLABLE B042 WO
+	{runeRange{0x10080, 0x100FA}, eawprN},   // Lo   [123] LINEAR B IDEOGRAM B100 MAN..LINEAR B IDEOGRAM VESSEL B305
+	{runeRange{0x10140, 0x10174}, eawprN},   // Nl    [53] GREEK ACROPHONIC ATTIC ONE QUARTER..GREEK ACROPHONIC STRATIAN FIFTY MNAS
+	{runeRange{0x1018C, 0x1018E}, eawprN},   // So     [3] GREEK SINUSOID SIGN..NOMISMA SIGN
+	{runeRange{0x101FD, 0x101FD}, eawprN},   // Mn         PHAISTOS DISC SIGN COMBINING OBLIQUE STROKE
+	{runeRange{0x102E1, 0x102FB}, eawprN},   // No    [27] COPTIC EPACT DIGIT ONE..COPTIC EPACT NUMBER NINE HUNDRED
+	{runeRange{0x10330, 0x10340}, eawprN},   // Lo    [17] GOTHIC LETTER AHSA..GOTHIC LETTER PAIRTHRA
+	{runeRange{0x10350, 0x10375}, eawprN},   // Lo    [38] OLD PERMIC LETTER AN..OLD PERMIC LETTER IA
+	{runeRange{0x103A0, 0x103C3}, eawprN},   // Lo    [36] OLD PERSIAN SIGN A..OLD PERSIAN SIGN HA
+	{runeRange{0x10400, 0x1044F}, eawprN},   // L&    [80] DESERET CAPITAL LETTER LONG I..DESERET SMALL LETTER EW
+	{runeRange{0x104B0, 0x104D3}, eawprN},   // Lu    [36] OSAGE CAPITAL LETTER A..OSAGE CAPITAL LETTER ZHA
+	{runeRange{0x1056F, 0x1056F}, eawprN},   // Po         CAUCASIAN ALBANIAN CITATION MARK
+	{runeRange{0x10594, 0x10595}, eawprN},   // Lu     [2] VITHKUQI CAPITAL LETTER Y..VITHKUQI CAPITAL LETTER ZE
+	{runeRange{0x105BB, 0x105BC}, eawprN},   // Ll     [2] VITHKUQI SMALL LETTER Y..VITHKUQI SMALL LETTER ZE
+	{runeRange{0x10780, 0x10785}, eawprN},   // Lm     [6] MODIFIER LETTER SMALL CAPITAL AA..MODIFIER LETTER SMALL B WITH HOOK
+	{runeRange{0x10808, 0x10808}, eawprN},   // Lo         CYPRIOT SYLLABLE JO
+	{runeRange{0x1083F, 0x1083F}, eawprN},   // Lo         CYPRIOT SYLLABLE ZO
+	{runeRange{0x10860, 0x10876}, eawprN},   // Lo    [23] PALMYRENE LETTER ALEPH..PALMYRENE LETTER TAW
+	{runeRange{0x108A7, 0x108AF}, eawprN},   // No     [9] NABATAEAN NUMBER ONE..NABATAEAN NUMBER ONE HUNDRED
+	{runeRange{0x10900, 0x10915}, eawprN},   // Lo    [22] PHOENICIAN LETTER ALF..PHOENICIAN LETTER TAU
+	{runeRange{0x1093F, 0x1093F}, eawprN},   // Po         LYDIAN TRIANGULAR MARK
+	{runeRange{0x109BE, 0x109BF}, eawprN},   // Lo     [2] MEROITIC CURSIVE LOGOGRAM RMT..MEROITIC CURSIVE LOGOGRAM IMN
+	{runeRange{0x10A01, 0x10A03}, eawprN},   // Mn     [3] KHAROSHTHI VOWEL SIGN I..KHAROSHTHI VOWEL SIGN VOCALIC R
+	{runeRange{0x10A15, 0x10A17}, eawprN},   // Lo     [3] KHAROSHTHI LETTER CA..KHAROSHTHI LETTER JA
+	{runeRange{0x10A40, 0x10A48}, eawprN},   // No     [9] KHAROSHTHI DIGIT ONE..KHAROSHTHI FRACTION ONE HALF
+	{runeRange{0x10A7F, 0x10A7F}, eawprN},   // Po         OLD SOUTH ARABIAN NUMERIC INDICATOR
+	{runeRange{0x10AC8, 0x10AC8}, eawprN},   // So         MANICHAEAN SIGN UD
+	{runeRange{0x10AF0, 0x10AF6}, eawprN},   // Po     [7] MANICHAEAN PUNCTUATION STAR..MANICHAEAN PUNCTUATION LINE FILLER
+	{runeRange{0x10B58, 0x10B5F}, eawprN},   // No     [8] INSCRIPTIONAL PARTHIAN NUMBER ONE..INSCRIPTIONAL PARTHIAN NUMBER ONE THOUSAND
+	{runeRange{0x10B99, 0x10B9C}, eawprN},   // Po     [4] PSALTER PAHLAVI SECTION MARK..PSALTER PAHLAVI FOUR DOTS WITH DOT
+	{runeRange{0x10CC0, 0x10CF2}, eawprN},   // Ll    [51] OLD HUNGARIAN SMALL LETTER A..OLD HUNGARIAN SMALL LETTER US
+	{runeRange{0x10D30, 0x10D39}, eawprN},   // Nd    [10] HANIFI ROHINGYA DIGIT ZERO..HANIFI ROHINGYA DIGIT NINE
+	{runeRange{0x10EAD, 0x10EAD}, eawprN},   // Pd         YEZIDI HYPHENATION MARK
+	{runeRange{0x10F1D, 0x10F26}, eawprN},   // No    [10] OLD SOGDIAN NUMBER ONE..OLD SOGDIAN FRACTION ONE HALF
+	{runeRange{0x10F51, 0x10F54}, eawprN},   // No     [4] SOGDIAN NUMBER ONE..SOGDIAN NUMBER ONE HUNDRED
+	{runeRange{0x10F86, 0x10F89}, eawprN},   // Po     [4] OLD UYGHUR PUNCTUATION BAR..OLD UYGHUR PUNCTUATION FOUR DOTS
+	{runeRange{0x11000, 0x11000}, eawprN},   // Mc         BRAHMI SIGN CANDRABINDU
+	{runeRange{0x11038, 0x11046}, eawprN},   // Mn    [15] BRAHMI VOWEL SIGN AA..BRAHMI VIRAMA
+	{runeRange{0x11070, 0x11070}, eawprN},   // Mn         BRAHMI SIGN OLD TAMIL VIRAMA
+	{runeRange{0x1107F, 0x1107F}, eawprN},   // Mn         BRAHMI NUMBER JOINER
+	{runeRange{0x110B0, 0x110B2}, eawprN},   // Mc     [3] KAITHI VOWEL SIGN AA..KAITHI VOWEL SIGN II
+	{runeRange{0x110BB, 0x110BC}, eawprN},   // Po     [2] KAITHI ABBREVIATION SIGN..KAITHI ENUMERATION SIGN
+	{runeRange{0x110CD, 0x110CD}, eawprN},   // Cf         KAITHI NUMBER SIGN ABOVE
+	{runeRange{0x11103, 0x11126}, eawprN},   // Lo    [36] CHAKMA LETTER AA..CHAKMA LETTER HAA
+	{runeRange{0x11136, 0x1113F}, eawprN},   // Nd    [10] CHAKMA DIGIT ZERO..CHAKMA DIGIT NINE
+	{runeRange{0x11147, 0x11147}, eawprN},   // Lo         CHAKMA LETTER VAA
+	{runeRange{0x11176, 0x11176}, eawprN},   // Lo         MAHAJANI LIGATURE SHRI
+	{runeRange{0x111B3, 0x111B5}, eawprN},   // Mc     [3] SHARADA VOWEL SIGN AA..SHARADA VOWEL SIGN II
+	{runeRange{0x111C5, 0x111C8}, eawprN},   // Po     [4] SHARADA DANDA..SHARADA SEPARATOR
+	{runeRange{0x111CF, 0x111CF}, eawprN},   // Mn         SHARADA SIGN INVERTED CANDRABINDU
+	{runeRange{0x111DC, 0x111DC}, eawprN},   // Lo         SHARADA HEADSTROKE
+	{runeRange{0x11213, 0x1122B}, eawprN},   // Lo    [25] KHOJKI LETTER NYA..KHOJKI LETTER LLA
+	{runeRange{0x11234, 0x11234}, eawprN},   // Mn         KHOJKI SIGN ANUSVARA
+	{runeRange{0x1123E, 0x1123E}, eawprN},   // Mn         KHOJKI SIGN SUKUN
+	{runeRange{0x11288, 0x11288}, eawprN},   // Lo         MULTANI LETTER GHA
+	{runeRange{0x112A9, 0x112A9}, eawprN},   // Po         MULTANI SECTION MARK
+	{runeRange{0x112E3, 0x112EA}, eawprN},   // Mn     [8] KHUDAWADI VOWEL SIGN U..KHUDAWADI SIGN VIRAMA
+	{runeRange{0x11305, 0x1130C}, eawprN},   // Lo     [8] GRANTHA LETTER A..GRANTHA LETTER VOCALIC L
+	{runeRange{0x11332, 0x11333}, eawprN},   // Lo     [2] GRANTHA LETTER LA..GRANTHA LETTER LLA
+	{runeRange{0x1133E, 0x1133F}, eawprN},   // Mc     [2] GRANTHA VOWEL SIGN AA..GRANTHA VOWEL SIGN I
+	{runeRange{0x1134B, 0x1134D}, eawprN},   // Mc     [3] GRANTHA VOWEL SIGN OO..GRANTHA SIGN VIRAMA
+	{runeRange{0x11362, 0x11363}, eawprN},   // Mc     [2] GRANTHA VOWEL SIGN VOCALIC L..GRANTHA VOWEL SIGN VOCALIC LL
+	{runeRange{0x11435, 0x11437}, eawprN},   // Mc     [3] NEWA VOWEL SIGN AA..NEWA VOWEL SIGN II
+	{runeRange{0x11445, 0x11445}, eawprN},   // Mc         NEWA SIGN VISARGA
+	{runeRange{0x11450, 0x11459}, eawprN},   // Nd    [10] NEWA DIGIT ZERO..NEWA DIGIT NINE
+	{runeRange{0x1145F, 0x11461}, eawprN},   // Lo     [3] NEWA LETTER VEDIC ANUSVARA..NEWA SIGN UPADHMANIYA
+	{runeRange{0x114B9, 0x114B9}, eawprN},   // Mc         TIRHUTA VOWEL SIGN E
+	{runeRange{0x114C1, 0x114C1}, eawprN},   // Mc         TIRHUTA SIGN VISARGA
+	{runeRange{0x114C7, 0x114C7}, eawprN},   // Lo         TIRHUTA OM
+	{runeRange{0x115B2, 0x115B5}, eawprN},   // Mn     [4] SIDDHAM VOWEL SIGN U..SIDDHAM VOWEL SIGN VOCALIC RR
+	{runeRange{0x115BF, 0x115C0}, eawprN},   // Mn     [2] SIDDHAM SIGN VIRAMA..SIDDHAM SIGN NUKTA
+	{runeRange{0x11600, 0x1162F}, eawprN},   // Lo    [48] MODI LETTER A..MODI LETTER LLA
+	{runeRange{0x1163D, 0x1163D}, eawprN},   // Mn         MODI SIGN ANUSVARA
+	{runeRange{0x11644, 0x11644}, eawprN},   // Lo         MODI SIGN HUVA
+	{runeRange{0x116AB, 0x116AB}, eawprN},   // Mn         TAKRI SIGN ANUSVARA
+	{runeRange{0x116B0, 0x116B5}, eawprN},   // Mn     [6] TAKRI VOWEL SIGN U..TAKRI VOWEL SIGN AU
+	{runeRange{0x116B9, 0x116B9}, eawprN},   // Po         TAKRI ABBREVIATION SIGN
+	{runeRange{0x11720, 0x11721}, eawprN},   // Mc     [2] AHOM VOWEL SIGN A..AHOM VOWEL SIGN AA
+	{runeRange{0x11730, 0x11739}, eawprN},   // Nd    [10] AHOM DIGIT ZERO..AHOM DIGIT NINE
+	{runeRange{0x11740, 0x11746}, eawprN},   // Lo     [7] AHOM LETTER CA..AHOM LETTER LLA
+	{runeRange{0x11838, 0x11838}, eawprN},   // Mc         DOGRA SIGN VISARGA
+	{runeRange{0x118E0, 0x118E9}, eawprN},   // Nd    [10] WARANG CITI DIGIT ZERO..WARANG CITI DIGIT NINE
+	{runeRange{0x11909, 0x11909}, eawprN},   // Lo         DIVES AKURU LETTER O
+	{runeRange{0x11930, 0x11935}, eawprN},   // Mc     [6] DIVES AKURU VOWEL SIGN AA..DIVES AKURU VOWEL SIGN E
+	{runeRange{0x1193E, 0x1193E}, eawprN},   // Mn         DIVES AKURU VIRAMA
+	{runeRange{0x11942, 0x11942}, eawprN},   // Mc         DIVES AKURU MEDIAL RA
+	{runeRange{0x119A0, 0x119A7}, eawprN},   // Lo     [8] NANDINAGARI LETTER A..NANDINAGARI LETTER VOCALIC RR
+	{runeRange{0x119DA, 0x119DB}, eawprN},   // Mn     [2] NANDINAGARI VOWEL SIGN E..NANDINAGARI VOWEL SIGN AI
+	{runeRange{0x119E2, 0x119E2}, eawprN},   // Po         NANDINAGARI SIGN SIDDHAM
+	{runeRange{0x11A01, 0x11A0A}, eawprN},   // Mn    [10] ZANABAZAR SQUARE VOWEL SIGN I..ZANABAZAR SQUARE VOWEL LENGTH MARK
+	{runeRange{0x11A3A, 0x11A3A}, eawprN},   // Lo         ZANABAZAR SQUARE CLUSTER-INITIAL LETTER RA
+	{runeRange{0x11A50, 0x11A50}, eawprN},   // Lo         SOYOMBO LETTER A
+	{runeRange{0x11A5C, 0x11A89}, eawprN},   // Lo    [46] SOYOMBO LETTER KA..SOYOMBO CLUSTER-INITIAL LETTER SA
+	{runeRange{0x11A9A, 0x11A9C}, eawprN},   // Po     [3] SOYOMBO MARK TSHEG..SOYOMBO MARK DOUBLE SHAD
+	{runeRange{0x11AC0, 0x11AF8}, eawprN},   // Lo    [57] PAU CIN HAU LETTER PA..PAU CIN HAU GLOTTAL STOP FINAL
+	{runeRange{0x11C2F, 0x11C2F}, eawprN},   // Mc         BHAIKSUKI VOWEL SIGN AA
+	{runeRange{0x11C3F, 0x11C3F}, eawprN},   // Mn         BHAIKSUKI SIGN VIRAMA
+	{runeRange{0x11C5A, 0x11C6C}, eawprN},   // No    [19] BHAIKSUKI NUMBER ONE..BHAIKSUKI HUNDREDS UNIT MARK
+	{runeRange{0x11CA9, 0x11CA9}, eawprN},   // Mc         MARCHEN SUBJOINED LETTER YA
+	{runeRange{0x11CB4, 0x11CB4}, eawprN},   // Mc         MARCHEN VOWEL SIGN O
+	{runeRange{0x11D0B, 0x11D30}, eawprN},   // Lo    [38] MASARAM GONDI LETTER AU..MASARAM GONDI LETTER TRA
+	{runeRange{0x11D3F, 0x11D45}, eawprN},   // Mn     [7] MASARAM GONDI VOWEL SIGN AU..MASARAM GONDI VIRAMA
+	{runeRange{0x11D60, 0x11D65}, eawprN},   // Lo     [6] GUNJALA GONDI LETTER A..GUNJALA GONDI LETTER UU
+	{runeRange{0x11D90, 0x11D91}, eawprN},   // Mn     [2] GUNJALA GONDI VOWEL SIGN EE..GUNJALA GONDI VOWEL SIGN AI
+	{runeRange{0x11D97, 0x11D97}, eawprN},   // Mn         GUNJALA GONDI VIRAMA
+	{runeRange{0x11EF3, 0x11EF4}, eawprN},   // Mn     [2] MAKASAR VOWEL SIGN I..MAKASAR VOWEL SIGN U
+	{runeRange{0x11F02, 0x11F02}, eawprN},   // Lo         KAWI SIGN REPHA
+	{runeRange{0x11F34, 0x11F35}, eawprN},   // Mc     [2] KAWI VOWEL SIGN AA..KAWI VOWEL SIGN ALTERNATE AA
+	{runeRange{0x11F41, 0x11F41}, eawprN},   // Mc         KAWI SIGN KILLER
+	{runeRange{0x11FB0, 0x11FB0}, eawprN},   // Lo         LISU LETTER YHA
+	{runeRange{0x11FE1, 0x11FF1}, eawprN},   // So    [17] TAMIL SIGN PAARAM..TAMIL SIGN VAKAIYARAA
+	{runeRange{0x12470, 0x12474}, eawprN},   // Po     [5] CUNEIFORM PUNCTUATION SIGN OLD ASSYRIAN WORD DIVIDER..CUNEIFORM PUNCTUATION SIGN DIAGONAL QUADCOLON
+	{runeRange{0x13000, 0x1342F}, eawprN},   // Lo  [1072] EGYPTIAN HIEROGLYPH A001..EGYPTIAN HIEROGLYPH V011D
+	{runeRange{0x13447, 0x13455}, eawprN},   // Mn    [15] EGYPTIAN HIEROGLYPH MODIFIER DAMAGED AT TOP START..EGYPTIAN HIEROGLYPH MODIFIER DAMAGED
+	{runeRange{0x16A60, 0x16A69}, eawprN},   // Nd    [10] MRO DIGIT ZERO..MRO DIGIT NINE
+	{runeRange{0x16AD0, 0x16AED}, eawprN},   // Lo    [30] BASSA VAH LETTER ENNI..BASSA VAH LETTER I
+	{runeRange{0x16B30, 0x16B36}, eawprN},   // Mn     [7] PAHAWH HMONG MARK CIM TUB..PAHAWH HMONG MARK CIM TAUM
+	{runeRange{0x16B44, 0x16B44}, eawprN},   // Po         PAHAWH HMONG SIGN XAUS
+	{runeRange{0x16B63, 0x16B77}, eawprN},   // Lo    [21] PAHAWH HMONG SIGN VOS LUB..PAHAWH HMONG SIGN CIM NRES TOS
+	{runeRange{0x16E97, 0x16E9A}, eawprN},   // Po     [4] MEDEFAIDRIN COMMA..MEDEFAIDRIN EXCLAMATION OH
+	{runeRange{0x16F51, 0x16F87}, eawprN},   // Mc    [55] MIAO SIGN ASPIRATION..MIAO VOWEL SIGN UI
+	{runeRange{0x16FE2, 0x16FE2}, eawprW},   // Po         OLD CHINESE HOOK MARK
+	{runeRange{0x17000, 0x187F7}, eawprW},   // Lo  [6136] TANGUT IDEOGRAPH-17000..TANGUT IDEOGRAPH-187F7
+	{runeRange{0x1AFF0, 0x1AFF3}, eawprW},   // Lm     [4] KATAKANA LETTER MINNAN TONE-2..KATAKANA LETTER MINNAN TONE-5
+	{runeRange{0x1B100, 0x1B122}, eawprW},   // Lo    [35] HENTAIGANA LETTER RE-3..KATAKANA LETTER ARCHAIC WU
+	{runeRange{0x1B164, 0x1B167}, eawprW},   // Lo     [4] KATAKANA LETTER SMALL WI..KATAKANA LETTER SMALL N
+	{runeRange{0x1BC80, 0x1BC88}, eawprN},   // Lo     [9] DUPLOYAN AFFIX HIGH ACUTE..DUPLOYAN AFFIX HIGH VERTICAL
+	{runeRange{0x1BC9F, 0x1BC9F}, eawprN},   // Po         DUPLOYAN PUNCTUATION CHINOOK FULL STOP
+	{runeRange{0x1CF50, 0x1CFC3}, eawprN},   // So   [116] ZNAMENNY NEUME KRYUK..ZNAMENNY NEUME PAUK
+	{runeRange{0x1D165, 0x1D166}, eawprN},   // Mc     [2] MUSICAL SYMBOL COMBINING STEM..MUSICAL SYMBOL COMBINING SPRECHGESANG STEM
+	{runeRange{0x1D173, 0x1D17A}, eawprN},   // Cf     [8] MUSICAL SYMBOL BEGIN BEAM..MUSICAL SYMBOL END PHRASE
+	{runeRange{0x1D18C, 0x1D1A9}, eawprN},   // So    [30] MUSICAL SYMBOL RINFORZANDO..MUSICAL SYMBOL DEGREE SLASH
+	{runeRange{0x1D242, 0x1D244}, eawprN},   // Mn     [3] COMBINING GREEK MUSICAL TRISEME..COMBINING GREEK MUSICAL PENTASEME
+	{runeRange{0x1D300, 0x1D356}, eawprN},   // So    [87] MONOGRAM FOR EARTH..TETRAGRAM FOR FOSTERING
+	{runeRange{0x1D49E, 0x1D49F}, eawprN},   // Lu     [2] MATHEMATICAL SCRIPT CAPITAL C..MATHEMATICAL SCRIPT CAPITAL D
+	{runeRange{0x1D4AE, 0x1D4B9}, eawprN},   // L&    [12] MATHEMATICAL SCRIPT CAPITAL S..MATHEMATICAL SCRIPT SMALL D
+	{runeRange{0x1D507, 0x1D50A}, eawprN},   // Lu     [4] MATHEMATICAL FRAKTUR CAPITAL D..MATHEMATICAL FRAKTUR CAPITAL G
+	{runeRange{0x1D53B, 0x1D53E}, eawprN},   // Lu     [4] MATHEMATICAL DOUBLE-STRUCK CAPITAL D..MATHEMATICAL DOUBLE-STRUCK CAPITAL G
+	{runeRange{0x1D552, 0x1D6A5}, eawprN},   // L&   [340] MATHEMATICAL DOUBLE-STRUCK SMALL A..MATHEMATICAL ITALIC SMALL DOTLESS J
+	{runeRange{0x1D6DB, 0x1D6DB}, eawprN},   // Sm         MATHEMATICAL BOLD PARTIAL DIFFERENTIAL
+	{runeRange{0x1D715, 0x1D715}, eawprN},   // Sm         MATHEMATICAL ITALIC PARTIAL DIFFERENTIAL
+	{runeRange{0x1D74F, 0x1D74F}, eawprN},   // Sm         MATHEMATICAL BOLD ITALIC PARTIAL DIFFERENTIAL
+	{runeRange{0x1D789, 0x1D789}, eawprN},   // Sm         MATHEMATICAL SANS-SERIF BOLD PARTIAL DIFFERENTIAL
+	{runeRange{0x1D7C3, 0x1D7C3}, eawprN},   // Sm         MATHEMATICAL SANS-SERIF BOLD ITALIC PARTIAL DIFFERENTIAL
+	{runeRange{0x1DA00, 0x1DA36}, eawprN},   // Mn    [55] SIGNWRITING HEAD RIM..SIGNWRITING AIR SUCKING IN
+	{runeRange{0x1DA75, 0x1DA75}, eawprN},   // Mn         SIGNWRITING UPPER BODY TILTING FROM HIP JOINTS
+	{runeRange{0x1DA87, 0x1DA8B}, eawprN},   // Po     [5] SIGNWRITING COMMA..SIGNWRITING PARENTHESIS
+	{runeRange{0x1DF0A, 0x1DF0A}, eawprN},   // Lo         LATIN LETTER RETROFLEX CLICK WITH RETROFLEX HOOK
+	{runeRange{0x1E008, 0x1E018}, eawprN},   // Mn    [17] COMBINING GLAGOLITIC LETTER ZEMLJA..COMBINING GLAGOLITIC LETTER HERU
+	{runeRange{0x1E030, 0x1E06D}, eawprN},   // Lm    [62] MODIFIER LETTER CYRILLIC SMALL A..MODIFIER LETTER CYRILLIC SMALL STRAIGHT U WITH STROKE
+	{runeRange{0x1E137, 0x1E13D}, eawprN},   // Lm     [7] NYIAKENG PUACHUE HMONG SIGN FOR PERSON..NYIAKENG PUACHUE HMONG SYLLABLE LENGTHENER
+	{runeRange{0x1E290, 0x1E2AD}, eawprN},   // Lo    [30] TOTO LETTER PA..TOTO LETTER A
+	{runeRange{0x1E2F0, 0x1E2F9}, eawprN},   // Nd    [10] WANCHO DIGIT ZERO..WANCHO DIGIT NINE
+	{runeRange{0x1E4EC, 0x1E4EF}, eawprN},   // Mn     [4] NAG MUNDARI SIGN MUHOR..NAG MUNDARI SIGN SUTUH
+	{runeRange{0x1E7ED, 0x1E7EE}, eawprN},   // Lo     [2] ETHIOPIC SYLLABLE GURAGE MWI..ETHIOPIC SYLLABLE GURAGE MWEE
+	{runeRange{0x1E8D0, 0x1E8D6}, eawprN},   // Mn     [7] MENDE KIKAKUI COMBINING NUMBER TEENS..MENDE KIKAKUI COMBINING NUMBER MILLIONS
+	{runeRange{0x1E950, 0x1E959}, eawprN},   // Nd    [10] ADLAM DIGIT ZERO..ADLAM DIGIT NINE
+	{runeRange{0x1ECAD, 0x1ECAF}, eawprN},   // No     [3] INDIC SIYAQ FRACTION ONE QUARTER..INDIC SIYAQ FRACTION THREE QUARTERS
+	{runeRange{0x1ED2E, 0x1ED2E}, eawprN},   // So         OTTOMAN SIYAQ MARRATAN
+	{runeRange{0x1EE21, 0x1EE22}, eawprN},   // Lo     [2] ARABIC MATHEMATICAL INITIAL BEH..ARABIC MATHEMATICAL INITIAL JEEM
+	{runeRange{0x1EE34, 0x1EE37}, eawprN},   // Lo     [4] ARABIC MATHEMATICAL INITIAL SHEEN..ARABIC MATHEMATICAL INITIAL KHAH
+	{runeRange{0x1EE47, 0x1EE47}, eawprN},   // Lo         ARABIC MATHEMATICAL TAILED HAH
+	{runeRange{0x1EE51, 0x1EE52}, eawprN},   // Lo     [2] ARABIC MATHEMATICAL TAILED SAD..ARABIC MATHEMATICAL TAILED QAF
+	{runeRange{0x1EE5B, 0x1EE5B}, eawprN},   // Lo         ARABIC MATHEMATICAL TAILED GHAIN
+	{runeRange{0x1EE64, 0x1EE64}, eawprN},   // Lo         ARABIC MATHEMATICAL STRETCHED HEH
+	{runeRange{0x1EE79, 0x1EE7C}, eawprN},   // Lo     [4] ARABIC MATHEMATICAL STRETCHED DAD..ARABIC MATHEMATICAL STRETCHED DOTLESS BEH
+	{runeRange{0x1EEA1, 0x1EEA3}, eawprN},   // Lo     [3] ARABIC MATHEMATICAL DOUBLE-STRUCK BEH..ARABIC MATHEMATICAL DOUBLE-STRUCK DAL
+	{runeRange{0x1F000, 0x1F003}, eawprN},   // So     [4] MAHJONG TILE EAST WIND..MAHJONG TILE NORTH WIND
+	{runeRange{0x1F0A0, 0x1F0AE}, eawprN},   // So    [15] PLAYING CARD BACK..PLAYING CARD KING OF SPADES
+	{runeRange{0x1F0D1, 0x1F0F5}, eawprN},   // So    [37] PLAYING CARD ACE OF CLUBS..PLAYING CARD TRUMP-21
+	{runeRange{0x1F110, 0x1F12D}, eawprA},   // So    [30] PARENTHESIZED LATIN CAPITAL LETTER A..CIRCLED CD
+	{runeRange{0x1F170, 0x1F18D}, eawprA},   // So    [30] NEGATIVE SQUARED LATIN CAPITAL LETTER A..NEGATIVE SQUARED SA
+	{runeRange{0x1F19B, 0x1F1AC}, eawprA},   // So    [18] SQUARED THREE D..SQUARED VOD
+	{runeRange{0x1F210, 0x1F23B}, eawprW},   // So    [44] SQUARED CJK UNIFIED IDEOGRAPH-624B..SQUARED CJK UNIFIED IDEOGRAPH-914D
+	{runeRange{0x1F300, 0x1F320}, eawprW},   // So    [33] CYCLONE..SHOOTING STAR
+	{runeRange{0x1F337, 0x1F37C}, eawprW},   // So    [70] TULIP..BABY BOTTLE
+	{runeRange{0x1F3A0, 0x1F3CA}, eawprW},   // So    [43] CAROUSEL HORSE..SWIMMER
+	{runeRange{0x1F3E0, 0x1F3F0}, eawprW},   // So    [17] HOUSE BUILDING..EUROPEAN CASTLE
+	{runeRange{0x1F3F8, 0x1F3FA}, eawprW},   // So     [3] BADMINTON RACQUET AND SHUTTLECOCK..AMPHORA
+	{runeRange{0x1F440, 0x1F440}, eawprW},   // So         EYES
+	{runeRange{0x1F4FF, 0x1F53D}, eawprW},   // So    [63] PRAYER BEADS..DOWN-POINTING SMALL RED TRIANGLE
+	{runeRange{0x1F550, 0x1F567}, eawprW},   // So    [24] CLOCK FACE ONE OCLOCK..CLOCK FACE TWELVE-THIRTY
+	{runeRange{0x1F595, 0x1F596}, eawprW},   // So     [2] REVERSED HAND WITH MIDDLE FINGER EXTENDED..RAISED HAND WITH PART BETWEEN MIDDLE AND RING FINGERS
+	{runeRange{0x1F5FB, 0x1F5FF}, eawprW},   // So     [5] MOUNT FUJI..MOYAI
+	{runeRange{0x1F6C6, 0x1F6CB}, eawprN},   // So     [6] TRIANGLE WITH ROUNDED CORNERS..COUCH AND LAMP
+	{runeRange{0x1F6D3, 0x1F6D4}, eawprN},   // So     [2] STUPA..PAGODA
+	{runeRange{0x1F6EB, 0x1F6EC}, eawprW},   // So     [2] AIRPLANE DEPARTURE..AIRPLANE ARRIVING
+	{runeRange{0x1F77B, 0x1F77F}, eawprN},   // So     [5] HAUMEA..ORCUS
+	{runeRange{0x1F800, 0x1F80B}, eawprN},   // So    [12] LEFTWARDS ARROW WITH SMALL TRIANGLE ARROWHEAD..DOWNWARDS ARROW WITH LARGE TRIANGLE ARROWHEAD
+	{runeRange{0x1F890, 0x1F8AD}, eawprN},   // So    [30] LEFTWARDS TRIANGLE ARROWHEAD..WHITE ARROW SHAFT WIDTH TWO THIRDS
+	{runeRange{0x1F93B, 0x1F93B}, eawprN},   // So         MODERN PENTATHLON
+	{runeRange{0x1FA00, 0x1FA53}, eawprN},   // So    [84] NEUTRAL CHESS KING..BLACK CHESS KNIGHT-BISHOP
+	{runeRange{0x1FA90, 0x1FABD}, eawprW},   // So    [46] RINGED PLANET..WING
+	{runeRange{0x1FAF0, 0x1FAF8}, eawprW},   // So     [9] HAND WITH INDEX FINGER AND THUMB CROSSED..RIGHTWARDS PUSHING HAND
+	{runeRange{0x20000, 0x2A6DF}, eawprW},   // Lo [42720] CJK UNIFIED IDEOGRAPH-20000..CJK UNIFIED IDEOGRAPH-2A6DF
+	{runeRange{0x2B740, 0x2B81D}, eawprW},   // Lo   [222] CJK UNIFIED IDEOGRAPH-2B740..CJK UNIFIED IDEOGRAPH-2B81D
+	{runeRange{0x2CEB0, 0x2EBE0}, eawprW},   // Lo  [7473] CJK UNIFIED IDEOGRAPH-2CEB0..CJK UNIFIED IDEOGRAPH-2EBE0
+	{runeRange{0x2FA20, 0x2FFFD}, eawprW},   // Cn  [1502] <reserved-2FA20>..<reserved-2FFFD>
+	{runeRange{0x323B0, 0x3FFFD}, eawprW},   // Cn [56398] <reserved-323B0>..<reserved-3FFFD>
 	{runeRange{0xF0000, 0xFFFFD}, eawprA},   // Co [65534] <private-use-F0000>..<private-use-FFFFD>
+	{runeRange{0x0020, 0x0020}, eawprNa},    // Zs         SPACE
+	{runeRange{0x0028, 0x0028}, eawprNa},    // Ps         LEFT PARENTHESIS
+	{runeRange{0x002C, 0x002C}, eawprNa},    // Po         COMMA
+	{runeRange{0x003A, 0x003B}, eawprNa},    // Po     [2] COLON..SEMICOLON
+	{runeRange{0x005B, 0x005B}, eawprNa},    // Ps         LEFT SQUARE BRACKET
+	{runeRange{0x005F, 0x005F}, eawprNa},    // Pc         LOW LINE
+	{runeRange{0x007C, 0x007C}, eawprNa},    // Sm         VERTICAL LINE
+	{runeRange{0x0080, 0x009F}, eawprN},     // Cc    [32] <control-0080>..<control-009F>
+	{runeRange{0x00A4, 0x00A4}, eawprA},     // Sc         CURRENCY SIGN
+	{runeRange{0x00A8, 0x00A8}, eawprA},     // Sk         DIAERESIS
+	{runeRange{0x00AC, 0x00AC}, eawprNa},    // Sm         NOT SIGN
+	{runeRange{0x00B0, 0x00B0}, eawprA},     // So         DEGREE SIGN
+	{runeRange{0x00B5, 0x00B5}, eawprN},     // Ll         MICRO SIGN
+	{runeRange{0x00BA, 0x00BA}, eawprA},     // Lo         MASCULINE ORDINAL INDICATOR
+	{runeRange{0x00C0, 0x00C5}, eawprN},     // Lu     [6] LATIN CAPITAL LETTER A WITH GRAVE..LATIN CAPITAL LETTER A WITH RING ABOVE
+	{runeRange{0x00D1, 0x00D6}, eawprN},     // Lu     [6] LATIN CAPITAL LETTER N WITH TILDE..LATIN CAPITAL LETTER O WITH DIAERESIS
+	{runeRange{0x00DE, 0x00E1}, eawprA},     // L&     [4] LATIN CAPITAL LETTER THORN..LATIN SMALL LETTER A WITH ACUTE
+	{runeRange{0x00E8, 0x00EA}, eawprA},     // Ll     [3] LATIN SMALL LETTER E WITH GRAVE..LATIN SMALL LETTER E WITH CIRCUMFLEX
+	{runeRange{0x00F0, 0x00F0}, eawprA},     // Ll         LATIN SMALL LETTER ETH
+	{runeRange{0x00F7, 0x00F7}, eawprA},     // Sm         DIVISION SIGN
+	{runeRange{0x00FD, 0x00FD}, eawprN},     // Ll         LATIN SMALL LETTER Y WITH ACUTE
+	{runeRange{0x0101, 0x0101}, eawprA},     // Ll         LATIN SMALL LETTER A WITH MACRON
+	{runeRange{0x0113, 0x0113}, eawprA},     // Ll         LATIN SMALL LETTER E WITH MACRON
+	{runeRange{0x0126, 0x0127}, eawprA},     // L&     [2] LATIN CAPITAL LETTER H WITH STROKE..LATIN SMALL LETTER H WITH STROKE
+	{runeRange{0x0131, 0x0133}, eawprA},     // L&     [3] LATIN SMALL LETTER DOTLESS I..LATIN SMALL LIGATURE IJ
+	{runeRange{0x013F, 0x0142}, eawprA},     // L&     [4] LATIN CAPITAL LETTER L WITH MIDDLE DOT..LATIN SMALL LETTER L WITH STROKE
+	{runeRange{0x0148, 0x014B}, eawprA},     // L&     [4] LATIN SMALL LETTER N WITH CARON..LATIN SMALL LETTER ENG
+	{runeRange{0x0152, 0x0153}, eawprA},     // L&     [2] LATIN CAPITAL LIGATURE OE..LATIN SMALL LIGATURE OE
+	{runeRange{0x016B, 0x016B}, eawprA},     // Ll         LATIN SMALL LETTER U WITH MACRON
+	{runeRange{0x01BC, 0x01BF}, eawprN},     // L&     [4] LATIN CAPITAL LETTER TONE FIVE..LATIN LETTER WYNN
+	{runeRange{0x01CF, 0x01CF}, eawprN},     // Lu         LATIN CAPITAL LETTER I WITH CARON
+	{runeRange{0x01D3, 0x01D3}, eawprN},     // Lu         LATIN CAPITAL LETTER U WITH CARON
+	{runeRange{0x01D7, 0x01D7}, eawprN},     // Lu         LATIN CAPITAL LETTER U WITH DIAERESIS AND ACUTE
+	{runeRange{0x01DB, 0x01DB}, eawprN},     // Lu         LATIN CAPITAL LETTER U WITH DIAERESIS AND GRAVE
+	{runeRange{0x0251, 0x0251}, eawprA},     // Ll         LATIN SMALL LETTER ALPHA
+	{runeRange{0x0294, 0x0294}, eawprN},     // Lo         LATIN LETTER GLOTTAL STOP
+	{runeRange{0x02C4, 0x02C4}, eawprA},     // Sk         MODIFIER LETTER UP ARROWHEAD
+	{runeRange{0x02C8, 0x02C8}, eawprN},     // Lm         MODIFIER LETTER VERTICAL LINE
+	{runeRange{0x02CE, 0x02CF}, eawprN},     // Lm     [2] MODIFIER LETTER LOW GRAVE ACCENT..MODIFIER LETTER LOW ACUTE ACCENT
+	{runeRange{0x02D8, 0x02DB}, eawprA},     // Sk     [4] BREVE..OGONEK
+	{runeRange{0x02DF, 0x02DF}, eawprA},     // Sk         MODIFIER LETTER CROSS ACCENT
+	{runeRange{0x02ED, 0x02ED}, eawprN},     // Sk         MODIFIER LETTER UNASPIRATED
+	{runeRange{0x0370, 0x0373}, eawprN},     // L&     [4] GREEK CAPITAL LETTER HETA..GREEK SMALL LETTER ARCHAIC SAMPI
+	{runeRange{0x037A, 0x037A}, eawprN},     // Lm         GREEK YPOGEGRAMMENI
+	{runeRange{0x0384, 0x0385}, eawprN},     // Sk     [2] GREEK TONOS..GREEK DIALYTIKA TONOS
+	{runeRange{0x038C, 0x038C}, eawprN},     // Lu         GREEK CAPITAL LETTER OMICRON WITH TONOS
+	{runeRange{0x03AA, 0x03B0}, eawprN},     // L&     [7] GREEK CAPITAL LETTER IOTA WITH DIALYTIKA..GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND TONOS
+	{runeRange{0x03CA, 0x03F5}, eawprN},     // L&    [44] GREEK SMALL LETTER IOTA WITH DIALYTIKA..GREEK LUNATE EPSILON SYMBOL
+	{runeRange{0x0401, 0x0401}, eawprA},     // Lu         CYRILLIC CAPITAL LETTER IO
+	{runeRange{0x0451, 0x0451}, eawprA},     // Ll         CYRILLIC SMALL LETTER IO
+	{runeRange{0x0488, 0x0489}, eawprN},     // Me     [2] COMBINING CYRILLIC HUNDRED THOUSANDS SIGN..COMBINING CYRILLIC MILLIONS SIGN
+	{runeRange{0x0559, 0x0559}, eawprN},     // Lm         ARMENIAN MODIFIER LETTER LEFT HALF RING
+	{runeRange{0x058A, 0x058A}, eawprN},     // Pd         ARMENIAN HYPHEN
+	{runeRange{0x05BE, 0x05BE}, eawprN},     // Pd         HEBREW PUNCTUATION MAQAF
+	{runeRange{0x05C3, 0x05C3}, eawprN},     // Po         HEBREW PUNCTUATION SOF PASUQ
+	{runeRange{0x05D0, 0x05EA}, eawprN},     // Lo    [27] HEBREW LETTER ALEF..HEBREW LETTER TAV
+	{runeRange{0x0606, 0x0608}, eawprN},     // Sm     [3] ARABIC-INDIC CUBE ROOT..ARABIC RAY
+	{runeRange{0x060E, 0x060F}, eawprN},     // So     [2] ARABIC POETIC VERSE SIGN..ARABIC SIGN MISRA
+	{runeRange{0x061D, 0x061F}, eawprN},     // Po     [3] ARABIC END OF TEXT MARK..ARABIC QUESTION MARK
+	{runeRange{0x064B, 0x065F}, eawprN},     // Mn    [21] ARABIC FATHATAN..ARABIC WAVY HAMZA BELOW
+	{runeRange{0x0670, 0x0670}, eawprN},     // Mn         ARABIC LETTER SUPERSCRIPT ALEF
+	{runeRange{0x06D6, 0x06DC}, eawprN},     // Mn     [7] ARABIC SMALL HIGH LIGATURE SAD WITH LAM WITH ALEF MAKSURA..ARABIC SMALL HIGH SEEN
+	{runeRange{0x06E5, 0x06E6}, eawprN},     // Lm     [2] ARABIC SMALL WAW..ARABIC SMALL YEH
+	{runeRange{0x06EE, 0x06EF}, eawprN},     // Lo     [2] ARABIC LETTER DAL WITH INVERTED V..ARABIC LETTER REH WITH INVERTED V
+	{runeRange{0x06FF, 0x06FF}, eawprN},     // Lo         ARABIC LETTER HEH WITH INVERTED V
+	{runeRange{0x0711, 0x0711}, eawprN},     // Mn         SYRIAC LETTER SUPERSCRIPT ALAPH
+	{runeRange{0x0750, 0x077F}, eawprN},     // Lo    [48] ARABIC LETTER BEH WITH THREE DOTS HORIZONTALLY BELOW..ARABIC LETTER KAF WITH TWO DOTS ABOVE
+	{runeRange{0x07C0, 0x07C9}, eawprN},     // Nd    [10] NKO DIGIT ZERO..NKO DIGIT NINE
+	{runeRange{0x07F6, 0x07F6}, eawprN},     // So         NKO SYMBOL OO DENNEN
+	{runeRange{0x07FE, 0x07FF}, eawprN},     // Sc     [2] NKO DOROME SIGN..NKO TAMAN SIGN
+	{runeRange{0x081B, 0x0823}, eawprN},     // Mn     [9] SAMARITAN MARK EPENTHETIC YUT..SAMARITAN VOWEL SIGN A
+	{runeRange{0x0829, 0x082D}, eawprN},     // Mn     [5] SAMARITAN VOWEL SIGN LONG I..SAMARITAN MARK NEQUDAA
+	{runeRange{0x085E, 0x085E}, eawprN},     // Po         MANDAIC PUNCTUATION
+	{runeRange{0x0889, 0x088E}, eawprN},     // Lo     [6] ARABIC LETTER NOON WITH INVERTED SMALL V..ARABIC VERTICAL TAIL
+	{runeRange{0x08C9, 0x08C9}, eawprN},     // Lm         ARABIC SMALL FARSI YEH
+	{runeRange{0x0900, 0x0902}, eawprN},     // Mn     [3] DEVANAGARI SIGN INVERTED CANDRABINDU..DEVANAGARI SIGN ANUSVARA
+	{runeRange{0x093B, 0x093B}, eawprN},     // Mc         DEVANAGARI VOWEL SIGN OOE
+	{runeRange{0x0941, 0x0948}, eawprN},     // Mn     [8] DEVANAGARI VOWEL SIGN U..DEVANAGARI VOWEL SIGN AI
+	{runeRange{0x0950, 0x0950}, eawprN},     // Lo         DEVANAGARI OM
+	{runeRange{0x0964, 0x0965}, eawprN},     // Po     [2] DEVANAGARI DANDA..DEVANAGARI DOUBLE DANDA
+	{runeRange{0x0972, 0x097F}, eawprN},     // Lo    [14] DEVANAGARI LETTER CANDRA A..DEVANAGARI LETTER BBA
+	{runeRange{0x0985, 0x098C}, eawprN},     // Lo     [8] BENGALI LETTER A..BENGALI LETTER VOCALIC L
+	{runeRange{0x09B2, 0x09B2}, eawprN},     // Lo         BENGALI LETTER LA
+	{runeRange{0x09BE, 0x09C0}, eawprN},     // Mc     [3] BENGALI VOWEL SIGN AA..BENGALI VOWEL SIGN II
+	{runeRange{0x09CD, 0x09CD}, eawprN},     // Mn         BENGALI SIGN VIRAMA
+	{runeRange{0x09DF, 0x09E1}, eawprN},     // Lo     [3] BENGALI LETTER YYA..BENGALI LETTER VOCALIC LL
+	{runeRange{0x09F2, 0x09F3}, eawprN},     // Sc     [2] BENGALI RUPEE MARK..BENGALI RUPEE SIGN
+	{runeRange{0x09FC, 0x09FC}, eawprN},     // Lo         BENGALI LETTER VEDIC ANUSVARA
+	{runeRange{0x0A03, 0x0A03}, eawprN},     // Mc         GURMUKHI SIGN VISARGA
+	{runeRange{0x0A2A, 0x0A30}, eawprN},     // Lo     [7] GURMUKHI LETTER PA..GURMUKHI LETTER RA
+	{runeRange{0x0A3C, 0x0A3C}, eawprN},     // Mn         GURMUKHI SIGN NUKTA
+	{runeRange{0x0A4B, 0x0A4D}, eawprN},     // Mn     [3] GURMUKHI VOWEL SIGN OO..GURMUKHI SIGN VIRAMA
+	{runeRange{0x0A66, 0x0A6F}, eawprN},     // Nd    [10] GURMUKHI DIGIT ZERO..GURMUKHI DIGIT NINE
+	{runeRange{0x0A76, 0x0A76}, eawprN},     // Po         GURMUKHI ABBREVIATION SIGN
+	{runeRange{0x0A8F, 0x0A91}, eawprN},     // Lo     [3] GUJARATI LETTER E..GUJARATI VOWEL CANDRA O
+	{runeRange{0x0AB5, 0x0AB9}, eawprN},     // Lo     [5] GUJARATI LETTER VA..GUJARATI LETTER HA
+	{runeRange{0x0AC1, 0x0AC5}, eawprN},     // Mn     [5] GUJARATI VOWEL SIGN U..GUJARATI VOWEL SIGN CANDRA E
+	{runeRange{0x0ACD, 0x0ACD}, eawprN},     // Mn         GUJARATI SIGN VIRAMA
+	{runeRange{0x0AE6, 0x0AEF}, eawprN},     // Nd    [10] GUJARATI DIGIT ZERO..GUJARATI DIGIT NINE
+	{runeRange{0x0AFA, 0x0AFF}, eawprN},     // Mn     [6] GUJARATI SIGN SUKUN..GUJARATI SIGN TWO-CIRCLE NUKTA ABOVE
+	{runeRange{0x0B0F, 0x0B10}, eawprN},     // Lo     [2] ORIYA LETTER E..ORIYA LETTER AI
+	{runeRange{0x0B35, 0x0B39}, eawprN},     // Lo     [5] ORIYA LETTER VA..ORIYA LETTER HA
+	{runeRange{0x0B3F, 0x0B3F}, eawprN},     // Mn         ORIYA VOWEL SIGN I
+	{runeRange{0x0B4B, 0x0B4C}, eawprN},     // Mc     [2] ORIYA VOWEL SIGN O..ORIYA VOWEL SIGN AU
+	{runeRange{0x0B5C, 0x0B5D}, eawprN},     // Lo     [2] ORIYA LETTER RRA..ORIYA LETTER RHA
+	{runeRange{0x0B70, 0x0B70}, eawprN},     // So         ORIYA ISSHAR
+	{runeRange{0x0B83, 0x0B83}, eawprN},     // Lo         TAMIL SIGN VISARGA
+	{runeRange{0x0B99, 0x0B9A}, eawprN},     // Lo     [2] TAMIL LETTER NGA..TAMIL LETTER CA
+	{runeRange{0x0BA8, 0x0BAA}, eawprN},     // Lo     [3] TAMIL LETTER NA..TAMIL LETTER PA
+	{runeRange{0x0BC1, 0x0BC2}, eawprN},     // Mc     [2] TAMIL VOWEL SIGN U..TAMIL VOWEL SIGN UU
+	{runeRange{0x0BD0, 0x0BD0}, eawprN},     // Lo         TAMIL OM
+	{runeRange{0x0BF3, 0x0BF8}, eawprN},     // So     [6] TAMIL DAY SIGN..TAMIL AS ABOVE SIGN
+	{runeRange{0x0C01, 0x0C03}, eawprN},     // Mc     [3] TELUGU SIGN CANDRABINDU..TELUGU SIGN VISARGA
+	{runeRange{0x0C12, 0x0C28}, eawprN},     // Lo    [23] TELUGU LETTER O..TELUGU LETTER NA
+	{runeRange{0x0C3E, 0x0C40}, eawprN},     // Mn     [3] TELUGU VOWEL SIGN AA..TELUGU VOWEL SIGN II
+	{runeRange{0x0C55, 0x0C56}, eawprN},     // Mn     [2] TELUGU LENGTH MARK..TELUGU AI LENGTH MARK
+	{runeRange{0x0C62, 0x0C63}, eawprN},     // Mn     [2] TELUGU VOWEL SIGN VOCALIC L..TELUGU VOWEL SIGN VOCALIC LL
+	{runeRange{0x0C7F, 0x0C7F}, eawprN},     // So         TELUGU SIGN TUUMU
+	{runeRange{0x0C84, 0x0C84}, eawprN},     // Po         KANNADA SIGN SIDDHAM
+	{runeRange{0x0CAA, 0x0CB3}, eawprN},     // Lo    [10] KANNADA LETTER PA..KANNADA LETTER LLA
+	{runeRange{0x0CBE, 0x0CBE}, eawprN},     // Mc         KANNADA VOWEL SIGN AA
+	{runeRange{0x0CC7, 0x0CC8}, eawprN},     // Mc     [2] KANNADA VOWEL SIGN EE..KANNADA VOWEL SIGN AI
+	{runeRange{0x0CDD, 0x0CDE}, eawprN},     // Lo     [2] KANNADA LETTER NAKAARA POLLU..KANNADA LETTER FA
+	{runeRange{0x0CF1, 0x0CF2}, eawprN},     // Lo     [2] KANNADA SIGN JIHVAMULIYA..KANNADA SIGN UPADHMANIYA
+	{runeRange{0x0D04, 0x0D0C}, eawprN},     // Lo     [9] MALAYALAM LETTER VEDIC ANUSVARA..MALAYALAM LETTER VOCALIC L
+	{runeRange{0x0D3D, 0x0D3D}, eawprN},     // Lo         MALAYALAM SIGN AVAGRAHA
+	{runeRange{0x0D4A, 0x0D4C}, eawprN},     // Mc     [3] MALAYALAM VOWEL SIGN O..MALAYALAM VOWEL SIGN AU
+	{runeRange{0x0D54, 0x0D56}, eawprN},     // Lo     [3] MALAYALAM LETTER CHILLU M..MALAYALAM LETTER CHILLU LLL
+	{runeRange{0x0D62, 0x0D63}, eawprN},     // Mn     [2] MALAYALAM VOWEL SIGN VOCALIC L..MALAYALAM VOWEL SIGN VOCALIC LL
+	{runeRange{0x0D7A, 0x0D7F}, eawprN},     // Lo     [6] MALAYALAM LETTER CHILLU NN..MALAYALAM LETTER CHILLU K
+	{runeRange{0x0D9A, 0x0DB1}, eawprN},     // Lo    [24] SINHALA LETTER ALPAPRAANA KAYANNA..SINHALA LETTER DANTAJA NAYANNA
+	{runeRange{0x0DCA, 0x0DCA}, eawprN},     // Mn         SINHALA SIGN AL-LAKUNA
+	{runeRange{0x0DD8, 0x0DDF}, eawprN},     // Mc     [8] SINHALA VOWEL SIGN GAETTA-PILLA..SINHALA VOWEL SIGN GAYANUKITTA
+	{runeRange{0x0E01, 0x0E30}, eawprN},     // Lo    [48] THAI CHARACTER KO KAI..THAI CHARACTER SARA A
+	{runeRange{0x0E3F, 0x0E3F}, eawprN},     // Sc         THAI CURRENCY SYMBOL BAHT
+	{runeRange{0x0E4F, 0x0E4F}, eawprN},     // Po         THAI CHARACTER FONGMAN
+	{runeRange{0x0E84, 0x0E84}, eawprN},     // Lo         LAO LETTER KHO TAM
+	{runeRange{0x0EA7, 0x0EB0}, eawprN},     // Lo    [10] LAO LETTER WO..LAO VOWEL SIGN A
+	{runeRange{0x0EBD, 0x0EBD}, eawprN},     // Lo         LAO SEMIVOWEL SIGN NYO
+	{runeRange{0x0ED0, 0x0ED9}, eawprN},     // Nd    [10] LAO DIGIT ZERO..LAO DIGIT NINE
+	{runeRange{0x0F04, 0x0F12}, eawprN},     // Po    [15] TIBETAN MARK INITIAL YIG MGO MDUN MA..TIBETAN MARK RGYA GRAM SHAD
+	{runeRange{0x0F18, 0x0F19}, eawprN},     // Mn     [2] TIBETAN ASTROLOGICAL SIGN -KHYUD PA..TIBETAN ASTROLOGICAL SIGN SDONG TSHUGS
+	{runeRange{0x0F34, 0x0F34}, eawprN},     // So         TIBETAN MARK BSDUS RTAGS
+	{runeRange{0x0F38, 0x0F38}, eawprN},     // So         TIBETAN MARK CHE MGO
+	{runeRange{0x0F3C, 0x0F3C}, eawprN},     // Ps         TIBETAN MARK ANG KHANG GYON
+	{runeRange{0x0F49, 0x0F6C}, eawprN},     // Lo    [36] TIBETAN LETTER NYA..TIBETAN LETTER RRA
+	{runeRange{0x0F85, 0x0F85}, eawprN},     // Po         TIBETAN MARK PALUTA
+	{runeRange{0x0F99, 0x0FBC}, eawprN},     // Mn    [36] TIBETAN SUBJOINED LETTER NYA..TIBETAN SUBJOINED LETTER FIXED-FORM RA
+	{runeRange{0x0FCE, 0x0FCF}, eawprN},     // So     [2] TIBETAN SIGN RDEL NAG RDEL DKAR..TIBETAN SIGN RDEL NAG GSUM
+	{runeRange{0x1000, 0x102A}, eawprN},     // Lo    [43] MYANMAR LETTER KA..MYANMAR LETTER AU
+	{runeRange{0x1032, 0x1037}, eawprN},     // Mn     [6] MYANMAR VOWEL SIGN AI..MYANMAR SIGN DOT BELOW
+	{runeRange{0x103D, 0x103E}, eawprN},     // Mn     [2] MYANMAR CONSONANT SIGN MEDIAL WA..MYANMAR CONSONANT SIGN MEDIAL HA
+	{runeRange{0x1050, 0x1055}, eawprN},     // Lo     [6] MYANMAR LETTER SHA..MYANMAR LETTER VOCALIC LL
+	{runeRange{0x105E, 0x1060}, eawprN},     // Mn     [3] MYANMAR CONSONANT SIGN MON MEDIAL NA..MYANMAR CONSONANT SIGN MON MEDIAL LA
+	{runeRange{0x1067, 0x106D}, eawprN},     // Mc     [7] MYANMAR VOWEL SIGN WESTERN PWO KAREN EU..MYANMAR SIGN WESTERN PWO KAREN TONE-5
+	{runeRange{0x1082, 0x1082}, eawprN},     // Mn         MYANMAR CONSONANT SIGN SHAN MEDIAL WA
+	{runeRange{0x108D, 0x108D}, eawprN},     // Mn         MYANMAR SIGN SHAN COUNCIL EMPHATIC TONE
+	{runeRange{0x109A, 0x109C}, eawprN},     // Mc     [3] MYANMAR SIGN KHAMTI TONE-1..MYANMAR VOWEL SIGN AITON A
+	{runeRange{0x10C7, 0x10C7}, eawprN},     // Lu         GEORGIAN CAPITAL LETTER YN
+	{runeRange{0x10FC, 0x10FC}, eawprN},     // Lm         MODIFIER LETTER GEORGIAN NAR
+	{runeRange{0x1200, 0x1248}, eawprN},     // Lo    [73] ETHIOPIC SYLLABLE HA..ETHIOPIC SYLLABLE QWA
+	{runeRange{0x125A, 0x125D}, eawprN},     // Lo     [4] ETHIOPIC SYLLABLE QHWI..ETHIOPIC SYLLABLE QHWE
+	{runeRange{0x12B2, 0x12B5}, eawprN},     // Lo     [4] ETHIOPIC SYLLABLE KWI..ETHIOPIC SYLLABLE KWE
+	{runeRange{0x12C8, 0x12D6}, eawprN},     // Lo    [15] ETHIOPIC SYLLABLE WA..ETHIOPIC SYLLABLE PHARYNGEAL O
+	{runeRange{0x135D, 0x135F}, eawprN},     // Mn     [3] ETHIOPIC COMBINING GEMINATION AND VOWEL LENGTH MARK..ETHIOPIC COMBINING GEMINATION MARK
+	{runeRange{0x1390, 0x1399}, eawprN},     // So    [10] ETHIOPIC TONAL MARK YIZET..ETHIOPIC TONAL MARK KURT
+	{runeRange{0x1401, 0x166C}, eawprN},     // Lo   [620] CANADIAN SYLLABICS E..CANADIAN SYLLABICS CARRIER TTSA
+	{runeRange{0x1680, 0x1680}, eawprN},     // Zs         OGHAM SPACE MARK
+	{runeRange{0x16A0, 0x16EA}, eawprN},     // Lo    [75] RUNIC LETTER FEHU FEOH FE F..RUNIC LETTER X
+	{runeRange{0x1700, 0x1711}, eawprN},     // Lo    [18] TAGALOG LETTER A..TAGALOG LETTER HA
+	{runeRange{0x1720, 0x1731}, eawprN},     // Lo    [18] HANUNOO LETTER A..HANUNOO LETTER HA
+	{runeRange{0x1740, 0x1751}, eawprN},     // Lo    [18] BUHID LETTER A..BUHID LETTER HA
+	{runeRange{0x1772, 0x1773}, eawprN},     // Mn     [2] TAGBANWA VOWEL SIGN I..TAGBANWA VOWEL SIGN U
+	{runeRange{0x17B7, 0x17BD}, eawprN},     // Mn     [7] KHMER VOWEL SIGN I..KHMER VOWEL SIGN UA
+	{runeRange{0x17C9, 0x17D3}, eawprN},     // Mn    [11] KHMER SIGN MUUSIKATOAN..KHMER SIGN BATHAMASAT
+	{runeRange{0x17DB, 0x17DB}, eawprN},     // Sc         KHMER CURRENCY SYMBOL RIEL
+	{runeRange{0x17F0, 0x17F9}, eawprN},     // No    [10] KHMER SYMBOL LEK ATTAK SON..KHMER SYMBOL LEK ATTAK PRAM-BUON
+	{runeRange{0x180B, 0x180D}, eawprN},     // Mn     [3] MONGOLIAN FREE VARIATION SELECTOR ONE..MONGOLIAN FREE VARIATION SELECTOR THREE
+	{runeRange{0x1820, 0x1842}, eawprN},     // Lo    [35] MONGOLIAN LETTER A..MONGOLIAN LETTER CHI
+	{runeRange{0x1885, 0x1886}, eawprN},     // Mn     [2] MONGOLIAN LETTER ALI GALI BALUDA..MONGOLIAN LETTER ALI GALI THREE BALUDA
+	{runeRange{0x18B0, 0x18F5}, eawprN},     // Lo    [70] CANADIAN SYLLABICS OY..CANADIAN SYLLABICS CARRIER DENTAL S
+	{runeRange{0x1927, 0x1928}, eawprN},     // Mn     [2] LIMBU VOWEL SIGN E..LIMBU VOWEL SIGN O
+	{runeRange{0x1933, 0x1938}, eawprN},     // Mc     [6] LIMBU SMALL LETTER TA..LIMBU SMALL LETTER LA
+	{runeRange{0x1946, 0x194F}, eawprN},     // Nd    [10] LIMBU DIGIT ZERO..LIMBU DIGIT NINE
+	{runeRange{0x19B0, 0x19C9}, eawprN},     // Lo    [26] NEW TAI LUE VOWEL SIGN VOWEL SHORTENER..NEW TAI LUE TONE MARK-2
+	{runeRange{0x19E0, 0x19FF}, eawprN},     // So    [32] KHMER SYMBOL PATHAMASAT..KHMER SYMBOL DAP-PRAM ROC
+	{runeRange{0x1A1B, 0x1A1B}, eawprN},     // Mn         BUGINESE VOWEL SIGN AE
+	{runeRange{0x1A56, 0x1A56}, eawprN},     // Mn         TAI THAM CONSONANT SIGN MEDIAL LA
+	{runeRange{0x1A61, 0x1A61}, eawprN},     // Mc         TAI THAM VOWEL SIGN A
+	{runeRange{0x1A6D, 0x1A72}, eawprN},     // Mc     [6] TAI THAM VOWEL SIGN OY..TAI THAM VOWEL SIGN THAM AI
+	{runeRange{0x1A90, 0x1A99}, eawprN},     // Nd    [10] TAI THAM THAM DIGIT ZERO..TAI THAM THAM DIGIT NINE
+	{runeRange{0x1AB0, 0x1ABD}, eawprN},     // Mn    [14] COMBINING DOUBLED CIRCUMFLEX ACCENT..COMBINING PARENTHESES BELOW
+	{runeRange{0x1B04, 0x1B04}, eawprN},     // Mc         BALINESE SIGN BISAH
+	{runeRange{0x1B36, 0x1B3A}, eawprN},     // Mn     [5] BALINESE VOWEL SIGN ULU..BALINESE VOWEL SIGN RA REPA
+	{runeRange{0x1B42, 0x1B42}, eawprN},     // Mn         BALINESE VOWEL SIGN PEPET
+	{runeRange{0x1B5A, 0x1B60}, eawprN},     // Po     [7] BALINESE PANTI..BALINESE PAMENENG
+	{runeRange{0x1B7D, 0x1B7E}, eawprN},     // Po     [2] BALINESE PANTI LANTANG..BALINESE PAMADA LANTANG
+	{runeRange{0x1BA1, 0x1BA1}, eawprN},     // Mc         SUNDANESE CONSONANT SIGN PAMINGKAL
+	{runeRange{0x1BAA, 0x1BAA}, eawprN},     // Mc         SUNDANESE SIGN PAMAAEH
+	{runeRange{0x1BBA, 0x1BBF}, eawprN},     // Lo     [6] SUNDANESE AVAGRAHA..SUNDANESE LETTER FINAL M
+	{runeRange{0x1BE8, 0x1BE9}, eawprN},     // Mn     [2] BATAK VOWEL SIGN PAKPAK E..BATAK VOWEL SIGN EE
+	{runeRange{0x1BEF, 0x1BF1}, eawprN},     // Mn     [3] BATAK VOWEL SIGN U FOR SIMALUNGUN SA..BATAK CONSONANT SIGN H
+	{runeRange{0x1C24, 0x1C2B}, eawprN},     // Mc     [8] LEPCHA SUBJOINED LETTER YA..LEPCHA VOWEL SIGN UU
+	{runeRange{0x1C3B, 0x1C3F}, eawprN},     // Po     [5] LEPCHA PUNCTUATION TA-ROL..LEPCHA PUNCTUATION TSHOOK
+	{runeRange{0x1C5A, 0x1C77}, eawprN},     // Lo    [30] OL CHIKI LETTER LA..OL CHIKI LETTER OH
+	{runeRange{0x1C90, 0x1CBA}, eawprN},     // Lu    [43] GEORGIAN MTAVRULI CAPITAL LETTER AN..GEORGIAN MTAVRULI CAPITAL LETTER AIN
+	{runeRange{0x1CD3, 0x1CD3}, eawprN},     // Po         VEDIC SIGN NIHSHVASA
+	{runeRange{0x1CE9, 0x1CEC}, eawprN},     // Lo     [4] VEDIC SIGN ANUSVARA ANTARGOMUKHA..VEDIC SIGN ANUSVARA VAMAGOMUKHA WITH TAIL
+	{runeRange{0x1CF5, 0x1CF6}, eawprN},     // Lo     [2] VEDIC SIGN JIHVAMULIYA..VEDIC SIGN UPADHMANIYA
+	{runeRange{0x1D00, 0x1D2B}, eawprN},     // Ll    [44] LATIN LETTER SMALL CAPITAL A..CYRILLIC LETTER SMALL CAPITAL EL
+	{runeRange{0x1D79, 0x1D7F}, eawprN},     // Ll     [7] LATIN SMALL LETTER INSULAR G..LATIN SMALL LETTER UPSILON WITH STROKE
+	{runeRange{0x1E00, 0x1EFF}, eawprN},     // L&   [256] LATIN CAPITAL LETTER A WITH RING BELOW..LATIN SMALL LETTER Y WITH LOOP
+	{runeRange{0x1F48, 0x1F4D}, eawprN},     // Lu     [6] GREEK CAPITAL LETTER OMICRON WITH PSILI..GREEK CAPITAL LETTER OMICRON WITH DASIA AND OXIA
+	{runeRange{0x1F5D, 0x1F5D}, eawprN},     // Lu         GREEK CAPITAL LETTER UPSILON WITH DASIA AND OXIA
+	{runeRange{0x1FBD, 0x1FBD}, eawprN},     // Sk         GREEK KORONIS
+	{runeRange{0x1FC6, 0x1FCC}, eawprN},     // L&     [7] GREEK SMALL LETTER ETA WITH PERISPOMENI..GREEK CAPITAL LETTER ETA WITH PROSGEGRAMMENI
+	{runeRange{0x1FDD, 0x1FDF}, eawprN},     // Sk     [3] GREEK DASIA AND VARIA..GREEK DASIA AND PERISPOMENI
+	{runeRange{0x1FF6, 0x1FFC}, eawprN},     // L&     [7] GREEK SMALL LETTER OMEGA WITH PERISPOMENI..GREEK CAPITAL LETTER OMEGA WITH PROSGEGRAMMENI
+	{runeRange{0x2010, 0x2010}, eawprA},     // Pd         HYPHEN
+	{runeRange{0x2017, 0x2017}, eawprN},     // Po         DOUBLE LOW LINE
+	{runeRange{0x201B, 0x201B}, eawprN},     // Pi         SINGLE HIGH-REVERSED-9 QUOTATION MARK
+	{runeRange{0x201F, 0x201F}, eawprN},     // Pi         DOUBLE HIGH-REVERSED-9 QUOTATION MARK
+	{runeRange{0x2028, 0x2028}, eawprN},     // Zl         LINE SEPARATOR
+	{runeRange{0x2030, 0x2030}, eawprA},     // Po         PER MILLE SIGN
+	{runeRange{0x2035, 0x2035}, eawprA},     // Po         REVERSED PRIME
+	{runeRange{0x203B, 0x203B}, eawprA},     // Po         REFERENCE MARK
+	{runeRange{0x2041, 0x2043}, eawprN},     // Po     [3] CARET INSERTION POINT..HYPHEN BULLET
+	{runeRange{0x2047, 0x2051}, eawprN},     // Po    [11] DOUBLE QUESTION MARK..TWO ASTERISKS ALIGNED VERTICALLY
+	{runeRange{0x2055, 0x205E}, eawprN},     // Po    [10] FLOWER PUNCTUATION MARK..VERTICAL FOUR DOTS
+	{runeRange{0x2070, 0x2070}, eawprN},     // No         SUPERSCRIPT ZERO
+	{runeRange{0x207A, 0x207C}, eawprN},     // Sm     [3] SUPERSCRIPT PLUS SIGN..SUPERSCRIPT EQUALS SIGN
+	{runeRange{0x2080, 0x2080}, eawprN},     // No         SUBSCRIPT ZERO
+	{runeRange{0x208D, 0x208D}, eawprN},     // Ps         SUBSCRIPT LEFT PARENTHESIS
+	{runeRange{0x20A9, 0x20A9}, eawprH},     // Sc         WON SIGN
+	{runeRange{0x20D0, 0x20DC}, eawprN},     // Mn    [13] COMBINING LEFT HARPOON ABOVE..COMBINING FOUR DOTS ABOVE
+	{runeRange{0x20E5, 0x20F0}, eawprN},     // Mn    [12] COMBINING REVERSE SOLIDUS OVERLAY..COMBINING ASTERISK ABOVE
+	{runeRange{0x2104, 0x2104}, eawprN},     // So         CENTRE LINE SYMBOL
+	{runeRange{0x2108, 0x2108}, eawprN},     // So         SCRUPLE
+	{runeRange{0x2114, 0x2114}, eawprN},     // So         L B BAR SYMBOL
+	{runeRange{0x2118, 0x2118}, eawprN},     // Sm         SCRIPT CAPITAL P
+	{runeRange{0x2123, 0x2123}, eawprN},     // So         VERSICLE
+	{runeRange{0x2127, 0x2127}, eawprN},     // So         INVERTED OHM SIGN
+	{runeRange{0x212B, 0x212B}, eawprA},     // Lu         ANGSTROM SIGN
+	{runeRange{0x2135, 0x2138}, eawprN},     // Lo     [4] ALEF SYMBOL..DALET SYMBOL
+	{runeRange{0x2140, 0x2144}, eawprN},     // Sm     [5] DOUBLE-STRUCK N-ARY SUMMATION..TURNED SANS-SERIF CAPITAL Y
+	{runeRange{0x214C, 0x214D}, eawprN},     // So     [2] PER SIGN..AKTIESELSKAB
+	{runeRange{0x2153, 0x2154}, eawprA},     // No     [2] VULGAR FRACTION ONE THIRD..VULGAR FRACTION TWO THIRDS
+	{runeRange{0x2160, 0x216B}, eawprA},     // Nl    [12] ROMAN NUMERAL ONE..ROMAN NUMERAL TWELVE
+	{runeRange{0x2183, 0x2184}, eawprN},     // L&     [2] ROMAN NUMERAL REVERSED ONE HUNDRED..LATIN SMALL LETTER REVERSED C
+	{runeRange{0x2190, 0x2194}, eawprA},     // Sm     [5] LEFTWARDS ARROW..LEFT RIGHT ARROW
+	{runeRange{0x21A0, 0x21A0}, eawprN},     // Sm         RIGHTWARDS TWO HEADED ARROW
+	{runeRange{0x21A6, 0x21A6}, eawprN},     // Sm         RIGHTWARDS ARROW FROM BAR
+	{runeRange{0x21B8, 0x21B9}, eawprA},     // So     [2] NORTH WEST ARROW TO LONG BAR..LEFTWARDS ARROW TO BAR OVER RIGHTWARDS ARROW TO BAR
+	{runeRange{0x21D2, 0x21D2}, eawprA},     // Sm         RIGHTWARDS DOUBLE ARROW
+	{runeRange{0x21E7, 0x21E7}, eawprA},     // So         UPWARDS WHITE ARROW
+	{runeRange{0x2201, 0x2201}, eawprN},     // Sm         COMPLEMENT
+	{runeRange{0x2209, 0x220A}, eawprN},     // Sm     [2] NOT AN ELEMENT OF..SMALL ELEMENT OF
+	{runeRange{0x2210, 0x2210}, eawprN},     // Sm         N-ARY COPRODUCT
+	{runeRange{0x2216, 0x2219}, eawprN},     // Sm     [4] SET MINUS..BULLET OPERATOR
+	{runeRange{0x2221, 0x2222}, eawprN},     // Sm     [2] MEASURED ANGLE..SPHERICAL ANGLE
+	{runeRange{0x2226, 0x2226}, eawprN},     // Sm         NOT PARALLEL TO
+	{runeRange{0x222F, 0x2233}, eawprN},     // Sm     [5] SURFACE INTEGRAL..ANTICLOCKWISE CONTOUR INTEGRAL
+	{runeRange{0x223E, 0x2247}, eawprN},     // Sm    [10] INVERTED LAZY S..NEITHER APPROXIMATELY NOR ACTUALLY EQUAL TO
+	{runeRange{0x224D, 0x2251}, eawprN},     // Sm     [5] EQUIVALENT TO..GEOMETRICALLY EQUAL TO
+	{runeRange{0x2260, 0x2261}, eawprA},     // Sm     [2] NOT EQUAL TO..IDENTICAL TO
+	{runeRange{0x2264, 0x2267}, eawprA},     // Sm     [4] LESS-THAN OR EQUAL TO..GREATER-THAN OVER EQUAL TO
+	{runeRange{0x226A, 0x226B}, eawprA},     // Sm     [2] MUCH LESS-THAN..MUCH GREATER-THAN
+	{runeRange{0x226E, 0x226F}, eawprA},     // Sm     [2] NOT LESS-THAN..NOT GREATER-THAN
+	{runeRange{0x2282, 0x2283}, eawprA},     // Sm     [2] SUBSET OF..SUPERSET OF
+	{runeRange{0x2286, 0x2287}, eawprA},     // Sm     [2] SUBSET OF OR EQUAL TO..SUPERSET OF OR EQUAL TO
+	{runeRange{0x2295, 0x2295}, eawprA},     // Sm         CIRCLED PLUS
+	{runeRange{0x2299, 0x2299}, eawprA},     // Sm         CIRCLED DOT OPERATOR
+	{runeRange{0x22A5, 0x22A5}, eawprA},     // Sm         UP TACK
+	{runeRange{0x22BF, 0x22BF}, eawprA},     // Sm         RIGHT TRIANGLE
+	{runeRange{0x2300, 0x2307}, eawprN},     // So     [8] DIAMETER SIGN..WAVY LINE
+	{runeRange{0x2309, 0x2309}, eawprN},     // Pe         RIGHT CEILING
+	{runeRange{0x230B, 0x230B}, eawprN},     // Pe         RIGHT FLOOR
+	{runeRange{0x2312, 0x2312}, eawprA},     // So         ARC
+	{runeRange{0x231A, 0x231B}, eawprW},     // So     [2] WATCH..HOURGLASS
+	{runeRange{0x2320, 0x2321}, eawprN},     // Sm     [2] TOP HALF INTEGRAL..BOTTOM HALF INTEGRAL
+	{runeRange{0x2329, 0x2329}, eawprW},     // Ps         LEFT-POINTING ANGLE BRACKET
+	{runeRange{0x232B, 0x237B}, eawprN},     // So    [81] ERASE TO THE LEFT..NOT CHECK MARK
+	{runeRange{0x237D, 0x239A}, eawprN},     // So    [30] SHOULDERED OPEN BOX..CLEAR SCREEN SYMBOL
+	{runeRange{0x23B4, 0x23DB}, eawprN},     // So    [40] TOP SQUARE BRACKET..FUSE
+	{runeRange{0x23E2, 0x23E8}, eawprN},     // So     [7] WHITE TRAPEZIUM..DECIMAL EXPONENT SYMBOL
+	{runeRange{0x23ED, 0x23EF}, eawprN},     // So     [3] BLACK RIGHT-POINTING DOUBLE TRIANGLE WITH VERTICAL BAR..BLACK RIGHT-POINTING TRIANGLE WITH DOUBLE VERTICAL BAR
+	{runeRange{0x23F1, 0x23F2}, eawprN},     // So     [2] STOPWATCH..TIMER CLOCK
+	{runeRange{0x23F4, 0x23FF}, eawprN},     // So    [12] BLACK MEDIUM LEFT-POINTING TRIANGLE..OBSERVER EYE SYMBOL
+	{runeRange{0x2440, 0x244A}, eawprN},     // So    [11] OCR HOOK..OCR DOUBLE BACKSLASH
+	{runeRange{0x249C, 0x24E9}, eawprA},     // So    [78] PARENTHESIZED LATIN SMALL LETTER A..CIRCLED LATIN SMALL LETTER Z
+	{runeRange{0x24EB, 0x24FF}, eawprA},     // No    [21] NEGATIVE CIRCLED NUMBER ELEVEN..NEGATIVE CIRCLED DIGIT ZERO
+	{runeRange{0x254C, 0x254F}, eawprN},     // So     [4] BOX DRAWINGS LIGHT DOUBLE DASH HORIZONTAL..BOX DRAWINGS HEAVY DOUBLE DASH VERTICAL
+	{runeRange{0x2574, 0x257F}, eawprN},     // So    [12] BOX DRAWINGS LIGHT LEFT..BOX DRAWINGS HEAVY UP AND LIGHT DOWN
+	{runeRange{0x2590, 0x2591}, eawprN},     // So     [2] RIGHT HALF BLOCK..LIGHT SHADE
+	{runeRange{0x2596, 0x259F}, eawprN},     // So    [10] QUADRANT LOWER LEFT..QUADRANT UPPER RIGHT AND LOWER LEFT AND LOWER RIGHT
+	{runeRange{0x25A2, 0x25A2}, eawprN},     // So         WHITE SQUARE WITH ROUNDED CORNERS
+	{runeRange{0x25AA, 0x25B1}, eawprN},     // So     [8] BLACK SMALL SQUARE..WHITE PARALLELOGRAM
+	{runeRange{0x25B4, 0x25B5}, eawprN},     // So     [2] BLACK UP-POINTING SMALL TRIANGLE..WHITE UP-POINTING SMALL TRIANGLE
+	{runeRange{0x25B7, 0x25B7}, eawprA},     // Sm         WHITE RIGHT-POINTING TRIANGLE
+	{runeRange{0x25BC, 0x25BD}, eawprA},     // So     [2] BLACK DOWN-POINTING TRIANGLE..WHITE DOWN-POINTING TRIANGLE
+	{runeRange{0x25C0, 0x25C0}, eawprA},     // So         BLACK LEFT-POINTING TRIANGLE
+	{runeRange{0x25C2, 0x25C5}, eawprN},     // So     [4] BLACK LEFT-POINTING SMALL TRIANGLE..WHITE LEFT-POINTING POINTER
+	{runeRange{0x25C9, 0x25CA}, eawprN},     // So     [2] FISHEYE..LOZENGE
+	{runeRange{0x25CC, 0x25CD}, eawprN},     // So     [2] DOTTED CIRCLE..CIRCLE WITH VERTICAL FILL
+	{runeRange{0x25D2, 0x25E1}, eawprN},     // So    [16] CIRCLE WITH LOWER HALF BLACK..LOWER HALF CIRCLE
+	{runeRange{0x25E6, 0x25EE}, eawprN},     // So     [9] WHITE BULLET..UP-POINTING TRIANGLE WITH RIGHT HALF BLACK
+	{runeRange{0x25F0, 0x25F7}, eawprN},     // So     [8] WHITE SQUARE WITH UPPER LEFT QUADRANT..WHITE CIRCLE WITH UPPER RIGHT QUADRANT
+	{runeRange{0x25FD, 0x25FE}, eawprW},     // Sm     [2] WHITE MEDIUM SMALL SQUARE..BLACK MEDIUM SMALL SQUARE
+	{runeRange{0x2600, 0x2604}, eawprN},     // So     [5] BLACK SUN WITH RAYS..COMET
+	{runeRange{0x2607, 0x2608}, eawprN},     // So     [2] LIGHTNING..THUNDERSTORM
+	{runeRange{0x260A, 0x260D}, eawprN},     // So     [4] ASCENDING NODE..OPPOSITION
+	{runeRange{0x2610, 0x2613}, eawprN},     // So     [4] BALLOT BOX..SALTIRE
+	{runeRange{0x2616, 0x261B}, eawprN},     // So     [6] WHITE SHOGI PIECE..BLACK RIGHT POINTING INDEX
+	{runeRange{0x261D, 0x261D}, eawprN},     // So         WHITE UP POINTING INDEX
+	{runeRange{0x261F, 0x263F}, eawprN},     // So    [33] WHITE DOWN POINTING INDEX..MERCURY
+	{runeRange{0x2641, 0x2641}, eawprN},     // So         EARTH
+	{runeRange{0x2643, 0x2647}, eawprN},     // So     [5] JUPITER..PLUTO
+	{runeRange{0x2654, 0x265F}, eawprN},     // So    [12] WHITE CHESS KING..BLACK CHESS PAWN
+	{runeRange{0x2662, 0x2662}, eawprN},     // So         WHITE DIAMOND SUIT
+	{runeRange{0x2666, 0x2666}, eawprN},     // So         BLACK DIAMOND SUIT
+	{runeRange{0x266B, 0x266B}, eawprN},     // So         BEAMED EIGHTH NOTES
+	{runeRange{0x266E, 0x266E}, eawprN},     // So         MUSIC NATURAL SIGN
+	{runeRange{0x2670, 0x267E}, eawprN},     // So    [15] WEST SYRIAC CROSS..PERMANENT PAPER SIGN
+	{runeRange{0x2680, 0x2692}, eawprN},     // So    [19] DIE FACE-1..HAMMER AND PICK
+	{runeRange{0x2694, 0x269D}, eawprN},     // So    [10] CROSSED SWORDS..OUTLINED WHITE STAR
+	{runeRange{0x26A0, 0x26A0}, eawprN},     // So         WARNING SIGN
+	{runeRange{0x26A2, 0x26A9}, eawprN},     // So     [8] DOUBLED FEMALE SIGN..HORIZONTAL MALE WITH STROKE SIGN
+	{runeRange{0x26AC, 0x26BC}, eawprN},     // So    [17] MEDIUM SMALL WHITE CIRCLE..SESQUIQUADRATE
+	{runeRange{0x26BF, 0x26BF}, eawprA},     // So         SQUARED KEY
+	{runeRange{0x26C4, 0x26C5}, eawprW},     // So     [2] SNOWMAN WITHOUT SNOW..SUN BEHIND CLOUD
+	{runeRange{0x26CE, 0x26CE}, eawprW},     // So         OPHIUCHUS
+	{runeRange{0x26D4, 0x26D4}, eawprW},     // So         NO ENTRY
+	{runeRange{0x26E2, 0x26E2}, eawprN},     // So         ASTRONOMICAL SYMBOL FOR URANUS
+	{runeRange{0x26E4, 0x26E7}, eawprN},     // So     [4] PENTAGRAM..INVERTED PENTAGRAM
+	{runeRange{0x26EA, 0x26EA}, eawprW},     // So         CHURCH
+	{runeRange{0x26F2, 0x26F3}, eawprW},     // So     [2] FOUNTAIN..FLAG IN HOLE
+	{runeRange{0x26F5, 0x26F5}, eawprW},     // So         SAILBOAT
+	{runeRange{0x26FA, 0x26FA}, eawprW},     // So         TENT
+	{runeRange{0x26FD, 0x26FD}, eawprW},     // So         FUEL PUMP
+	{runeRange{0x2700, 0x2704}, eawprN},     // So     [5] BLACK SAFETY SCISSORS..WHITE SCISSORS
+	{runeRange{0x2706, 0x2709}, eawprN},     // So     [4] TELEPHONE LOCATION SIGN..ENVELOPE
+	{runeRange{0x270C, 0x2727}, eawprN},     // So    [28] VICTORY HAND..WHITE FOUR POINTED STAR
+	{runeRange{0x2729, 0x273C}, eawprN},     // So    [20] STRESS OUTLINED WHITE STAR..OPEN CENTRE TEARDROP-SPOKED ASTERISK
+	{runeRange{0x273E, 0x274B}, eawprN},     // So    [14] SIX PETALLED BLACK AND WHITE FLORETTE..HEAVY EIGHT TEARDROP-SPOKED PROPELLER ASTERISK
+	{runeRange{0x274D, 0x274D}, eawprN},     // So         SHADOWED WHITE CIRCLE
+	{runeRange{0x274F, 0x2752}, eawprN},     // So     [4] LOWER RIGHT DROP-SHADOWED WHITE SQUARE..UPPER RIGHT SHADOWED WHITE SQUARE
+	{runeRange{0x2756, 0x2756}, eawprN},     // So         BLACK DIAMOND MINUS WHITE X
+	{runeRange{0x2758, 0x2767}, eawprN},     // So    [16] LIGHT VERTICAL BAR..ROTATED FLORAL HEART BULLET
+	{runeRange{0x2769, 0x2769}, eawprN},     // Pe         MEDIUM RIGHT PARENTHESIS ORNAMENT
+	{runeRange{0x276B, 0x276B}, eawprN},     // Pe         MEDIUM FLATTENED RIGHT PARENTHESIS ORNAMENT
+	{runeRange{0x276D, 0x276D}, eawprN},     // Pe         MEDIUM RIGHT-POINTING ANGLE BRACKET ORNAMENT
+	{runeRange{0x276F, 0x276F}, eawprN},     // Pe         HEAVY RIGHT-POINTING ANGLE QUOTATION MARK ORNAMENT
+	{runeRange{0x2771, 0x2771}, eawprN},     // Pe         HEAVY RIGHT-POINTING ANGLE BRACKET ORNAMENT
+	{runeRange{0x2773, 0x2773}, eawprN},     // Pe         LIGHT RIGHT TORTOISE SHELL BRACKET ORNAMENT
+	{runeRange{0x2775, 0x2775}, eawprN},     // Pe         MEDIUM RIGHT CURLY BRACKET ORNAMENT
+	{runeRange{0x2780, 0x2793}, eawprN},     // No    [20] DINGBAT CIRCLED SANS-SERIF DIGIT ONE..DINGBAT NEGATIVE CIRCLED SANS-SERIF NUMBER TEN
+	{runeRange{0x2795, 0x2797}, eawprW},     // So     [3] HEAVY PLUS SIGN..HEAVY DIVISION SIGN
+	{runeRange{0x27B0, 0x27B0}, eawprW},     // So         CURLY LOOP
+	{runeRange{0x27BF, 0x27BF}, eawprW},     // So         DOUBLE CURLY LOOP
+	{runeRange{0x27C5, 0x27C5}, eawprN},     // Ps         LEFT S-SHAPED BAG DELIMITER
+	{runeRange{0x27C7, 0x27E5}, eawprN},     // Sm    [31] OR WITH DOT INSIDE..WHITE SQUARE WITH RIGHTWARDS TICK
+	{runeRange{0x27E7, 0x27E7}, eawprNa},    // Pe         MATHEMATICAL RIGHT WHITE SQUARE BRACKET
+	{runeRange{0x27E9, 0x27E9}, eawprNa},    // Pe         MATHEMATICAL RIGHT ANGLE BRACKET
+	{runeRange{0x27EB, 0x27EB}, eawprNa},    // Pe         MATHEMATICAL RIGHT DOUBLE ANGLE BRACKET
+	{runeRange{0x27ED, 0x27ED}, eawprNa},    // Pe         MATHEMATICAL RIGHT WHITE TORTOISE SHELL BRACKET
+	{runeRange{0x27EF, 0x27EF}, eawprN},     // Pe         MATHEMATICAL RIGHT FLATTENED PARENTHESIS
+	{runeRange{0x2800, 0x28FF}, eawprN},     // So   [256] BRAILLE PATTERN BLANK..BRAILLE PATTERN DOTS-12345678
+	{runeRange{0x2980, 0x2982}, eawprN},     // Sm     [3] TRIPLE VERTICAL BAR DELIMITER..Z NOTATION TYPE COLON
+	{runeRange{0x2984, 0x2984}, eawprN},     // Pe         RIGHT WHITE CURLY BRACKET
+	{runeRange{0x2986, 0x2986}, eawprNa},    // Pe         RIGHT WHITE PARENTHESIS
+	{runeRange{0x2988, 0x2988}, eawprN},     // Pe         Z NOTATION RIGHT IMAGE BRACKET
+	{runeRange{0x298A, 0x298A}, eawprN},     // Pe         Z NOTATION RIGHT BINDING BRACKET
+	{runeRange{0x298C, 0x298C}, eawprN},     // Pe         RIGHT SQUARE BRACKET WITH UNDERBAR
+	{runeRange{0x298E, 0x298E}, eawprN},     // Pe         RIGHT SQUARE BRACKET WITH TICK IN BOTTOM CORNER
+	{runeRange{0x2990, 0x2990}, eawprN},     // Pe         RIGHT SQUARE BRACKET WITH TICK IN TOP CORNER
+	{runeRange{0x2992, 0x2992}, eawprN},     // Pe         RIGHT ANGLE BRACKET WITH DOT
+	{runeRange{0x2994, 0x2994}, eawprN},     // Pe         RIGHT ARC GREATER-THAN BRACKET
+	{runeRange{0x2996, 0x2996}, eawprN},     // Pe         DOUBLE RIGHT ARC LESS-THAN BRACKET
+	{runeRange{0x2998, 0x2998}, eawprN},     // Pe         RIGHT BLACK TORTOISE SHELL BRACKET
+	{runeRange{0x29D8, 0x29D8}, eawprN},     // Ps         LEFT WIGGLY FENCE
+	{runeRange{0x29DA, 0x29DA}, eawprN},     // Ps         LEFT DOUBLE WIGGLY FENCE
+	{runeRange{0x29DC, 0x29FB}, eawprN},     // Sm    [32] INCOMPLETE INFINITY..TRIPLE PLUS
+	{runeRange{0x29FD, 0x29FD}, eawprN},     // Pe         RIGHT-POINTING CURVED ANGLE BRACKET
+	{runeRange{0x2A00, 0x2AFF}, eawprN},     // Sm   [256] N-ARY CIRCLED DOT OPERATOR..N-ARY WHITE VERTICAL BAR
+	{runeRange{0x2B1B, 0x2B1C}, eawprW},     // So     [2] BLACK LARGE SQUARE..WHITE LARGE SQUARE
+	{runeRange{0x2B30, 0x2B44}, eawprN},     // Sm    [21] LEFT ARROW WITH SMALL CIRCLE..RIGHTWARDS ARROW THROUGH SUPERSET
+	{runeRange{0x2B47, 0x2B4C}, eawprN},     // Sm     [6] REVERSE TILDE OPERATOR ABOVE RIGHTWARDS ARROW..RIGHTWARDS ARROW ABOVE REVERSE TILDE OPERATOR
+	{runeRange{0x2B50, 0x2B50}, eawprW},     // So         WHITE MEDIUM STAR
+	{runeRange{0x2B55, 0x2B55}, eawprW},     // So         HEAVY LARGE CIRCLE
+	{runeRange{0x2B5A, 0x2B73}, eawprN},     // So    [26] SLANTED NORTH ARROW WITH HOOKED HEAD..DOWNWARDS TRIANGLE-HEADED ARROW TO BAR
+	{runeRange{0x2B97, 0x2BFF}, eawprN},     // So   [105] SYMBOL FOR TYPE A ELECTRONICS..HELLSCHREIBER PAUSE SYMBOL
+	{runeRange{0x2C60, 0x2C7B}, eawprN},     // L&    [28] LATIN CAPITAL LETTER L WITH DOUBLE BAR..LATIN LETTER SMALL CAPITAL TURNED E
+	{runeRange{0x2C7E, 0x2C7F}, eawprN},     // Lu     [2] LATIN CAPITAL LETTER S WITH SWASH TAIL..LATIN CAPITAL LETTER Z WITH SWASH TAIL
+	{runeRange{0x2CE5, 0x2CEA}, eawprN},     // So     [6] COPTIC SYMBOL MI RO..COPTIC SYMBOL SHIMA SIMA
+	{runeRange{0x2CEF, 0x2CF1}, eawprN},     // Mn     [3] COPTIC COMBINING NI ABOVE..COPTIC COMBINING SPIRITUS LENIS
+	{runeRange{0x2CF9, 0x2CFC}, eawprN},     // Po     [4] COPTIC OLD NUBIAN FULL STOP..COPTIC OLD NUBIAN VERSE DIVIDER
+	{runeRange{0x2CFE, 0x2CFF}, eawprN},     // Po     [2] COPTIC FULL STOP..COPTIC MORPHOLOGICAL DIVIDER
+	{runeRange{0x2D27, 0x2D27}, eawprN},     // Ll         GEORGIAN SMALL LETTER YN
+	{runeRange{0x2D30, 0x2D67}, eawprN},     // Lo    [56] TIFINAGH LETTER YA..TIFINAGH LETTER YO
+	{runeRange{0x2D70, 0x2D70}, eawprN},     // Po         TIFINAGH SEPARATOR MARK
+	{runeRange{0x2D80, 0x2D96}, eawprN},     // Lo    [23] ETHIOPIC SYLLABLE LOA..ETHIOPIC SYLLABLE GGWE
+	{runeRange{0x2DA8, 0x2DAE}, eawprN},     // Lo     [7] ETHIOPIC SYLLABLE CCA..ETHIOPIC SYLLABLE CCO
+	{runeRange{0x2DB8, 0x2DBE}, eawprN},     // Lo     [7] ETHIOPIC SYLLABLE CCHA..ETHIOPIC SYLLABLE CCHO
+	{runeRange{0x2DC8, 0x2DCE}, eawprN},     // Lo     [7] ETHIOPIC SYLLABLE KYA..ETHIOPIC SYLLABLE KYO
+	{runeRange{0x2DD8, 0x2DDE}, eawprN},     // Lo     [7] ETHIOPIC SYLLABLE GYA..ETHIOPIC SYLLABLE GYO
+	{runeRange{0x2E00, 0x2E01}, eawprN},     // Po     [2] RIGHT ANGLE SUBSTITUTION MARKER..RIGHT ANGLE DOTTED SUBSTITUTION MARKER
+	{runeRange{0x2E03, 0x2E03}, eawprN},     // Pf         RIGHT SUBSTITUTION BRACKET
+	{runeRange{0x2E05, 0x2E05}, eawprN},     // Pf         RIGHT DOTTED SUBSTITUTION BRACKET
+	{runeRange{0x2E09, 0x2E09}, eawprN},     // Pi         LEFT TRANSPOSITION BRACKET
+	{runeRange{0x2E0B, 0x2E0B}, eawprN},     // Po         RAISED SQUARE
+	{runeRange{0x2E0D, 0x2E0D}, eawprN},     // Pf         RIGHT RAISED OMISSION BRACKET
+	{runeRange{0x2E17, 0x2E17}, eawprN},     // Pd         DOUBLE OBLIQUE HYPHEN
+	{runeRange{0x2E1A, 0x2E1A}, eawprN},     // Pd         HYPHEN WITH DIAERESIS
+	{runeRange{0x2E1C, 0x2E1C}, eawprN},     // Pi         LEFT LOW PARAPHRASE BRACKET
+	{runeRange{0x2E1E, 0x2E1F}, eawprN},     // Po     [2] TILDE WITH DOT ABOVE..TILDE WITH DOT BELOW
+	{runeRange{0x2E21, 0x2E21}, eawprN},     // Pf         RIGHT VERTICAL BAR WITH QUILL
+	{runeRange{0x2E23, 0x2E23}, eawprN},     // Pe         TOP RIGHT HALF BRACKET
+	{runeRange{0x2E25, 0x2E25}, eawprN},     // Pe         BOTTOM RIGHT HALF BRACKET
+	{runeRange{0x2E27, 0x2E27}, eawprN},     // Pe         RIGHT SIDEWAYS U BRACKET
+	{runeRange{0x2E29, 0x2E29}, eawprN},     // Pe         RIGHT DOUBLE PARENTHESIS
+	{runeRange{0x2E2F, 0x2E2F}, eawprN},     // Lm         VERTICAL TILDE
+	{runeRange{0x2E3A, 0x2E3B}, eawprN},     // Pd     [2] TWO-EM DASH..THREE-EM DASH
+	{runeRange{0x2E40, 0x2E40}, eawprN},     // Pd         DOUBLE HYPHEN
+	{runeRange{0x2E42, 0x2E42}, eawprN},     // Ps         DOUBLE LOW-REVERSED-9 QUOTATION MARK
+	{runeRange{0x2E50, 0x2E51}, eawprN},     // So     [2] CROSS PATTY WITH RIGHT CROSSBAR..CROSS PATTY WITH LEFT CROSSBAR
+	{runeRange{0x2E55, 0x2E55}, eawprN},     // Ps         LEFT SQUARE BRACKET WITH STROKE
+	{runeRange{0x2E57, 0x2E57}, eawprN},     // Ps         LEFT SQUARE BRACKET WITH DOUBLE STROKE
+	{runeRange{0x2E59, 0x2E59}, eawprN},     // Ps         TOP HALF LEFT PARENTHESIS
+	{runeRange{0x2E5B, 0x2E5B}, eawprN},     // Ps         BOTTOM HALF LEFT PARENTHESIS
+	{runeRange{0x2E5D, 0x2E5D}, eawprN},     // Pd         OBLIQUE HYPHEN
+	{runeRange{0x2E9B, 0x2EF3}, eawprW},     // So    [89] CJK RADICAL CHOKE..CJK RADICAL C-SIMPLIFIED TURTLE
+	{runeRange{0x2FF0, 0x2FFB}, eawprW},     // So    [12] IDEOGRAPHIC DESCRIPTION CHARACTER LEFT TO RIGHT..IDEOGRAPHIC DESCRIPTION CHARACTER OVERLAID
+	{runeRange{0x3001, 0x3003}, eawprW},     // Po     [3] IDEOGRAPHIC COMMA..DITTO MARK
+	{runeRange{0x3005, 0x3005}, eawprW},     // Lm         IDEOGRAPHIC ITERATION MARK
+	{runeRange{0x3007, 0x3007}, eawprW},     // Nl         IDEOGRAPHIC NUMBER ZERO
+	{runeRange{0x3009, 0x3009}, eawprW},     // Pe         RIGHT ANGLE BRACKET
+	{runeRange{0x300B, 0x300B}, eawprW},     // Pe         RIGHT DOUBLE ANGLE BRACKET
+	{runeRange{0x300D, 0x300D}, eawprW},     // Pe         RIGHT CORNER BRACKET
+	{runeRange{0x300F, 0x300F}, eawprW},     // Pe         RIGHT WHITE CORNER BRACKET
+	{runeRange{0x3011, 0x3011}, eawprW},     // Pe         RIGHT BLACK LENTICULAR BRACKET
+	{runeRange{0x3014, 0x3014}, eawprW},     // Ps         LEFT TORTOISE SHELL BRACKET
+	{runeRange{0x3016, 0x3016}, eawprW},     // Ps         LEFT WHITE LENTICULAR BRACKET
+	{runeRange{0x3018, 0x3018}, eawprW},     // Ps         LEFT WHITE TORTOISE SHELL BRACKET
+	{runeRange{0x301A, 0x301A}, eawprW},     // Ps         LEFT WHITE SQUARE BRACKET
+	{runeRange{0x301C, 0x301C}, eawprW},     // Pd         WAVE DASH
+	{runeRange{0x301E, 0x301F}, eawprW},     // Pe     [2] DOUBLE PRIME QUOTATION MARK..LOW DOUBLE PRIME QUOTATION MARK
+	{runeRange{0x3021, 0x3029}, eawprW},     // Nl     [9] HANGZHOU NUMERAL ONE..HANGZHOU NUMERAL NINE
+	{runeRange{0x302E, 0x302F}, eawprW},     // Mc     [2] HANGUL SINGLE DOT TONE MARK..HANGUL DOUBLE DOT TONE MARK
+	{runeRange{0x3031, 0x3035}, eawprW},     // Lm     [5] VERTICAL KANA REPEAT MARK..VERTICAL KANA REPEAT MARK LOWER HALF
+	{runeRange{0x3038, 0x303A}, eawprW},     // Nl     [3] HANGZHOU NUMERAL TEN..HANGZHOU NUMERAL THIRTY
+	{runeRange{0x303C, 0x303C}, eawprW},     // Lo         MASU MARK
+	{runeRange{0x303E, 0x303E}, eawprW},     // So         IDEOGRAPHIC VARIATION INDICATOR
+	{runeRange{0x3041, 0x3096}, eawprW},     // Lo    [86] HIRAGANA LETTER SMALL A..HIRAGANA LETTER SMALL KE
+	{runeRange{0x309B, 0x309C}, eawprW},     // Sk     [2] KATAKANA-HIRAGANA VOICED SOUND MARK..KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK
+	{runeRange{0x309F, 0x309F}, eawprW},     // Lo         HIRAGANA DIGRAPH YORI
+	{runeRange{0x30A1, 0x30FA}, eawprW},     // Lo    [90] KATAKANA LETTER SMALL A..KATAKANA LETTER VO
+	{runeRange{0x30FC, 0x30FE}, eawprW},     // Lm     [3] KATAKANA-HIRAGANA PROLONGED SOUND MARK..KATAKANA VOICED ITERATION MARK
+	{runeRange{0x3105, 0x312F}, eawprW},     // Lo    [43] BOPOMOFO LETTER B..BOPOMOFO LETTER NN
+	{runeRange{0x3190, 0x3191}, eawprW},     // So     [2] IDEOGRAPHIC ANNOTATION LINKING MARK..IDEOGRAPHIC ANNOTATION REVERSE MARK
+	{runeRange{0x3196, 0x319F}, eawprW},     // So    [10] IDEOGRAPHIC ANNOTATION TOP MARK..IDEOGRAPHIC ANNOTATION MAN MARK
+	{runeRange{0x31C0, 0x31E3}, eawprW},     // So    [36] CJK STROKE T..CJK STROKE Q
+	{runeRange{0x3200, 0x321E}, eawprW},     // So    [31] PARENTHESIZED HANGUL KIYEOK..PARENTHESIZED KOREAN CHARACTER O HU
+	{runeRange{0x322A, 0x3247}, eawprW},     // So    [30] PARENTHESIZED IDEOGRAPH MOON..CIRCLED IDEOGRAPH KOTO
+	{runeRange{0x3250, 0x3250}, eawprW},     // So         PARTNERSHIP SIGN
+	{runeRange{0x3260, 0x327F}, eawprW},     // So    [32] CIRCLED HANGUL KIYEOK..KOREAN STANDARD SYMBOL
+	{runeRange{0x328A, 0x32B0}, eawprW},     // So    [39] CIRCLED IDEOGRAPH MOON..CIRCLED IDEOGRAPH NIGHT
+	{runeRange{0x32C0, 0x32FF}, eawprW},     // So    [64] IDEOGRAPHIC TELEGRAPH SYMBOL FOR JANUARY..SQUARE ERA NAME REIWA
+	{runeRange{0x3400, 0x4DBF}, eawprW},     // Lo  [6592] CJK UNIFIED IDEOGRAPH-3400..CJK UNIFIED IDEOGRAPH-4DBF
+	{runeRange{0x4E00, 0x9FFF}, eawprW},     // Lo [20992] CJK UNIFIED IDEOGRAPH-4E00..CJK UNIFIED IDEOGRAPH-9FFF
+	{runeRange{0xA015, 0xA015}, eawprW},     // Lm         YI SYLLABLE WU
+	{runeRange{0xA490, 0xA4C6}, eawprW},     // So    [55] YI RADICAL QOT..YI RADICAL KE
+	{runeRange{0xA4F8, 0xA4FD}, eawprN},     // Lm     [6] LISU LETTER TONE MYA TI..LISU LETTER TONE MYA JEU
+	{runeRange{0xA500, 0xA60B}, eawprN},     // Lo   [268] VAI SYLLABLE EE..VAI SYLLABLE NG
+	{runeRange{0xA60D, 0xA60F}, eawprN},     // Po     [3] VAI COMMA..VAI QUESTION MARK
+	{runeRange{0xA620, 0xA629}, eawprN},     // Nd    [10] VAI DIGIT ZERO..VAI DIGIT NINE
+	{runeRange{0xA640, 0xA66D}, eawprN},     // L&    [46] CYRILLIC CAPITAL LETTER ZEMLYA..CYRILLIC SMALL LETTER DOUBLE MONOCULAR O
+	{runeRange{0xA66F, 0xA66F}, eawprN},     // Mn         COMBINING CYRILLIC VZMET
+	{runeRange{0xA673, 0xA673}, eawprN},     // Po         SLAVONIC ASTERISK
+	{runeRange{0xA67E, 0xA67E}, eawprN},     // Po         CYRILLIC KAVYKA
+	{runeRange{0xA680, 0xA69B}, eawprN},     // L&    [28] CYRILLIC CAPITAL LETTER DWE..CYRILLIC SMALL LETTER CROSSED O
+	{runeRange{0xA69E, 0xA69F}, eawprN},     // Mn     [2] COMBINING CYRILLIC LETTER EF..COMBINING CYRILLIC LETTER IOTIFIED E
+	{runeRange{0xA6E6, 0xA6EF}, eawprN},     // Nl    [10] BAMUM LETTER MO..BAMUM LETTER KOGHOM
+	{runeRange{0xA6F2, 0xA6F7}, eawprN},     // Po     [6] BAMUM NJAEMLI..BAMUM QUESTION MARK
+	{runeRange{0xA717, 0xA71F}, eawprN},     // Lm     [9] MODIFIER LETTER DOT VERTICAL BAR..MODIFIER LETTER LOW INVERTED EXCLAMATION MARK
+	{runeRange{0xA722, 0xA76F}, eawprN},     // L&    [78] LATIN CAPITAL LETTER EGYPTOLOGICAL ALEF..LATIN SMALL LETTER CON
+	{runeRange{0xA771, 0xA787}, eawprN},     // L&    [23] LATIN SMALL LETTER DUM..LATIN SMALL LETTER INSULAR T
+	{runeRange{0xA789, 0xA78A}, eawprN},     // Sk     [2] MODIFIER LETTER COLON..MODIFIER LETTER SHORT EQUALS SIGN
+	{runeRange{0xA78F, 0xA78F}, eawprN},     // Lo         LATIN LETTER SINOLOGICAL DOT
+	{runeRange{0xA7D0, 0xA7D1}, eawprN},     // L&     [2] LATIN CAPITAL LETTER CLOSED INSULAR G..LATIN SMALL LETTER CLOSED INSULAR G
+	{runeRange{0xA7D5, 0xA7D9}, eawprN},     // L&     [5] LATIN SMALL LETTER DOUBLE WYNN..LATIN SMALL LETTER SIGMOID S
+	{runeRange{0xA7F5, 0xA7F6}, eawprN},     // L&     [2] LATIN CAPITAL LETTER REVERSED HALF H..LATIN SMALL LETTER REVERSED HALF H
+	{runeRange{0xA7F8, 0xA7F9}, eawprN},     // Lm     [2] MODIFIER LETTER CAPITAL H WITH STROKE..MODIFIER LETTER SMALL LIGATURE OE
+	{runeRange{0xA7FB, 0xA7FF}, eawprN},     // Lo     [5] LATIN EPIGRAPHIC LETTER REVERSED F..LATIN EPIGRAPHIC LETTER ARCHAIC M
+	{runeRange{0xA802, 0xA802}, eawprN},     // Mn         SYLOTI NAGRI SIGN DVISVARA
+	{runeRange{0xA806, 0xA806}, eawprN},     // Mn         SYLOTI NAGRI SIGN HASANTA
+	{runeRange{0xA80B, 0xA80B}, eawprN},     // Mn         SYLOTI NAGRI SIGN ANUSVARA
+	{runeRange{0xA823, 0xA824}, eawprN},     // Mc     [2] SYLOTI NAGRI VOWEL SIGN A..SYLOTI NAGRI VOWEL SIGN I
+	{runeRange{0xA827, 0xA827}, eawprN},     // Mc         SYLOTI NAGRI VOWEL SIGN OO
+	{runeRange{0xA82C, 0xA82C}, eawprN},     // Mn         SYLOTI NAGRI SIGN ALTERNATE HASANTA
+	{runeRange{0xA836, 0xA837}, eawprN},     // So     [2] NORTH INDIC QUARTER MARK..NORTH INDIC PLACEHOLDER MARK
+	{runeRange{0xA839, 0xA839}, eawprN},     // So         NORTH INDIC QUANTITY MARK
+	{runeRange{0xA874, 0xA877}, eawprN},     // Po     [4] PHAGS-PA SINGLE HEAD MARK..PHAGS-PA MARK DOUBLE SHAD
+	{runeRange{0xA882, 0xA8B3}, eawprN},     // Lo    [50] SAURASHTRA LETTER A..SAURASHTRA LETTER LLA
+	{runeRange{0xA8C4, 0xA8C5}, eawprN},     // Mn     [2] SAURASHTRA SIGN VIRAMA..SAURASHTRA SIGN CANDRABINDU
+	{runeRange{0xA8D0, 0xA8D9}, eawprN},     // Nd    [10] SAURASHTRA DIGIT ZERO..SAURASHTRA DIGIT NINE
+	{runeRange{0xA8F2, 0xA8F7}, eawprN},     // Lo     [6] DEVANAGARI SIGN SPACING CANDRABINDU..DEVANAGARI SIGN CANDRABINDU AVAGRAHA
+	{runeRange{0xA8FB, 0xA8FB}, eawprN},     // Lo         DEVANAGARI HEADSTROKE
+	{runeRange{0xA8FD, 0xA8FE}, eawprN},     // Lo     [2] DEVANAGARI JAIN OM..DEVANAGARI LETTER AY
+	{runeRange{0xA900, 0xA909}, eawprN},     // Nd    [10] KAYAH LI DIGIT ZERO..KAYAH LI DIGIT NINE
+	{runeRange{0xA926, 0xA92D}, eawprN},     // Mn     [8] KAYAH LI VOWEL UE..KAYAH LI TONE CALYA PLOPHU
+	{runeRange{0xA930, 0xA946}, eawprN},     // Lo    [23] REJANG LETTER KA..REJANG LETTER A
+	{runeRange{0xA952, 0xA953}, eawprN},     // Mc     [2] REJANG CONSONANT SIGN H..REJANG VIRAMA
+	{runeRange{0xA960, 0xA97C}, eawprW},     // Lo    [29] HANGUL CHOSEONG TIKEUT-MIEUM..HANGUL CHOSEONG SSANGYEORINHIEUH
+	{runeRange{0xA983, 0xA983}, eawprN},     // Mc         JAVANESE SIGN WIGNYAN
+	{runeRange{0xA9B3, 0xA9B3}, eawprN},     // Mn         JAVANESE SIGN CECAK TELU
+	{runeRange{0xA9B6, 0xA9B9}, eawprN},     // Mn     [4] JAVANESE VOWEL SIGN WULU..JAVANESE VOWEL SIGN SUKU MENDUT
+	{runeRange{0xA9BC, 0xA9BD}, eawprN},     // Mn     [2] JAVANESE VOWEL SIGN PEPET..JAVANESE CONSONANT SIGN KERET
+	{runeRange{0xA9C1, 0xA9CD}, eawprN},     // Po    [13] JAVANESE LEFT RERENGGAN..JAVANESE TURNED PADA PISELEH
+	{runeRange{0xA9D0, 0xA9D9}, eawprN},     // Nd    [10] JAVANESE DIGIT ZERO..JAVANESE DIGIT NINE
+	{runeRange{0xA9E0, 0xA9E4}, eawprN},     // Lo     [5] MYANMAR LETTER SHAN GHA..MYANMAR LETTER SHAN BHA
+	{runeRange{0xA9E6, 0xA9E6}, eawprN},     // Lm         MYANMAR MODIFIER LETTER SHAN REDUPLICATION
+	{runeRange{0xA9F0, 0xA9F9}, eawprN},     // Nd    [10] MYANMAR TAI LAING DIGIT ZERO..MYANMAR TAI LAING DIGIT NINE
+	{runeRange{0xAA00, 0xAA28}, eawprN},     // Lo    [41] CHAM LETTER A..CHAM LETTER HA
+	{runeRange{0xAA2F, 0xAA30}, eawprN},     // Mc     [2] CHAM VOWEL SIGN O..CHAM VOWEL SIGN AI
+	{runeRange{0xAA33, 0xAA34}, eawprN},     // Mc     [2] CHAM CONSONANT SIGN YA..CHAM CONSONANT SIGN RA
+	{runeRange{0xAA40, 0xAA42}, eawprN},     // Lo     [3] CHAM LETTER FINAL K..CHAM LETTER FINAL NG
+	{runeRange{0xAA44, 0xAA4B}, eawprN},     // Lo     [8] CHAM LETTER FINAL CH..CHAM LETTER FINAL SS
+	{runeRange{0xAA4D, 0xAA4D}, eawprN},     // Mc         CHAM CONSONANT SIGN FINAL H
+	{runeRange{0xAA5C, 0xAA5F}, eawprN},     // Po     [4] CHAM PUNCTUATION SPIRAL..CHAM PUNCTUATION TRIPLE DANDA
+	{runeRange{0xAA70, 0xAA70}, eawprN},     // Lm         MYANMAR MODIFIER LETTER KHAMTI REDUPLICATION
+	{runeRange{0xAA77, 0xAA79}, eawprN},     // So     [3] MYANMAR SYMBOL AITON EXCLAMATION..MYANMAR SYMBOL AITON TWO
+	{runeRange{0xAA7B, 0xAA7B}, eawprN},     // Mc         MYANMAR SIGN PAO KAREN TONE
+	{runeRange{0xAA7D, 0xAA7D}, eawprN},     // Mc         MYANMAR SIGN TAI LAING TONE-5
+	{runeRange{0xAA80, 0xAAAF}, eawprN},     // Lo    [48] TAI VIET LETTER LOW KO..TAI VIET LETTER HIGH O
+	{runeRange{0xAAB1, 0xAAB1}, eawprN},     // Lo         TAI VIET VOWEL AA
+	{runeRange{0xAAB5, 0xAAB6}, eawprN},     // Lo     [2] TAI VIET VOWEL E..TAI VIET VOWEL O
+	{runeRange{0xAAB9, 0xAABD}, eawprN},     // Lo     [5] TAI VIET VOWEL UEA..TAI VIET VOWEL AN
+	{runeRange{0xAAC0, 0xAAC0}, eawprN},     // Lo         TAI VIET TONE MAI NUENG
+	{runeRange{0xAAC2, 0xAAC2}, eawprN},     // Lo         TAI VIET TONE MAI SONG
+	{runeRange{0xAADD, 0xAADD}, eawprN},     // Lm         TAI VIET SYMBOL SAM
+	{runeRange{0xAAE0, 0xAAEA}, eawprN},     // Lo    [11] MEETEI MAYEK LETTER E..MEETEI MAYEK LETTER SSA
+	{runeRange{0xAAEC, 0xAAED}, eawprN},     // Mn     [2] MEETEI MAYEK VOWEL SIGN UU..MEETEI MAYEK VOWEL SIGN AAI
+	{runeRange{0xAAF0, 0xAAF1}, eawprN},     // Po     [2] MEETEI MAYEK CHEIKHAN..MEETEI MAYEK AHANG KHUDAM
+	{runeRange{0xAAF3, 0xAAF4}, eawprN},     // Lm     [2] MEETEI MAYEK SYLLABLE REPETITION MARK..MEETEI MAYEK WORD REPETITION MARK
+	{runeRange{0xAAF6, 0xAAF6}, eawprN},     // Mn         MEETEI MAYEK VIRAMA
+	{runeRange{0xAB09, 0xAB0E}, eawprN},     // Lo     [6] ETHIOPIC SYLLABLE DDHU..ETHIOPIC SYLLABLE DDHO
+	{runeRange{0xAB20, 0xAB26}, eawprN},     // Lo     [7] ETHIOPIC SYLLABLE CCHHA..ETHIOPIC SYLLABLE CCHHO
+	{runeRange{0xAB30, 0xAB5A}, eawprN},     // Ll    [43] LATIN SMALL LETTER BARRED ALPHA..LATIN SMALL LETTER Y WITH SHORT RIGHT LEG
+	{runeRange{0xAB5C, 0xAB5F}, eawprN},     // Lm     [4] MODIFIER LETTER SMALL HENG..MODIFIER LETTER SMALL U WITH LEFT HOOK
+	{runeRange{0xAB69, 0xAB69}, eawprN},     // Lm         MODIFIER LETTER SMALL TURNED W
+	{runeRange{0xAB70, 0xABBF}, eawprN},     // Ll    [80] CHEROKEE SMALL LETTER A..CHEROKEE SMALL LETTER YA
+	{runeRange{0xABE3, 0xABE4}, eawprN},     // Mc     [2] MEETEI MAYEK VOWEL SIGN ONAP..MEETEI MAYEK VOWEL SIGN INAP
+	{runeRange{0xABE6, 0xABE7}, eawprN},     // Mc     [2] MEETEI MAYEK VOWEL SIGN YENAP..MEETEI MAYEK VOWEL SIGN SOUNAP
+	{runeRange{0xABE9, 0xABEA}, eawprN},     // Mc     [2] MEETEI MAYEK VOWEL SIGN CHEINAP..MEETEI MAYEK VOWEL SIGN NUNG
+	{runeRange{0xABEC, 0xABEC}, eawprN},     // Mc         MEETEI MAYEK LUM IYEK
+	{runeRange{0xABF0, 0xABF9}, eawprN},     // Nd    [10] MEETEI MAYEK DIGIT ZERO..MEETEI MAYEK DIGIT NINE
+	{runeRange{0xD7B0, 0xD7C6}, eawprN},     // Lo    [23] HANGUL JUNGSEONG O-YEO..HANGUL JUNGSEONG ARAEA-E
+	{runeRange{0xD800, 0xDB7F}, eawprN},     // Cs   [896] <surrogate-D800>..<surrogate-DB7F>
+	{runeRange{0xDC00, 0xDFFF}, eawprN},     // Cs  [1024] <surrogate-DC00>..<surrogate-DFFF>
+	{runeRange{0xF900, 0xFA6D}, eawprW},     // Lo   [366] CJK COMPATIBILITY IDEOGRAPH-F900..CJK COMPATIBILITY IDEOGRAPH-FA6D
+	{runeRange{0xFA70, 0xFAD9}, eawprW},     // Lo   [106] CJK COMPATIBILITY IDEOGRAPH-FA70..CJK COMPATIBILITY IDEOGRAPH-FAD9
+	{runeRange{0xFB00, 0xFB06}, eawprN},     // Ll     [7] LATIN SMALL LIGATURE FF..LATIN SMALL LIGATURE ST
+	{runeRange{0xFB1D, 0xFB1D}, eawprN},     // Lo         HEBREW LETTER YOD WITH HIRIQ
+	{runeRange{0xFB1F, 0xFB28}, eawprN},     // Lo    [10] HEBREW LIGATURE YIDDISH YOD YOD PATAH..HEBREW LETTER WIDE TAV
+	{runeRange{0xFB2A, 0xFB36}, eawprN},     // Lo    [13] HEBREW LETTER SHIN WITH SHIN DOT..HEBREW LETTER ZAYIN WITH DAGESH
+	{runeRange{0xFB3E, 0xFB3E}, eawprN},     // Lo         HEBREW LETTER MEM WITH DAGESH
+	{runeRange{0xFB43, 0xFB44}, eawprN},     // Lo     [2] HEBREW LETTER FINAL PE WITH DAGESH..HEBREW LETTER PE WITH DAGESH
+	{runeRange{0xFB50, 0xFBB1}, eawprN},     // Lo    [98] ARABIC LETTER ALEF WASLA ISOLATED FORM..ARABIC LETTER YEH BARREE WITH HAMZA ABOVE FINAL FORM
+	{runeRange{0xFBD3, 0xFD3D}, eawprN},     // Lo   [363] ARABIC LETTER NG ISOLATED FORM..ARABIC LIGATURE ALEF WITH FATHATAN ISOLATED FORM
+	{runeRange{0xFD3F, 0xFD3F}, eawprN},     // Ps         ORNATE RIGHT PARENTHESIS
+	{runeRange{0xFD50, 0xFD8F}, eawprN},     // Lo    [64] ARABIC LIGATURE TEH WITH JEEM WITH MEEM INITIAL FORM..ARABIC LIGATURE MEEM WITH KHAH WITH MEEM INITIAL FORM
+	{runeRange{0xFDCF, 0xFDCF}, eawprN},     // So         ARABIC LIGATURE SALAAMUHU ALAYNAA
+	{runeRange{0xFDFC, 0xFDFC}, eawprN},     // Sc         RIAL SIGN
+	{runeRange{0xFE00, 0xFE0F}, eawprA},     // Mn    [16] VARIATION SELECTOR-1..VARIATION SELECTOR-16
+	{runeRange{0xFE17, 0xFE17}, eawprW},     // Ps         PRESENTATION FORM FOR VERTICAL LEFT WHITE LENTICULAR BRACKET
+	{runeRange{0xFE19, 0xFE19}, eawprW},     // Po         PRESENTATION FORM FOR VERTICAL HORIZONTAL ELLIPSIS
+	{runeRange{0xFE30, 0xFE30}, eawprW},     // Po         PRESENTATION FORM FOR VERTICAL TWO DOT LEADER
+	{runeRange{0xFE33, 0xFE34}, eawprW},     // Pc     [2] PRESENTATION FORM FOR VERTICAL LOW LINE..PRESENTATION FORM FOR VERTICAL WAVY LOW LINE
+	{runeRange{0xFE36, 0xFE36}, eawprW},     // Pe         PRESENTATION FORM FOR VERTICAL RIGHT PARENTHESIS
+	{runeRange{0xFE38, 0xFE38}, eawprW},     // Pe         PRESENTATION FORM FOR VERTICAL RIGHT CURLY BRACKET
+	{runeRange{0xFE3A, 0xFE3A}, eawprW},     // Pe         PRESENTATION FORM FOR VERTICAL RIGHT TORTOISE SHELL BRACKET
+	{runeRange{0xFE3C, 0xFE3C}, eawprW},     // Pe         PRESENTATION FORM FOR VERTICAL RIGHT BLACK LENTICULAR BRACKET
+	{runeRange{0xFE3E, 0xFE3E}, eawprW},     // Pe         PRESENTATION FORM FOR VERTICAL RIGHT DOUBLE ANGLE BRACKET
+	{runeRange{0xFE40, 0xFE40}, eawprW},     // Pe         PRESENTATION FORM FOR VERTICAL RIGHT ANGLE BRACKET
+	{runeRange{0xFE42, 0xFE42}, eawprW},     // Pe         PRESENTATION FORM FOR VERTICAL RIGHT CORNER BRACKET
+	{runeRange{0xFE44, 0xFE44}, eawprW},     // Pe         PRESENTATION FORM FOR VERTICAL RIGHT WHITE CORNER BRACKET
+	{runeRange{0xFE47, 0xFE47}, eawprW},     // Ps         PRESENTATION FORM FOR VERTICAL LEFT SQUARE BRACKET
+	{runeRange{0xFE49, 0xFE4C}, eawprW},     // Po     [4] DASHED OVERLINE..DOUBLE WAVY OVERLINE
+	{runeRange{0xFE50, 0xFE52}, eawprW},     // Po     [3] SMALL COMMA..SMALL FULL STOP
+	{runeRange{0xFE58, 0xFE58}, eawprW},     // Pd         SMALL EM DASH
+	{runeRange{0xFE5A, 0xFE5A}, eawprW},     // Pe         SMALL RIGHT PARENTHESIS
+	{runeRange{0xFE5C, 0xFE5C}, eawprW},     // Pe         SMALL RIGHT CURLY BRACKET
+	{runeRange{0xFE5E, 0xFE5E}, eawprW},     // Pe         SMALL RIGHT TORTOISE SHELL BRACKET
+	{runeRange{0xFE62, 0xFE62}, eawprW},     // Sm         SMALL PLUS SIGN
+	{runeRange{0xFE64, 0xFE66}, eawprW},     // Sm     [3] SMALL LESS-THAN SIGN..SMALL EQUALS SIGN
+	{runeRange{0xFE69, 0xFE69}, eawprW},     // Sc         SMALL DOLLAR SIGN
+	{runeRange{0xFE70, 0xFE74}, eawprN},     // Lo     [5] ARABIC FATHATAN ISOLATED FORM..ARABIC KASRATAN ISOLATED FORM
+	{runeRange{0xFEFF, 0xFEFF}, eawprN},     // Cf         ZERO WIDTH NO-BREAK SPACE
+	{runeRange{0xFF04, 0xFF04}, eawprF},     // Sc         FULLWIDTH DOLLAR SIGN
+	{runeRange{0xFF08, 0xFF08}, eawprF},     // Ps         FULLWIDTH LEFT PARENTHESIS
+	{runeRange{0xFF0A, 0xFF0A}, eawprF},     // Po         FULLWIDTH ASTERISK
+	{runeRange{0xFF0C, 0xFF0C}, eawprF},     // Po         FULLWIDTH COMMA
+	{runeRange{0xFF0E, 0xFF0F}, eawprF},     // Po     [2] FULLWIDTH FULL STOP..FULLWIDTH SOLIDUS
+	{runeRange{0xFF1A, 0xFF1B}, eawprF},     // Po     [2] FULLWIDTH COLON..FULLWIDTH SEMICOLON
+	{runeRange{0xFF1F, 0xFF20}, eawprF},     // Po     [2] FULLWIDTH QUESTION MARK..FULLWIDTH COMMERCIAL AT
+	{runeRange{0xFF3B, 0xFF3B}, eawprF},     // Ps         FULLWIDTH LEFT SQUARE BRACKET
+	{runeRange{0xFF3D, 0xFF3D}, eawprF},     // Pe         FULLWIDTH RIGHT SQUARE BRACKET
+	{runeRange{0xFF3F, 0xFF3F}, eawprF},     // Pc         FULLWIDTH LOW LINE
+	{runeRange{0xFF41, 0xFF5A}, eawprF},     // Ll    [26] FULLWIDTH LATIN SMALL LETTER A..FULLWIDTH LATIN SMALL LETTER Z
+	{runeRange{0xFF5C, 0xFF5C}, eawprF},     // Sm         FULLWIDTH VERTICAL LINE
+	{runeRange{0xFF5E, 0xFF5E}, eawprF},     // Sm         FULLWIDTH TILDE
+	{runeRange{0xFF60, 0xFF60}, eawprF},     // Pe         FULLWIDTH RIGHT WHITE PARENTHESIS
+	{runeRange{0xFF62, 0xFF62}, eawprH},     // Ps         HALFWIDTH LEFT CORNER BRACKET
+	{runeRange{0xFF64, 0xFF65}, eawprH},     // Po     [2] HALFWIDTH IDEOGRAPHIC COMMA..HALFWIDTH KATAKANA MIDDLE DOT
+	{runeRange{0xFF70, 0xFF70}, eawprH},     // Lm         HALFWIDTH KATAKANA-HIRAGANA PROLONGED SOUND MARK
+	{runeRange{0xFF9E, 0xFF9F}, eawprH},     // Lm     [2] HALFWIDTH KATAKANA VOICED SOUND MARK..HALFWIDTH KATAKANA SEMI-VOICED SOUND MARK
+	{runeRange{0xFFC2, 0xFFC7}, eawprH},     // Lo     [6] HALFWIDTH HANGUL LETTER A..HALFWIDTH HANGUL LETTER E
+	{runeRange{0xFFD2, 0xFFD7}, eawprH},     // Lo     [6] HALFWIDTH HANGUL LETTER YO..HALFWIDTH HANGUL LETTER YU
+	{runeRange{0xFFE0, 0xFFE1}, eawprF},     // Sc     [2] FULLWIDTH CENT SIGN..FULLWIDTH POUND SIGN
+	{runeRange{0xFFE3, 0xFFE3}, eawprF},     // Sk         FULLWIDTH MACRON
+	{runeRange{0xFFE5, 0xFFE6}, eawprF},     // Sc     [2] FULLWIDTH YEN SIGN..FULLWIDTH WON SIGN
+	{runeRange{0xFFE9, 0xFFEC}, eawprH},     // Sm     [4] HALFWIDTH LEFTWARDS ARROW..HALFWIDTH DOWNWARDS ARROW
+	{runeRange{0xFFF9, 0xFFFB}, eawprN},     // Cf     [3] INTERLINEAR ANNOTATION ANCHOR..INTERLINEAR ANNOTATION TERMINATOR
+	{runeRange{0xFFFD, 0xFFFD}, eawprA},     // So         REPLACEMENT CHARACTER
+	{runeRange{0x1000D, 0x10026}, eawprN},   // Lo    [26] LINEAR B SYLLABLE B036 JO..LINEAR B SYLLABLE B032 QO
+	{runeRange{0x1003C, 0x1003D}, eawprN},   // Lo     [2] LINEAR B SYLLABLE B017 ZA..LINEAR B SYLLABLE B074 ZE
+	{runeRange{0x10050, 0x1005D}, eawprN},   // Lo    [14] LINEAR B SYMBOL B018..LINEAR B SYMBOL B089
+	{runeRange{0x10100, 0x10102}, eawprN},   // Po     [3] AEGEAN WORD SEPARATOR LINE..AEGEAN CHECK MARK
+	{runeRange{0x10137, 0x1013F}, eawprN},   // So     [9] AEGEAN WEIGHT BASE UNIT..AEGEAN MEASURE THIRD SUBUNIT
+	{runeRange{0x10175, 0x10178}, eawprN},   // No     [4] GREEK ONE HALF SIGN..GREEK THREE QUARTERS SIGN
+	{runeRange{0x1018A, 0x1018B}, eawprN},   // No     [2] GREEK ZERO SIGN..GREEK ONE QUARTER SIGN
+	{runeRange{0x10190, 0x1019C}, eawprN},   // So    [13] ROMAN SEXTANS SIGN..ASCIA SYMBOL
+	{runeRange{0x101D0, 0x101FC}, eawprN},   // So    [45] PHAISTOS DISC SIGN PEDESTRIAN..PHAISTOS DISC SIGN WAVY BAND
+	{runeRange{0x10280, 0x1029C}, eawprN},   // Lo    [29] LYCIAN LETTER A..LYCIAN LETTER X
+	{runeRange{0x102E0, 0x102E0}, eawprN},   // Mn         COPTIC EPACT THOUSANDS MARK
+	{runeRange{0x10300, 0x1031F}, eawprN},   // Lo    [32] OLD ITALIC LETTER A..OLD ITALIC LETTER ESS
+	{runeRange{0x1032D, 0x1032F}, eawprN},   // Lo     [3] OLD ITALIC LETTER YE..OLD ITALIC LETTER SOUTHERN TSE
+	{runeRange{0x10341, 0x10341}, eawprN},   // Nl         GOTHIC LETTER NINETY
+	{runeRange{0x1034A, 0x1034A}, eawprN},   // Nl         GOTHIC LETTER NINE HUNDRED
+	{runeRange{0x10376, 0x1037A}, eawprN},   // Mn     [5] COMBINING OLD PERMIC LETTER AN..COMBINING OLD PERMIC LETTER SII
+	{runeRange{0x1039F, 0x1039F}, eawprN},   // Po         UGARITIC WORD DIVIDER
+	{runeRange{0x103C8, 0x103CF}, eawprN},   // Lo     [8] OLD PERSIAN SIGN AURAMAZDAA..OLD PERSIAN SIGN BUUMISH
+	{runeRange{0x103D1, 0x103D5}, eawprN},   // Nl     [5] OLD PERSIAN NUMBER ONE..OLD PERSIAN NUMBER HUNDRED
+	{runeRange{0x10450, 0x1047F}, eawprN},   // Lo    [48] SHAVIAN LETTER PEEP..SHAVIAN LETTER YEW
+	{runeRange{0x104A0, 0x104A9}, eawprN},   // Nd    [10] OSMANYA DIGIT ZERO..OSMANYA DIGIT NINE
+	{runeRange{0x104D8, 0x104FB}, eawprN},   // Ll    [36] OSAGE SMALL LETTER A..OSAGE SMALL LETTER ZHA
+	{runeRange{0x10530, 0x10563}, eawprN},   // Lo    [52] CAUCASIAN ALBANIAN LETTER ALT..CAUCASIAN ALBANIAN LETTER KIW
+	{runeRange{0x10570, 0x1057A}, eawprN},   // Lu    [11] VITHKUQI CAPITAL LETTER A..VITHKUQI CAPITAL LETTER GA
+	{runeRange{0x1058C, 0x10592}, eawprN},   // Lu     [7] VITHKUQI CAPITAL LETTER SE..VITHKUQI CAPITAL LETTER XE
+	{runeRange{0x10597, 0x105A1}, eawprN},   // Ll    [11] VITHKUQI SMALL LETTER A..VITHKUQI SMALL LETTER GA
+	{runeRange{0x105B3, 0x105B9}, eawprN},   // Ll     [7] VITHKUQI SMALL LETTER SE..VITHKUQI SMALL LETTER XE
+	{runeRange{0x10600, 0x10736}, eawprN},   // Lo   [311] LINEAR A SIGN AB001..LINEAR A SIGN A664
+	{runeRange{0x10760, 0x10767}, eawprN},   // Lo     [8] LINEAR A SIGN A800..LINEAR A SIGN A807
+	{runeRange{0x10787, 0x107B0}, eawprN},   // Lm    [42] MODIFIER LETTER SMALL DZ DIGRAPH..MODIFIER LETTER SMALL V WITH RIGHT HOOK
+	{runeRange{0x10800, 0x10805}, eawprN},   // Lo     [6] CYPRIOT SYLLABLE A..CYPRIOT SYLLABLE JA
+	{runeRange{0x1080A, 0x10835}, eawprN},   // Lo    [44] CYPRIOT SYLLABLE KA..CYPRIOT SYLLABLE WO
+	{runeRange{0x1083C, 0x1083C}, eawprN},   // Lo         CYPRIOT SYLLABLE ZA
+	{runeRange{0x10840, 0x10855}, eawprN},   // Lo    [22] IMPERIAL ARAMAIC LETTER ALEPH..IMPERIAL ARAMAIC LETTER TAW
+	{runeRange{0x10858, 0x1085F}, eawprN},   // No     [8] IMPERIAL ARAMAIC NUMBER ONE..IMPERIAL ARAMAIC NUMBER TEN THOUSAND
+	{runeRange{0x10877, 0x10878}, eawprN},   // So     [2] PALMYRENE LEFT-POINTING FLEURON..PALMYRENE RIGHT-POINTING FLEURON
+	{runeRange{0x10880, 0x1089E}, eawprN},   // Lo    [31] NABATAEAN LETTER FINAL ALEPH..NABATAEAN LETTER TAW
+	{runeRange{0x108E0, 0x108F2}, eawprN},   // Lo    [19] HATRAN LETTER ALEPH..HATRAN LETTER QOPH
+	{runeRange{0x108FB, 0x108FF}, eawprN},   // No     [5] HATRAN NUMBER ONE..HATRAN NUMBER ONE HUNDRED
+	{runeRange{0x10916, 0x1091B}, eawprN},   // No     [6] PHOENICIAN NUMBER ONE..PHOENICIAN NUMBER THREE
+	{runeRange{0x10920, 0x10939}, eawprN},   // Lo    [26] LYDIAN LETTER A..LYDIAN LETTER C
+	{runeRange{0x10980, 0x1099F}, eawprN},   // Lo    [32] MEROITIC HIEROGLYPHIC LETTER A..MEROITIC HIEROGLYPHIC SYMBOL VIDJ-2
+	{runeRange{0x109BC, 0x109BD}, eawprN},   // No     [2] MEROITIC CURSIVE FRACTION ELEVEN TWELFTHS..MEROITIC CURSIVE FRACTION ONE HALF
+	{runeRange{0x109C0, 0x109CF}, eawprN},   // No    [16] MEROITIC CURSIVE NUMBER ONE..MEROITIC CURSIVE NUMBER SEVENTY
+	{runeRange{0x10A00, 0x10A00}, eawprN},   // Lo         KHAROSHTHI LETTER A
+	{runeRange{0x10A05, 0x10A06}, eawprN},   // Mn     [2] KHAROSHTHI VOWEL SIGN E..KHAROSHTHI VOWEL SIGN O
+	{runeRange{0x10A10, 0x10A13}, eawprN},   // Lo     [4] KHAROSHTHI LETTER KA..KHAROSHTHI LETTER GHA
+	{runeRange{0x10A19, 0x10A35}, eawprN},   // Lo    [29] KHAROSHTHI LETTER NYA..KHAROSHTHI LETTER VHA
+	{runeRange{0x10A3F, 0x10A3F}, eawprN},   // Mn         KHAROSHTHI VIRAMA
+	{runeRange{0x10A50, 0x10A58}, eawprN},   // Po     [9] KHAROSHTHI PUNCTUATION DOT..KHAROSHTHI PUNCTUATION LINES
+	{runeRange{0x10A7D, 0x10A7E}, eawprN},   // No     [2] OLD SOUTH ARABIAN NUMBER ONE..OLD SOUTH ARABIAN NUMBER FIFTY
+	{runeRange{0x10A80, 0x10A9C}, eawprN},   // Lo    [29] OLD NORTH ARABIAN LETTER HEH..OLD NORTH ARABIAN LETTER ZAH
+	{runeRange{0x10AC0, 0x10AC7}, eawprN},   // Lo     [8] MANICHAEAN LETTER ALEPH..MANICHAEAN LETTER WAW
+	{runeRange{0x10AC9, 0x10AE4}, eawprN},   // Lo    [28] MANICHAEAN LETTER ZAYIN..MANICHAEAN LETTER TAW
+	{runeRange{0x10AEB, 0x10AEF}, eawprN},   // No     [5] MANICHAEAN NUMBER ONE..MANICHAEAN NUMBER ONE HUNDRED
+	{runeRange{0x10B00, 0x10B35}, eawprN},   // Lo    [54] AVESTAN LETTER A..AVESTAN LETTER HE
+	{runeRange{0x10B40, 0x10B55}, eawprN},   // Lo    [22] INSCRIPTIONAL PARTHIAN LETTER ALEPH..INSCRIPTIONAL PARTHIAN LETTER TAW
+	{runeRange{0x10B60, 0x10B72}, eawprN},   // Lo    [19] INSCRIPTIONAL PAHLAVI LETTER ALEPH..INSCRIPTIONAL PAHLAVI LETTER TAW
+	{runeRange{0x10B80, 0x10B91}, eawprN},   // Lo    [18] PSALTER PAHLAVI LETTER ALEPH..PSALTER PAHLAVI LETTER TAW
+	{runeRange{0x10BA9, 0x10BAF}, eawprN},   // No     [7] PSALTER PAHLAVI NUMBER ONE..PSALTER PAHLAVI NUMBER ONE HUNDRED
+	{runeRange{0x10C80, 0x10CB2}, eawprN},   // Lu    [51] OLD HUNGARIAN CAPITAL LETTER A..OLD HUNGARIAN CAPITAL LETTER US
+	{runeRange{0x10CFA, 0x10CFF}, eawprN},   // No     [6] OLD HUNGARIAN NUMBER ONE..OLD HUNGARIAN NUMBER ONE THOUSAND
+	{runeRange{0x10D24, 0x10D27}, eawprN},   // Mn     [4] HANIFI ROHINGYA SIGN HARBAHAY..HANIFI ROHINGYA SIGN TASSI
+	{runeRange{0x10E60, 0x10E7E}, eawprN},   // No    [31] RUMI DIGIT ONE..RUMI FRACTION TWO THIRDS
+	{runeRange{0x10EAB, 0x10EAC}, eawprN},   // Mn     [2] YEZIDI COMBINING HAMZA MARK..YEZIDI COMBINING MADDA MARK
+	{runeRange{0x10EB0, 0x10EB1}, eawprN},   // Lo     [2] YEZIDI LETTER LAM WITH DOT ABOVE..YEZIDI LETTER YOT WITH CIRCUMFLEX ABOVE
+	{runeRange{0x10F00, 0x10F1C}, eawprN},   // Lo    [29] OLD SOGDIAN LETTER ALEPH..OLD SOGDIAN LETTER FINAL TAW WITH VERTICAL TAIL
+	{runeRange{0x10F27, 0x10F27}, eawprN},   // Lo         OLD SOGDIAN LIGATURE AYIN-DALETH
+	{runeRange{0x10F46, 0x10F50}, eawprN},   // Mn    [11] SOGDIAN COMBINING DOT BELOW..SOGDIAN COMBINING STROKE BELOW
+	{runeRange{0x10F55, 0x10F59}, eawprN},   // Po     [5] SOGDIAN PUNCTUATION TWO VERTICAL BARS..SOGDIAN PUNCTUATION HALF CIRCLE WITH DOT
+	{runeRange{0x10F82, 0x10F85}, eawprN},   // Mn     [4] OLD UYGHUR COMBINING DOT ABOVE..OLD UYGHUR COMBINING TWO DOTS BELOW
+	{runeRange{0x10FB0, 0x10FC4}, eawprN},   // Lo    [21] CHORASMIAN LETTER ALEPH..CHORASMIAN LETTER TAW
+	{runeRange{0x10FE0, 0x10FF6}, eawprN},   // Lo    [23] ELYMAIC LETTER ALEPH..ELYMAIC LIGATURE ZAYIN-YODH
+	{runeRange{0x11001, 0x11001}, eawprN},   // Mn         BRAHMI SIGN ANUSVARA
+	{runeRange{0x11003, 0x11037}, eawprN},   // Lo    [53] BRAHMI SIGN JIHVAMULIYA..BRAHMI LETTER OLD TAMIL NNNA
+	{runeRange{0x11047, 0x1104D}, eawprN},   // Po     [7] BRAHMI DANDA..BRAHMI PUNCTUATION LOTUS
+	{runeRange{0x11066, 0x1106F}, eawprN},   // Nd    [10] BRAHMI DIGIT ZERO..BRAHMI DIGIT NINE
+	{runeRange{0x11071, 0x11072}, eawprN},   // Lo     [2] BRAHMI LETTER OLD TAMIL SHORT E..BRAHMI LETTER OLD TAMIL SHORT O
+	{runeRange{0x11075, 0x11075}, eawprN},   // Lo         BRAHMI LETTER OLD TAMIL LLA
+	{runeRange{0x11080, 0x11081}, eawprN},   // Mn     [2] KAITHI SIGN CANDRABINDU..KAITHI SIGN ANUSVARA
+	{runeRange{0x11083, 0x110AF}, eawprN},   // Lo    [45] KAITHI LETTER A..KAITHI LETTER HA
+	{runeRange{0x110B3, 0x110B6}, eawprN},   // Mn     [4] KAITHI VOWEL SIGN U..KAITHI VOWEL SIGN AI
+	{runeRange{0x110B9, 0x110BA}, eawprN},   // Mn     [2] KAITHI SIGN VIRAMA..KAITHI SIGN NUKTA
+	{runeRange{0x110BD, 0x110BD}, eawprN},   // Cf         KAITHI NUMBER SIGN
+	{runeRange{0x110C2, 0x110C2}, eawprN},   // Mn         KAITHI VOWEL SIGN VOCALIC R
+	{runeRange{0x110D0, 0x110E8}, eawprN},   // Lo    [25] SORA SOMPENG LETTER SAH..SORA SOMPENG LETTER MAE
+	{runeRange{0x11100, 0x11102}, eawprN},   // Mn     [3] CHAKMA SIGN CANDRABINDU..CHAKMA SIGN VISARGA
+	{runeRange{0x11127, 0x1112B}, eawprN},   // Mn     [5] CHAKMA VOWEL SIGN A..CHAKMA VOWEL SIGN UU
+	{runeRange{0x1112D, 0x11134}, eawprN},   // Mn     [8] CHAKMA VOWEL SIGN AI..CHAKMA MAAYYAA
+	{runeRange{0x11140, 0x11143}, eawprN},   // Po     [4] CHAKMA SECTION MARK..CHAKMA QUESTION MARK
+	{runeRange{0x11145, 0x11146}, eawprN},   // Mc     [2] CHAKMA VOWEL SIGN AA..CHAKMA VOWEL SIGN EI
+	{runeRange{0x11150, 0x11172}, eawprN},   // Lo    [35] MAHAJANI LETTER A..MAHAJANI LETTER RRA
+	{runeRange{0x11174, 0x11175}, eawprN},   // Po     [2] MAHAJANI ABBREVIATION SIGN..MAHAJANI SECTION MARK
+	{runeRange{0x11180, 0x11181}, eawprN},   // Mn     [2] SHARADA SIGN CANDRABINDU..SHARADA SIGN ANUSVARA
+	{runeRange{0x11183, 0x111B2}, eawprN},   // Lo    [48] SHARADA LETTER A..SHARADA LETTER HA
+	{runeRange{0x111B6, 0x111BE}, eawprN},   // Mn     [9] SHARADA VOWEL SIGN U..SHARADA VOWEL SIGN O
+	{runeRange{0x111C1, 0x111C4}, eawprN},   // Lo     [4] SHARADA SIGN AVAGRAHA..SHARADA OM
+	{runeRange{0x111C9, 0x111CC}, eawprN},   // Mn     [4] SHARADA SANDHI MARK..SHARADA EXTRA SHORT VOWEL MARK
+	{runeRange{0x111CE, 0x111CE}, eawprN},   // Mc         SHARADA VOWEL SIGN PRISHTHAMATRA E
+	{runeRange{0x111D0, 0x111D9}, eawprN},   // Nd    [10] SHARADA DIGIT ZERO..SHARADA DIGIT NINE
+	{runeRange{0x111DB, 0x111DB}, eawprN},   // Po         SHARADA SIGN SIDDHAM
+	{runeRange{0x111DD, 0x111DF}, eawprN},   // Po     [3] SHARADA CONTINUATION SIGN..SHARADA SECTION MARK-2
+	{runeRange{0x11200, 0x11211}, eawprN},   // Lo    [18] KHOJKI LETTER A..KHOJKI LETTER JJA
+	{runeRange{0x1122C, 0x1122E}, eawprN},   // Mc     [3] KHOJKI VOWEL SIGN AA..KHOJKI VOWEL SIGN II
+	{runeRange{0x11232, 0x11233}, eawprN},   // Mc     [2] KHOJKI VOWEL SIGN O..KHOJKI VOWEL SIGN AU
+	{runeRange{0x11235, 0x11235}, eawprN},   // Mc         KHOJKI SIGN VIRAMA
+	{runeRange{0x11238, 0x1123D}, eawprN},   // Po     [6] KHOJKI DANDA..KHOJKI ABBREVIATION SIGN
+	{runeRange{0x1123F, 0x11240}, eawprN},   // Lo     [2] KHOJKI LETTER QA..KHOJKI LETTER SHORT I
+	{runeRange{0x11280, 0x11286}, eawprN},   // Lo     [7] MULTANI LETTER A..MULTANI LETTER GA
+	{runeRange{0x1128A, 0x1128D}, eawprN},   // Lo     [4] MULTANI LETTER CA..MULTANI LETTER JJA
+	{runeRange{0x1129F, 0x112A8}, eawprN},   // Lo    [10] MULTANI LETTER BHA..MULTANI LETTER RHA
+	{runeRange{0x112B0, 0x112DE}, eawprN},   // Lo    [47] KHUDAWADI LETTER A..KHUDAWADI LETTER HA
+	{runeRange{0x112E0, 0x112E2}, eawprN},   // Mc     [3] KHUDAWADI VOWEL SIGN AA..KHUDAWADI VOWEL SIGN II
+	{runeRange{0x112F0, 0x112F9}, eawprN},   // Nd    [10] KHUDAWADI DIGIT ZERO..KHUDAWADI DIGIT NINE
+	{runeRange{0x11302, 0x11303}, eawprN},   // Mc     [2] GRANTHA SIGN ANUSVARA..GRANTHA SIGN VISARGA
+	{runeRange{0x1130F, 0x11310}, eawprN},   // Lo     [2] GRANTHA LETTER EE..GRANTHA LETTER AI
+	{runeRange{0x1132A, 0x11330}, eawprN},   // Lo     [7] GRANTHA LETTER PA..GRANTHA LETTER RA
+	{runeRange{0x11335, 0x11339}, eawprN},   // Lo     [5] GRANTHA LETTER VA..GRANTHA LETTER HA
+	{runeRange{0x1133D, 0x1133D}, eawprN},   // Lo         GRANTHA SIGN AVAGRAHA
+	{runeRange{0x11340, 0x11340}, eawprN},   // Mn         GRANTHA VOWEL SIGN II
+	{runeRange{0x11347, 0x11348}, eawprN},   // Mc     [2] GRANTHA VOWEL SIGN EE..GRANTHA VOWEL SIGN AI
+	{runeRange{0x11350, 0x11350}, eawprN},   // Lo         GRANTHA OM
+	{runeRange{0x1135D, 0x11361}, eawprN},   // Lo     [5] GRANTHA SIGN PLUTA..GRANTHA LETTER VOCALIC LL
+	{runeRange{0x11366, 0x1136C}, eawprN},   // Mn     [7] COMBINING GRANTHA DIGIT ZERO..COMBINING GRANTHA DIGIT SIX
+	{runeRange{0x11400, 0x11434}, eawprN},   // Lo    [53] NEWA LETTER A..NEWA LETTER HA
+	{runeRange{0x11438, 0x1143F}, eawprN},   // Mn     [8] NEWA VOWEL SIGN U..NEWA VOWEL SIGN AI
+	{runeRange{0x11442, 0x11444}, eawprN},   // Mn     [3] NEWA SIGN VIRAMA..NEWA SIGN ANUSVARA
+	{runeRange{0x11446, 0x11446}, eawprN},   // Mn         NEWA SIGN NUKTA
+	{runeRange{0x1144B, 0x1144F}, eawprN},   // Po     [5] NEWA DANDA..NEWA ABBREVIATION SIGN
+	{runeRange{0x1145A, 0x1145B}, eawprN},   // Po     [2] NEWA DOUBLE COMMA..NEWA PLACEHOLDER MARK
+	{runeRange{0x1145E, 0x1145E}, eawprN},   // Mn         NEWA SANDHI MARK
+	{runeRange{0x11480, 0x114AF}, eawprN},   // Lo    [48] TIRHUTA ANJI..TIRHUTA LETTER HA
+	{runeRange{0x114B3, 0x114B8}, eawprN},   // Mn     [6] TIRHUTA VOWEL SIGN U..TIRHUTA VOWEL SIGN VOCALIC LL
+	{runeRange{0x114BA, 0x114BA}, eawprN},   // Mn         TIRHUTA VOWEL SIGN SHORT E
+	{runeRange{0x114BF, 0x114C0}, eawprN},   // Mn     [2] TIRHUTA SIGN CANDRABINDU..TIRHUTA SIGN ANUSVARA
+	{runeRange{0x114C2, 0x114C3}, eawprN},   // Mn     [2] TIRHUTA SIGN VIRAMA..TIRHUTA SIGN NUKTA
+	{runeRange{0x114C6, 0x114C6}, eawprN},   // Po         TIRHUTA ABBREVIATION SIGN
+	{runeRange{0x114D0, 0x114D9}, eawprN},   // Nd    [10] TIRHUTA DIGIT ZERO..TIRHUTA DIGIT NINE
+	{runeRange{0x115AF, 0x115B1}, eawprN},   // Mc     [3] SIDDHAM VOWEL SIGN AA..SIDDHAM VOWEL SIGN II
+	{runeRange{0x115B8, 0x115BB}, eawprN},   // Mc     [4] SIDDHAM VOWEL SIGN E..SIDDHAM VOWEL SIGN AU
+	{runeRange{0x115BE, 0x115BE}, eawprN},   // Mc         SIDDHAM SIGN VISARGA
+	{runeRange{0x115C1, 0x115D7}, eawprN},   // Po    [23] SIDDHAM SIGN SIDDHAM..SIDDHAM SECTION MARK WITH CIRCLES AND FOUR ENCLOSURES
+	{runeRange{0x115DC, 0x115DD}, eawprN},   // Mn     [2] SIDDHAM VOWEL SIGN ALTERNATE U..SIDDHAM VOWEL SIGN ALTERNATE UU
+	{runeRange{0x11630, 0x11632}, eawprN},   // Mc     [3] MODI VOWEL SIGN AA..MODI VOWEL SIGN II
+	{runeRange{0x1163B, 0x1163C}, eawprN},   // Mc     [2] MODI VOWEL SIGN O..MODI VOWEL SIGN AU
+	{runeRange{0x1163E, 0x1163E}, eawprN},   // Mc         MODI SIGN VISARGA
+	{runeRange{0x11641, 0x11643}, eawprN},   // Po     [3] MODI DANDA..MODI ABBREVIATION SIGN
+	{runeRange{0x11650, 0x11659}, eawprN},   // Nd    [10] MODI DIGIT ZERO..MODI DIGIT NINE
+	{runeRange{0x11680, 0x116AA}, eawprN},   // Lo    [43] TAKRI LETTER A..TAKRI LETTER RRA
+	{runeRange{0x116AC, 0x116AC}, eawprN},   // Mc         TAKRI SIGN VISARGA
+	{runeRange{0x116AE, 0x116AF}, eawprN},   // Mc     [2] TAKRI VOWEL SIGN I..TAKRI VOWEL SIGN II
+	{runeRange{0x116B6, 0x116B6}, eawprN},   // Mc         TAKRI SIGN VIRAMA
+	{runeRange{0x116B8, 0x116B8}, eawprN},   // Lo         TAKRI LETTER ARCHAIC KHA
+	{runeRange{0x116C0, 0x116C9}, eawprN},   // Nd    [10] TAKRI DIGIT ZERO..TAKRI DIGIT NINE
+	{runeRange{0x1171D, 0x1171F}, eawprN},   // Mn     [3] AHOM CONSONANT SIGN MEDIAL LA..AHOM CONSONANT SIGN MEDIAL LIGATING RA
+	{runeRange{0x11722, 0x11725}, eawprN},   // Mn     [4] AHOM VOWEL SIGN I..AHOM VOWEL SIGN UU
+	{runeRange{0x11727, 0x1172B}, eawprN},   // Mn     [5] AHOM VOWEL SIGN AW..AHOM SIGN KILLER
+	{runeRange{0x1173A, 0x1173B}, eawprN},   // No     [2] AHOM NUMBER TEN..AHOM NUMBER TWENTY
+	{runeRange{0x1173F, 0x1173F}, eawprN},   // So         AHOM SYMBOL VI
+	{runeRange{0x11800, 0x1182B}, eawprN},   // Lo    [44] DOGRA LETTER A..DOGRA LETTER RRA
+	{runeRange{0x1182F, 0x11837}, eawprN},   // Mn     [9] DOGRA VOWEL SIGN U..DOGRA SIGN ANUSVARA
+	{runeRange{0x11839, 0x1183A}, eawprN},   // Mn     [2] DOGRA SIGN VIRAMA..DOGRA SIGN NUKTA
+	{runeRange{0x118A0, 0x118DF}, eawprN},   // L&    [64] WARANG CITI CAPITAL LETTER NGAA..WARANG CITI SMALL LETTER VIYO
+	{runeRange{0x118EA, 0x118F2}, eawprN},   // No     [9] WARANG CITI NUMBER TEN..WARANG CITI NUMBER NINETY
+	{runeRange{0x11900, 0x11906}, eawprN},   // Lo     [7] DIVES AKURU LETTER A..DIVES AKURU LETTER E
+	{runeRange{0x1190C, 0x11913}, eawprN},   // Lo     [8] DIVES AKURU LETTER KA..DIVES AKURU LETTER JA
+	{runeRange{0x11918, 0x1192F}, eawprN},   // Lo    [24] DIVES AKURU LETTER DDA..DIVES AKURU LETTER ZA
+	{runeRange{0x11937, 0x11938}, eawprN},   // Mc     [2] DIVES AKURU VOWEL SIGN AI..DIVES AKURU VOWEL SIGN O
+	{runeRange{0x1193D, 0x1193D}, eawprN},   // Mc         DIVES AKURU SIGN HALANTA
+	{runeRange{0x1193F, 0x1193F}, eawprN},   // Lo         DIVES AKURU PREFIXED NASAL SIGN
+	{runeRange{0x11941, 0x11941}, eawprN},   // Lo         DIVES AKURU INITIAL RA
+	{runeRange{0x11943, 0x11943}, eawprN},   // Mn         DIVES AKURU SIGN NUKTA
+	{runeRange{0x11950, 0x11959}, eawprN},   // Nd    [10] DIVES AKURU DIGIT ZERO..DIVES AKURU DIGIT NINE
+	{runeRange{0x119AA, 0x119D0}, eawprN},   // Lo    [39] NANDINAGARI LETTER E..NANDINAGARI LETTER RRA
+	{runeRange{0x119D4, 0x119D7}, eawprN},   // Mn     [4] NANDINAGARI VOWEL SIGN U..NANDINAGARI VOWEL SIGN VOCALIC RR
+	{runeRange{0x119DC, 0x119DF}, eawprN},   // Mc     [4] NANDINAGARI VOWEL SIGN O..NANDINAGARI SIGN VISARGA
+	{runeRange{0x119E1, 0x119E1}, eawprN},   // Lo         NANDINAGARI SIGN AVAGRAHA
+	{runeRange{0x119E3, 0x119E3}, eawprN},   // Lo         NANDINAGARI HEADSTROKE
+	{runeRange{0x11A00, 0x11A00}, eawprN},   // Lo         ZANABAZAR SQUARE LETTER A
+	{runeRange{0x11A0B, 0x11A32}, eawprN},   // Lo    [40] ZANABAZAR SQUARE LETTER KA..ZANABAZAR SQUARE LETTER KSSA
+	{runeRange{0x11A39, 0x11A39}, eawprN},   // Mc         ZANABAZAR SQUARE SIGN VISARGA
+	{runeRange{0x11A3B, 0x11A3E}, eawprN},   // Mn     [4] ZANABAZAR SQUARE CLUSTER-FINAL LETTER YA..ZANABAZAR SQUARE CLUSTER-FINAL LETTER VA
+	{runeRange{0x11A47, 0x11A47}, eawprN},   // Mn         ZANABAZAR SQUARE SUBJOINER
+	{runeRange{0x11A51, 0x11A56}, eawprN},   // Mn     [6] SOYOMBO VOWEL SIGN I..SOYOMBO VOWEL SIGN OE
+	{runeRange{0x11A59, 0x11A5B}, eawprN},   // Mn     [3] SOYOMBO VOWEL SIGN VOCALIC R..SOYOMBO VOWEL LENGTH MARK
+	{runeRange{0x11A8A, 0x11A96}, eawprN},   // Mn    [13] SOYOMBO FINAL CONSONANT SIGN G..SOYOMBO SIGN ANUSVARA
+	{runeRange{0x11A98, 0x11A99}, eawprN},   // Mn     [2] SOYOMBO GEMINATION MARK..SOYOMBO SUBJOINER
+	{runeRange{0x11A9D, 0x11A9D}, eawprN},   // Lo         SOYOMBO MARK PLUTA
+	{runeRange{0x11AB0, 0x11ABF}, eawprN},   // Lo    [16] CANADIAN SYLLABICS NATTILIK HI..CANADIAN SYLLABICS SPA
+	{runeRange{0x11B00, 0x11B09}, eawprN},   // Po    [10] DEVANAGARI HEAD MARK..DEVANAGARI SIGN MINDU
+	{runeRange{0x11C0A, 0x11C2E}, eawprN},   // Lo    [37] BHAIKSUKI LETTER E..BHAIKSUKI LETTER HA
+	{runeRange{0x11C30, 0x11C36}, eawprN},   // Mn     [7] BHAIKSUKI VOWEL SIGN I..BHAIKSUKI VOWEL SIGN VOCALIC L
+	{runeRange{0x11C3E, 0x11C3E}, eawprN},   // Mc         BHAIKSUKI SIGN VISARGA
+	{runeRange{0x11C40, 0x11C40}, eawprN},   // Lo         BHAIKSUKI SIGN AVAGRAHA
+	{runeRange{0x11C50, 0x11C59}, eawprN},   // Nd    [10] BHAIKSUKI DIGIT ZERO..BHAIKSUKI DIGIT NINE
+	{runeRange{0x11C70, 0x11C71}, eawprN},   // Po     [2] MARCHEN HEAD MARK..MARCHEN MARK SHAD
+	{runeRange{0x11C92, 0x11CA7}, eawprN},   // Mn    [22] MARCHEN SUBJOINED LETTER KA..MARCHEN SUBJOINED LETTER ZA
+	{runeRange{0x11CAA, 0x11CB0}, eawprN},   // Mn     [7] MARCHEN SUBJOINED LETTER RA..MARCHEN VOWEL SIGN AA
+	{runeRange{0x11CB2, 0x11CB3}, eawprN},   // Mn     [2] MARCHEN VOWEL SIGN U..MARCHEN VOWEL SIGN E
+	{runeRange{0x11CB5, 0x11CB6}, eawprN},   // Mn     [2] MARCHEN SIGN ANUSVARA..MARCHEN SIGN CANDRABINDU
+	{runeRange{0x11D08, 0x11D09}, eawprN},   // Lo     [2] MASARAM GONDI LETTER AI..MASARAM GONDI LETTER O
+	{runeRange{0x11D31, 0x11D36}, eawprN},   // Mn     [6] MASARAM GONDI VOWEL SIGN AA..MASARAM GONDI VOWEL SIGN VOCALIC R
+	{runeRange{0x11D3C, 0x11D3D}, eawprN},   // Mn     [2] MASARAM GONDI VOWEL SIGN AI..MASARAM GONDI VOWEL SIGN O
+	{runeRange{0x11D46, 0x11D46}, eawprN},   // Lo         MASARAM GONDI REPHA
+	{runeRange{0x11D50, 0x11D59}, eawprN},   // Nd    [10] MASARAM GONDI DIGIT ZERO..MASARAM GONDI DIGIT NINE
+	{runeRange{0x11D67, 0x11D68}, eawprN},   // Lo     [2] GUNJALA GONDI LETTER EE..GUNJALA GONDI LETTER AI
+	{runeRange{0x11D8A, 0x11D8E}, eawprN},   // Mc     [5] GUNJALA GONDI VOWEL SIGN AA..GUNJALA GONDI VOWEL SIGN UU
+	{runeRange{0x11D93, 0x11D94}, eawprN},   // Mc     [2] GUNJALA GONDI VOWEL SIGN OO..GUNJALA GONDI VOWEL SIGN AU
+	{runeRange{0x11D96, 0x11D96}, eawprN},   // Mc         GUNJALA GONDI SIGN VISARGA
+	{runeRange{0x11D98, 0x11D98}, eawprN},   // Lo         GUNJALA GONDI OM
+	{runeRange{0x11EE0, 0x11EF2}, eawprN},   // Lo    [19] MAKASAR LETTER KA..MAKASAR ANGKA
+	{runeRange{0x11EF5, 0x11EF6}, eawprN},   // Mc     [2] MAKASAR VOWEL SIGN E..MAKASAR VOWEL SIGN O
+	{runeRange{0x11F00, 0x11F01}, eawprN},   // Mn     [2] KAWI SIGN CANDRABINDU..KAWI SIGN ANUSVARA
+	{runeRange{0x11F03, 0x11F03}, eawprN},   // Mc         KAWI SIGN VISARGA
+	{runeRange{0x11F12, 0x11F33}, eawprN},   // Lo    [34] KAWI LETTER KA..KAWI LETTER JNYA
+	{runeRange{0x11F36, 0x11F3A}, eawprN},   // Mn     [5] KAWI VOWEL SIGN I..KAWI VOWEL SIGN VOCALIC R
+	{runeRange{0x11F40, 0x11F40}, eawprN},   // Mn         KAWI VOWEL SIGN EU
+	{runeRange{0x11F42, 0x11F42}, eawprN},   // Mn         KAWI CONJOINER
+	{runeRange{0x11F50, 0x11F59}, eawprN},   // Nd    [10] KAWI DIGIT ZERO..KAWI DIGIT NINE
+	{runeRange{0x11FC0, 0x11FD4}, eawprN},   // No    [21] TAMIL FRACTION ONE THREE-HUNDRED-AND-TWENTIETH..TAMIL FRACTION DOWNSCALING FACTOR KIIZH
+	{runeRange{0x11FDD, 0x11FE0}, eawprN},   // Sc     [4] TAMIL SIGN KAACU..TAMIL SIGN VARAAKAN
+	{runeRange{0x11FFF, 0x11FFF}, eawprN},   // Po         TAMIL PUNCTUATION END OF TEXT
+	{runeRange{0x12400, 0x1246E}, eawprN},   // Nl   [111] CUNEIFORM NUMERIC SIGN TWO ASH..CUNEIFORM NUMERIC SIGN NINE U VARIANT FORM
+	{runeRange{0x12480, 0x12543}, eawprN},   // Lo   [196] CUNEIFORM SIGN AB TIMES NUN TENU..CUNEIFORM SIGN ZU5 TIMES THREE DISH TENU
+	{runeRange{0x12FF1, 0x12FF2}, eawprN},   // Po     [2] CYPRO-MINOAN SIGN CM301..CYPRO-MINOAN SIGN CM302
+	{runeRange{0x13430, 0x1343F}, eawprN},   // Cf    [16] EGYPTIAN HIEROGLYPH VERTICAL JOINER..EGYPTIAN HIEROGLYPH END WALLED ENCLOSURE
+	{runeRange{0x13441, 0x13446}, eawprN},   // Lo     [6] EGYPTIAN HIEROGLYPH FULL BLANK..EGYPTIAN HIEROGLYPH WIDE LOST SIGN
+	{runeRange{0x14400, 0x14646}, eawprN},   // Lo   [583] ANATOLIAN HIEROGLYPH A001..ANATOLIAN HIEROGLYPH A530
+	{runeRange{0x16A40, 0x16A5E}, eawprN},   // Lo    [31] MRO LETTER TA..MRO LETTER TEK
+	{runeRange{0x16A6E, 0x16A6F}, eawprN},   // Po     [2] MRO DANDA..MRO DOUBLE DANDA
+	{runeRange{0x16AC0, 0x16AC9}, eawprN},   // Nd    [10] TANGSA DIGIT ZERO..TANGSA DIGIT NINE
+	{runeRange{0x16AF0, 0x16AF4}, eawprN},   // Mn     [5] BASSA VAH COMBINING HIGH TONE..BASSA VAH COMBINING HIGH-LOW TONE
+	{runeRange{0x16B00, 0x16B2F}, eawprN},   // Lo    [48] PAHAWH HMONG VOWEL KEEB..PAHAWH HMONG CONSONANT CAU
+	{runeRange{0x16B37, 0x16B3B}, eawprN},   // Po     [5] PAHAWH HMONG SIGN VOS THOM..PAHAWH HMONG SIGN VOS FEEM
+	{runeRange{0x16B40, 0x16B43}, eawprN},   // Lm     [4] PAHAWH HMONG SIGN VOS SEEV..PAHAWH HMONG SIGN IB YAM
+	{runeRange{0x16B45, 0x16B45}, eawprN},   // So         PAHAWH HMONG SIGN CIM TSOV ROG
+	{runeRange{0x16B5B, 0x16B61}, eawprN},   // No     [7] PAHAWH HMONG NUMBER TENS..PAHAWH HMONG NUMBER TRILLIONS
+	{runeRange{0x16B7D, 0x16B8F}, eawprN},   // Lo    [19] PAHAWH HMONG CLAN SIGN TSHEEJ..PAHAWH HMONG CLAN SIGN VWJ
+	{runeRange{0x16E80, 0x16E96}, eawprN},   // No    [23] MEDEFAIDRIN DIGIT ZERO..MEDEFAIDRIN DIGIT THREE ALTERNATE FORM
+	{runeRange{0x16F00, 0x16F4A}, eawprN},   // Lo    [75] MIAO LETTER PA..MIAO LETTER RTE
+	{runeRange{0x16F50, 0x16F50}, eawprN},   // Lo         MIAO LETTER NASALIZATION
+	{runeRange{0x16F8F, 0x16F92}, eawprN},   // Mn     [4] MIAO TONE RIGHT..MIAO TONE BELOW
+	{runeRange{0x16FE0, 0x16FE1}, eawprW},   // Lm     [2] TANGUT ITERATION MARK..NUSHU ITERATION MARK
+	{runeRange{0x16FE3, 0x16FE3}, eawprW},   // Lm         OLD CHINESE ITERATION MARK
+	{runeRange{0x16FF0, 0x16FF1}, eawprW},   // Mc     [2] VIETNAMESE ALTERNATE READING MARK CA..VIETNAMESE ALTERNATE READING MARK NHAY
+	{runeRange{0x18800, 0x18AFF}, eawprW},   // Lo   [768] TANGUT COMPONENT-001..TANGUT COMPONENT-768
+	{runeRange{0x18D00, 0x18D08}, eawprW},   // Lo     [9] TANGUT IDEOGRAPH-18D00..TANGUT IDEOGRAPH-18D08
+	{runeRange{0x1AFF5, 0x1AFFB}, eawprW},   // Lm     [7] KATAKANA LETTER MINNAN TONE-7..KATAKANA LETTER MINNAN NASALIZED TONE-5
+	{runeRange{0x1B000, 0x1B0FF}, eawprW},   // Lo   [256] KATAKANA LETTER ARCHAIC E..HENTAIGANA LETTER RE-2
+	{runeRange{0x1B132, 0x1B132}, eawprW},   // Lo         HIRAGANA LETTER SMALL KO
+	{runeRange{0x1B155, 0x1B155}, eawprW},   // Lo         KATAKANA LETTER SMALL KO
+	{runeRange{0x1B170, 0x1B2FB}, eawprW},   // Lo   [396] NUSHU CHARACTER-1B170..NUSHU CHARACTER-1B2FB
+	{runeRange{0x1BC70, 0x1BC7C}, eawprN},   // Lo    [13] DUPLOYAN AFFIX LEFT HORIZONTAL SECANT..DUPLOYAN AFFIX ATTACHED TANGENT HOOK
+	{runeRange{0x1BC90, 0x1BC99}, eawprN},   // Lo    [10] DUPLOYAN AFFIX LOW ACUTE..DUPLOYAN AFFIX LOW ARROW
+	{runeRange{0x1BC9D, 0x1BC9E}, eawprN},   // Mn     [2] DUPLOYAN THICK LETTER SELECTOR..DUPLOYAN DOUBLE MARK
+	{runeRange{0x1BCA0, 0x1BCA3}, eawprN},   // Cf     [4] SHORTHAND FORMAT LETTER OVERLAP..SHORTHAND FORMAT UP STEP
+	{runeRange{0x1CF30, 0x1CF46}, eawprN},   // Mn    [23] ZNAMENNY COMBINING TONAL RANGE MARK MRACHNO..ZNAMENNY PRIZNAK MODIFIER ROG
+	{runeRange{0x1D000, 0x1D0F5}, eawprN},   // So   [246] BYZANTINE MUSICAL SYMBOL PSILI..BYZANTINE MUSICAL SYMBOL GORGON NEO KATO
+	{runeRange{0x1D129, 0x1D164}, eawprN},   // So    [60] MUSICAL SYMBOL MULTIPLE MEASURE REST..MUSICAL SYMBOL ONE HUNDRED TWENTY-EIGHTH NOTE
+	{runeRange{0x1D167, 0x1D169}, eawprN},   // Mn     [3] MUSICAL SYMBOL COMBINING TREMOLO-1..MUSICAL SYMBOL COMBINING TREMOLO-3
+	{runeRange{0x1D16D, 0x1D172}, eawprN},   // Mc     [6] MUSICAL SYMBOL COMBINING AUGMENTATION DOT..MUSICAL SYMBOL COMBINING FLAG-5
+	{runeRange{0x1D17B, 0x1D182}, eawprN},   // Mn     [8] MUSICAL SYMBOL COMBINING ACCENT..MUSICAL SYMBOL COMBINING LOURE
+	{runeRange{0x1D185, 0x1D18B}, eawprN},   // Mn     [7] MUSICAL SYMBOL COMBINING DOIT..MUSICAL SYMBOL COMBINING TRIPLE TONGUE
+	{runeRange{0x1D1AA, 0x1D1AD}, eawprN},   // Mn     [4] MUSICAL SYMBOL COMBINING DOWN BOW..MUSICAL SYMBOL COMBINING SNAP PIZZICATO
+	{runeRange{0x1D200, 0x1D241}, eawprN},   // So    [66] GREEK VOCAL NOTATION SYMBOL-1..GREEK INSTRUMENTAL NOTATION SYMBOL-54
+	{runeRange{0x1D245, 0x1D245}, eawprN},   // So         GREEK MUSICAL LEIMMA
+	{runeRange{0x1D2E0, 0x1D2F3}, eawprN},   // No    [20] MAYAN NUMERAL ZERO..MAYAN NUMERAL NINETEEN
+	{runeRange{0x1D360, 0x1D378}, eawprN},   // No    [25] COUNTING ROD UNIT DIGIT ONE..TALLY MARK FIVE
+	{runeRange{0x1D456, 0x1D49C}, eawprN},   // L&    [71] MATHEMATICAL ITALIC SMALL I..MATHEMATICAL SCRIPT CAPITAL A
+	{runeRange{0x1D4A2, 0x1D4A2}, eawprN},   // Lu         MATHEMATICAL SCRIPT CAPITAL G
+	{runeRange{0x1D4A9, 0x1D4AC}, eawprN},   // Lu     [4] MATHEMATICAL SCRIPT CAPITAL N..MATHEMATICAL SCRIPT CAPITAL Q
+	{runeRange{0x1D4BB, 0x1D4BB}, eawprN},   // Ll         MATHEMATICAL SCRIPT SMALL F
+	{runeRange{0x1D4C5, 0x1D505}, eawprN},   // L&    [65] MATHEMATICAL SCRIPT SMALL P..MATHEMATICAL FRAKTUR CAPITAL B
+	{runeRange{0x1D50D, 0x1D514}, eawprN},   // Lu     [8] MATHEMATICAL FRAKTUR CAPITAL J..MATHEMATICAL FRAKTUR CAPITAL Q
+	{runeRange{0x1D51E, 0x1D539}, eawprN},   // L&    [28] MATHEMATICAL FRAKTUR SMALL A..MATHEMATICAL DOUBLE-STRUCK CAPITAL B
+	{runeRange{0x1D540, 0x1D544}, eawprN},   // Lu     [5] MATHEMATICAL DOUBLE-STRUCK CAPITAL I..MATHEMATICAL DOUBLE-STRUCK CAPITAL M
+	{runeRange{0x1D54A, 0x1D550}, eawprN},   // Lu     [7] MATHEMATICAL DOUBLE-STRUCK CAPITAL S..MATHEMATICAL DOUBLE-STRUCK CAPITAL Y
+	{runeRange{0x1D6A8, 0x1D6C0}, eawprN},   // Lu    [25] MATHEMATICAL BOLD CAPITAL ALPHA..MATHEMATICAL BOLD CAPITAL OMEGA
+	{runeRange{0x1D6C2, 0x1D6DA}, eawprN},   // Ll    [25] MATHEMATICAL BOLD SMALL ALPHA..MATHEMATICAL BOLD SMALL OMEGA
+	{runeRange{0x1D6DC, 0x1D6FA}, eawprN},   // L&    [31] MATHEMATICAL BOLD EPSILON SYMBOL..MATHEMATICAL ITALIC CAPITAL OMEGA
+	{runeRange{0x1D6FC, 0x1D714}, eawprN},   // Ll    [25] MATHEMATICAL ITALIC SMALL ALPHA..MATHEMATICAL ITALIC SMALL OMEGA
+	{runeRange{0x1D716, 0x1D734}, eawprN},   // L&    [31] MATHEMATICAL ITALIC EPSILON SYMBOL..MATHEMATICAL BOLD ITALIC CAPITAL OMEGA
+	{runeRange{0x1D736, 0x1D74E}, eawprN},   // Ll    [25] MATHEMATICAL BOLD ITALIC SMALL ALPHA..MATHEMATICAL BOLD ITALIC SMALL OMEGA
+	{runeRange{0x1D750, 0x1D76E}, eawprN},   // L&    [31] MATHEMATICAL BOLD ITALIC EPSILON SYMBOL..MATHEMATICAL SANS-SERIF BOLD CAPITAL OMEGA
+	{runeRange{0x1D770, 0x1D788}, eawprN},   // Ll    [25] MATHEMATICAL SANS-SERIF BOLD SMALL ALPHA..MATHEMATICAL SANS-SERIF BOLD SMALL OMEGA
+	{runeRange{0x1D78A, 0x1D7A8}, eawprN},   // L&    [31] MATHEMATICAL SANS-SERIF BOLD EPSILON SYMBOL..MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL OMEGA
+	{runeRange{0x1D7AA, 0x1D7C2}, eawprN},   // Ll    [25] MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL ALPHA..MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL OMEGA
+	{runeRange{0x1D7C4, 0x1D7CB}, eawprN},   // L&     [8] MATHEMATICAL SANS-SERIF BOLD ITALIC EPSILON SYMBOL..MATHEMATICAL BOLD SMALL DIGAMMA
+	{runeRange{0x1D800, 0x1D9FF}, eawprN},   // So   [512] SIGNWRITING HAND-FIST INDEX..SIGNWRITING HEAD
+	{runeRange{0x1DA37, 0x1DA3A}, eawprN},   // So     [4] SIGNWRITING AIR BLOW SMALL ROTATIONS..SIGNWRITING BREATH EXHALE
+	{runeRange{0x1DA6D, 0x1DA74}, eawprN},   // So     [8] SIGNWRITING SHOULDER HIP SPINE..SIGNWRITING TORSO-FLOORPLANE TWISTING
+	{runeRange{0x1DA76, 0x1DA83}, eawprN},   // So    [14] SIGNWRITING LIMB COMBINATION..SIGNWRITING LOCATION DEPTH
+	{runeRange{0x1DA85, 0x1DA86}, eawprN},   // So     [2] SIGNWRITING LOCATION TORSO..SIGNWRITING LOCATION LIMBS DIGITS
+	{runeRange{0x1DA9B, 0x1DA9F}, eawprN},   // Mn     [5] SIGNWRITING FILL MODIFIER-2..SIGNWRITING FILL MODIFIER-6
+	{runeRange{0x1DF00, 0x1DF09}, eawprN},   // Ll    [10] LATIN SMALL LETTER FENG DIGRAPH WITH TRILL..LATIN SMALL LETTER T WITH HOOK AND RETROFLEX HOOK
+	{runeRange{0x1DF0B, 0x1DF1E}, eawprN},   // Ll    [20] LATIN SMALL LETTER ESH WITH DOUBLE BAR..LATIN SMALL LETTER S WITH CURL
+	{runeRange{0x1E000, 0x1E006}, eawprN},   // Mn     [7] COMBINING GLAGOLITIC LETTER AZU..COMBINING GLAGOLITIC LETTER ZHIVETE
+	{runeRange{0x1E01B, 0x1E021}, eawprN},   // Mn     [7] COMBINING GLAGOLITIC LETTER SHTA..COMBINING GLAGOLITIC LETTER YATI
+	{runeRange{0x1E026, 0x1E02A}, eawprN},   // Mn     [5] COMBINING GLAGOLITIC LETTER YO..COMBINING GLAGOLITIC LETTER FITA
+	{runeRange{0x1E08F, 0x1E08F}, eawprN},   // Mn         COMBINING CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I
+	{runeRange{0x1E130, 0x1E136}, eawprN},   // Mn     [7] NYIAKENG PUACHUE HMONG TONE-B..NYIAKENG PUACHUE HMONG TONE-D
+	{runeRange{0x1E140, 0x1E149}, eawprN},   // Nd    [10] NYIAKENG PUACHUE HMONG DIGIT ZERO..NYIAKENG PUACHUE HMONG DIGIT NINE
+	{runeRange{0x1E14F, 0x1E14F}, eawprN},   // So         NYIAKENG PUACHUE HMONG CIRCLED CA
+	{runeRange{0x1E2AE, 0x1E2AE}, eawprN},   // Mn         TOTO SIGN RISING TONE
+	{runeRange{0x1E2EC, 0x1E2EF}, eawprN},   // Mn     [4] WANCHO TONE TUP..WANCHO TONE KOINI
+	{runeRange{0x1E2FF, 0x1E2FF}, eawprN},   // Sc         WANCHO NGUN SIGN
+	{runeRange{0x1E4EB, 0x1E4EB}, eawprN},   // Lm         NAG MUNDARI SIGN OJOD
+	{runeRange{0x1E4F0, 0x1E4F9}, eawprN},   // Nd    [10] NAG MUNDARI DIGIT ZERO..NAG MUNDARI DIGIT NINE
+	{runeRange{0x1E7E8, 0x1E7EB}, eawprN},   // Lo     [4] ETHIOPIC SYLLABLE GURAGE HHWA..ETHIOPIC SYLLABLE HHWE
+	{runeRange{0x1E7F0, 0x1E7FE}, eawprN},   // Lo    [15] ETHIOPIC SYLLABLE GURAGE QWI..ETHIOPIC SYLLABLE GURAGE PWEE
+	{runeRange{0x1E8C7, 0x1E8CF}, eawprN},   // No     [9] MENDE KIKAKUI DIGIT ONE..MENDE KIKAKUI DIGIT NINE
+	{runeRange{0x1E900, 0x1E943}, eawprN},   // L&    [68] ADLAM CAPITAL LETTER ALIF..ADLAM SMALL LETTER SHA
+	{runeRange{0x1E94B, 0x1E94B}, eawprN},   // Lm         ADLAM NASALIZATION MARK
+	{runeRange{0x1E95E, 0x1E95F}, eawprN},   // Po     [2] ADLAM INITIAL EXCLAMATION MARK..ADLAM INITIAL QUESTION MARK
+	{runeRange{0x1ECAC, 0x1ECAC}, eawprN},   // So         INDIC SIYAQ PLACEHOLDER
+	{runeRange{0x1ECB0, 0x1ECB0}, eawprN},   // Sc         INDIC SIYAQ RUPEE MARK
+	{runeRange{0x1ED01, 0x1ED2D}, eawprN},   // No    [45] OTTOMAN SIYAQ NUMBER ONE..OTTOMAN SIYAQ NUMBER NINETY THOUSAND
+	{runeRange{0x1ED2F, 0x1ED3D}, eawprN},   // No    [15] OTTOMAN SIYAQ ALTERNATE NUMBER TWO..OTTOMAN SIYAQ FRACTION ONE SIXTH
+	{runeRange{0x1EE05, 0x1EE1F}, eawprN},   // Lo    [27] ARABIC MATHEMATICAL WAW..ARABIC MATHEMATICAL DOTLESS QAF
+	{runeRange{0x1EE24, 0x1EE24}, eawprN},   // Lo         ARABIC MATHEMATICAL INITIAL HEH
+	{runeRange{0x1EE29, 0x1EE32}, eawprN},   // Lo    [10] ARABIC MATHEMATICAL INITIAL YEH..ARABIC MATHEMATICAL INITIAL QAF
+	{runeRange{0x1EE39, 0x1EE39}, eawprN},   // Lo         ARABIC MATHEMATICAL INITIAL DAD
+	{runeRange{0x1EE42, 0x1EE42}, eawprN},   // Lo         ARABIC MATHEMATICAL TAILED JEEM
+	{runeRange{0x1EE49, 0x1EE49}, eawprN},   // Lo         ARABIC MATHEMATICAL TAILED YEH
+	{runeRange{0x1EE4D, 0x1EE4F}, eawprN},   // Lo     [3] ARABIC MATHEMATICAL TAILED NOON..ARABIC MATHEMATICAL TAILED AIN
+	{runeRange{0x1EE54, 0x1EE54}, eawprN},   // Lo         ARABIC MATHEMATICAL TAILED SHEEN
+	{runeRange{0x1EE59, 0x1EE59}, eawprN},   // Lo         ARABIC MATHEMATICAL TAILED DAD
+	{runeRange{0x1EE5D, 0x1EE5D}, eawprN},   // Lo         ARABIC MATHEMATICAL TAILED DOTLESS NOON
+	{runeRange{0x1EE61, 0x1EE62}, eawprN},   // Lo     [2] ARABIC MATHEMATICAL STRETCHED BEH..ARABIC MATHEMATICAL STRETCHED JEEM
+	{runeRange{0x1EE67, 0x1EE6A}, eawprN},   // Lo     [4] ARABIC MATHEMATICAL STRETCHED HAH..ARABIC MATHEMATICAL STRETCHED KAF
+	{runeRange{0x1EE74, 0x1EE77}, eawprN},   // Lo     [4] ARABIC MATHEMATICAL STRETCHED SHEEN..ARABIC MATHEMATICAL STRETCHED KHAH
+	{runeRange{0x1EE7E, 0x1EE7E}, eawprN},   // Lo         ARABIC MATHEMATICAL STRETCHED DOTLESS FEH
+	{runeRange{0x1EE8B, 0x1EE9B}, eawprN},   // Lo    [17] ARABIC MATHEMATICAL LOOPED LAM..ARABIC MATHEMATICAL LOOPED GHAIN
+	{runeRange{0x1EEA5, 0x1EEA9}, eawprN},   // Lo     [5] ARABIC MATHEMATICAL DOUBLE-STRUCK WAW..ARABIC MATHEMATICAL DOUBLE-STRUCK YEH
+	{runeRange{0x1EEF0, 0x1EEF1}, eawprN},   // Sm     [2] ARABIC MATHEMATICAL OPERATOR MEEM WITH HAH WITH TATWEEL..ARABIC MATHEMATICAL OPERATOR HAH WITH DAL
+	{runeRange{0x1F004, 0x1F004}, eawprW},   // So         MAHJONG TILE RED DRAGON
+	{runeRange{0x1F030, 0x1F093}, eawprN},   // So   [100] DOMINO TILE HORIZONTAL BACK..DOMINO TILE VERTICAL-06-06
+	{runeRange{0x1F0B1, 0x1F0BF}, eawprN},   // So    [15] PLAYING CARD ACE OF HEARTS..PLAYING CARD RED JOKER
+	{runeRange{0x1F0CF, 0x1F0CF}, eawprW},   // So         PLAYING CARD BLACK JOKER
+	{runeRange{0x1F100, 0x1F10A}, eawprA},   // No    [11] DIGIT ZERO FULL STOP..DIGIT NINE COMMA
+	{runeRange{0x1F10D, 0x1F10F}, eawprN},   // So     [3] CIRCLED ZERO WITH SLASH..CIRCLED DOLLAR SIGN WITH OVERLAID BACKSLASH
+	{runeRange{0x1F12E, 0x1F12F}, eawprN},   // So     [2] CIRCLED WZ..COPYLEFT SYMBOL
+	{runeRange{0x1F16A, 0x1F16F}, eawprN},   // So     [6] RAISED MC SIGN..CIRCLED HUMAN FIGURE
+	{runeRange{0x1F18E, 0x1F18E}, eawprW},   // So         NEGATIVE SQUARED AB
+	{runeRange{0x1F191, 0x1F19A}, eawprW},   // So    [10] SQUARED CL..SQUARED VS
+	{runeRange{0x1F1AD, 0x1F1AD}, eawprN},   // So         MASK WORK SYMBOL
+	{runeRange{0x1F200, 0x1F202}, eawprW},   // So     [3] SQUARE HIRAGANA HOKA..SQUARED KATAKANA SA
+	{runeRange{0x1F240, 0x1F248}, eawprW},   // So     [9] TORTOISE SHELL BRACKETED CJK UNIFIED IDEOGRAPH-672C..TORTOISE SHELL BRACKETED CJK UNIFIED IDEOGRAPH-6557
+	{runeRange{0x1F260, 0x1F265}, eawprW},   // So     [6] ROUNDED SYMBOL FOR FU..ROUNDED SYMBOL FOR CAI
+	{runeRange{0x1F321, 0x1F32C}, eawprN},   // So    [12] THERMOMETER..WIND BLOWING FACE
+	{runeRange{0x1F336, 0x1F336}, eawprN},   // So         HOT PEPPER
+	{runeRange{0x1F37D, 0x1F37D}, eawprN},   // So         FORK AND KNIFE WITH PLATE
+	{runeRange{0x1F394, 0x1F39F}, eawprN},   // So    [12] HEART WITH TIP ON THE LEFT..ADMISSION TICKETS
+	{runeRange{0x1F3CB, 0x1F3CE}, eawprN},   // So     [4] WEIGHT LIFTER..RACING CAR
+	{runeRange{0x1F3D4, 0x1F3DF}, eawprN},   // So    [12] SNOW CAPPED MOUNTAIN..STADIUM
+	{runeRange{0x1F3F1, 0x1F3F3}, eawprN},   // So     [3] WHITE PENNANT..WAVING WHITE FLAG
+	{runeRange{0x1F3F5, 0x1F3F7}, eawprN},   // So     [3] ROSETTE..LABEL
+	{runeRange{0x1F3FB, 0x1F3FF}, eawprW},   // Sk     [5] EMOJI MODIFIER FITZPATRICK TYPE-1-2..EMOJI MODIFIER FITZPATRICK TYPE-6
+	{runeRange{0x1F43F, 0x1F43F}, eawprN},   // So         CHIPMUNK
+	{runeRange{0x1F441, 0x1F441}, eawprN},   // So         EYE
+	{runeRange{0x1F4FD, 0x1F4FE}, eawprN},   // So     [2] FILM PROJECTOR..PORTABLE STEREO
+	{runeRange{0x1F53E, 0x1F54A}, eawprN},   // So    [13] LOWER RIGHT SHADOWED WHITE CIRCLE..DOVE OF PEACE
+	{runeRange{0x1F54F, 0x1F54F}, eawprN},   // So         BOWL OF HYGIEIA
+	{runeRange{0x1F568, 0x1F579}, eawprN},   // So    [18] RIGHT SPEAKER..JOYSTICK
+	{runeRange{0x1F57B, 0x1F594}, eawprN},   // So    [26] LEFT HAND TELEPHONE RECEIVER..REVERSED VICTORY HAND
+	{runeRange{0x1F597, 0x1F5A3}, eawprN},   // So    [13] WHITE DOWN POINTING LEFT HAND INDEX..BLACK DOWN POINTING BACKHAND INDEX
+	{runeRange{0x1F5A5, 0x1F5FA}, eawprN},   // So    [86] DESKTOP COMPUTER..WORLD MAP
+	{runeRange{0x1F600, 0x1F64F}, eawprW},   // So    [80] GRINNING FACE..PERSON WITH FOLDED HANDS
+	{runeRange{0x1F680, 0x1F6C5}, eawprW},   // So    [70] ROCKET..LEFT LUGGAGE
+	{runeRange{0x1F6CC, 0x1F6CC}, eawprW},   // So         SLEEPING ACCOMMODATION
+	{runeRange{0x1F6D0, 0x1F6D2}, eawprW},   // So     [3] PLACE OF WORSHIP..SHOPPING TROLLEY
+	{runeRange{0x1F6D5, 0x1F6D7}, eawprW},   // So     [3] HINDU TEMPLE..ELEVATOR
+	{runeRange{0x1F6E0, 0x1F6EA}, eawprN},   // So    [11] HAMMER AND WRENCH..NORTHEAST-POINTING AIRPLANE
+	{runeRange{0x1F6F0, 0x1F6F3}, eawprN},   // So     [4] SATELLITE..PASSENGER SHIP
+	{runeRange{0x1F700, 0x1F776}, eawprN},   // So   [119] ALCHEMICAL SYMBOL FOR QUINTESSENCE..LUNAR ECLIPSE
+	{runeRange{0x1F780, 0x1F7D9}, eawprN},   // So    [90] BLACK LEFT-POINTING ISOSCELES RIGHT TRIANGLE..NINE POINTED WHITE STAR
+	{runeRange{0x1F7F0, 0x1F7F0}, eawprW},   // So         HEAVY EQUALS SIGN
+	{runeRange{0x1F810, 0x1F847}, eawprN},   // So    [56] LEFTWARDS ARROW WITH SMALL EQUILATERAL ARROWHEAD..DOWNWARDS HEAVY ARROW
+	{runeRange{0x1F860, 0x1F887}, eawprN},   // So    [40] WIDE-HEADED LEFTWARDS LIGHT BARB ARROW..WIDE-HEADED SOUTH WEST VERY HEAVY BARB ARROW
+	{runeRange{0x1F8B0, 0x1F8B1}, eawprN},   // So     [2] ARROW POINTING UPWARDS THEN NORTH WEST..ARROW POINTING RIGHTWARDS THEN CURVING SOUTH WEST
+	{runeRange{0x1F90C, 0x1F93A}, eawprW},   // So    [47] PINCHED FINGERS..FENCER
+	{runeRange{0x1F93C, 0x1F945}, eawprW},   // So    [10] WRESTLERS..GOAL NET
+	{runeRange{0x1F947, 0x1F9FF}, eawprW},   // So   [185] FIRST PLACE MEDAL..NAZAR AMULET
+	{runeRange{0x1FA60, 0x1FA6D}, eawprN},   // So    [14] XIANGQI RED GENERAL..XIANGQI BLACK SOLDIER
+	{runeRange{0x1FA80, 0x1FA88}, eawprW},   // So     [9] YO-YO..FLUTE
+	{runeRange{0x1FABF, 0x1FAC5}, eawprW},   // So     [7] GOOSE..PERSON WITH CROWN
+	{runeRange{0x1FAE0, 0x1FAE8}, eawprW},   // So     [9] MELTING FACE..SHAKING FACE
+	{runeRange{0x1FB00, 0x1FB92}, eawprN},   // So   [147] BLOCK SEXTANT-1..UPPER HALF INVERSE MEDIUM SHADE AND LOWER HALF BLOCK
+	{runeRange{0x1FBF0, 0x1FBF9}, eawprN},   // Nd    [10] SEGMENTED DIGIT ZERO..SEGMENTED DIGIT NINE
+	{runeRange{0x2A6E0, 0x2A6FF}, eawprW},   // Cn    [32] <reserved-2A6E0>..<reserved-2A6FF>
+	{runeRange{0x2B73A, 0x2B73F}, eawprW},   // Cn     [6] <reserved-2B73A>..<reserved-2B73F>
+	{runeRange{0x2B81E, 0x2B81F}, eawprW},   // Cn     [2] <reserved-2B81E>..<reserved-2B81F>
+	{runeRange{0x2CEA2, 0x2CEAF}, eawprW},   // Cn    [14] <reserved-2CEA2>..<reserved-2CEAF>
+	{runeRange{0x2EBE1, 0x2F7FF}, eawprW},   // Cn  [3103] <reserved-2EBE1>..<reserved-2F7FF>
+	{runeRange{0x2FA1E, 0x2FA1F}, eawprW},   // Cn     [2] <reserved-2FA1E>..<reserved-2FA1F>
+	{runeRange{0x30000, 0x3134A}, eawprW},   // Lo  [4939] CJK UNIFIED IDEOGRAPH-30000..CJK UNIFIED IDEOGRAPH-3134A
+	{runeRange{0x31350, 0x323AF}, eawprW},   // Lo  [4192] CJK UNIFIED IDEOGRAPH-31350..CJK UNIFIED IDEOGRAPH-323AF
+	{runeRange{0xE0001, 0xE0001}, eawprN},   // Cf         LANGUAGE TAG
+	{runeRange{0xE0100, 0xE01EF}, eawprA},   // Mn   [240] VARIATION SELECTOR-17..VARIATION SELECTOR-256
 	{runeRange{0x100000, 0x10FFFD}, eawprA}, // Co [65534] <private-use-100000>..<private-use-10FFFD>
+	{runeRange{0x0000, 0x001F}, eawprN},     // Cc    [32] <control-0000>..<control-001F>
+	{runeRange{0x0021, 0x0023}, eawprNa},    // Po     [3] EXCLAMATION MARK..NUMBER SIGN
+	{runeRange{0x0025, 0x0027}, eawprNa},    // Po     [3] PERCENT SIGN..APOSTROPHE
+	{runeRange{0x0029, 0x0029}, eawprNa},    // Pe         RIGHT PARENTHESIS
+	{runeRange{0x002B, 0x002B}, eawprNa},    // Sm         PLUS SIGN
+	{runeRange{0x002D, 0x002D}, eawprNa},    // Pd         HYPHEN-MINUS
+	{runeRange{0x0030, 0x0039}, eawprNa},    // Nd    [10] DIGIT ZERO..DIGIT NINE
+	{runeRange{0x003C, 0x003E}, eawprNa},    // Sm     [3] LESS-THAN SIGN..GREATER-THAN SIGN
+	{runeRange{0x0041, 0x005A}, eawprNa},    // Lu    [26] LATIN CAPITAL LETTER A..LATIN CAPITAL LETTER Z
+	{runeRange{0x005C, 0x005C}, eawprNa},    // Po         REVERSE SOLIDUS
+	{runeRange{0x005E, 0x005E}, eawprNa},    // Sk         CIRCUMFLEX ACCENT
+	{runeRange{0x0060, 0x0060}, eawprNa},    // Sk         GRAVE ACCENT
+	{runeRange{0x007B, 0x007B}, eawprNa},    // Ps         LEFT CURLY BRACKET
+	{runeRange{0x007D, 0x007D}, eawprNa},    // Pe         RIGHT CURLY BRACKET
+	{runeRange{0x007F, 0x007F}, eawprN},     // Cc         <control-007F>
+	{runeRange{0x00A0, 0x00A0}, eawprN},     // Zs         NO-BREAK SPACE
+	{runeRange{0x00A2, 0x00A3}, eawprNa},    // Sc     [2] CENT SIGN..POUND SIGN
+	{runeRange{0x00A5, 0x00A5}, eawprNa},    // Sc         YEN SIGN
+	{runeRange{0x00A7, 0x00A7}, eawprA},     // Po         SECTION SIGN
+	{runeRange{0x00A9, 0x00A9}, eawprN},     // So         COPYRIGHT SIGN
+	{runeRange{0x00AB, 0x00AB}, eawprN},     // Pi         LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
+	{runeRange{0x00AD, 0x00AD}, eawprA},     // Cf         SOFT HYPHEN
+	{runeRange{0x00AF, 0x00AF}, eawprNa},    // Sk         MACRON
+	{runeRange{0x00B1, 0x00B1}, eawprA},     // Sm         PLUS-MINUS SIGN
+	{runeRange{0x00B4, 0x00B4}, eawprA},     // Sk         ACUTE ACCENT
+	{runeRange{0x00B6, 0x00B7}, eawprA},     // Po     [2] PILCROW SIGN..MIDDLE DOT
+	{runeRange{0x00B9, 0x00B9}, eawprA},     // No         SUPERSCRIPT ONE
+	{runeRange{0x00BB, 0x00BB}, eawprN},     // Pf         RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
+	{runeRange{0x00BF, 0x00BF}, eawprA},     // Po         INVERTED QUESTION MARK
+	{runeRange{0x00C6, 0x00C6}, eawprA},     // Lu         LATIN CAPITAL LETTER AE
+	{runeRange{0x00D0, 0x00D0}, eawprA},     // Lu         LATIN CAPITAL LETTER ETH
+	{runeRange{0x00D7, 0x00D7}, eawprA},     // Sm         MULTIPLICATION SIGN
+	{runeRange{0x00D9, 0x00DD}, eawprN},     // Lu     [5] LATIN CAPITAL LETTER U WITH GRAVE..LATIN CAPITAL LETTER Y WITH ACUTE
+	{runeRange{0x00E2, 0x00E5}, eawprN},     // Ll     [4] LATIN SMALL LETTER A WITH CIRCUMFLEX..LATIN SMALL LETTER A WITH RING ABOVE
+	{runeRange{0x00E7, 0x00E7}, eawprN},     // Ll         LATIN SMALL LETTER C WITH CEDILLA
+	{runeRange{0x00EB, 0x00EB}, eawprN},     // Ll         LATIN SMALL LETTER E WITH DIAERESIS
+	{runeRange{0x00EE, 0x00EF}, eawprN},     // Ll     [2] LATIN SMALL LETTER I WITH CIRCUMFLEX..LATIN SMALL LETTER I WITH DIAERESIS
+	{runeRange{0x00F1, 0x00F1}, eawprN},     // Ll         LATIN SMALL LETTER N WITH TILDE
+	{runeRange{0x00F4, 0x00F6}, eawprN},     // Ll     [3] LATIN SMALL LETTER O WITH CIRCUMFLEX..LATIN SMALL LETTER O WITH DIAERESIS
+	{runeRange{0x00F8, 0x00FA}, eawprA},     // Ll     [3] LATIN SMALL LETTER O WITH STROKE..LATIN SMALL LETTER U WITH ACUTE
+	{runeRange{0x00FC, 0x00FC}, eawprA},     // Ll         LATIN SMALL LETTER U WITH DIAERESIS
+	{runeRange{0x00FE, 0x00FE}, eawprA},     // Ll         LATIN SMALL LETTER THORN
+	{runeRange{0x0100, 0x0100}, eawprN},     // Lu         LATIN CAPITAL LETTER A WITH MACRON
+	{runeRange{0x0102, 0x0110}, eawprN},     // L&    [15] LATIN CAPITAL LETTER A WITH BREVE..LATIN CAPITAL LETTER D WITH STROKE
+	{runeRange{0x0112, 0x0112}, eawprN},     // Lu         LATIN CAPITAL LETTER E WITH MACRON
+	{runeRange{0x0114, 0x011A}, eawprN},     // L&     [7] LATIN CAPITAL LETTER E WITH BREVE..LATIN CAPITAL LETTER E WITH CARON
+	{runeRange{0x011C, 0x0125}, eawprN},     // L&    [10] LATIN CAPITAL LETTER G WITH CIRCUMFLEX..LATIN SMALL LETTER H WITH CIRCUMFLEX
+	{runeRange{0x0128, 0x012A}, eawprN},     // L&     [3] LATIN CAPITAL LETTER I WITH TILDE..LATIN CAPITAL LETTER I WITH MACRON
+	{runeRange{0x012C, 0x0130}, eawprN},     // L&     [5] LATIN CAPITAL LETTER I WITH BREVE..LATIN CAPITAL LETTER I WITH DOT ABOVE
+	{runeRange{0x0134, 0x0137}, eawprN},     // L&     [4] LATIN CAPITAL LETTER J WITH CIRCUMFLEX..LATIN SMALL LETTER K WITH CEDILLA
+	{runeRange{0x0139, 0x013E}, eawprN},     // L&     [6] LATIN CAPITAL LETTER L WITH ACUTE..LATIN SMALL LETTER L WITH CARON
+	{runeRange{0x0143, 0x0143}, eawprN},     // Lu         LATIN CAPITAL LETTER N WITH ACUTE
+	{runeRange{0x0145, 0x0147}, eawprN},     // L&     [3] LATIN CAPITAL LETTER N WITH CEDILLA..LATIN CAPITAL LETTER N WITH CARON
+	{runeRange{0x014C, 0x014C}, eawprN},     // Lu         LATIN CAPITAL LETTER O WITH MACRON
+	{runeRange{0x014E, 0x0151}, eawprN},     // L&     [4] LATIN CAPITAL LETTER O WITH BREVE..LATIN SMALL LETTER O WITH DOUBLE ACUTE
+	{runeRange{0x0154, 0x0165}, eawprN},     // L&    [18] LATIN CAPITAL LETTER R WITH ACUTE..LATIN SMALL LETTER T WITH CARON
+	{runeRange{0x0168, 0x016A}, eawprN},     // L&     [3] LATIN CAPITAL LETTER U WITH TILDE..LATIN CAPITAL LETTER U WITH MACRON
+	{runeRange{0x016C, 0x017F}, eawprN},     // L&    [20] LATIN CAPITAL LETTER U WITH BREVE..LATIN SMALL LETTER LONG S
+	{runeRange{0x01BB, 0x01BB}, eawprN},     // Lo         LATIN LETTER TWO WITH STROKE
+	{runeRange{0x01C0, 0x01C3}, eawprN},     // Lo     [4] LATIN LETTER DENTAL CLICK..LATIN LETTER RETROFLEX CLICK
+	{runeRange{0x01CE, 0x01CE}, eawprA},     // Ll         LATIN SMALL LETTER A WITH CARON
+	{runeRange{0x01D0, 0x01D0}, eawprA},     // Ll         LATIN SMALL LETTER I WITH CARON
+	{runeRange{0x01D2, 0x01D2}, eawprA},     // Ll         LATIN SMALL LETTER O WITH CARON
+	{runeRange{0x01D4, 0x01D4}, eawprA},     // Ll         LATIN SMALL LETTER U WITH CARON
+	{runeRange{0x01D6, 0x01D6}, eawprA},     // Ll         LATIN SMALL LETTER U WITH DIAERESIS AND MACRON
+	{runeRange{0x01D8, 0x01D8}, eawprA},     // Ll         LATIN SMALL LETTER U WITH DIAERESIS AND ACUTE
+	{runeRange{0x01DA, 0x01DA}, eawprA},     // Ll         LATIN SMALL LETTER U WITH DIAERESIS AND CARON
+	{runeRange{0x01DC, 0x01DC}, eawprA},     // Ll         LATIN SMALL LETTER U WITH DIAERESIS AND GRAVE
+	{runeRange{0x0250, 0x0250}, eawprN},     // Ll         LATIN SMALL LETTER TURNED A
+	{runeRange{0x0252, 0x0260}, eawprN},     // Ll    [15] LATIN SMALL LETTER TURNED ALPHA..LATIN SMALL LETTER G WITH HOOK
+	{runeRange{0x0262, 0x0293}, eawprN},     // Ll    [50] LATIN LETTER SMALL CAPITAL G..LATIN SMALL LETTER EZH WITH CURL
+	{runeRange{0x0295, 0x02AF}, eawprN},     // Ll    [27] LATIN LETTER PHARYNGEAL VOICED FRICATIVE..LATIN SMALL LETTER TURNED H WITH FISHHOOK AND TAIL
+	{runeRange{0x02C2, 0x02C3}, eawprN},     // Sk     [2] MODIFIER LETTER LEFT ARROWHEAD..MODIFIER LETTER RIGHT ARROWHEAD
+	{runeRange{0x02C5, 0x02C5}, eawprN},     // Sk         MODIFIER LETTER DOWN ARROWHEAD
+	{runeRange{0x02C7, 0x02C7}, eawprA},     // Lm         CARON
+	{runeRange{0x02C9, 0x02CB}, eawprA},     // Lm     [3] MODIFIER LETTER MACRON..MODIFIER LETTER GRAVE ACCENT
+	{runeRange{0x02CD, 0x02CD}, eawprA},     // Lm         MODIFIER LETTER LOW MACRON
+	{runeRange{0x02D0, 0x02D0}, eawprA},     // Lm         MODIFIER LETTER TRIANGULAR COLON
+	{runeRange{0x02D2, 0x02D7}, eawprN},     // Sk     [6] MODIFIER LETTER CENTRED RIGHT HALF RING..MODIFIER LETTER MINUS SIGN
+	{runeRange{0x02DC, 0x02DC}, eawprN},     // Sk         SMALL TILDE
+	{runeRange{0x02DE, 0x02DE}, eawprN},     // Sk         MODIFIER LETTER RHOTIC HOOK
+	{runeRange{0x02E0, 0x02E4}, eawprN},     // Lm     [5] MODIFIER LETTER SMALL GAMMA..MODIFIER LETTER SMALL REVERSED GLOTTAL STOP
+	{runeRange{0x02EC, 0x02EC}, eawprN},     // Lm         MODIFIER LETTER VOICING
+	{runeRange{0x02EE, 0x02EE}, eawprN},     // Lm         MODIFIER LETTER DOUBLE APOSTROPHE
+	{runeRange{0x0300, 0x036F}, eawprA},     // Mn   [112] COMBINING GRAVE ACCENT..COMBINING LATIN SMALL LETTER X
+	{runeRange{0x0374, 0x0374}, eawprN},     // Lm         GREEK NUMERAL SIGN
+	{runeRange{0x0376, 0x0377}, eawprN},     // L&     [2] GREEK CAPITAL LETTER PAMPHYLIAN DIGAMMA..GREEK SMALL LETTER PAMPHYLIAN DIGAMMA
+	{runeRange{0x037B, 0x037D}, eawprN},     // Ll     [3] GREEK SMALL REVERSED LUNATE SIGMA SYMBOL..GREEK SMALL REVERSED DOTTED LUNATE SIGMA SYMBOL
+	{runeRange{0x037F, 0x037F}, eawprN},     // Lu         GREEK CAPITAL LETTER YOT
+	{runeRange{0x0386, 0x0386}, eawprN},     // Lu         GREEK CAPITAL LETTER ALPHA WITH TONOS
+	{runeRange{0x0388, 0x038A}, eawprN},     // Lu     [3] GREEK CAPITAL LETTER EPSILON WITH TONOS..GREEK CAPITAL LETTER IOTA WITH TONOS
+	{runeRange{0x038E, 0x0390}, eawprN},     // L&     [3] GREEK CAPITAL LETTER UPSILON WITH TONOS..GREEK SMALL LETTER IOTA WITH DIALYTIKA AND TONOS
+	{runeRange{0x03A3, 0x03A9}, eawprA},     // Lu     [7] GREEK CAPITAL LETTER SIGMA..GREEK CAPITAL LETTER OMEGA
+	{runeRange{0x03B1, 0x03C1}, eawprA},     // Ll    [17] GREEK SMALL LETTER ALPHA..GREEK SMALL LETTER RHO
+	{runeRange{0x03C3, 0x03C9}, eawprA},     // Ll     [7] GREEK SMALL LETTER SIGMA..GREEK SMALL LETTER OMEGA
+	{runeRange{0x03F6, 0x03F6}, eawprN},     // Sm         GREEK REVERSED LUNATE EPSILON SYMBOL
+	{runeRange{0x0400, 0x0400}, eawprN},     // Lu         CYRILLIC CAPITAL LETTER IE WITH GRAVE
+	{runeRange{0x0402, 0x040F}, eawprN},     // Lu    [14] CYRILLIC CAPITAL LETTER DJE..CYRILLIC CAPITAL LETTER DZHE
+	{runeRange{0x0450, 0x0450}, eawprN},     // Ll         CYRILLIC SMALL LETTER IE WITH GRAVE
+	{runeRange{0x0452, 0x0481}, eawprN},     // L&    [48] CYRILLIC SMALL LETTER DJE..CYRILLIC SMALL LETTER KOPPA
+	{runeRange{0x0483, 0x0487}, eawprN},     // Mn     [5] COMBINING CYRILLIC TITLO..COMBINING CYRILLIC POKRYTIE
+	{runeRange{0x048A, 0x04FF}, eawprN},     // L&   [118] CYRILLIC CAPITAL LETTER SHORT I WITH TAIL..CYRILLIC SMALL LETTER HA WITH STROKE
+	{runeRange{0x0531, 0x0556}, eawprN},     // Lu    [38] ARMENIAN CAPITAL LETTER AYB..ARMENIAN CAPITAL LETTER FEH
+	{runeRange{0x055A, 0x055F}, eawprN},     // Po     [6] ARMENIAN APOSTROPHE..ARMENIAN ABBREVIATION MARK
+	{runeRange{0x0589, 0x0589}, eawprN},     // Po         ARMENIAN FULL STOP
+	{runeRange{0x058D, 0x058E}, eawprN},     // So     [2] RIGHT-FACING ARMENIAN ETERNITY SIGN..LEFT-FACING ARMENIAN ETERNITY SIGN
+	{runeRange{0x0591, 0x05BD}, eawprN},     // Mn    [45] HEBREW ACCENT ETNAHTA..HEBREW POINT METEG
+	{runeRange{0x05BF, 0x05BF}, eawprN},     // Mn         HEBREW POINT RAFE
+	{runeRange{0x05C1, 0x05C2}, eawprN},     // Mn     [2] HEBREW POINT SHIN DOT..HEBREW POINT SIN DOT
+	{runeRange{0x05C4, 0x05C5}, eawprN},     // Mn     [2] HEBREW MARK UPPER DOT..HEBREW MARK LOWER DOT
+	{runeRange{0x05C7, 0x05C7}, eawprN},     // Mn         HEBREW POINT QAMATS QATAN
+	{runeRange{0x05EF, 0x05F2}, eawprN},     // Lo     [4] HEBREW YOD TRIANGLE..HEBREW LIGATURE YIDDISH DOUBLE YOD
+	{runeRange{0x0600, 0x0605}, eawprN},     // Cf     [6] ARABIC NUMBER SIGN..ARABIC NUMBER MARK ABOVE
+	{runeRange{0x0609, 0x060A}, eawprN},     // Po     [2] ARABIC-INDIC PER MILLE SIGN..ARABIC-INDIC PER TEN THOUSAND SIGN
+	{runeRange{0x060C, 0x060D}, eawprN},     // Po     [2] ARABIC COMMA..ARABIC DATE SEPARATOR
+	{runeRange{0x0610, 0x061A}, eawprN},     // Mn    [11] ARABIC SIGN SALLALLAHOU ALAYHE WASSALLAM..ARABIC SMALL KASRA
+	{runeRange{0x061C, 0x061C}, eawprN},     // Cf         ARABIC LETTER MARK
+	{runeRange{0x0620, 0x063F}, eawprN},     // Lo    [32] ARABIC LETTER KASHMIRI YEH..ARABIC LETTER FARSI YEH WITH THREE DOTS ABOVE
+	{runeRange{0x0641, 0x064A}, eawprN},     // Lo    [10] ARABIC LETTER FEH..ARABIC LETTER YEH
+	{runeRange{0x0660, 0x0669}, eawprN},     // Nd    [10] ARABIC-INDIC DIGIT ZERO..ARABIC-INDIC DIGIT NINE
+	{runeRange{0x066E, 0x066F}, eawprN},     // Lo     [2] ARABIC LETTER DOTLESS BEH..ARABIC LETTER DOTLESS QAF
+	{runeRange{0x0671, 0x06D3}, eawprN},     // Lo    [99] ARABIC LETTER ALEF WASLA..ARABIC LETTER YEH BARREE WITH HAMZA ABOVE
+	{runeRange{0x06D5, 0x06D5}, eawprN},     // Lo         ARABIC LETTER AE
+	{runeRange{0x06DD, 0x06DD}, eawprN},     // Cf         ARABIC END OF AYAH
+	{runeRange{0x06DF, 0x06E4}, eawprN},     // Mn     [6] ARABIC SMALL HIGH ROUNDED ZERO..ARABIC SMALL HIGH MADDA
+	{runeRange{0x06E7, 0x06E8}, eawprN},     // Mn     [2] ARABIC SMALL HIGH YEH..ARABIC SMALL HIGH NOON
+	{runeRange{0x06EA, 0x06ED}, eawprN},     // Mn     [4] ARABIC EMPTY CENTRE LOW STOP..ARABIC SMALL LOW MEEM
+	{runeRange{0x06F0, 0x06F9}, eawprN},     // Nd    [10] EXTENDED ARABIC-INDIC DIGIT ZERO..EXTENDED ARABIC-INDIC DIGIT NINE
+	{runeRange{0x06FD, 0x06FE}, eawprN},     // So     [2] ARABIC SIGN SINDHI AMPERSAND..ARABIC SIGN SINDHI POSTPOSITION MEN
+	{runeRange{0x0700, 0x070D}, eawprN},     // Po    [14] SYRIAC END OF PARAGRAPH..SYRIAC HARKLEAN ASTERISCUS
+	{runeRange{0x0710, 0x0710}, eawprN},     // Lo         SYRIAC LETTER ALAPH
+	{runeRange{0x0712, 0x072F}, eawprN},     // Lo    [30] SYRIAC LETTER BETH..SYRIAC LETTER PERSIAN DHALATH
+	{runeRange{0x074D, 0x074F}, eawprN},     // Lo     [3] SYRIAC LETTER SOGDIAN ZHAIN..SYRIAC LETTER SOGDIAN FE
+	{runeRange{0x0780, 0x07A5}, eawprN},     // Lo    [38] THAANA LETTER HAA..THAANA LETTER WAAVU
+	{runeRange{0x07B1, 0x07B1}, eawprN},     // Lo         THAANA LETTER NAA
+	{runeRange{0x07CA, 0x07EA}, eawprN},     // Lo    [33] NKO LETTER A..NKO LETTER JONA RA
+	{runeRange{0x07F4, 0x07F5}, eawprN},     // Lm     [2] NKO HIGH TONE APOSTROPHE..NKO LOW TONE APOSTROPHE
+	{runeRange{0x07F7, 0x07F9}, eawprN},     // Po     [3] NKO SYMBOL GBAKURUNEN..NKO EXCLAMATION MARK
+	{runeRange{0x07FD, 0x07FD}, eawprN},     // Mn         NKO DANTAYALAN
+	{runeRange{0x0800, 0x0815}, eawprN},     // Lo    [22] SAMARITAN LETTER ALAF..SAMARITAN LETTER TAAF
+	{runeRange{0x081A, 0x081A}, eawprN},     // Lm         SAMARITAN MODIFIER LETTER EPENTHETIC YUT
+	{runeRange{0x0824, 0x0824}, eawprN},     // Lm         SAMARITAN MODIFIER LETTER SHORT A
+	{runeRange{0x0828, 0x0828}, eawprN},     // Lm         SAMARITAN MODIFIER LETTER I
+	{runeRange{0x0830, 0x083E}, eawprN},     // Po    [15] SAMARITAN PUNCTUATION NEQUDAA..SAMARITAN PUNCTUATION ANNAAU
+	{runeRange{0x0859, 0x085B}, eawprN},     // Mn     [3] MANDAIC AFFRICATION MARK..MANDAIC GEMINATION MARK
+	{runeRange{0x0860, 0x086A}, eawprN},     // Lo    [11] SYRIAC LETTER MALAYALAM NGA..SYRIAC LETTER MALAYALAM SSA
+	{runeRange{0x0888, 0x0888}, eawprN},     // Sk         ARABIC RAISED ROUND DOT
+	{runeRange{0x0890, 0x0891}, eawprN},     // Cf     [2] ARABIC POUND MARK ABOVE..ARABIC PIASTRE MARK ABOVE
+	{runeRange{0x08A0, 0x08C8}, eawprN},     // Lo    [41] ARABIC LETTER BEH WITH SMALL V BELOW..ARABIC LETTER GRAF
+	{runeRange{0x08CA, 0x08E1}, eawprN},     // Mn    [24] ARABIC SMALL HIGH FARSI YEH..ARABIC SMALL HIGH SIGN SAFHA
+	{runeRange{0x08E3, 0x08FF}, eawprN},     // Mn    [29] ARABIC TURNED DAMMA BELOW..ARABIC MARK SIDEWAYS NOON GHUNNA
+	{runeRange{0x0903, 0x0903}, eawprN},     // Mc         DEVANAGARI SIGN VISARGA
+	{runeRange{0x093A, 0x093A}, eawprN},     // Mn         DEVANAGARI VOWEL SIGN OE
+	{runeRange{0x093C, 0x093C}, eawprN},     // Mn         DEVANAGARI SIGN NUKTA
+	{runeRange{0x093E, 0x0940}, eawprN},     // Mc     [3] DEVANAGARI VOWEL SIGN AA..DEVANAGARI VOWEL SIGN II
+	{runeRange{0x0949, 0x094C}, eawprN},     // Mc     [4] DEVANAGARI VOWEL SIGN CANDRA O..DEVANAGARI VOWEL SIGN AU
+	{runeRange{0x094E, 0x094F}, eawprN},     // Mc     [2] DEVANAGARI VOWEL SIGN PRISHTHAMATRA E..DEVANAGARI VOWEL SIGN AW
+	{runeRange{0x0951, 0x0957}, eawprN},     // Mn     [7] DEVANAGARI STRESS SIGN UDATTA..DEVANAGARI VOWEL SIGN UUE
+	{runeRange{0x0962, 0x0963}, eawprN},     // Mn     [2] DEVANAGARI VOWEL SIGN VOCALIC L..DEVANAGARI VOWEL SIGN VOCALIC LL
+	{runeRange{0x0966, 0x096F}, eawprN},     // Nd    [10] DEVANAGARI DIGIT ZERO..DEVANAGARI DIGIT NINE
+	{runeRange{0x0971, 0x0971}, eawprN},     // Lm         DEVANAGARI SIGN HIGH SPACING DOT
+	{runeRange{0x0980, 0x0980}, eawprN},     // Lo         BENGALI ANJI
+	{runeRange{0x0982, 0x0983}, eawprN},     // Mc     [2] BENGALI SIGN ANUSVARA..BENGALI SIGN VISARGA
+	{runeRange{0x098F, 0x0990}, eawprN},     // Lo     [2] BENGALI LETTER E..BENGALI LETTER AI
+	{runeRange{0x09AA, 0x09B0}, eawprN},     // Lo     [7] BENGALI LETTER PA..BENGALI LETTER RA
+	{runeRange{0x09B6, 0x09B9}, eawprN},     // Lo     [4] BENGALI LETTER SHA..BENGALI LETTER HA
+	{runeRange{0x09BD, 0x09BD}, eawprN},     // Lo         BENGALI SIGN AVAGRAHA
+	{runeRange{0x09C1, 0x09C4}, eawprN},     // Mn     [4] BENGALI VOWEL SIGN U..BENGALI VOWEL SIGN VOCALIC RR
+	{runeRange{0x09CB, 0x09CC}, eawprN},     // Mc     [2] BENGALI VOWEL SIGN O..BENGALI VOWEL SIGN AU
+	{runeRange{0x09CE, 0x09CE}, eawprN},     // Lo         BENGALI LETTER KHANDA TA
+	{runeRange{0x09DC, 0x09DD}, eawprN},     // Lo     [2] BENGALI LETTER RRA..BENGALI LETTER RHA
+	{runeRange{0x09E2, 0x09E3}, eawprN},     // Mn     [2] BENGALI VOWEL SIGN VOCALIC L..BENGALI VOWEL SIGN VOCALIC LL
+	{runeRange{0x09F0, 0x09F1}, eawprN},     // Lo     [2] BENGALI LETTER RA WITH MIDDLE DIAGONAL..BENGALI LETTER RA WITH LOWER DIAGONAL
+	{runeRange{0x09F4, 0x09F9}, eawprN},     // No     [6] BENGALI CURRENCY NUMERATOR ONE..BENGALI CURRENCY DENOMINATOR SIXTEEN
+	{runeRange{0x09FB, 0x09FB}, eawprN},     // Sc         BENGALI GANDA MARK
+	{runeRange{0x09FD, 0x09FD}, eawprN},     // Po         BENGALI ABBREVIATION SIGN
+	{runeRange{0x0A01, 0x0A02}, eawprN},     // Mn     [2] GURMUKHI SIGN ADAK BINDI..GURMUKHI SIGN BINDI
+	{runeRange{0x0A05, 0x0A0A}, eawprN},     // Lo     [6] GURMUKHI LETTER A..GURMUKHI LETTER UU
+	{runeRange{0x0A13, 0x0A28}, eawprN},     // Lo    [22] GURMUKHI LETTER OO..GURMUKHI LETTER NA
+	{runeRange{0x0A32, 0x0A33}, eawprN},     // Lo     [2] GURMUKHI LETTER LA..GURMUKHI LETTER LLA
+	{runeRange{0x0A38, 0x0A39}, eawprN},     // Lo     [2] GURMUKHI LETTER SA..GURMUKHI LETTER HA
+	{runeRange{0x0A3E, 0x0A40}, eawprN},     // Mc     [3] GURMUKHI VOWEL SIGN AA..GURMUKHI VOWEL SIGN II
+	{runeRange{0x0A47, 0x0A48}, eawprN},     // Mn     [2] GURMUKHI VOWEL SIGN EE..GURMUKHI VOWEL SIGN AI
+	{runeRange{0x0A51, 0x0A51}, eawprN},     // Mn         GURMUKHI SIGN UDAAT
+	{runeRange{0x0A5E, 0x0A5E}, eawprN},     // Lo         GURMUKHI LETTER FA
+	{runeRange{0x0A70, 0x0A71}, eawprN},     // Mn     [2] GURMUKHI TIPPI..GURMUKHI ADDAK
+	{runeRange{0x0A75, 0x0A75}, eawprN},     // Mn         GURMUKHI SIGN YAKASH
+	{runeRange{0x0A81, 0x0A82}, eawprN},     // Mn     [2] GUJARATI SIGN CANDRABINDU..GUJARATI SIGN ANUSVARA
+	{runeRange{0x0A85, 0x0A8D}, eawprN},     // Lo     [9] GUJARATI LETTER A..GUJARATI VOWEL CANDRA E
+	{runeRange{0x0A93, 0x0AA8}, eawprN},     // Lo    [22] GUJARATI LETTER O..GUJARATI LETTER NA
+	{runeRange{0x0AB2, 0x0AB3}, eawprN},     // Lo     [2] GUJARATI LETTER LA..GUJARATI LETTER LLA
+	{runeRange{0x0ABC, 0x0ABC}, eawprN},     // Mn         GUJARATI SIGN NUKTA
+	{runeRange{0x0ABE, 0x0AC0}, eawprN},     // Mc     [3] GUJARATI VOWEL SIGN AA..GUJARATI VOWEL SIGN II
+	{runeRange{0x0AC7, 0x0AC8}, eawprN},     // Mn     [2] GUJARATI VOWEL SIGN E..GUJARATI VOWEL SIGN AI
+	{runeRange{0x0ACB, 0x0ACC}, eawprN},     // Mc     [2] GUJARATI VOWEL SIGN O..GUJARATI VOWEL SIGN AU
+	{runeRange{0x0AD0, 0x0AD0}, eawprN},     // Lo         GUJARATI OM
+	{runeRange{0x0AE2, 0x0AE3}, eawprN},     // Mn     [2] GUJARATI VOWEL SIGN VOCALIC L..GUJARATI VOWEL SIGN VOCALIC LL
+	{runeRange{0x0AF0, 0x0AF0}, eawprN},     // Po         GUJARATI ABBREVIATION SIGN
+	{runeRange{0x0AF9, 0x0AF9}, eawprN},     // Lo         GUJARATI LETTER ZHA
+	{runeRange{0x0B01, 0x0B01}, eawprN},     // Mn         ORIYA SIGN CANDRABINDU
+	{runeRange{0x0B05, 0x0B0C}, eawprN},     // Lo     [8] ORIYA LETTER A..ORIYA LETTER VOCALIC L
+	{runeRange{0x0B13, 0x0B28}, eawprN},     // Lo    [22] ORIYA LETTER O..ORIYA LETTER NA
+	{runeRange{0x0B32, 0x0B33}, eawprN},     // Lo     [2] ORIYA LETTER LA..ORIYA LETTER LLA
+	{runeRange{0x0B3C, 0x0B3C}, eawprN},     // Mn         ORIYA SIGN NUKTA
+	{runeRange{0x0B3E, 0x0B3E}, eawprN},     // Mc         ORIYA VOWEL SIGN AA
+	{runeRange{0x0B40, 0x0B40}, eawprN},     // Mc         ORIYA VOWEL SIGN II
+	{runeRange{0x0B47, 0x0B48}, eawprN},     // Mc     [2] ORIYA VOWEL SIGN E..ORIYA VOWEL SIGN AI
+	{runeRange{0x0B4D, 0x0B4D}, eawprN},     // Mn         ORIYA SIGN VIRAMA
+	{runeRange{0x0B57, 0x0B57}, eawprN},     // Mc         ORIYA AU LENGTH MARK
+	{runeRange{0x0B5F, 0x0B61}, eawprN},     // Lo     [3] ORIYA LETTER YYA..ORIYA LETTER VOCALIC LL
+	{runeRange{0x0B66, 0x0B6F}, eawprN},     // Nd    [10] ORIYA DIGIT ZERO..ORIYA DIGIT NINE
+	{runeRange{0x0B71, 0x0B71}, eawprN},     // Lo         ORIYA LETTER WA
+	{runeRange{0x0B82, 0x0B82}, eawprN},     // Mn         TAMIL SIGN ANUSVARA
+	{runeRange{0x0B85, 0x0B8A}, eawprN},     // Lo     [6] TAMIL LETTER A..TAMIL LETTER UU
+	{runeRange{0x0B92, 0x0B95}, eawprN},     // Lo     [4] TAMIL LETTER O..TAMIL LETTER KA
+	{runeRange{0x0B9C, 0x0B9C}, eawprN},     // Lo         TAMIL LETTER JA
+	{runeRange{0x0BA3, 0x0BA4}, eawprN},     // Lo     [2] TAMIL LETTER NNA..TAMIL LETTER TA
+	{runeRange{0x0BAE, 0x0BB9}, eawprN},     // Lo    [12] TAMIL LETTER MA..TAMIL LETTER HA
+	{runeRange{0x0BC0, 0x0BC0}, eawprN},     // Mn         TAMIL VOWEL SIGN II
+	{runeRange{0x0BC6, 0x0BC8}, eawprN},     // Mc     [3] TAMIL VOWEL SIGN E..TAMIL VOWEL SIGN AI
+	{runeRange{0x0BCD, 0x0BCD}, eawprN},     // Mn         TAMIL SIGN VIRAMA
+	{runeRange{0x0BD7, 0x0BD7}, eawprN},     // Mc         TAMIL AU LENGTH MARK
+	{runeRange{0x0BF0, 0x0BF2}, eawprN},     // No     [3] TAMIL NUMBER TEN..TAMIL NUMBER ONE THOUSAND
+	{runeRange{0x0BF9, 0x0BF9}, eawprN},     // Sc         TAMIL RUPEE SIGN
+	{runeRange{0x0C00, 0x0C00}, eawprN},     // Mn         TELUGU SIGN COMBINING CANDRABINDU ABOVE
+	{runeRange{0x0C04, 0x0C04}, eawprN},     // Mn         TELUGU SIGN COMBINING ANUSVARA ABOVE
+	{runeRange{0x0C0E, 0x0C10}, eawprN},     // Lo     [3] TELUGU LETTER E..TELUGU LETTER AI
+	{runeRange{0x0C2A, 0x0C39}, eawprN},     // Lo    [16] TELUGU LETTER PA..TELUGU LETTER HA
+	{runeRange{0x0C3D, 0x0C3D}, eawprN},     // Lo         TELUGU SIGN AVAGRAHA
+	{runeRange{0x0C41, 0x0C44}, eawprN},     // Mc     [4] TELUGU VOWEL SIGN U..TELUGU VOWEL SIGN VOCALIC RR
+	{runeRange{0x0C4A, 0x0C4D}, eawprN},     // Mn     [4] TELUGU VOWEL SIGN O..TELUGU SIGN VIRAMA
+	{runeRange{0x0C58, 0x0C5A}, eawprN},     // Lo     [3] TELUGU LETTER TSA..TELUGU LETTER RRRA
+	{runeRange{0x0C60, 0x0C61}, eawprN},     // Lo     [2] TELUGU LETTER VOCALIC RR..TELUGU LETTER VOCALIC LL
+	{runeRange{0x0C66, 0x0C6F}, eawprN},     // Nd    [10] TELUGU DIGIT ZERO..TELUGU DIGIT NINE
+	{runeRange{0x0C78, 0x0C7E}, eawprN},     // No     [7] TELUGU FRACTION DIGIT ZERO FOR ODD POWERS OF FOUR..TELUGU FRACTION DIGIT THREE FOR EVEN POWERS OF FOUR
+	{runeRange{0x0C80, 0x0C80}, eawprN},     // Lo         KANNADA SIGN SPACING CANDRABINDU
+	{runeRange{0x0C82, 0x0C83}, eawprN},     // Mc     [2] KANNADA SIGN ANUSVARA..KANNADA SIGN VISARGA
+	{runeRange{0x0C85, 0x0C8C}, eawprN},     // Lo     [8] KANNADA LETTER A..KANNADA LETTER VOCALIC L
+	{runeRange{0x0C92, 0x0CA8}, eawprN},     // Lo    [23] KANNADA LETTER O..KANNADA LETTER NA
+	{runeRange{0x0CB5, 0x0CB9}, eawprN},     // Lo     [5] KANNADA LETTER VA..KANNADA LETTER HA
+	{runeRange{0x0CBD, 0x0CBD}, eawprN},     // Lo         KANNADA SIGN AVAGRAHA
+	{runeRange{0x0CBF, 0x0CBF}, eawprN},     // Mn         KANNADA VOWEL SIGN I
+	{runeRange{0x0CC6, 0x0CC6}, eawprN},     // Mn         KANNADA VOWEL SIGN E
+	{runeRange{0x0CCA, 0x0CCB}, eawprN},     // Mc     [2] KANNADA VOWEL SIGN O..KANNADA VOWEL SIGN OO
+	{runeRange{0x0CD5, 0x0CD6}, eawprN},     // Mc     [2] KANNADA LENGTH MARK..KANNADA AI LENGTH MARK
+	{runeRange{0x0CE0, 0x0CE1}, eawprN},     // Lo     [2] KANNADA LETTER VOCALIC RR..KANNADA LETTER VOCALIC LL
+	{runeRange{0x0CE6, 0x0CEF}, eawprN},     // Nd    [10] KANNADA DIGIT ZERO..KANNADA DIGIT NINE
+	{runeRange{0x0CF3, 0x0CF3}, eawprN},     // Mc         KANNADA SIGN COMBINING ANUSVARA ABOVE RIGHT
+	{runeRange{0x0D02, 0x0D03}, eawprN},     // Mc     [2] MALAYALAM SIGN ANUSVARA..MALAYALAM SIGN VISARGA
+	{runeRange{0x0D0E, 0x0D10}, eawprN},     // Lo     [3] MALAYALAM LETTER E..MALAYALAM LETTER AI
+	{runeRange{0x0D3B, 0x0D3C}, eawprN},     // Mn     [2] MALAYALAM SIGN VERTICAL BAR VIRAMA..MALAYALAM SIGN CIRCULAR VIRAMA
+	{runeRange{0x0D3E, 0x0D40}, eawprN},     // Mc     [3] MALAYALAM VOWEL SIGN AA..MALAYALAM VOWEL SIGN II
+	{runeRange{0x0D46, 0x0D48}, eawprN},     // Mc     [3] MALAYALAM VOWEL SIGN E..MALAYALAM VOWEL SIGN AI
+	{runeRange{0x0D4D, 0x0D4D}, eawprN},     // Mn         MALAYALAM SIGN VIRAMA
+	{runeRange{0x0D4F, 0x0D4F}, eawprN},     // So         MALAYALAM SIGN PARA
+	{runeRange{0x0D57, 0x0D57}, eawprN},     // Mc         MALAYALAM AU LENGTH MARK
+	{runeRange{0x0D5F, 0x0D61}, eawprN},     // Lo     [3] MALAYALAM LETTER ARCHAIC II..MALAYALAM LETTER VOCALIC LL
+	{runeRange{0x0D66, 0x0D6F}, eawprN},     // Nd    [10] MALAYALAM DIGIT ZERO..MALAYALAM DIGIT NINE
+	{runeRange{0x0D79, 0x0D79}, eawprN},     // So         MALAYALAM DATE MARK
+	{runeRange{0x0D81, 0x0D81}, eawprN},     // Mn         SINHALA SIGN CANDRABINDU
+	{runeRange{0x0D85, 0x0D96}, eawprN},     // Lo    [18] SINHALA LETTER AYANNA..SINHALA LETTER AUYANNA
+	{runeRange{0x0DB3, 0x0DBB}, eawprN},     // Lo     [9] SINHALA LETTER SANYAKA DAYANNA..SINHALA LETTER RAYANNA
+	{runeRange{0x0DC0, 0x0DC6}, eawprN},     // Lo     [7] SINHALA LETTER VAYANNA..SINHALA LETTER FAYANNA
+	{runeRange{0x0DCF, 0x0DD1}, eawprN},     // Mc     [3] SINHALA VOWEL SIGN AELA-PILLA..SINHALA VOWEL SIGN DIGA AEDA-PILLA
+	{runeRange{0x0DD6, 0x0DD6}, eawprN},     // Mn         SINHALA VOWEL SIGN DIGA PAA-PILLA
+	{runeRange{0x0DE6, 0x0DEF}, eawprN},     // Nd    [10] SINHALA LITH DIGIT ZERO..SINHALA LITH DIGIT NINE
+	{runeRange{0x0DF4, 0x0DF4}, eawprN},     // Po         SINHALA PUNCTUATION KUNDDALIYA
+	{runeRange{0x0E31, 0x0E31}, eawprN},     // Mn         THAI CHARACTER MAI HAN-AKAT
+	{runeRange{0x0E34, 0x0E3A}, eawprN},     // Mn     [7] THAI CHARACTER SARA I..THAI CHARACTER PHINTHU
+	{runeRange{0x0E40, 0x0E45}, eawprN},     // Lo     [6] THAI CHARACTER SARA E..THAI CHARACTER LAKKHANGYAO
+	{runeRange{0x0E47, 0x0E4E}, eawprN},     // Mn     [8] THAI CHARACTER MAITAIKHU..THAI CHARACTER YAMAKKAN
+	{runeRange{0x0E50, 0x0E59}, eawprN},     // Nd    [10] THAI DIGIT ZERO..THAI DIGIT NINE
+	{runeRange{0x0E81, 0x0E82}, eawprN},     // Lo     [2] LAO LETTER KO..LAO LETTER KHO SUNG
+	{runeRange{0x0E86, 0x0E8A}, eawprN},     // Lo     [5] LAO LETTER PALI GHA..LAO LETTER SO TAM
+	{runeRange{0x0EA5, 0x0EA5}, eawprN},     // Lo         LAO LETTER LO LOOT
+	{runeRange{0x0EB1, 0x0EB1}, eawprN},     // Mn         LAO VOWEL SIGN MAI KAN
+	{runeRange{0x0EB4, 0x0EBC}, eawprN},     // Mn     [9] LAO VOWEL SIGN I..LAO SEMIVOWEL SIGN LO
+	{runeRange{0x0EC0, 0x0EC4}, eawprN},     // Lo     [5] LAO VOWEL SIGN E..LAO VOWEL SIGN AI
+	{runeRange{0x0EC8, 0x0ECE}, eawprN},     // Mn     [7] LAO TONE MAI EK..LAO YAMAKKAN
+	{runeRange{0x0EDC, 0x0EDF}, eawprN},     // Lo     [4] LAO HO NO..LAO LETTER KHMU NYO
+	{runeRange{0x0F01, 0x0F03}, eawprN},     // So     [3] TIBETAN MARK GTER YIG MGO TRUNCATED A..TIBETAN MARK GTER YIG MGO -UM GTER TSHEG MA
+	{runeRange{0x0F13, 0x0F13}, eawprN},     // So         TIBETAN MARK CARET -DZUD RTAGS ME LONG CAN
+	{runeRange{0x0F15, 0x0F17}, eawprN},     // So     [3] TIBETAN LOGOTYPE SIGN CHAD RTAGS..TIBETAN ASTROLOGICAL SIGN SGRA GCAN -CHAR RTAGS
+	{runeRange{0x0F1A, 0x0F1F}, eawprN},     // So     [6] TIBETAN SIGN RDEL DKAR GCIG..TIBETAN SIGN RDEL DKAR RDEL NAG
+	{runeRange{0x0F2A, 0x0F33}, eawprN},     // No    [10] TIBETAN DIGIT HALF ONE..TIBETAN DIGIT HALF ZERO
+	{runeRange{0x0F35, 0x0F35}, eawprN},     // Mn         TIBETAN MARK NGAS BZUNG NYI ZLA
+	{runeRange{0x0F37, 0x0F37}, eawprN},     // Mn         TIBETAN MARK NGAS BZUNG SGOR RTAGS
+	{runeRange{0x0F39, 0x0F39}, eawprN},     // Mn         TIBETAN MARK TSA -PHRU
+	{runeRange{0x0F3B, 0x0F3B}, eawprN},     // Pe         TIBETAN MARK GUG RTAGS GYAS
+	{runeRange{0x0F3D, 0x0F3D}, eawprN},     // Pe         TIBETAN MARK ANG KHANG GYAS
+	{runeRange{0x0F40, 0x0F47}, eawprN},     // Lo     [8] TIBETAN LETTER KA..TIBETAN LETTER JA
+	{runeRange{0x0F71, 0x0F7E}, eawprN},     // Mn    [14] TIBETAN VOWEL SIGN AA..TIBETAN SIGN RJES SU NGA RO
+	{runeRange{0x0F80, 0x0F84}, eawprN},     // Mn     [5] TIBETAN VOWEL SIGN REVERSED I..TIBETAN MARK HALANTA
+	{runeRange{0x0F86, 0x0F87}, eawprN},     // Mn     [2] TIBETAN SIGN LCI RTAGS..TIBETAN SIGN YANG RTAGS
+	{runeRange{0x0F8D, 0x0F97}, eawprN},     // Mn    [11] TIBETAN SUBJOINED SIGN LCE TSA CAN..TIBETAN SUBJOINED LETTER JA
+	{runeRange{0x0FBE, 0x0FC5}, eawprN},     // So     [8] TIBETAN KU RU KHA..TIBETAN SYMBOL RDO RJE
+	{runeRange{0x0FC7, 0x0FCC}, eawprN},     // So     [6] TIBETAN SYMBOL RDO RJE RGYA GRAM..TIBETAN SYMBOL NOR BU BZHI -KHYIL
+	{runeRange{0x0FD0, 0x0FD4}, eawprN},     // Po     [5] TIBETAN MARK BSKA- SHOG GI MGO RGYAN..TIBETAN MARK CLOSING BRDA RNYING YIG MGO SGAB MA
+	{runeRange{0x0FD9, 0x0FDA}, eawprN},     // Po     [2] TIBETAN MARK LEADING MCHAN RTAGS..TIBETAN MARK TRAILING MCHAN RTAGS
+	{runeRange{0x102B, 0x102C}, eawprN},     // Mc     [2] MYANMAR VOWEL SIGN TALL AA..MYANMAR VOWEL SIGN AA
+	{runeRange{0x1031, 0x1031}, eawprN},     // Mc         MYANMAR VOWEL SIGN E
+	{runeRange{0x1038, 0x1038}, eawprN},     // Mc         MYANMAR SIGN VISARGA
+	{runeRange{0x103B, 0x103C}, eawprN},     // Mc     [2] MYANMAR CONSONANT SIGN MEDIAL YA..MYANMAR CONSONANT SIGN MEDIAL RA
+	{runeRange{0x103F, 0x103F}, eawprN},     // Lo         MYANMAR LETTER GREAT SA
+	{runeRange{0x104A, 0x104F}, eawprN},     // Po     [6] MYANMAR SIGN LITTLE SECTION..MYANMAR SYMBOL GENITIVE
+	{runeRange{0x1056, 0x1057}, eawprN},     // Mc     [2] MYANMAR VOWEL SIGN VOCALIC R..MYANMAR VOWEL SIGN VOCALIC RR
+	{runeRange{0x105A, 0x105D}, eawprN},     // Lo     [4] MYANMAR LETTER MON NGA..MYANMAR LETTER MON BBE
+	{runeRange{0x1061, 0x1061}, eawprN},     // Lo         MYANMAR LETTER SGAW KAREN SHA
+	{runeRange{0x1065, 0x1066}, eawprN},     // Lo     [2] MYANMAR LETTER WESTERN PWO KAREN THA..MYANMAR LETTER WESTERN PWO KAREN PWA
+	{runeRange{0x106E, 0x1070}, eawprN},     // Lo     [3] MYANMAR LETTER EASTERN PWO KAREN NNA..MYANMAR LETTER EASTERN PWO KAREN GHWA
+	{runeRange{0x1075, 0x1081}, eawprN},     // Lo    [13] MYANMAR LETTER SHAN KA..MYANMAR LETTER SHAN HA
+	{runeRange{0x1083, 0x1084}, eawprN},     // Mc     [2] MYANMAR VOWEL SIGN SHAN AA..MYANMAR VOWEL SIGN SHAN E
+	{runeRange{0x1087, 0x108C}, eawprN},     // Mc     [6] MYANMAR SIGN SHAN TONE-2..MYANMAR SIGN SHAN COUNCIL TONE-3
+	{runeRange{0x108E, 0x108E}, eawprN},     // Lo         MYANMAR LETTER RUMAI PALAUNG FA
+	{runeRange{0x1090, 0x1099}, eawprN},     // Nd    [10] MYANMAR SHAN DIGIT ZERO..MYANMAR SHAN DIGIT NINE
+	{runeRange{0x109D, 0x109D}, eawprN},     // Mn         MYANMAR VOWEL SIGN AITON AI
+	{runeRange{0x10A0, 0x10C5}, eawprN},     // Lu    [38] GEORGIAN CAPITAL LETTER AN..GEORGIAN CAPITAL LETTER HOE
+	{runeRange{0x10CD, 0x10CD}, eawprN},     // Lu         GEORGIAN CAPITAL LETTER AEN
+	{runeRange{0x10FB, 0x10FB}, eawprN},     // Po         GEORGIAN PARAGRAPH SEPARATOR
+	{runeRange{0x10FD, 0x10FF}, eawprN},     // Ll     [3] GEORGIAN LETTER AEN..GEORGIAN LETTER LABIAL SIGN
+	{runeRange{0x1160, 0x11FF}, eawprN},     // Lo   [160] HANGUL JUNGSEONG FILLER..HANGUL JONGSEONG SSANGNIEUN
+	{runeRange{0x124A, 0x124D}, eawprN},     // Lo     [4] ETHIOPIC SYLLABLE QWI..ETHIOPIC SYLLABLE QWE
+	{runeRange{0x1258, 0x1258}, eawprN},     // Lo         ETHIOPIC SYLLABLE QHWA
+	{runeRange{0x1260, 0x1288}, eawprN},     // Lo    [41] ETHIOPIC SYLLABLE BA..ETHIOPIC SYLLABLE XWA
+	{runeRange{0x1290, 0x12B0}, eawprN},     // Lo    [33] ETHIOPIC SYLLABLE NA..ETHIOPIC SYLLABLE KWA
+	{runeRange{0x12B8, 0x12BE}, eawprN},     // Lo     [7] ETHIOPIC SYLLABLE KXA..ETHIOPIC SYLLABLE KXO
+	{runeRange{0x12C2, 0x12C5}, eawprN},     // Lo     [4] ETHIOPIC SYLLABLE KXWI..ETHIOPIC SYLLABLE KXWE
+	{runeRange{0x12D8, 0x1310}, eawprN},     // Lo    [57] ETHIOPIC SYLLABLE ZA..ETHIOPIC SYLLABLE GWA
+	{runeRange{0x1318, 0x135A}, eawprN},     // Lo    [67] ETHIOPIC SYLLABLE GGA..ETHIOPIC SYLLABLE FYA
+	{runeRange{0x1360, 0x1368}, eawprN},     // Po     [9] ETHIOPIC SECTION MARK..ETHIOPIC PARAGRAPH SEPARATOR
+	{runeRange{0x1380, 0x138F}, eawprN},     // Lo    [16] ETHIOPIC SYLLABLE SEBATBEIT MWA..ETHIOPIC SYLLABLE PWE
+	{runeRange{0x13A0, 0x13F5}, eawprN},     // Lu    [86] CHEROKEE LETTER A..CHEROKEE LETTER MV
+	{runeRange{0x1400, 0x1400}, eawprN},     // Pd         CANADIAN SYLLABICS HYPHEN
+	{runeRange{0x166D, 0x166D}, eawprN},     // So         CANADIAN SYLLABICS CHI SIGN
+	{runeRange{0x166F, 0x167F}, eawprN},     // Lo    [17] CANADIAN SYLLABICS QAI..CANADIAN SYLLABICS BLACKFOOT W
+	{runeRange{0x1681, 0x169A}, eawprN},     // Lo    [26] OGHAM LETTER BEITH..OGHAM LETTER PEITH
+	{runeRange{0x169C, 0x169C}, eawprN},     // Pe         OGHAM REVERSED FEATHER MARK
+	{runeRange{0x16EB, 0x16ED}, eawprN},     // Po     [3] RUNIC SINGLE PUNCTUATION..RUNIC CROSS PUNCTUATION
+	{runeRange{0x16F1, 0x16F8}, eawprN},     // Lo     [8] RUNIC LETTER K..RUNIC LETTER FRANKS CASKET AESC
+	{runeRange{0x1712, 0x1714}, eawprN},     // Mn     [3] TAGALOG VOWEL SIGN I..TAGALOG SIGN VIRAMA
+	{runeRange{0x171F, 0x171F}, eawprN},     // Lo         TAGALOG LETTER ARCHAIC RA
+	{runeRange{0x1732, 0x1733}, eawprN},     // Mn     [2] HANUNOO VOWEL SIGN I..HANUNOO VOWEL SIGN U
+	{runeRange{0x1735, 0x1736}, eawprN},     // Po     [2] PHILIPPINE SINGLE PUNCTUATION..PHILIPPINE DOUBLE PUNCTUATION
+	{runeRange{0x1752, 0x1753}, eawprN},     // Mn     [2] BUHID VOWEL SIGN I..BUHID VOWEL SIGN U
+	{runeRange{0x176E, 0x1770}, eawprN},     // Lo     [3] TAGBANWA LETTER LA..TAGBANWA LETTER SA
+	{runeRange{0x1780, 0x17B3}, eawprN},     // Lo    [52] KHMER LETTER KA..KHMER INDEPENDENT VOWEL QAU
+	{runeRange{0x17B6, 0x17B6}, eawprN},     // Mc         KHMER VOWEL SIGN AA
+	{runeRange{0x17BE, 0x17C5}, eawprN},     // Mc     [8] KHMER VOWEL SIGN OE..KHMER VOWEL SIGN AU
+	{runeRange{0x17C7, 0x17C8}, eawprN},     // Mc     [2] KHMER SIGN REAHMUK..KHMER SIGN YUUKALEAPINTU
+	{runeRange{0x17D4, 0x17D6}, eawprN},     // Po     [3] KHMER SIGN KHAN..KHMER SIGN CAMNUC PII KUUH
+	{runeRange{0x17D8, 0x17DA}, eawprN},     // Po     [3] KHMER SIGN BEYYAL..KHMER SIGN KOOMUUT
+	{runeRange{0x17DC, 0x17DC}, eawprN},     // Lo         KHMER SIGN AVAKRAHASANYA
+	{runeRange{0x17E0, 0x17E9}, eawprN},     // Nd    [10] KHMER DIGIT ZERO..KHMER DIGIT NINE
+	{runeRange{0x1800, 0x1805}, eawprN},     // Po     [6] MONGOLIAN BIRGA..MONGOLIAN FOUR DOTS
+	{runeRange{0x1807, 0x180A}, eawprN},     // Po     [4] MONGOLIAN SIBE SYLLABLE BOUNDARY MARKER..MONGOLIAN NIRUGU
+	{runeRange{0x180E, 0x180E}, eawprN},     // Cf         MONGOLIAN VOWEL SEPARATOR
+	{runeRange{0x1810, 0x1819}, eawprN},     // Nd    [10] MONGOLIAN DIGIT ZERO..MONGOLIAN DIGIT NINE
+	{runeRange{0x1843, 0x1843}, eawprN},     // Lm         MONGOLIAN LETTER TODO LONG VOWEL SIGN
+	{runeRange{0x1880, 0x1884}, eawprN},     // Lo     [5] MONGOLIAN LETTER ALI GALI ANUSVARA ONE..MONGOLIAN LETTER ALI GALI INVERTED UBADAMA
+	{runeRange{0x1887, 0x18A8}, eawprN},     // Lo    [34] MONGOLIAN LETTER ALI GALI A..MONGOLIAN LETTER MANCHU ALI GALI BHA
+	{runeRange{0x18AA, 0x18AA}, eawprN},     // Lo         MONGOLIAN LETTER MANCHU ALI GALI LHA
+	{runeRange{0x1900, 0x191E}, eawprN},     // Lo    [31] LIMBU VOWEL-CARRIER LETTER..LIMBU LETTER TRA
+	{runeRange{0x1923, 0x1926}, eawprN},     // Mc     [4] LIMBU VOWEL SIGN EE..LIMBU VOWEL SIGN AU
+	{runeRange{0x1929, 0x192B}, eawprN},     // Mc     [3] LIMBU SUBJOINED LETTER YA..LIMBU SUBJOINED LETTER WA
+	{runeRange{0x1932, 0x1932}, eawprN},     // Mn         LIMBU SMALL LETTER ANUSVARA
+	{runeRange{0x1939, 0x193B}, eawprN},     // Mn     [3] LIMBU SIGN MUKPHRENG..LIMBU SIGN SA-I
+	{runeRange{0x1944, 0x1945}, eawprN},     // Po     [2] LIMBU EXCLAMATION MARK..LIMBU QUESTION MARK
+	{runeRange{0x1950, 0x196D}, eawprN},     // Lo    [30] TAI LE LETTER KA..TAI LE LETTER AI
+	{runeRange{0x1980, 0x19AB}, eawprN},     // Lo    [44] NEW TAI LUE LETTER HIGH QA..NEW TAI LUE LETTER LOW SUA
+	{runeRange{0x19D0, 0x19D9}, eawprN},     // Nd    [10] NEW TAI LUE DIGIT ZERO..NEW TAI LUE DIGIT NINE
+	{runeRange{0x19DE, 0x19DF}, eawprN},     // So     [2] NEW TAI LUE SIGN LAE..NEW TAI LUE SIGN LAEV
+	{runeRange{0x1A00, 0x1A16}, eawprN},     // Lo    [23] BUGINESE LETTER KA..BUGINESE LETTER HA
+	{runeRange{0x1A19, 0x1A1A}, eawprN},     // Mc     [2] BUGINESE VOWEL SIGN E..BUGINESE VOWEL SIGN O
+	{runeRange{0x1A1E, 0x1A1F}, eawprN},     // Po     [2] BUGINESE PALLAWA..BUGINESE END OF SECTION
+	{runeRange{0x1A55, 0x1A55}, eawprN},     // Mc         TAI THAM CONSONANT SIGN MEDIAL RA
+	{runeRange{0x1A57, 0x1A57}, eawprN},     // Mc         TAI THAM CONSONANT SIGN LA TANG LAI
+	{runeRange{0x1A60, 0x1A60}, eawprN},     // Mn         TAI THAM SIGN SAKOT
+	{runeRange{0x1A62, 0x1A62}, eawprN},     // Mn         TAI THAM VOWEL SIGN MAI SAT
+	{runeRange{0x1A65, 0x1A6C}, eawprN},     // Mn     [8] TAI THAM VOWEL SIGN I..TAI THAM VOWEL SIGN OA BELOW
+	{runeRange{0x1A73, 0x1A7C}, eawprN},     // Mn    [10] TAI THAM VOWEL SIGN OA ABOVE..TAI THAM SIGN KHUEN-LUE KARAN
+	{runeRange{0x1A80, 0x1A89}, eawprN},     // Nd    [10] TAI THAM HORA DIGIT ZERO..TAI THAM HORA DIGIT NINE
+	{runeRange{0x1AA0, 0x1AA6}, eawprN},     // Po     [7] TAI THAM SIGN WIANG..TAI THAM SIGN REVERSED ROTATED RANA
+	{runeRange{0x1AA8, 0x1AAD}, eawprN},     // Po     [6] TAI THAM SIGN KAAN..TAI THAM SIGN CAANG
+	{runeRange{0x1ABE, 0x1ABE}, eawprN},     // Me         COMBINING PARENTHESES OVERLAY
+	{runeRange{0x1B00, 0x1B03}, eawprN},     // Mn     [4] BALINESE SIGN ULU RICEM..BALINESE SIGN SURANG
+	{runeRange{0x1B05, 0x1B33}, eawprN},     // Lo    [47] BALINESE LETTER AKARA..BALINESE LETTER HA
+	{runeRange{0x1B35, 0x1B35}, eawprN},     // Mc         BALINESE VOWEL SIGN TEDUNG
+	{runeRange{0x1B3B, 0x1B3B}, eawprN},     // Mc         BALINESE VOWEL SIGN RA REPA TEDUNG
+	{runeRange{0x1B3D, 0x1B41}, eawprN},     // Mc     [5] BALINESE VOWEL SIGN LA LENGA TEDUNG..BALINESE VOWEL SIGN TALING REPA TEDUNG
+	{runeRange{0x1B43, 0x1B44}, eawprN},     // Mc     [2] BALINESE VOWEL SIGN PEPET TEDUNG..BALINESE ADEG ADEG
+	{runeRange{0x1B50, 0x1B59}, eawprN},     // Nd    [10] BALINESE DIGIT ZERO..BALINESE DIGIT NINE
+	{runeRange{0x1B61, 0x1B6A}, eawprN},     // So    [10] BALINESE MUSICAL SYMBOL DONG..BALINESE MUSICAL SYMBOL DANG GEDE
+	{runeRange{0x1B74, 0x1B7C}, eawprN},     // So     [9] BALINESE MUSICAL SYMBOL RIGHT-HAND OPEN DUG..BALINESE MUSICAL SYMBOL LEFT-HAND OPEN PING
+	{runeRange{0x1B80, 0x1B81}, eawprN},     // Mn     [2] SUNDANESE SIGN PANYECEK..SUNDANESE SIGN PANGLAYAR
+	{runeRange{0x1B83, 0x1BA0}, eawprN},     // Lo    [30] SUNDANESE LETTER A..SUNDANESE LETTER HA
+	{runeRange{0x1BA2, 0x1BA5}, eawprN},     // Mn     [4] SUNDANESE CONSONANT SIGN PANYAKRA..SUNDANESE VOWEL SIGN PANYUKU
+	{runeRange{0x1BA8, 0x1BA9}, eawprN},     // Mn     [2] SUNDANESE VOWEL SIGN PAMEPET..SUNDANESE VOWEL SIGN PANEULEUNG
+	{runeRange{0x1BAB, 0x1BAD}, eawprN},     // Mn     [3] SUNDANESE SIGN VIRAMA..SUNDANESE CONSONANT SIGN PASANGAN WA
+	{runeRange{0x1BB0, 0x1BB9}, eawprN},     // Nd    [10] SUNDANESE DIGIT ZERO..SUNDANESE DIGIT NINE
+	{runeRange{0x1BC0, 0x1BE5}, eawprN},     // Lo    [38] BATAK LETTER A..BATAK LETTER U
+	{runeRange{0x1BE7, 0x1BE7}, eawprN},     // Mc         BATAK VOWEL SIGN E
+	{runeRange{0x1BEA, 0x1BEC}, eawprN},     // Mc     [3] BATAK VOWEL SIGN I..BATAK VOWEL SIGN O
+	{runeRange{0x1BEE, 0x1BEE}, eawprN},     // Mc         BATAK VOWEL SIGN U
+	{runeRange{0x1BF2, 0x1BF3}, eawprN},     // Mc     [2] BATAK PANGOLAT..BATAK PANONGONAN
+	{runeRange{0x1C00, 0x1C23}, eawprN},     // Lo    [36] LEPCHA LETTER KA..LEPCHA LETTER A
+	{runeRange{0x1C2C, 0x1C33}, eawprN},     // Mn     [8] LEPCHA VOWEL SIGN E..LEPCHA CONSONANT SIGN T
+	{runeRange{0x1C36, 0x1C37}, eawprN},     // Mn     [2] LEPCHA SIGN RAN..LEPCHA SIGN NUKTA
+	{runeRange{0x1C40, 0x1C49}, eawprN},     // Nd    [10] LEPCHA DIGIT ZERO..LEPCHA DIGIT NINE
+	{runeRange{0x1C50, 0x1C59}, eawprN},     // Nd    [10] OL CHIKI DIGIT ZERO..OL CHIKI DIGIT NINE
+	{runeRange{0x1C78, 0x1C7D}, eawprN},     // Lm     [6] OL CHIKI MU TTUDDAG..OL CHIKI AHAD
+	{runeRange{0x1C80, 0x1C88}, eawprN},     // Ll     [9] CYRILLIC SMALL LETTER ROUNDED VE..CYRILLIC SMALL LETTER UNBLENDED UK
+	{runeRange{0x1CBD, 0x1CBF}, eawprN},     // Lu     [3] GEORGIAN MTAVRULI CAPITAL LETTER AEN..GEORGIAN MTAVRULI CAPITAL LETTER LABIAL SIGN
+	{runeRange{0x1CD0, 0x1CD2}, eawprN},     // Mn     [3] VEDIC TONE KARSHANA..VEDIC TONE PRENKHA
+	{runeRange{0x1CD4, 0x1CE0}, eawprN},     // Mn    [13] VEDIC SIGN YAJURVEDIC MIDLINE SVARITA..VEDIC TONE RIGVEDIC KASHMIRI INDEPENDENT SVARITA
+	{runeRange{0x1CE2, 0x1CE8}, eawprN},     // Mn     [7] VEDIC SIGN VISARGA SVARITA..VEDIC SIGN VISARGA ANUDATTA WITH TAIL
+	{runeRange{0x1CED, 0x1CED}, eawprN},     // Mn         VEDIC SIGN TIRYAK
+	{runeRange{0x1CF4, 0x1CF4}, eawprN},     // Mn         VEDIC TONE CANDRA ABOVE
+	{runeRange{0x1CF7, 0x1CF7}, eawprN},     // Mc         VEDIC SIGN ATIKRAMA
+	{runeRange{0x1CFA, 0x1CFA}, eawprN},     // Lo         VEDIC SIGN DOUBLE ANUSVARA ANTARGOMUKHA
+	{runeRange{0x1D2C, 0x1D6A}, eawprN},     // Lm    [63] MODIFIER LETTER CAPITAL A..GREEK SUBSCRIPT SMALL LETTER CHI
+	{runeRange{0x1D78, 0x1D78}, eawprN},     // Lm         MODIFIER LETTER CYRILLIC EN
+	{runeRange{0x1D80, 0x1D9A}, eawprN},     // Ll    [27] LATIN SMALL LETTER B WITH PALATAL HOOK..LATIN SMALL LETTER EZH WITH RETROFLEX HOOK
+	{runeRange{0x1DC0, 0x1DFF}, eawprN},     // Mn    [64] COMBINING DOTTED GRAVE ACCENT..COMBINING RIGHT ARROWHEAD AND DOWN ARROWHEAD BELOW
+	{runeRange{0x1F00, 0x1F15}, eawprN},     // L&    [22] GREEK SMALL LETTER ALPHA WITH PSILI..GREEK SMALL LETTER EPSILON WITH DASIA AND OXIA
+	{runeRange{0x1F20, 0x1F45}, eawprN},     // L&    [38] GREEK SMALL LETTER ETA WITH PSILI..GREEK SMALL LETTER OMICRON WITH DASIA AND OXIA
+	{runeRange{0x1F50, 0x1F57}, eawprN},     // Ll     [8] GREEK SMALL LETTER UPSILON WITH PSILI..GREEK SMALL LETTER UPSILON WITH DASIA AND PERISPOMENI
+	{runeRange{0x1F5B, 0x1F5B}, eawprN},     // Lu         GREEK CAPITAL LETTER UPSILON WITH DASIA AND VARIA
+	{runeRange{0x1F5F, 0x1F7D}, eawprN},     // L&    [31] GREEK CAPITAL LETTER UPSILON WITH DASIA AND PERISPOMENI..GREEK SMALL LETTER OMEGA WITH OXIA
+	{runeRange{0x1FB6, 0x1FBC}, eawprN},     // L&     [7] GREEK SMALL LETTER ALPHA WITH PERISPOMENI..GREEK CAPITAL LETTER ALPHA WITH PROSGEGRAMMENI
+	{runeRange{0x1FBE, 0x1FBE}, eawprN},     // Ll         GREEK PROSGEGRAMMENI
+	{runeRange{0x1FC2, 0x1FC4}, eawprN},     // Ll     [3] GREEK SMALL LETTER ETA WITH VARIA AND YPOGEGRAMMENI..GREEK SMALL LETTER ETA WITH OXIA AND YPOGEGRAMMENI
+	{runeRange{0x1FCD, 0x1FCF}, eawprN},     // Sk     [3] GREEK PSILI AND VARIA..GREEK PSILI AND PERISPOMENI
+	{runeRange{0x1FD6, 0x1FDB}, eawprN},     // L&     [6] GREEK SMALL LETTER IOTA WITH PERISPOMENI..GREEK CAPITAL LETTER IOTA WITH OXIA
+	{runeRange{0x1FE0, 0x1FEC}, eawprN},     // L&    [13] GREEK SMALL LETTER UPSILON WITH VRACHY..GREEK CAPITAL LETTER RHO WITH DASIA
+	{runeRange{0x1FF2, 0x1FF4}, eawprN},     // Ll     [3] GREEK SMALL LETTER OMEGA WITH VARIA AND YPOGEGRAMMENI..GREEK SMALL LETTER OMEGA WITH OXIA AND YPOGEGRAMMENI
+	{runeRange{0x1FFD, 0x1FFE}, eawprN},     // Sk     [2] GREEK OXIA..GREEK DASIA
+	{runeRange{0x200B, 0x200F}, eawprN},     // Cf     [5] ZERO WIDTH SPACE..RIGHT-TO-LEFT MARK
+	{runeRange{0x2011, 0x2012}, eawprN},     // Pd     [2] NON-BREAKING HYPHEN..FIGURE DASH
+	{runeRange{0x2016, 0x2016}, eawprA},     // Po         DOUBLE VERTICAL LINE
+	{runeRange{0x2018, 0x2018}, eawprA},     // Pi         LEFT SINGLE QUOTATION MARK
+	{runeRange{0x201A, 0x201A}, eawprN},     // Ps         SINGLE LOW-9 QUOTATION MARK
+	{runeRange{0x201C, 0x201C}, eawprA},     // Pi         LEFT DOUBLE QUOTATION MARK
+	{runeRange{0x201E, 0x201E}, eawprN},     // Ps         DOUBLE LOW-9 QUOTATION MARK
+	{runeRange{0x2020, 0x2022}, eawprA},     // Po     [3] DAGGER..BULLET
+	{runeRange{0x2024, 0x2027}, eawprA},     // Po     [4] ONE DOT LEADER..HYPHENATION POINT
+	{runeRange{0x2029, 0x2029}, eawprN},     // Zp         PARAGRAPH SEPARATOR
+	{runeRange{0x202F, 0x202F}, eawprN},     // Zs         NARROW NO-BREAK SPACE
+	{runeRange{0x2031, 0x2031}, eawprN},     // Po         PER TEN THOUSAND SIGN
+	{runeRange{0x2034, 0x2034}, eawprN},     // Po         TRIPLE PRIME
+	{runeRange{0x2036, 0x2038}, eawprN},     // Po     [3] REVERSED DOUBLE PRIME..CARET
+	{runeRange{0x203A, 0x203A}, eawprN},     // Pf         SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
+	{runeRange{0x203C, 0x203D}, eawprN},     // Po     [2] DOUBLE EXCLAMATION MARK..INTERROBANG
+	{runeRange{0x203F, 0x2040}, eawprN},     // Pc     [2] UNDERTIE..CHARACTER TIE
+	{runeRange{0x2044, 0x2044}, eawprN},     // Sm         FRACTION SLASH
+	{runeRange{0x2046, 0x2046}, eawprN},     // Pe         RIGHT SQUARE BRACKET WITH QUILL
+	{runeRange{0x2052, 0x2052}, eawprN},     // Sm         COMMERCIAL MINUS SIGN
+	{runeRange{0x2054, 0x2054}, eawprN},     // Pc         INVERTED UNDERTIE
+	{runeRange{0x205F, 0x205F}, eawprN},     // Zs         MEDIUM MATHEMATICAL SPACE
+	{runeRange{0x2066, 0x206F}, eawprN},     // Cf    [10] LEFT-TO-RIGHT ISOLATE..NOMINAL DIGIT SHAPES
+	{runeRange{0x2071, 0x2071}, eawprN},     // Lm         SUPERSCRIPT LATIN SMALL LETTER I
+	{runeRange{0x2075, 0x2079}, eawprN},     // No     [5] SUPERSCRIPT FIVE..SUPERSCRIPT NINE
+	{runeRange{0x207D, 0x207D}, eawprN},     // Ps         SUPERSCRIPT LEFT PARENTHESIS
+	{runeRange{0x207F, 0x207F}, eawprA},     // Lm         SUPERSCRIPT LATIN SMALL LETTER N
+	{runeRange{0x2081, 0x2084}, eawprA},     // No     [4] SUBSCRIPT ONE..SUBSCRIPT FOUR
+	{runeRange{0x208A, 0x208C}, eawprN},     // Sm     [3] SUBSCRIPT PLUS SIGN..SUBSCRIPT EQUALS SIGN
+	{runeRange{0x208E, 0x208E}, eawprN},     // Pe         SUBSCRIPT RIGHT PARENTHESIS
+	{runeRange{0x20A0, 0x20A8}, eawprN},     // Sc     [9] EURO-CURRENCY SIGN..RUPEE SIGN
+	{runeRange{0x20AA, 0x20AB}, eawprN},     // Sc     [2] NEW SHEQEL SIGN..DONG SIGN
+	{runeRange{0x20AD, 0x20C0}, eawprN},     // Sc    [20] KIP SIGN..SOM SIGN
+	{runeRange{0x20DD, 0x20E0}, eawprN},     // Me     [4] COMBINING ENCLOSING CIRCLE..COMBINING ENCLOSING CIRCLE BACKSLASH
+	{runeRange{0x20E2, 0x20E4}, eawprN},     // Me     [3] COMBINING ENCLOSING SCREEN..COMBINING ENCLOSING UPWARD POINTING TRIANGLE
+	{runeRange{0x2100, 0x2101}, eawprN},     // So     [2] ACCOUNT OF..ADDRESSED TO THE SUBJECT
+	{runeRange{0x2103, 0x2103}, eawprA},     // So         DEGREE CELSIUS
+	{runeRange{0x2105, 0x2105}, eawprA},     // So         CARE OF
+	{runeRange{0x2107, 0x2107}, eawprN},     // Lu         EULER CONSTANT
+	{runeRange{0x2109, 0x2109}, eawprA},     // So         DEGREE FAHRENHEIT
+	{runeRange{0x2113, 0x2113}, eawprA},     // Ll         SCRIPT SMALL L
+	{runeRange{0x2115, 0x2115}, eawprN},     // Lu         DOUBLE-STRUCK CAPITAL N
+	{runeRange{0x2117, 0x2117}, eawprN},     // So         SOUND RECORDING COPYRIGHT
+	{runeRange{0x2119, 0x211D}, eawprN},     // Lu     [5] DOUBLE-STRUCK CAPITAL P..DOUBLE-STRUCK CAPITAL R
+	{runeRange{0x2121, 0x2122}, eawprA},     // So     [2] TELEPHONE SIGN..TRADE MARK SIGN
+	{runeRange{0x2124, 0x2124}, eawprN},     // Lu         DOUBLE-STRUCK CAPITAL Z
+	{runeRange{0x2126, 0x2126}, eawprA},     // Lu         OHM SIGN
+	{runeRange{0x2128, 0x2128}, eawprN},     // Lu         BLACK-LETTER CAPITAL Z
+	{runeRange{0x212A, 0x212A}, eawprN},     // Lu         KELVIN SIGN
+	{runeRange{0x212C, 0x212D}, eawprN},     // Lu     [2] SCRIPT CAPITAL B..BLACK-LETTER CAPITAL C
+	{runeRange{0x212F, 0x2134}, eawprN},     // L&     [6] SCRIPT SMALL E..SCRIPT SMALL O
+	{runeRange{0x2139, 0x2139}, eawprN},     // Ll         INFORMATION SOURCE
+	{runeRange{0x213C, 0x213F}, eawprN},     // L&     [4] DOUBLE-STRUCK SMALL PI..DOUBLE-STRUCK CAPITAL PI
+	{runeRange{0x2145, 0x2149}, eawprN},     // L&     [5] DOUBLE-STRUCK ITALIC CAPITAL D..DOUBLE-STRUCK ITALIC SMALL J
+	{runeRange{0x214B, 0x214B}, eawprN},     // Sm         TURNED AMPERSAND
+	{runeRange{0x214E, 0x214E}, eawprN},     // Ll         TURNED SMALL F
+	{runeRange{0x2150, 0x2152}, eawprN},     // No     [3] VULGAR FRACTION ONE SEVENTH..VULGAR FRACTION ONE TENTH
+	{runeRange{0x2155, 0x215A}, eawprN},     // No     [6] VULGAR FRACTION ONE FIFTH..VULGAR FRACTION FIVE SIXTHS
+	{runeRange{0x215F, 0x215F}, eawprN},     // No         FRACTION NUMERATOR ONE
+	{runeRange{0x216C, 0x216F}, eawprN},     // Nl     [4] ROMAN NUMERAL FIFTY..ROMAN NUMERAL ONE THOUSAND
+	{runeRange{0x217A, 0x2182}, eawprN},     // Nl     [9] SMALL ROMAN NUMERAL ELEVEN..ROMAN NUMERAL TEN THOUSAND
+	{runeRange{0x2185, 0x2188}, eawprN},     // Nl     [4] ROMAN NUMERAL SIX LATE FORM..ROMAN NUMERAL ONE HUNDRED THOUSAND
+	{runeRange{0x218A, 0x218B}, eawprN},     // So     [2] TURNED DIGIT TWO..TURNED DIGIT THREE
+	{runeRange{0x2195, 0x2199}, eawprA},     // So     [5] UP DOWN ARROW..SOUTH WEST ARROW
+	{runeRange{0x219C, 0x219F}, eawprN},     // So     [4] LEFTWARDS WAVE ARROW..UPWARDS TWO HEADED ARROW
+	{runeRange{0x21A1, 0x21A2}, eawprN},     // So     [2] DOWNWARDS TWO HEADED ARROW..LEFTWARDS ARROW WITH TAIL
+	{runeRange{0x21A4, 0x21A5}, eawprN},     // So     [2] LEFTWARDS ARROW FROM BAR..UPWARDS ARROW FROM BAR
+	{runeRange{0x21A7, 0x21AD}, eawprN},     // So     [7] DOWNWARDS ARROW FROM BAR..LEFT RIGHT WAVE ARROW
+	{runeRange{0x21AF, 0x21B7}, eawprN},     // So     [9] DOWNWARDS ZIGZAG ARROW..CLOCKWISE TOP SEMICIRCLE ARROW
+	{runeRange{0x21BA, 0x21CD}, eawprN},     // So    [20] ANTICLOCKWISE OPEN CIRCLE ARROW..LEFTWARDS DOUBLE ARROW WITH STROKE
+	{runeRange{0x21D0, 0x21D1}, eawprN},     // So     [2] LEFTWARDS DOUBLE ARROW..UPWARDS DOUBLE ARROW
+	{runeRange{0x21D3, 0x21D3}, eawprN},     // So         DOWNWARDS DOUBLE ARROW
+	{runeRange{0x21D5, 0x21E6}, eawprN},     // So    [18] UP DOWN DOUBLE ARROW..LEFTWARDS WHITE ARROW
+	{runeRange{0x21E8, 0x21F3}, eawprN},     // So    [12] RIGHTWARDS WHITE ARROW..UP DOWN WHITE ARROW
+	{runeRange{0x2200, 0x2200}, eawprA},     // Sm         FOR ALL
+	{runeRange{0x2202, 0x2203}, eawprA},     // Sm     [2] PARTIAL DIFFERENTIAL..THERE EXISTS
+	{runeRange{0x2207, 0x2208}, eawprA},     // Sm     [2] NABLA..ELEMENT OF
+	{runeRange{0x220B, 0x220B}, eawprA},     // Sm         CONTAINS AS MEMBER
+	{runeRange{0x220F, 0x220F}, eawprA},     // Sm         N-ARY PRODUCT
+	{runeRange{0x2211, 0x2211}, eawprA},     // Sm         N-ARY SUMMATION
+	{runeRange{0x2215, 0x2215}, eawprA},     // Sm         DIVISION SLASH
+	{runeRange{0x221A, 0x221A}, eawprA},     // Sm         SQUARE ROOT
+	{runeRange{0x221D, 0x2220}, eawprA},     // Sm     [4] PROPORTIONAL TO..ANGLE
+	{runeRange{0x2223, 0x2223}, eawprA},     // Sm         DIVIDES
+	{runeRange{0x2225, 0x2225}, eawprA},     // Sm         PARALLEL TO
+	{runeRange{0x2227, 0x222C}, eawprA},     // Sm     [6] LOGICAL AND..DOUBLE INTEGRAL
+	{runeRange{0x222E, 0x222E}, eawprA},     // Sm         CONTOUR INTEGRAL
+	{runeRange{0x2234, 0x2237}, eawprA},     // Sm     [4] THEREFORE..PROPORTION
+	{runeRange{0x223C, 0x223D}, eawprA},     // Sm     [2] TILDE OPERATOR..REVERSED TILDE
+	{runeRange{0x2248, 0x2248}, eawprA},     // Sm         ALMOST EQUAL TO
+	{runeRange{0x224C, 0x224C}, eawprA},     // Sm         ALL EQUAL TO
+	{runeRange{0x2252, 0x2252}, eawprA},     // Sm         APPROXIMATELY EQUAL TO OR THE IMAGE OF
 }

--- a/emoji.go
+++ b/emoji.go
@@ -9,408 +9,408 @@ package uniseg
 // ("Extended_Pictographic" only)
 // See https://www.unicode.org/license.html for the Unicode license agreement.
 var emoji = dictionary[emojiProperty]{
-	{runeRange{0x0023, 0x0023}, prEmoji},   // E0.0   [1] (#️)       hash sign
-	{runeRange{0x002A, 0x002A}, prEmoji},   // E0.0   [1] (*️)       asterisk
-	{runeRange{0x0030, 0x0039}, prEmoji},   // E0.0  [10] (0️..9️)    digit zero..digit nine
-	{runeRange{0x00A9, 0x00A9}, prEmoji},   // E0.6   [1] (©️)       copyright
-	{runeRange{0x00AE, 0x00AE}, prEmoji},   // E0.6   [1] (®️)       registered
-	{runeRange{0x203C, 0x203C}, prEmoji},   // E0.6   [1] (‼️)       double exclamation mark
-	{runeRange{0x2049, 0x2049}, prEmoji},   // E0.6   [1] (⁉️)       exclamation question mark
-	{runeRange{0x2122, 0x2122}, prEmoji},   // E0.6   [1] (™️)       trade mark
-	{runeRange{0x2139, 0x2139}, prEmoji},   // E0.6   [1] (ℹ️)       information
-	{runeRange{0x2194, 0x2199}, prEmoji},   // E0.6   [6] (↔️..↙️)    left-right arrow..down-left arrow
-	{runeRange{0x21A9, 0x21AA}, prEmoji},   // E0.6   [2] (↩️..↪️)    right arrow curving left..left arrow curving right
-	{runeRange{0x231A, 0x231B}, prEmoji},   // E0.6   [2] (⌚..⌛)    watch..hourglass done
-	{runeRange{0x2328, 0x2328}, prEmoji},   // E1.0   [1] (⌨️)       keyboard
-	{runeRange{0x23CF, 0x23CF}, prEmoji},   // E1.0   [1] (⏏️)       eject button
-	{runeRange{0x23E9, 0x23EC}, prEmoji},   // E0.6   [4] (⏩..⏬)    fast-forward button..fast down button
-	{runeRange{0x23ED, 0x23EE}, prEmoji},   // E0.7   [2] (⏭️..⏮️)    next track button..last track button
-	{runeRange{0x23EF, 0x23EF}, prEmoji},   // E1.0   [1] (⏯️)       play or pause button
-	{runeRange{0x23F0, 0x23F0}, prEmoji},   // E0.6   [1] (⏰)       alarm clock
-	{runeRange{0x23F1, 0x23F2}, prEmoji},   // E1.0   [2] (⏱️..⏲️)    stopwatch..timer clock
-	{runeRange{0x23F3, 0x23F3}, prEmoji},   // E0.6   [1] (⏳)       hourglass not done
-	{runeRange{0x23F8, 0x23FA}, prEmoji},   // E0.7   [3] (⏸️..⏺️)    pause button..record button
-	{runeRange{0x24C2, 0x24C2}, prEmoji},   // E0.6   [1] (Ⓜ️)       circled M
-	{runeRange{0x25AA, 0x25AB}, prEmoji},   // E0.6   [2] (▪️..▫️)    black small square..white small square
-	{runeRange{0x25B6, 0x25B6}, prEmoji},   // E0.6   [1] (▶️)       play button
-	{runeRange{0x25C0, 0x25C0}, prEmoji},   // E0.6   [1] (◀️)       reverse button
-	{runeRange{0x25FB, 0x25FE}, prEmoji},   // E0.6   [4] (◻️..◾)    white medium square..black medium-small square
-	{runeRange{0x2600, 0x2601}, prEmoji},   // E0.6   [2] (☀️..☁️)    sun..cloud
-	{runeRange{0x2602, 0x2603}, prEmoji},   // E0.7   [2] (☂️..☃️)    umbrella..snowman
-	{runeRange{0x2604, 0x2604}, prEmoji},   // E1.0   [1] (☄️)       comet
-	{runeRange{0x260E, 0x260E}, prEmoji},   // E0.6   [1] (☎️)       telephone
-	{runeRange{0x2611, 0x2611}, prEmoji},   // E0.6   [1] (☑️)       check box with check
-	{runeRange{0x2614, 0x2615}, prEmoji},   // E0.6   [2] (☔..☕)    umbrella with rain drops..hot beverage
-	{runeRange{0x2618, 0x2618}, prEmoji},   // E1.0   [1] (☘️)       shamrock
-	{runeRange{0x261D, 0x261D}, prEmoji},   // E0.6   [1] (☝️)       index pointing up
-	{runeRange{0x2620, 0x2620}, prEmoji},   // E1.0   [1] (☠️)       skull and crossbones
-	{runeRange{0x2622, 0x2623}, prEmoji},   // E1.0   [2] (☢️..☣️)    radioactive..biohazard
-	{runeRange{0x2626, 0x2626}, prEmoji},   // E1.0   [1] (☦️)       orthodox cross
-	{runeRange{0x262A, 0x262A}, prEmoji},   // E0.7   [1] (☪️)       star and crescent
-	{runeRange{0x262E, 0x262E}, prEmoji},   // E1.0   [1] (☮️)       peace symbol
-	{runeRange{0x262F, 0x262F}, prEmoji},   // E0.7   [1] (☯️)       yin yang
-	{runeRange{0x2638, 0x2639}, prEmoji},   // E0.7   [2] (☸️..☹️)    wheel of dharma..frowning face
-	{runeRange{0x263A, 0x263A}, prEmoji},   // E0.6   [1] (☺️)       smiling face
-	{runeRange{0x2640, 0x2640}, prEmoji},   // E4.0   [1] (♀️)       female sign
-	{runeRange{0x2642, 0x2642}, prEmoji},   // E4.0   [1] (♂️)       male sign
-	{runeRange{0x2648, 0x2653}, prEmoji},   // E0.6  [12] (♈..♓)    Aries..Pisces
-	{runeRange{0x265F, 0x265F}, prEmoji},   // E11.0  [1] (♟️)       chess pawn
-	{runeRange{0x2660, 0x2660}, prEmoji},   // E0.6   [1] (♠️)       spade suit
-	{runeRange{0x2663, 0x2663}, prEmoji},   // E0.6   [1] (♣️)       club suit
-	{runeRange{0x2665, 0x2666}, prEmoji},   // E0.6   [2] (♥️..♦️)    heart suit..diamond suit
-	{runeRange{0x2668, 0x2668}, prEmoji},   // E0.6   [1] (♨️)       hot springs
-	{runeRange{0x267B, 0x267B}, prEmoji},   // E0.6   [1] (♻️)       recycling symbol
-	{runeRange{0x267E, 0x267E}, prEmoji},   // E11.0  [1] (♾️)       infinity
-	{runeRange{0x267F, 0x267F}, prEmoji},   // E0.6   [1] (♿)       wheelchair symbol
-	{runeRange{0x2692, 0x2692}, prEmoji},   // E1.0   [1] (⚒️)       hammer and pick
-	{runeRange{0x2693, 0x2693}, prEmoji},   // E0.6   [1] (⚓)       anchor
-	{runeRange{0x2694, 0x2694}, prEmoji},   // E1.0   [1] (⚔️)       crossed swords
-	{runeRange{0x2695, 0x2695}, prEmoji},   // E4.0   [1] (⚕️)       medical symbol
-	{runeRange{0x2696, 0x2697}, prEmoji},   // E1.0   [2] (⚖️..⚗️)    balance scale..alembic
-	{runeRange{0x2699, 0x2699}, prEmoji},   // E1.0   [1] (⚙️)       gear
-	{runeRange{0x269B, 0x269C}, prEmoji},   // E1.0   [2] (⚛️..⚜️)    atom symbol..fleur-de-lis
-	{runeRange{0x26A0, 0x26A1}, prEmoji},   // E0.6   [2] (⚠️..⚡)    warning..high voltage
-	{runeRange{0x26A7, 0x26A7}, prEmoji},   // E13.0  [1] (⚧️)       transgender symbol
-	{runeRange{0x26AA, 0x26AB}, prEmoji},   // E0.6   [2] (⚪..⚫)    white circle..black circle
-	{runeRange{0x26B0, 0x26B1}, prEmoji},   // E1.0   [2] (⚰️..⚱️)    coffin..funeral urn
-	{runeRange{0x26BD, 0x26BE}, prEmoji},   // E0.6   [2] (⚽..⚾)    soccer ball..baseball
-	{runeRange{0x26C4, 0x26C5}, prEmoji},   // E0.6   [2] (⛄..⛅)    snowman without snow..sun behind cloud
-	{runeRange{0x26C8, 0x26C8}, prEmoji},   // E0.7   [1] (⛈️)       cloud with lightning and rain
-	{runeRange{0x26CE, 0x26CE}, prEmoji},   // E0.6   [1] (⛎)       Ophiuchus
-	{runeRange{0x26CF, 0x26CF}, prEmoji},   // E0.7   [1] (⛏️)       pick
-	{runeRange{0x26D1, 0x26D1}, prEmoji},   // E0.7   [1] (⛑️)       rescue worker’s helmet
-	{runeRange{0x26D3, 0x26D3}, prEmoji},   // E0.7   [1] (⛓️)       chains
-	{runeRange{0x26D4, 0x26D4}, prEmoji},   // E0.6   [1] (⛔)       no entry
-	{runeRange{0x26E9, 0x26E9}, prEmoji},   // E0.7   [1] (⛩️)       shinto shrine
-	{runeRange{0x26EA, 0x26EA}, prEmoji},   // E0.6   [1] (⛪)       church
-	{runeRange{0x26F0, 0x26F1}, prEmoji},   // E0.7   [2] (⛰️..⛱️)    mountain..umbrella on ground
-	{runeRange{0x26F2, 0x26F3}, prEmoji},   // E0.6   [2] (⛲..⛳)    fountain..flag in hole
-	{runeRange{0x26F4, 0x26F4}, prEmoji},   // E0.7   [1] (⛴️)       ferry
-	{runeRange{0x26F5, 0x26F5}, prEmoji},   // E0.6   [1] (⛵)       sailboat
-	{runeRange{0x26F7, 0x26F9}, prEmoji},   // E0.7   [3] (⛷️..⛹️)    skier..person bouncing ball
-	{runeRange{0x26FA, 0x26FA}, prEmoji},   // E0.6   [1] (⛺)       tent
-	{runeRange{0x26FD, 0x26FD}, prEmoji},   // E0.6   [1] (⛽)       fuel pump
-	{runeRange{0x2702, 0x2702}, prEmoji},   // E0.6   [1] (✂️)       scissors
-	{runeRange{0x2705, 0x2705}, prEmoji},   // E0.6   [1] (✅)       check mark button
-	{runeRange{0x2708, 0x270C}, prEmoji},   // E0.6   [5] (✈️..✌️)    airplane..victory hand
-	{runeRange{0x270D, 0x270D}, prEmoji},   // E0.7   [1] (✍️)       writing hand
-	{runeRange{0x270F, 0x270F}, prEmoji},   // E0.6   [1] (✏️)       pencil
-	{runeRange{0x2712, 0x2712}, prEmoji},   // E0.6   [1] (✒️)       black nib
-	{runeRange{0x2714, 0x2714}, prEmoji},   // E0.6   [1] (✔️)       check mark
-	{runeRange{0x2716, 0x2716}, prEmoji},   // E0.6   [1] (✖️)       multiply
-	{runeRange{0x271D, 0x271D}, prEmoji},   // E0.7   [1] (✝️)       latin cross
-	{runeRange{0x2721, 0x2721}, prEmoji},   // E0.7   [1] (✡️)       star of David
-	{runeRange{0x2728, 0x2728}, prEmoji},   // E0.6   [1] (✨)       sparkles
-	{runeRange{0x2733, 0x2734}, prEmoji},   // E0.6   [2] (✳️..✴️)    eight-spoked asterisk..eight-pointed star
-	{runeRange{0x2744, 0x2744}, prEmoji},   // E0.6   [1] (❄️)       snowflake
-	{runeRange{0x2747, 0x2747}, prEmoji},   // E0.6   [1] (❇️)       sparkle
-	{runeRange{0x274C, 0x274C}, prEmoji},   // E0.6   [1] (❌)       cross mark
-	{runeRange{0x274E, 0x274E}, prEmoji},   // E0.6   [1] (❎)       cross mark button
-	{runeRange{0x2753, 0x2755}, prEmoji},   // E0.6   [3] (❓..❕)    red question mark..white exclamation mark
-	{runeRange{0x2757, 0x2757}, prEmoji},   // E0.6   [1] (❗)       red exclamation mark
-	{runeRange{0x2763, 0x2763}, prEmoji},   // E1.0   [1] (❣️)       heart exclamation
-	{runeRange{0x2764, 0x2764}, prEmoji},   // E0.6   [1] (❤️)       red heart
-	{runeRange{0x2795, 0x2797}, prEmoji},   // E0.6   [3] (➕..➗)    plus..divide
-	{runeRange{0x27A1, 0x27A1}, prEmoji},   // E0.6   [1] (➡️)       right arrow
-	{runeRange{0x27B0, 0x27B0}, prEmoji},   // E0.6   [1] (➰)       curly loop
-	{runeRange{0x27BF, 0x27BF}, prEmoji},   // E1.0   [1] (➿)       double curly loop
-	{runeRange{0x2934, 0x2935}, prEmoji},   // E0.6   [2] (⤴️..⤵️)    right arrow curving up..right arrow curving down
-	{runeRange{0x2B05, 0x2B07}, prEmoji},   // E0.6   [3] (⬅️..⬇️)    left arrow..down arrow
-	{runeRange{0x2B1B, 0x2B1C}, prEmoji},   // E0.6   [2] (⬛..⬜)    black large square..white large square
-	{runeRange{0x2B50, 0x2B50}, prEmoji},   // E0.6   [1] (⭐)       star
-	{runeRange{0x2B55, 0x2B55}, prEmoji},   // E0.6   [1] (⭕)       hollow red circle
-	{runeRange{0x3030, 0x3030}, prEmoji},   // E0.6   [1] (〰️)       wavy dash
-	{runeRange{0x303D, 0x303D}, prEmoji},   // E0.6   [1] (〽️)       part alternation mark
-	{runeRange{0x3297, 0x3297}, prEmoji},   // E0.6   [1] (㊗️)       Japanese “congratulations” button
-	{runeRange{0x3299, 0x3299}, prEmoji},   // E0.6   [1] (㊙️)       Japanese “secret” button
-	{runeRange{0x1F004, 0x1F004}, prEmoji}, // E0.6   [1] (🀄)       mahjong red dragon
-	{runeRange{0x1F0CF, 0x1F0CF}, prEmoji}, // E0.6   [1] (🃏)       joker
-	{runeRange{0x1F170, 0x1F171}, prEmoji}, // E0.6   [2] (🅰️..🅱️)    A button (blood type)..B button (blood type)
-	{runeRange{0x1F17E, 0x1F17F}, prEmoji}, // E0.6   [2] (🅾️..🅿️)    O button (blood type)..P button
-	{runeRange{0x1F18E, 0x1F18E}, prEmoji}, // E0.6   [1] (🆎)       AB button (blood type)
-	{runeRange{0x1F191, 0x1F19A}, prEmoji}, // E0.6  [10] (🆑..🆚)    CL button..VS button
-	{runeRange{0x1F1E6, 0x1F1FF}, prEmoji}, // E0.0  [26] (🇦..🇿)    regional indicator symbol letter a..regional indicator symbol letter z
-	{runeRange{0x1F201, 0x1F202}, prEmoji}, // E0.6   [2] (🈁..🈂️)    Japanese “here” button..Japanese “service charge” button
-	{runeRange{0x1F21A, 0x1F21A}, prEmoji}, // E0.6   [1] (🈚)       Japanese “free of charge” button
-	{runeRange{0x1F22F, 0x1F22F}, prEmoji}, // E0.6   [1] (🈯)       Japanese “reserved” button
-	{runeRange{0x1F232, 0x1F23A}, prEmoji}, // E0.6   [9] (🈲..🈺)    Japanese “prohibited” button..Japanese “open for business” button
-	{runeRange{0x1F250, 0x1F251}, prEmoji}, // E0.6   [2] (🉐..🉑)    Japanese “bargain” button..Japanese “acceptable” button
-	{runeRange{0x1F300, 0x1F30C}, prEmoji}, // E0.6  [13] (🌀..🌌)    cyclone..milky way
-	{runeRange{0x1F30D, 0x1F30E}, prEmoji}, // E0.7   [2] (🌍..🌎)    globe showing Europe-Africa..globe showing Americas
-	{runeRange{0x1F30F, 0x1F30F}, prEmoji}, // E0.6   [1] (🌏)       globe showing Asia-Australia
-	{runeRange{0x1F310, 0x1F310}, prEmoji}, // E1.0   [1] (🌐)       globe with meridians
-	{runeRange{0x1F311, 0x1F311}, prEmoji}, // E0.6   [1] (🌑)       new moon
-	{runeRange{0x1F312, 0x1F312}, prEmoji}, // E1.0   [1] (🌒)       waxing crescent moon
-	{runeRange{0x1F313, 0x1F315}, prEmoji}, // E0.6   [3] (🌓..🌕)    first quarter moon..full moon
-	{runeRange{0x1F316, 0x1F318}, prEmoji}, // E1.0   [3] (🌖..🌘)    waning gibbous moon..waning crescent moon
-	{runeRange{0x1F319, 0x1F319}, prEmoji}, // E0.6   [1] (🌙)       crescent moon
-	{runeRange{0x1F31A, 0x1F31A}, prEmoji}, // E1.0   [1] (🌚)       new moon face
-	{runeRange{0x1F31B, 0x1F31B}, prEmoji}, // E0.6   [1] (🌛)       first quarter moon face
-	{runeRange{0x1F31C, 0x1F31C}, prEmoji}, // E0.7   [1] (🌜)       last quarter moon face
-	{runeRange{0x1F31D, 0x1F31E}, prEmoji}, // E1.0   [2] (🌝..🌞)    full moon face..sun with face
-	{runeRange{0x1F31F, 0x1F320}, prEmoji}, // E0.6   [2] (🌟..🌠)    glowing star..shooting star
-	{runeRange{0x1F321, 0x1F321}, prEmoji}, // E0.7   [1] (🌡️)       thermometer
-	{runeRange{0x1F324, 0x1F32C}, prEmoji}, // E0.7   [9] (🌤️..🌬️)    sun behind small cloud..wind face
-	{runeRange{0x1F32D, 0x1F32F}, prEmoji}, // E1.0   [3] (🌭..🌯)    hot dog..burrito
-	{runeRange{0x1F330, 0x1F331}, prEmoji}, // E0.6   [2] (🌰..🌱)    chestnut..seedling
-	{runeRange{0x1F332, 0x1F333}, prEmoji}, // E1.0   [2] (🌲..🌳)    evergreen tree..deciduous tree
-	{runeRange{0x1F334, 0x1F335}, prEmoji}, // E0.6   [2] (🌴..🌵)    palm tree..cactus
-	{runeRange{0x1F336, 0x1F336}, prEmoji}, // E0.7   [1] (🌶️)       hot pepper
-	{runeRange{0x1F337, 0x1F34A}, prEmoji}, // E0.6  [20] (🌷..🍊)    tulip..tangerine
-	{runeRange{0x1F34B, 0x1F34B}, prEmoji}, // E1.0   [1] (🍋)       lemon
-	{runeRange{0x1F34C, 0x1F34F}, prEmoji}, // E0.6   [4] (🍌..🍏)    banana..green apple
-	{runeRange{0x1F350, 0x1F350}, prEmoji}, // E1.0   [1] (🍐)       pear
-	{runeRange{0x1F351, 0x1F37B}, prEmoji}, // E0.6  [43] (🍑..🍻)    peach..clinking beer mugs
-	{runeRange{0x1F37C, 0x1F37C}, prEmoji}, // E1.0   [1] (🍼)       baby bottle
-	{runeRange{0x1F37D, 0x1F37D}, prEmoji}, // E0.7   [1] (🍽️)       fork and knife with plate
-	{runeRange{0x1F37E, 0x1F37F}, prEmoji}, // E1.0   [2] (🍾..🍿)    bottle with popping cork..popcorn
-	{runeRange{0x1F380, 0x1F393}, prEmoji}, // E0.6  [20] (🎀..🎓)    ribbon..graduation cap
-	{runeRange{0x1F396, 0x1F397}, prEmoji}, // E0.7   [2] (🎖️..🎗️)    military medal..reminder ribbon
-	{runeRange{0x1F399, 0x1F39B}, prEmoji}, // E0.7   [3] (🎙️..🎛️)    studio microphone..control knobs
-	{runeRange{0x1F39E, 0x1F39F}, prEmoji}, // E0.7   [2] (🎞️..🎟️)    film frames..admission tickets
-	{runeRange{0x1F3A0, 0x1F3C4}, prEmoji}, // E0.6  [37] (🎠..🏄)    carousel horse..person surfing
-	{runeRange{0x1F3C5, 0x1F3C5}, prEmoji}, // E1.0   [1] (🏅)       sports medal
-	{runeRange{0x1F3C6, 0x1F3C6}, prEmoji}, // E0.6   [1] (🏆)       trophy
-	{runeRange{0x1F3C7, 0x1F3C7}, prEmoji}, // E1.0   [1] (🏇)       horse racing
-	{runeRange{0x1F3C8, 0x1F3C8}, prEmoji}, // E0.6   [1] (🏈)       american football
-	{runeRange{0x1F3C9, 0x1F3C9}, prEmoji}, // E1.0   [1] (🏉)       rugby football
-	{runeRange{0x1F3CA, 0x1F3CA}, prEmoji}, // E0.6   [1] (🏊)       person swimming
-	{runeRange{0x1F3CB, 0x1F3CE}, prEmoji}, // E0.7   [4] (🏋️..🏎️)    person lifting weights..racing car
-	{runeRange{0x1F3CF, 0x1F3D3}, prEmoji}, // E1.0   [5] (🏏..🏓)    cricket game..ping pong
-	{runeRange{0x1F3D4, 0x1F3DF}, prEmoji}, // E0.7  [12] (🏔️..🏟️)    snow-capped mountain..stadium
-	{runeRange{0x1F3E0, 0x1F3E3}, prEmoji}, // E0.6   [4] (🏠..🏣)    house..Japanese post office
-	{runeRange{0x1F3E4, 0x1F3E4}, prEmoji}, // E1.0   [1] (🏤)       post office
-	{runeRange{0x1F3E5, 0x1F3F0}, prEmoji}, // E0.6  [12] (🏥..🏰)    hospital..castle
-	{runeRange{0x1F3F3, 0x1F3F3}, prEmoji}, // E0.7   [1] (🏳️)       white flag
-	{runeRange{0x1F3F4, 0x1F3F4}, prEmoji}, // E1.0   [1] (🏴)       black flag
-	{runeRange{0x1F3F5, 0x1F3F5}, prEmoji}, // E0.7   [1] (🏵️)       rosette
-	{runeRange{0x1F3F7, 0x1F3F7}, prEmoji}, // E0.7   [1] (🏷️)       label
-	{runeRange{0x1F3F8, 0x1F407}, prEmoji}, // E1.0  [16] (🏸..🐇)    badminton..rabbit
-	{runeRange{0x1F408, 0x1F408}, prEmoji}, // E0.7   [1] (🐈)       cat
-	{runeRange{0x1F409, 0x1F40B}, prEmoji}, // E1.0   [3] (🐉..🐋)    dragon..whale
-	{runeRange{0x1F40C, 0x1F40E}, prEmoji}, // E0.6   [3] (🐌..🐎)    snail..horse
-	{runeRange{0x1F40F, 0x1F410}, prEmoji}, // E1.0   [2] (🐏..🐐)    ram..goat
-	{runeRange{0x1F411, 0x1F412}, prEmoji}, // E0.6   [2] (🐑..🐒)    ewe..monkey
-	{runeRange{0x1F413, 0x1F413}, prEmoji}, // E1.0   [1] (🐓)       rooster
-	{runeRange{0x1F414, 0x1F414}, prEmoji}, // E0.6   [1] (🐔)       chicken
-	{runeRange{0x1F415, 0x1F415}, prEmoji}, // E0.7   [1] (🐕)       dog
-	{runeRange{0x1F416, 0x1F416}, prEmoji}, // E1.0   [1] (🐖)       pig
-	{runeRange{0x1F417, 0x1F429}, prEmoji}, // E0.6  [19] (🐗..🐩)    boar..poodle
-	{runeRange{0x1F42A, 0x1F42A}, prEmoji}, // E1.0   [1] (🐪)       camel
-	{runeRange{0x1F42B, 0x1F43E}, prEmoji}, // E0.6  [20] (🐫..🐾)    two-hump camel..paw prints
-	{runeRange{0x1F43F, 0x1F43F}, prEmoji}, // E0.7   [1] (🐿️)       chipmunk
-	{runeRange{0x1F440, 0x1F440}, prEmoji}, // E0.6   [1] (👀)       eyes
-	{runeRange{0x1F441, 0x1F441}, prEmoji}, // E0.7   [1] (👁️)       eye
-	{runeRange{0x1F442, 0x1F464}, prEmoji}, // E0.6  [35] (👂..👤)    ear..bust in silhouette
-	{runeRange{0x1F465, 0x1F465}, prEmoji}, // E1.0   [1] (👥)       busts in silhouette
-	{runeRange{0x1F466, 0x1F46B}, prEmoji}, // E0.6   [6] (👦..👫)    boy..woman and man holding hands
-	{runeRange{0x1F46C, 0x1F46D}, prEmoji}, // E1.0   [2] (👬..👭)    men holding hands..women holding hands
-	{runeRange{0x1F46E, 0x1F4AC}, prEmoji}, // E0.6  [63] (👮..💬)    police officer..speech balloon
-	{runeRange{0x1F4AD, 0x1F4AD}, prEmoji}, // E1.0   [1] (💭)       thought balloon
-	{runeRange{0x1F4AE, 0x1F4B5}, prEmoji}, // E0.6   [8] (💮..💵)    white flower..dollar banknote
-	{runeRange{0x1F4B6, 0x1F4B7}, prEmoji}, // E1.0   [2] (💶..💷)    euro banknote..pound banknote
-	{runeRange{0x1F4B8, 0x1F4EB}, prEmoji}, // E0.6  [52] (💸..📫)    money with wings..closed mailbox with raised flag
-	{runeRange{0x1F4EC, 0x1F4ED}, prEmoji}, // E0.7   [2] (📬..📭)    open mailbox with raised flag..open mailbox with lowered flag
-	{runeRange{0x1F4EE, 0x1F4EE}, prEmoji}, // E0.6   [1] (📮)       postbox
-	{runeRange{0x1F4EF, 0x1F4EF}, prEmoji}, // E1.0   [1] (📯)       postal horn
-	{runeRange{0x1F4F0, 0x1F4F4}, prEmoji}, // E0.6   [5] (📰..📴)    newspaper..mobile phone off
-	{runeRange{0x1F4F5, 0x1F4F5}, prEmoji}, // E1.0   [1] (📵)       no mobile phones
-	{runeRange{0x1F4F6, 0x1F4F7}, prEmoji}, // E0.6   [2] (📶..📷)    antenna bars..camera
-	{runeRange{0x1F4F8, 0x1F4F8}, prEmoji}, // E1.0   [1] (📸)       camera with flash
-	{runeRange{0x1F4F9, 0x1F4FC}, prEmoji}, // E0.6   [4] (📹..📼)    video camera..videocassette
-	{runeRange{0x1F4FD, 0x1F4FD}, prEmoji}, // E0.7   [1] (📽️)       film projector
-	{runeRange{0x1F4FF, 0x1F502}, prEmoji}, // E1.0   [4] (📿..🔂)    prayer beads..repeat single button
-	{runeRange{0x1F503, 0x1F503}, prEmoji}, // E0.6   [1] (🔃)       clockwise vertical arrows
-	{runeRange{0x1F504, 0x1F507}, prEmoji}, // E1.0   [4] (🔄..🔇)    counterclockwise arrows button..muted speaker
-	{runeRange{0x1F508, 0x1F508}, prEmoji}, // E0.7   [1] (🔈)       speaker low volume
-	{runeRange{0x1F509, 0x1F509}, prEmoji}, // E1.0   [1] (🔉)       speaker medium volume
-	{runeRange{0x1F50A, 0x1F514}, prEmoji}, // E0.6  [11] (🔊..🔔)    speaker high volume..bell
-	{runeRange{0x1F515, 0x1F515}, prEmoji}, // E1.0   [1] (🔕)       bell with slash
-	{runeRange{0x1F516, 0x1F52B}, prEmoji}, // E0.6  [22] (🔖..🔫)    bookmark..water pistol
-	{runeRange{0x1F52C, 0x1F52D}, prEmoji}, // E1.0   [2] (🔬..🔭)    microscope..telescope
-	{runeRange{0x1F52E, 0x1F53D}, prEmoji}, // E0.6  [16] (🔮..🔽)    crystal ball..downwards button
-	{runeRange{0x1F549, 0x1F54A}, prEmoji}, // E0.7   [2] (🕉️..🕊️)    om..dove
-	{runeRange{0x1F54B, 0x1F54E}, prEmoji}, // E1.0   [4] (🕋..🕎)    kaaba..menorah
-	{runeRange{0x1F550, 0x1F55B}, prEmoji}, // E0.6  [12] (🕐..🕛)    one o’clock..twelve o’clock
-	{runeRange{0x1F55C, 0x1F567}, prEmoji}, // E0.7  [12] (🕜..🕧)    one-thirty..twelve-thirty
-	{runeRange{0x1F56F, 0x1F570}, prEmoji}, // E0.7   [2] (🕯️..🕰️)    candle..mantelpiece clock
-	{runeRange{0x1F573, 0x1F579}, prEmoji}, // E0.7   [7] (🕳️..🕹️)    hole..joystick
-	{runeRange{0x1F57A, 0x1F57A}, prEmoji}, // E3.0   [1] (🕺)       man dancing
-	{runeRange{0x1F587, 0x1F587}, prEmoji}, // E0.7   [1] (🖇️)       linked paperclips
-	{runeRange{0x1F58A, 0x1F58D}, prEmoji}, // E0.7   [4] (🖊️..🖍️)    pen..crayon
-	{runeRange{0x1F590, 0x1F590}, prEmoji}, // E0.7   [1] (🖐️)       hand with fingers splayed
-	{runeRange{0x1F595, 0x1F596}, prEmoji}, // E1.0   [2] (🖕..🖖)    middle finger..vulcan salute
-	{runeRange{0x1F5A4, 0x1F5A4}, prEmoji}, // E3.0   [1] (🖤)       black heart
-	{runeRange{0x1F5A5, 0x1F5A5}, prEmoji}, // E0.7   [1] (🖥️)       desktop computer
-	{runeRange{0x1F5A8, 0x1F5A8}, prEmoji}, // E0.7   [1] (🖨️)       printer
-	{runeRange{0x1F5B1, 0x1F5B2}, prEmoji}, // E0.7   [2] (🖱️..🖲️)    computer mouse..trackball
-	{runeRange{0x1F5BC, 0x1F5BC}, prEmoji}, // E0.7   [1] (🖼️)       framed picture
-	{runeRange{0x1F5C2, 0x1F5C4}, prEmoji}, // E0.7   [3] (🗂️..🗄️)    card index dividers..file cabinet
-	{runeRange{0x1F5D1, 0x1F5D3}, prEmoji}, // E0.7   [3] (🗑️..🗓️)    wastebasket..spiral calendar
-	{runeRange{0x1F5DC, 0x1F5DE}, prEmoji}, // E0.7   [3] (🗜️..🗞️)    clamp..rolled-up newspaper
-	{runeRange{0x1F5E1, 0x1F5E1}, prEmoji}, // E0.7   [1] (🗡️)       dagger
-	{runeRange{0x1F5E3, 0x1F5E3}, prEmoji}, // E0.7   [1] (🗣️)       speaking head
-	{runeRange{0x1F5E8, 0x1F5E8}, prEmoji}, // E2.0   [1] (🗨️)       left speech bubble
-	{runeRange{0x1F5EF, 0x1F5EF}, prEmoji}, // E0.7   [1] (🗯️)       right anger bubble
-	{runeRange{0x1F5F3, 0x1F5F3}, prEmoji}, // E0.7   [1] (🗳️)       ballot box with ballot
-	{runeRange{0x1F5FA, 0x1F5FA}, prEmoji}, // E0.7   [1] (🗺️)       world map
-	{runeRange{0x1F5FB, 0x1F5FF}, prEmoji}, // E0.6   [5] (🗻..🗿)    mount fuji..moai
-	{runeRange{0x1F600, 0x1F600}, prEmoji}, // E1.0   [1] (😀)       grinning face
-	{runeRange{0x1F601, 0x1F606}, prEmoji}, // E0.6   [6] (😁..😆)    beaming face with smiling eyes..grinning squinting face
-	{runeRange{0x1F607, 0x1F608}, prEmoji}, // E1.0   [2] (😇..😈)    smiling face with halo..smiling face with horns
-	{runeRange{0x1F609, 0x1F60D}, prEmoji}, // E0.6   [5] (😉..😍)    winking face..smiling face with heart-eyes
-	{runeRange{0x1F60E, 0x1F60E}, prEmoji}, // E1.0   [1] (😎)       smiling face with sunglasses
-	{runeRange{0x1F60F, 0x1F60F}, prEmoji}, // E0.6   [1] (😏)       smirking face
-	{runeRange{0x1F610, 0x1F610}, prEmoji}, // E0.7   [1] (😐)       neutral face
-	{runeRange{0x1F611, 0x1F611}, prEmoji}, // E1.0   [1] (😑)       expressionless face
-	{runeRange{0x1F612, 0x1F614}, prEmoji}, // E0.6   [3] (😒..😔)    unamused face..pensive face
 	{runeRange{0x1F615, 0x1F615}, prEmoji}, // E1.0   [1] (😕)       confused face
-	{runeRange{0x1F616, 0x1F616}, prEmoji}, // E0.6   [1] (😖)       confounded face
-	{runeRange{0x1F617, 0x1F617}, prEmoji}, // E1.0   [1] (😗)       kissing face
-	{runeRange{0x1F618, 0x1F618}, prEmoji}, // E0.6   [1] (😘)       face blowing a kiss
-	{runeRange{0x1F619, 0x1F619}, prEmoji}, // E1.0   [1] (😙)       kissing face with smiling eyes
-	{runeRange{0x1F61A, 0x1F61A}, prEmoji}, // E0.6   [1] (😚)       kissing face with closed eyes
-	{runeRange{0x1F61B, 0x1F61B}, prEmoji}, // E1.0   [1] (😛)       face with tongue
-	{runeRange{0x1F61C, 0x1F61E}, prEmoji}, // E0.6   [3] (😜..😞)    winking face with tongue..disappointed face
-	{runeRange{0x1F61F, 0x1F61F}, prEmoji}, // E1.0   [1] (😟)       worried face
-	{runeRange{0x1F620, 0x1F625}, prEmoji}, // E0.6   [6] (😠..😥)    angry face..sad but relieved face
-	{runeRange{0x1F626, 0x1F627}, prEmoji}, // E1.0   [2] (😦..😧)    frowning face with open mouth..anguished face
-	{runeRange{0x1F628, 0x1F62B}, prEmoji}, // E0.6   [4] (😨..😫)    fearful face..tired face
-	{runeRange{0x1F62C, 0x1F62C}, prEmoji}, // E1.0   [1] (😬)       grimacing face
-	{runeRange{0x1F62D, 0x1F62D}, prEmoji}, // E0.6   [1] (😭)       loudly crying face
-	{runeRange{0x1F62E, 0x1F62F}, prEmoji}, // E1.0   [2] (😮..😯)    face with open mouth..hushed face
-	{runeRange{0x1F630, 0x1F633}, prEmoji}, // E0.6   [4] (😰..😳)    anxious face with sweat..flushed face
-	{runeRange{0x1F634, 0x1F634}, prEmoji}, // E1.0   [1] (😴)       sleeping face
-	{runeRange{0x1F635, 0x1F635}, prEmoji}, // E0.6   [1] (😵)       face with crossed-out eyes
-	{runeRange{0x1F636, 0x1F636}, prEmoji}, // E1.0   [1] (😶)       face without mouth
-	{runeRange{0x1F637, 0x1F640}, prEmoji}, // E0.6  [10] (😷..🙀)    face with medical mask..weary cat
-	{runeRange{0x1F641, 0x1F644}, prEmoji}, // E1.0   [4] (🙁..🙄)    slightly frowning face..face with rolling eyes
-	{runeRange{0x1F645, 0x1F64F}, prEmoji}, // E0.6  [11] (🙅..🙏)    person gesturing NO..folded hands
-	{runeRange{0x1F680, 0x1F680}, prEmoji}, // E0.6   [1] (🚀)       rocket
-	{runeRange{0x1F681, 0x1F682}, prEmoji}, // E1.0   [2] (🚁..🚂)    helicopter..locomotive
-	{runeRange{0x1F683, 0x1F685}, prEmoji}, // E0.6   [3] (🚃..🚅)    railway car..bullet train
-	{runeRange{0x1F686, 0x1F686}, prEmoji}, // E1.0   [1] (🚆)       train
-	{runeRange{0x1F687, 0x1F687}, prEmoji}, // E0.6   [1] (🚇)       metro
-	{runeRange{0x1F688, 0x1F688}, prEmoji}, // E1.0   [1] (🚈)       light rail
-	{runeRange{0x1F689, 0x1F689}, prEmoji}, // E0.6   [1] (🚉)       station
-	{runeRange{0x1F68A, 0x1F68B}, prEmoji}, // E1.0   [2] (🚊..🚋)    tram..tram car
-	{runeRange{0x1F68C, 0x1F68C}, prEmoji}, // E0.6   [1] (🚌)       bus
-	{runeRange{0x1F68D, 0x1F68D}, prEmoji}, // E0.7   [1] (🚍)       oncoming bus
-	{runeRange{0x1F68E, 0x1F68E}, prEmoji}, // E1.0   [1] (🚎)       trolleybus
-	{runeRange{0x1F68F, 0x1F68F}, prEmoji}, // E0.6   [1] (🚏)       bus stop
-	{runeRange{0x1F690, 0x1F690}, prEmoji}, // E1.0   [1] (🚐)       minibus
-	{runeRange{0x1F691, 0x1F693}, prEmoji}, // E0.6   [3] (🚑..🚓)    ambulance..police car
-	{runeRange{0x1F694, 0x1F694}, prEmoji}, // E0.7   [1] (🚔)       oncoming police car
-	{runeRange{0x1F695, 0x1F695}, prEmoji}, // E0.6   [1] (🚕)       taxi
-	{runeRange{0x1F696, 0x1F696}, prEmoji}, // E1.0   [1] (🚖)       oncoming taxi
-	{runeRange{0x1F697, 0x1F697}, prEmoji}, // E0.6   [1] (🚗)       automobile
-	{runeRange{0x1F698, 0x1F698}, prEmoji}, // E0.7   [1] (🚘)       oncoming automobile
-	{runeRange{0x1F699, 0x1F69A}, prEmoji}, // E0.6   [2] (🚙..🚚)    sport utility vehicle..delivery truck
-	{runeRange{0x1F69B, 0x1F6A1}, prEmoji}, // E1.0   [7] (🚛..🚡)    articulated lorry..aerial tramway
-	{runeRange{0x1F6A2, 0x1F6A2}, prEmoji}, // E0.6   [1] (🚢)       ship
-	{runeRange{0x1F6A3, 0x1F6A3}, prEmoji}, // E1.0   [1] (🚣)       person rowing boat
-	{runeRange{0x1F6A4, 0x1F6A5}, prEmoji}, // E0.6   [2] (🚤..🚥)    speedboat..horizontal traffic light
-	{runeRange{0x1F6A6, 0x1F6A6}, prEmoji}, // E1.0   [1] (🚦)       vertical traffic light
-	{runeRange{0x1F6A7, 0x1F6AD}, prEmoji}, // E0.6   [7] (🚧..🚭)    construction..no smoking
-	{runeRange{0x1F6AE, 0x1F6B1}, prEmoji}, // E1.0   [4] (🚮..🚱)    litter in bin sign..non-potable water
-	{runeRange{0x1F6B2, 0x1F6B2}, prEmoji}, // E0.6   [1] (🚲)       bicycle
-	{runeRange{0x1F6B3, 0x1F6B5}, prEmoji}, // E1.0   [3] (🚳..🚵)    no bicycles..person mountain biking
-	{runeRange{0x1F6B6, 0x1F6B6}, prEmoji}, // E0.6   [1] (🚶)       person walking
-	{runeRange{0x1F6B7, 0x1F6B8}, prEmoji}, // E1.0   [2] (🚷..🚸)    no pedestrians..children crossing
-	{runeRange{0x1F6B9, 0x1F6BE}, prEmoji}, // E0.6   [6] (🚹..🚾)    men’s room..water closet
-	{runeRange{0x1F6BF, 0x1F6BF}, prEmoji}, // E1.0   [1] (🚿)       shower
-	{runeRange{0x1F6C0, 0x1F6C0}, prEmoji}, // E0.6   [1] (🛀)       person taking bath
-	{runeRange{0x1F6C1, 0x1F6C5}, prEmoji}, // E1.0   [5] (🛁..🛅)    bathtub..left luggage
-	{runeRange{0x1F6CB, 0x1F6CB}, prEmoji}, // E0.7   [1] (🛋️)       couch and lamp
-	{runeRange{0x1F6CC, 0x1F6CC}, prEmoji}, // E1.0   [1] (🛌)       person in bed
-	{runeRange{0x1F6CD, 0x1F6CF}, prEmoji}, // E0.7   [3] (🛍️..🛏️)    shopping bags..bed
-	{runeRange{0x1F6D0, 0x1F6D0}, prEmoji}, // E1.0   [1] (🛐)       place of worship
-	{runeRange{0x1F6D1, 0x1F6D2}, prEmoji}, // E3.0   [2] (🛑..🛒)    stop sign..shopping cart
-	{runeRange{0x1F6D5, 0x1F6D5}, prEmoji}, // E12.0  [1] (🛕)       hindu temple
-	{runeRange{0x1F6D6, 0x1F6D7}, prEmoji}, // E13.0  [2] (🛖..🛗)    hut..elevator
-	{runeRange{0x1F6DC, 0x1F6DC}, prEmoji}, // E15.0  [1] (🛜)       wireless
-	{runeRange{0x1F6DD, 0x1F6DF}, prEmoji}, // E14.0  [3] (🛝..🛟)    playground slide..ring buoy
-	{runeRange{0x1F6E0, 0x1F6E5}, prEmoji}, // E0.7   [6] (🛠️..🛥️)    hammer and wrench..motor boat
-	{runeRange{0x1F6E9, 0x1F6E9}, prEmoji}, // E0.7   [1] (🛩️)       small airplane
-	{runeRange{0x1F6EB, 0x1F6EC}, prEmoji}, // E1.0   [2] (🛫..🛬)    airplane departure..airplane arrival
-	{runeRange{0x1F6F0, 0x1F6F0}, prEmoji}, // E0.7   [1] (🛰️)       satellite
-	{runeRange{0x1F6F3, 0x1F6F3}, prEmoji}, // E0.7   [1] (🛳️)       passenger ship
-	{runeRange{0x1F6F4, 0x1F6F6}, prEmoji}, // E3.0   [3] (🛴..🛶)    kick scooter..canoe
-	{runeRange{0x1F6F7, 0x1F6F8}, prEmoji}, // E5.0   [2] (🛷..🛸)    sled..flying saucer
-	{runeRange{0x1F6F9, 0x1F6F9}, prEmoji}, // E11.0  [1] (🛹)       skateboard
-	{runeRange{0x1F6FA, 0x1F6FA}, prEmoji}, // E12.0  [1] (🛺)       auto rickshaw
-	{runeRange{0x1F6FB, 0x1F6FC}, prEmoji}, // E13.0  [2] (🛻..🛼)    pickup truck..roller skate
-	{runeRange{0x1F7E0, 0x1F7EB}, prEmoji}, // E12.0 [12] (🟠..🟫)    orange circle..brown square
-	{runeRange{0x1F7F0, 0x1F7F0}, prEmoji}, // E14.0  [1] (🟰)       heavy equals sign
-	{runeRange{0x1F90C, 0x1F90C}, prEmoji}, // E13.0  [1] (🤌)       pinched fingers
-	{runeRange{0x1F90D, 0x1F90F}, prEmoji}, // E12.0  [3] (🤍..🤏)    white heart..pinching hand
-	{runeRange{0x1F910, 0x1F918}, prEmoji}, // E1.0   [9] (🤐..🤘)    zipper-mouth face..sign of the horns
-	{runeRange{0x1F919, 0x1F91E}, prEmoji}, // E3.0   [6] (🤙..🤞)    call me hand..crossed fingers
-	{runeRange{0x1F91F, 0x1F91F}, prEmoji}, // E5.0   [1] (🤟)       love-you gesture
-	{runeRange{0x1F920, 0x1F927}, prEmoji}, // E3.0   [8] (🤠..🤧)    cowboy hat face..sneezing face
-	{runeRange{0x1F928, 0x1F92F}, prEmoji}, // E5.0   [8] (🤨..🤯)    face with raised eyebrow..exploding head
+	{runeRange{0x1F30D, 0x1F30E}, prEmoji}, // E0.7   [2] (🌍..🌎)    globe showing Europe-Africa..globe showing Americas
 	{runeRange{0x1F930, 0x1F930}, prEmoji}, // E3.0   [1] (🤰)       pregnant woman
-	{runeRange{0x1F931, 0x1F932}, prEmoji}, // E5.0   [2] (🤱..🤲)    breast-feeding..palms up together
-	{runeRange{0x1F933, 0x1F93A}, prEmoji}, // E3.0   [8] (🤳..🤺)    selfie..person fencing
-	{runeRange{0x1F93C, 0x1F93E}, prEmoji}, // E3.0   [3] (🤼..🤾)    people wrestling..person playing handball
-	{runeRange{0x1F93F, 0x1F93F}, prEmoji}, // E12.0  [1] (🤿)       diving mask
-	{runeRange{0x1F940, 0x1F945}, prEmoji}, // E3.0   [6] (🥀..🥅)    wilted flower..goal net
-	{runeRange{0x1F947, 0x1F94B}, prEmoji}, // E3.0   [5] (🥇..🥋)    1st place medal..martial arts uniform
-	{runeRange{0x1F94C, 0x1F94C}, prEmoji}, // E5.0   [1] (🥌)       curling stone
-	{runeRange{0x1F94D, 0x1F94F}, prEmoji}, // E11.0  [3] (🥍..🥏)    lacrosse..flying disc
-	{runeRange{0x1F950, 0x1F95E}, prEmoji}, // E3.0  [15] (🥐..🥞)    croissant..pancakes
-	{runeRange{0x1F95F, 0x1F96B}, prEmoji}, // E5.0  [13] (🥟..🥫)    dumpling..canned food
-	{runeRange{0x1F96C, 0x1F970}, prEmoji}, // E11.0  [5] (🥬..🥰)    leafy green..smiling face with hearts
-	{runeRange{0x1F971, 0x1F971}, prEmoji}, // E12.0  [1] (🥱)       yawning face
-	{runeRange{0x1F972, 0x1F972}, prEmoji}, // E13.0  [1] (🥲)       smiling face with tear
-	{runeRange{0x1F973, 0x1F976}, prEmoji}, // E11.0  [4] (🥳..🥶)    partying face..cold face
-	{runeRange{0x1F977, 0x1F978}, prEmoji}, // E13.0  [2] (🥷..🥸)    ninja..disguised face
-	{runeRange{0x1F979, 0x1F979}, prEmoji}, // E14.0  [1] (🥹)       face holding back tears
-	{runeRange{0x1F97A, 0x1F97A}, prEmoji}, // E11.0  [1] (🥺)       pleading face
-	{runeRange{0x1F97B, 0x1F97B}, prEmoji}, // E12.0  [1] (🥻)       sari
-	{runeRange{0x1F97C, 0x1F97F}, prEmoji}, // E11.0  [4] (🥼..🥿)    lab coat..flat shoe
-	{runeRange{0x1F980, 0x1F984}, prEmoji}, // E1.0   [5] (🦀..🦄)    crab..unicorn
-	{runeRange{0x1F985, 0x1F991}, prEmoji}, // E3.0  [13] (🦅..🦑)    eagle..squid
-	{runeRange{0x1F992, 0x1F997}, prEmoji}, // E5.0   [6] (🦒..🦗)    giraffe..cricket
-	{runeRange{0x1F998, 0x1F9A2}, prEmoji}, // E11.0 [11] (🦘..🦢)    kangaroo..swan
-	{runeRange{0x1F9A3, 0x1F9A4}, prEmoji}, // E13.0  [2] (🦣..🦤)    mammoth..dodo
-	{runeRange{0x1F9A5, 0x1F9AA}, prEmoji}, // E12.0  [6] (🦥..🦪)    sloth..oyster
-	{runeRange{0x1F9AB, 0x1F9AD}, prEmoji}, // E13.0  [3] (🦫..🦭)    beaver..seal
-	{runeRange{0x1F9AE, 0x1F9AF}, prEmoji}, // E12.0  [2] (🦮..🦯)    guide dog..white cane
-	{runeRange{0x1F9B0, 0x1F9B9}, prEmoji}, // E11.0 [10] (🦰..🦹)    red hair..supervillain
-	{runeRange{0x1F9BA, 0x1F9BF}, prEmoji}, // E12.0  [6] (🦺..🦿)    safety vest..mechanical leg
-	{runeRange{0x1F9C0, 0x1F9C0}, prEmoji}, // E1.0   [1] (🧀)       cheese wedge
-	{runeRange{0x1F9C1, 0x1F9C2}, prEmoji}, // E11.0  [2] (🧁..🧂)    cupcake..salt
+	{runeRange{0x26B0, 0x26B1}, prEmoji},   // E1.0   [2] (⚰️..⚱️)    coffin..funeral urn
+	{runeRange{0x1F441, 0x1F441}, prEmoji}, // E0.7   [1] (👁️)       eye
+	{runeRange{0x1F6B9, 0x1F6BE}, prEmoji}, // E0.6   [6] (🚹..🚾)    men’s room..water closet
 	{runeRange{0x1F9C3, 0x1F9CA}, prEmoji}, // E12.0  [8] (🧃..🧊)    beverage box..ice
-	{runeRange{0x1F9CB, 0x1F9CB}, prEmoji}, // E13.0  [1] (🧋)       bubble tea
-	{runeRange{0x1F9CC, 0x1F9CC}, prEmoji}, // E14.0  [1] (🧌)       troll
-	{runeRange{0x1F9CD, 0x1F9CF}, prEmoji}, // E12.0  [3] (🧍..🧏)    person standing..deaf person
-	{runeRange{0x1F9D0, 0x1F9E6}, prEmoji}, // E5.0  [23] (🧐..🧦)    face with monocle..socks
-	{runeRange{0x1F9E7, 0x1F9FF}, prEmoji}, // E11.0 [25] (🧧..🧿)    red envelope..nazar amulet
-	{runeRange{0x1FA70, 0x1FA73}, prEmoji}, // E12.0  [4] (🩰..🩳)    ballet shoes..shorts
-	{runeRange{0x1FA74, 0x1FA74}, prEmoji}, // E13.0  [1] (🩴)       thong sandal
-	{runeRange{0x1FA75, 0x1FA77}, prEmoji}, // E15.0  [3] (🩵..🩷)    light blue heart..pink heart
-	{runeRange{0x1FA78, 0x1FA7A}, prEmoji}, // E12.0  [3] (🩸..🩺)    drop of blood..stethoscope
-	{runeRange{0x1FA7B, 0x1FA7C}, prEmoji}, // E14.0  [2] (🩻..🩼)    x-ray..crutch
-	{runeRange{0x1FA80, 0x1FA82}, prEmoji}, // E12.0  [3] (🪀..🪂)    yo-yo..parachute
-	{runeRange{0x1FA83, 0x1FA86}, prEmoji}, // E13.0  [4] (🪃..🪆)    boomerang..nesting dolls
-	{runeRange{0x1FA87, 0x1FA88}, prEmoji}, // E15.0  [2] (🪇..🪈)    maracas..flute
-	{runeRange{0x1FA90, 0x1FA95}, prEmoji}, // E12.0  [6] (🪐..🪕)    ringed planet..banjo
-	{runeRange{0x1FA96, 0x1FAA8}, prEmoji}, // E13.0 [19] (🪖..🪨)    military helmet..rock
+	{runeRange{0x2614, 0x2615}, prEmoji},   // E0.6   [2] (☔..☕)    umbrella with rain drops..hot beverage
+	{runeRange{0x274C, 0x274C}, prEmoji},   // E0.6   [1] (❌)       cross mark
+	{runeRange{0x1F3A0, 0x1F3C4}, prEmoji}, // E0.6  [37] (🎠..🏄)    carousel horse..person surfing
+	{runeRange{0x1F55C, 0x1F567}, prEmoji}, // E0.7  [12] (🕜..🕧)    one-thirty..twelve-thirty
+	{runeRange{0x1F68E, 0x1F68E}, prEmoji}, // E1.0   [1] (🚎)       trolleybus
+	{runeRange{0x1F6F0, 0x1F6F0}, prEmoji}, // E0.7   [1] (🛰️)       satellite
+	{runeRange{0x1F979, 0x1F979}, prEmoji}, // E14.0  [1] (🥹)       face holding back tears
 	{runeRange{0x1FAA9, 0x1FAAC}, prEmoji}, // E14.0  [4] (🪩..🪬)    mirror ball..hamsa
-	{runeRange{0x1FAAD, 0x1FAAF}, prEmoji}, // E15.0  [3] (🪭..🪯)    folding hand fan..khanda
-	{runeRange{0x1FAB0, 0x1FAB6}, prEmoji}, // E13.0  [7] (🪰..🪶)    fly..feather
-	{runeRange{0x1FAB7, 0x1FABA}, prEmoji}, // E14.0  [4] (🪷..🪺)    lotus..nest with eggs
-	{runeRange{0x1FABB, 0x1FABD}, prEmoji}, // E15.0  [3] (🪻..🪽)    hyacinth..wing
-	{runeRange{0x1FABF, 0x1FABF}, prEmoji}, // E15.0  [1] (🪿)       goose
-	{runeRange{0x1FAC0, 0x1FAC2}, prEmoji}, // E13.0  [3] (🫀..🫂)    anatomical heart..people hugging
-	{runeRange{0x1FAC3, 0x1FAC5}, prEmoji}, // E14.0  [3] (🫃..🫅)    pregnant man..person with crown
+	{runeRange{0x23ED, 0x23EE}, prEmoji},   // E0.7   [2] (⏭️..⏮️)    next track button..last track button
+	{runeRange{0x2663, 0x2663}, prEmoji},   // E0.6   [1] (♣️)       club suit
+	{runeRange{0x26FA, 0x26FA}, prEmoji},   // E0.6   [1] (⛺)       tent
+	{runeRange{0x303D, 0x303D}, prEmoji},   // E0.6   [1] (〽️)       part alternation mark
+	{runeRange{0x1F330, 0x1F331}, prEmoji}, // E0.6   [2] (🌰..🌱)    chestnut..seedling
+	{runeRange{0x1F3F7, 0x1F3F7}, prEmoji}, // E0.7   [1] (🏷️)       label
+	{runeRange{0x1F4F8, 0x1F4F8}, prEmoji}, // E1.0   [1] (📸)       camera with flash
+	{runeRange{0x1F5E1, 0x1F5E1}, prEmoji}, // E0.7   [1] (🗡️)       dagger
+	{runeRange{0x1F634, 0x1F634}, prEmoji}, // E1.0   [1] (😴)       sleeping face
+	{runeRange{0x1F6A4, 0x1F6A5}, prEmoji}, // E0.6   [2] (🚤..🚥)    speedboat..horizontal traffic light
+	{runeRange{0x1F6D1, 0x1F6D2}, prEmoji}, // E3.0   [2] (🛑..🛒)    stop sign..shopping cart
+	{runeRange{0x1F7F0, 0x1F7F0}, prEmoji}, // E14.0  [1] (🟰)       heavy equals sign
+	{runeRange{0x1F94D, 0x1F94F}, prEmoji}, // E11.0  [3] (🥍..🥏)    lacrosse..flying disc
+	{runeRange{0x1F9A3, 0x1F9A4}, prEmoji}, // E13.0  [2] (🦣..🦤)    mammoth..dodo
+	{runeRange{0x1FA75, 0x1FA77}, prEmoji}, // E15.0  [3] (🩵..🩷)    light blue heart..pink heart
 	{runeRange{0x1FACE, 0x1FACF}, prEmoji}, // E15.0  [2] (🫎..🫏)    moose..donkey
-	{runeRange{0x1FAD0, 0x1FAD6}, prEmoji}, // E13.0  [7] (🫐..🫖)    blueberries..teapot
-	{runeRange{0x1FAD7, 0x1FAD9}, prEmoji}, // E14.0  [3] (🫗..🫙)    pouring liquid..jar
-	{runeRange{0x1FADA, 0x1FADB}, prEmoji}, // E15.0  [2] (🫚..🫛)    ginger root..pea pod
+	{runeRange{0x2122, 0x2122}, prEmoji},   // E0.6   [1] (™️)       trade mark
+	{runeRange{0x25B6, 0x25B6}, prEmoji},   // E0.6   [1] (▶️)       play button
+	{runeRange{0x262F, 0x262F}, prEmoji},   // E0.7   [1] (☯️)       yin yang
+	{runeRange{0x2694, 0x2694}, prEmoji},   // E1.0   [1] (⚔️)       crossed swords
+	{runeRange{0x26D4, 0x26D4}, prEmoji},   // E0.6   [1] (⛔)       no entry
+	{runeRange{0x2714, 0x2714}, prEmoji},   // E0.6   [1] (✔️)       check mark
+	{runeRange{0x27B0, 0x27B0}, prEmoji},   // E0.6   [1] (➰)       curly loop
+	{runeRange{0x1F191, 0x1F19A}, prEmoji}, // E0.6  [10] (🆑..🆚)    CL button..VS button
+	{runeRange{0x1F31A, 0x1F31A}, prEmoji}, // E1.0   [1] (🌚)       new moon face
+	{runeRange{0x1F351, 0x1F37B}, prEmoji}, // E0.6  [43] (🍑..🍻)    peach..clinking beer mugs
+	{runeRange{0x1F3CF, 0x1F3D3}, prEmoji}, // E1.0   [5] (🏏..🏓)    cricket game..ping pong
+	{runeRange{0x1F414, 0x1F414}, prEmoji}, // E0.6   [1] (🐔)       chicken
+	{runeRange{0x1F4B6, 0x1F4B7}, prEmoji}, // E1.0   [2] (💶..💷)    euro banknote..pound banknote
+	{runeRange{0x1F50A, 0x1F514}, prEmoji}, // E0.6  [11] (🔊..🔔)    speaker high volume..bell
+	{runeRange{0x1F5A4, 0x1F5A4}, prEmoji}, // E3.0   [1] (🖤)       black heart
+	{runeRange{0x1F601, 0x1F606}, prEmoji}, // E0.6   [6] (😁..😆)    beaming face with smiling eyes..grinning squinting face
+	{runeRange{0x1F61F, 0x1F61F}, prEmoji}, // E1.0   [1] (😟)       worried face
+	{runeRange{0x1F683, 0x1F685}, prEmoji}, // E0.6   [3] (🚃..🚅)    railway car..bullet train
+	{runeRange{0x1F698, 0x1F698}, prEmoji}, // E0.7   [1] (🚘)       oncoming automobile
+	{runeRange{0x1F6B2, 0x1F6B2}, prEmoji}, // E0.6   [1] (🚲)       bicycle
+	{runeRange{0x1F6CB, 0x1F6CB}, prEmoji}, // E0.7   [1] (🛋️)       couch and lamp
+	{runeRange{0x1F6DD, 0x1F6DF}, prEmoji}, // E14.0  [3] (🛝..🛟)    playground slide..ring buoy
+	{runeRange{0x1F6F9, 0x1F6F9}, prEmoji}, // E11.0  [1] (🛹)       skateboard
+	{runeRange{0x1F919, 0x1F91E}, prEmoji}, // E3.0   [6] (🤙..🤞)    call me hand..crossed fingers
+	{runeRange{0x1F93F, 0x1F93F}, prEmoji}, // E12.0  [1] (🤿)       diving mask
+	{runeRange{0x1F971, 0x1F971}, prEmoji}, // E12.0  [1] (🥱)       yawning face
+	{runeRange{0x1F980, 0x1F984}, prEmoji}, // E1.0   [5] (🦀..🦄)    crab..unicorn
+	{runeRange{0x1F9B0, 0x1F9B9}, prEmoji}, // E11.0 [10] (🦰..🦹)    red hair..supervillain
+	{runeRange{0x1F9D0, 0x1F9E6}, prEmoji}, // E5.0  [23] (🧐..🧦)    face with monocle..socks
+	{runeRange{0x1FA83, 0x1FA86}, prEmoji}, // E13.0  [4] (🪃..🪆)    boomerang..nesting dolls
+	{runeRange{0x1FABB, 0x1FABD}, prEmoji}, // E15.0  [3] (🪻..🪽)    hyacinth..wing
 	{runeRange{0x1FAE0, 0x1FAE7}, prEmoji}, // E14.0  [8] (🫠..🫧)    melting face..bubbles
-	{runeRange{0x1FAE8, 0x1FAE8}, prEmoji}, // E15.0  [1] (🫨)       shaking face
+	{runeRange{0x00A9, 0x00A9}, prEmoji},   // E0.6   [1] (©️)       copyright
+	{runeRange{0x231A, 0x231B}, prEmoji},   // E0.6   [2] (⌚..⌛)    watch..hourglass done
+	{runeRange{0x23F3, 0x23F3}, prEmoji},   // E0.6   [1] (⏳)       hourglass not done
+	{runeRange{0x2602, 0x2603}, prEmoji},   // E0.7   [2] (☂️..☃️)    umbrella..snowman
+	{runeRange{0x2622, 0x2623}, prEmoji},   // E1.0   [2] (☢️..☣️)    radioactive..biohazard
+	{runeRange{0x2642, 0x2642}, prEmoji},   // E4.0   [1] (♂️)       male sign
+	{runeRange{0x267E, 0x267E}, prEmoji},   // E11.0  [1] (♾️)       infinity
+	{runeRange{0x269B, 0x269C}, prEmoji},   // E1.0   [2] (⚛️..⚜️)    atom symbol..fleur-de-lis
+	{runeRange{0x26CE, 0x26CE}, prEmoji},   // E0.6   [1] (⛎)       Ophiuchus
+	{runeRange{0x26F2, 0x26F3}, prEmoji},   // E0.6   [2] (⛲..⛳)    fountain..flag in hole
+	{runeRange{0x2708, 0x270C}, prEmoji},   // E0.6   [5] (✈️..✌️)    airplane..victory hand
+	{runeRange{0x2728, 0x2728}, prEmoji},   // E0.6   [1] (✨)       sparkles
+	{runeRange{0x2763, 0x2763}, prEmoji},   // E1.0   [1] (❣️)       heart exclamation
+	{runeRange{0x2B1B, 0x2B1C}, prEmoji},   // E0.6   [2] (⬛..⬜)    black large square..white large square
+	{runeRange{0x1F0CF, 0x1F0CF}, prEmoji}, // E0.6   [1] (🃏)       joker
+	{runeRange{0x1F22F, 0x1F22F}, prEmoji}, // E0.6   [1] (🈯)       Japanese “reserved” button
+	{runeRange{0x1F312, 0x1F312}, prEmoji}, // E1.0   [1] (🌒)       waxing crescent moon
+	{runeRange{0x1F31F, 0x1F320}, prEmoji}, // E0.6   [2] (🌟..🌠)    glowing star..shooting star
+	{runeRange{0x1F337, 0x1F34A}, prEmoji}, // E0.6  [20] (🌷..🍊)    tulip..tangerine
+	{runeRange{0x1F380, 0x1F393}, prEmoji}, // E0.6  [20] (🎀..🎓)    ribbon..graduation cap
+	{runeRange{0x1F3C8, 0x1F3C8}, prEmoji}, // E0.6   [1] (🏈)       american football
+	{runeRange{0x1F3E5, 0x1F3F0}, prEmoji}, // E0.6  [12] (🏥..🏰)    hospital..castle
+	{runeRange{0x1F40C, 0x1F40E}, prEmoji}, // E0.6   [3] (🐌..🐎)    snail..horse
+	{runeRange{0x1F42A, 0x1F42A}, prEmoji}, // E1.0   [1] (🐪)       camel
+	{runeRange{0x1F46C, 0x1F46D}, prEmoji}, // E1.0   [2] (👬..👭)    men holding hands..women holding hands
+	{runeRange{0x1F4EF, 0x1F4EF}, prEmoji}, // E1.0   [1] (📯)       postal horn
+	{runeRange{0x1F503, 0x1F503}, prEmoji}, // E0.6   [1] (🔃)       clockwise vertical arrows
+	{runeRange{0x1F52E, 0x1F53D}, prEmoji}, // E0.6  [16] (🔮..🔽)    crystal ball..downwards button
+	{runeRange{0x1F587, 0x1F587}, prEmoji}, // E0.7   [1] (🖇️)       linked paperclips
+	{runeRange{0x1F5BC, 0x1F5BC}, prEmoji}, // E0.7   [1] (🖼️)       framed picture
+	{runeRange{0x1F5F3, 0x1F5F3}, prEmoji}, // E0.7   [1] (🗳️)       ballot box with ballot
+	{runeRange{0x1F60F, 0x1F60F}, prEmoji}, // E0.6   [1] (😏)       smirking face
+	{runeRange{0x1F619, 0x1F619}, prEmoji}, // E1.0   [1] (😙)       kissing face with smiling eyes
+	{runeRange{0x1F62C, 0x1F62C}, prEmoji}, // E1.0   [1] (😬)       grimacing face
+	{runeRange{0x1F641, 0x1F644}, prEmoji}, // E1.0   [4] (🙁..🙄)    slightly frowning face..face with rolling eyes
+	{runeRange{0x1F689, 0x1F689}, prEmoji}, // E0.6   [1] (🚉)       station
+	{runeRange{0x1F694, 0x1F694}, prEmoji}, // E0.7   [1] (🚔)       oncoming police car
+	{runeRange{0x1F6A2, 0x1F6A2}, prEmoji}, // E0.6   [1] (🚢)       ship
+	{runeRange{0x1F6A7, 0x1F6AD}, prEmoji}, // E0.6   [7] (🚧..🚭)    construction..no smoking
+	{runeRange{0x1F6B6, 0x1F6B6}, prEmoji}, // E0.6   [1] (🚶)       person walking
+	{runeRange{0x1F6C0, 0x1F6C0}, prEmoji}, // E0.6   [1] (🛀)       person taking bath
+	{runeRange{0x1F6CD, 0x1F6CF}, prEmoji}, // E0.7   [3] (🛍️..🛏️)    shopping bags..bed
+	{runeRange{0x1F6D6, 0x1F6D7}, prEmoji}, // E13.0  [2] (🛖..🛗)    hut..elevator
+	{runeRange{0x1F6E9, 0x1F6E9}, prEmoji}, // E0.7   [1] (🛩️)       small airplane
+	{runeRange{0x1F6F4, 0x1F6F6}, prEmoji}, // E3.0   [3] (🛴..🛶)    kick scooter..canoe
+	{runeRange{0x1F6FB, 0x1F6FC}, prEmoji}, // E13.0  [2] (🛻..🛼)    pickup truck..roller skate
+	{runeRange{0x1F90D, 0x1F90F}, prEmoji}, // E12.0  [3] (🤍..🤏)    white heart..pinching hand
+	{runeRange{0x1F920, 0x1F927}, prEmoji}, // E3.0   [8] (🤠..🤧)    cowboy hat face..sneezing face
+	{runeRange{0x1F933, 0x1F93A}, prEmoji}, // E3.0   [8] (🤳..🤺)    selfie..person fencing
+	{runeRange{0x1F947, 0x1F94B}, prEmoji}, // E3.0   [5] (🥇..🥋)    1st place medal..martial arts uniform
+	{runeRange{0x1F95F, 0x1F96B}, prEmoji}, // E5.0  [13] (🥟..🥫)    dumpling..canned food
+	{runeRange{0x1F973, 0x1F976}, prEmoji}, // E11.0  [4] (🥳..🥶)    partying face..cold face
+	{runeRange{0x1F97B, 0x1F97B}, prEmoji}, // E12.0  [1] (🥻)       sari
+	{runeRange{0x1F992, 0x1F997}, prEmoji}, // E5.0   [6] (🦒..🦗)    giraffe..cricket
+	{runeRange{0x1F9AB, 0x1F9AD}, prEmoji}, // E13.0  [3] (🦫..🦭)    beaver..seal
+	{runeRange{0x1F9C0, 0x1F9C0}, prEmoji}, // E1.0   [1] (🧀)       cheese wedge
+	{runeRange{0x1F9CC, 0x1F9CC}, prEmoji}, // E14.0  [1] (🧌)       troll
+	{runeRange{0x1FA70, 0x1FA73}, prEmoji}, // E12.0  [4] (🩰..🩳)    ballet shoes..shorts
+	{runeRange{0x1FA7B, 0x1FA7C}, prEmoji}, // E14.0  [2] (🩻..🩼)    x-ray..crutch
+	{runeRange{0x1FA90, 0x1FA95}, prEmoji}, // E12.0  [6] (🪐..🪕)    ringed planet..banjo
+	{runeRange{0x1FAB0, 0x1FAB6}, prEmoji}, // E13.0  [7] (🪰..🪶)    fly..feather
+	{runeRange{0x1FAC0, 0x1FAC2}, prEmoji}, // E13.0  [3] (🫀..🫂)    anatomical heart..people hugging
+	{runeRange{0x1FAD7, 0x1FAD9}, prEmoji}, // E14.0  [3] (🫗..🫙)    pouring liquid..jar
 	{runeRange{0x1FAF0, 0x1FAF6}, prEmoji}, // E14.0  [7] (🫰..🫶)    hand with index finger and thumb crossed..heart hands
+	{runeRange{0x002A, 0x002A}, prEmoji},   // E0.0   [1] (*️)       asterisk
+	{runeRange{0x203C, 0x203C}, prEmoji},   // E0.6   [1] (‼️)       double exclamation mark
+	{runeRange{0x2194, 0x2199}, prEmoji},   // E0.6   [6] (↔️..↙️)    left-right arrow..down-left arrow
+	{runeRange{0x23CF, 0x23CF}, prEmoji},   // E1.0   [1] (⏏️)       eject button
+	{runeRange{0x23F0, 0x23F0}, prEmoji},   // E0.6   [1] (⏰)       alarm clock
+	{runeRange{0x24C2, 0x24C2}, prEmoji},   // E0.6   [1] (Ⓜ️)       circled M
+	{runeRange{0x25FB, 0x25FE}, prEmoji},   // E0.6   [4] (◻️..◾)    white medium square..black medium-small square
+	{runeRange{0x260E, 0x260E}, prEmoji},   // E0.6   [1] (☎️)       telephone
+	{runeRange{0x261D, 0x261D}, prEmoji},   // E0.6   [1] (☝️)       index pointing up
+	{runeRange{0x262A, 0x262A}, prEmoji},   // E0.7   [1] (☪️)       star and crescent
+	{runeRange{0x263A, 0x263A}, prEmoji},   // E0.6   [1] (☺️)       smiling face
+	{runeRange{0x265F, 0x265F}, prEmoji},   // E11.0  [1] (♟️)       chess pawn
+	{runeRange{0x2668, 0x2668}, prEmoji},   // E0.6   [1] (♨️)       hot springs
+	{runeRange{0x2692, 0x2692}, prEmoji},   // E1.0   [1] (⚒️)       hammer and pick
+	{runeRange{0x2696, 0x2697}, prEmoji},   // E1.0   [2] (⚖️..⚗️)    balance scale..alembic
+	{runeRange{0x26A7, 0x26A7}, prEmoji},   // E13.0  [1] (⚧️)       transgender symbol
+	{runeRange{0x26C4, 0x26C5}, prEmoji},   // E0.6   [2] (⛄..⛅)    snowman without snow..sun behind cloud
+	{runeRange{0x26D1, 0x26D1}, prEmoji},   // E0.7   [1] (⛑️)       rescue worker’s helmet
+	{runeRange{0x26EA, 0x26EA}, prEmoji},   // E0.6   [1] (⛪)       church
+	{runeRange{0x26F5, 0x26F5}, prEmoji},   // E0.6   [1] (⛵)       sailboat
+	{runeRange{0x2702, 0x2702}, prEmoji},   // E0.6   [1] (✂️)       scissors
+	{runeRange{0x270F, 0x270F}, prEmoji},   // E0.6   [1] (✏️)       pencil
+	{runeRange{0x271D, 0x271D}, prEmoji},   // E0.7   [1] (✝️)       latin cross
+	{runeRange{0x2744, 0x2744}, prEmoji},   // E0.6   [1] (❄️)       snowflake
+	{runeRange{0x2753, 0x2755}, prEmoji},   // E0.6   [3] (❓..❕)    red question mark..white exclamation mark
+	{runeRange{0x2795, 0x2797}, prEmoji},   // E0.6   [3] (➕..➗)    plus..divide
+	{runeRange{0x2934, 0x2935}, prEmoji},   // E0.6   [2] (⤴️..⤵️)    right arrow curving up..right arrow curving down
+	{runeRange{0x2B55, 0x2B55}, prEmoji},   // E0.6   [1] (⭕)       hollow red circle
+	{runeRange{0x3299, 0x3299}, prEmoji},   // E0.6   [1] (㊙️)       Japanese “secret” button
+	{runeRange{0x1F17E, 0x1F17F}, prEmoji}, // E0.6   [2] (🅾️..🅿️)    O button (blood type)..P button
+	{runeRange{0x1F201, 0x1F202}, prEmoji}, // E0.6   [2] (🈁..🈂️)    Japanese “here” button..Japanese “service charge” button
+	{runeRange{0x1F250, 0x1F251}, prEmoji}, // E0.6   [2] (🉐..🉑)    Japanese “bargain” button..Japanese “acceptable” button
+	{runeRange{0x1F310, 0x1F310}, prEmoji}, // E1.0   [1] (🌐)       globe with meridians
+	{runeRange{0x1F316, 0x1F318}, prEmoji}, // E1.0   [3] (🌖..🌘)    waning gibbous moon..waning crescent moon
+	{runeRange{0x1F31C, 0x1F31C}, prEmoji}, // E0.7   [1] (🌜)       last quarter moon face
+	{runeRange{0x1F324, 0x1F32C}, prEmoji}, // E0.7   [9] (🌤️..🌬️)    sun behind small cloud..wind face
+	{runeRange{0x1F334, 0x1F335}, prEmoji}, // E0.6   [2] (🌴..🌵)    palm tree..cactus
+	{runeRange{0x1F34C, 0x1F34F}, prEmoji}, // E0.6   [4] (🍌..🍏)    banana..green apple
+	{runeRange{0x1F37D, 0x1F37D}, prEmoji}, // E0.7   [1] (🍽️)       fork and knife with plate
+	{runeRange{0x1F399, 0x1F39B}, prEmoji}, // E0.7   [3] (🎙️..🎛️)    studio microphone..control knobs
+	{runeRange{0x1F3C6, 0x1F3C6}, prEmoji}, // E0.6   [1] (🏆)       trophy
+	{runeRange{0x1F3CA, 0x1F3CA}, prEmoji}, // E0.6   [1] (🏊)       person swimming
+	{runeRange{0x1F3E0, 0x1F3E3}, prEmoji}, // E0.6   [4] (🏠..🏣)    house..Japanese post office
+	{runeRange{0x1F3F4, 0x1F3F4}, prEmoji}, // E1.0   [1] (🏴)       black flag
+	{runeRange{0x1F408, 0x1F408}, prEmoji}, // E0.7   [1] (🐈)       cat
+	{runeRange{0x1F411, 0x1F412}, prEmoji}, // E0.6   [2] (🐑..🐒)    ewe..monkey
+	{runeRange{0x1F416, 0x1F416}, prEmoji}, // E1.0   [1] (🐖)       pig
+	{runeRange{0x1F43F, 0x1F43F}, prEmoji}, // E0.7   [1] (🐿️)       chipmunk
+	{runeRange{0x1F465, 0x1F465}, prEmoji}, // E1.0   [1] (👥)       busts in silhouette
+	{runeRange{0x1F4AD, 0x1F4AD}, prEmoji}, // E1.0   [1] (💭)       thought balloon
+	{runeRange{0x1F4EC, 0x1F4ED}, prEmoji}, // E0.7   [2] (📬..📭)    open mailbox with raised flag..open mailbox with lowered flag
+	{runeRange{0x1F4F5, 0x1F4F5}, prEmoji}, // E1.0   [1] (📵)       no mobile phones
+	{runeRange{0x1F4FD, 0x1F4FD}, prEmoji}, // E0.7   [1] (📽️)       film projector
+	{runeRange{0x1F508, 0x1F508}, prEmoji}, // E0.7   [1] (🔈)       speaker low volume
+	{runeRange{0x1F516, 0x1F52B}, prEmoji}, // E0.6  [22] (🔖..🔫)    bookmark..water pistol
+	{runeRange{0x1F54B, 0x1F54E}, prEmoji}, // E1.0   [4] (🕋..🕎)    kaaba..menorah
+	{runeRange{0x1F573, 0x1F579}, prEmoji}, // E0.7   [7] (🕳️..🕹️)    hole..joystick
+	{runeRange{0x1F590, 0x1F590}, prEmoji}, // E0.7   [1] (🖐️)       hand with fingers splayed
+	{runeRange{0x1F5A8, 0x1F5A8}, prEmoji}, // E0.7   [1] (🖨️)       printer
+	{runeRange{0x1F5D1, 0x1F5D3}, prEmoji}, // E0.7   [3] (🗑️..🗓️)    wastebasket..spiral calendar
+	{runeRange{0x1F5E8, 0x1F5E8}, prEmoji}, // E2.0   [1] (🗨️)       left speech bubble
+	{runeRange{0x1F5FB, 0x1F5FF}, prEmoji}, // E0.6   [5] (🗻..🗿)    mount fuji..moai
+	{runeRange{0x1F609, 0x1F60D}, prEmoji}, // E0.6   [5] (😉..😍)    winking face..smiling face with heart-eyes
+	{runeRange{0x1F611, 0x1F611}, prEmoji}, // E1.0   [1] (😑)       expressionless face
+	{runeRange{0x1F617, 0x1F617}, prEmoji}, // E1.0   [1] (😗)       kissing face
+	{runeRange{0x1F61B, 0x1F61B}, prEmoji}, // E1.0   [1] (😛)       face with tongue
+	{runeRange{0x1F626, 0x1F627}, prEmoji}, // E1.0   [2] (😦..😧)    frowning face with open mouth..anguished face
+	{runeRange{0x1F62E, 0x1F62F}, prEmoji}, // E1.0   [2] (😮..😯)    face with open mouth..hushed face
+	{runeRange{0x1F636, 0x1F636}, prEmoji}, // E1.0   [1] (😶)       face without mouth
+	{runeRange{0x1F680, 0x1F680}, prEmoji}, // E0.6   [1] (🚀)       rocket
+	{runeRange{0x1F687, 0x1F687}, prEmoji}, // E0.6   [1] (🚇)       metro
+	{runeRange{0x1F68C, 0x1F68C}, prEmoji}, // E0.6   [1] (🚌)       bus
+	{runeRange{0x1F690, 0x1F690}, prEmoji}, // E1.0   [1] (🚐)       minibus
+	{runeRange{0x1F696, 0x1F696}, prEmoji}, // E1.0   [1] (🚖)       oncoming taxi
+	{runeRange{0x1F69B, 0x1F6A1}, prEmoji}, // E1.0   [7] (🚛..🚡)    articulated lorry..aerial tramway
+	{runeRange{0x1F6A3, 0x1F6A3}, prEmoji}, // E1.0   [1] (🚣)       person rowing boat
+	{runeRange{0x1F6A6, 0x1F6A6}, prEmoji}, // E1.0   [1] (🚦)       vertical traffic light
+	{runeRange{0x1F6AE, 0x1F6B1}, prEmoji}, // E1.0   [4] (🚮..🚱)    litter in bin sign..non-potable water
+	{runeRange{0x1F6B3, 0x1F6B5}, prEmoji}, // E1.0   [3] (🚳..🚵)    no bicycles..person mountain biking
+	{runeRange{0x1F6B7, 0x1F6B8}, prEmoji}, // E1.0   [2] (🚷..🚸)    no pedestrians..children crossing
+	{runeRange{0x1F6BF, 0x1F6BF}, prEmoji}, // E1.0   [1] (🚿)       shower
+	{runeRange{0x1F6C1, 0x1F6C5}, prEmoji}, // E1.0   [5] (🛁..🛅)    bathtub..left luggage
+	{runeRange{0x1F6CC, 0x1F6CC}, prEmoji}, // E1.0   [1] (🛌)       person in bed
+	{runeRange{0x1F6D0, 0x1F6D0}, prEmoji}, // E1.0   [1] (🛐)       place of worship
+	{runeRange{0x1F6D5, 0x1F6D5}, prEmoji}, // E12.0  [1] (🛕)       hindu temple
+	{runeRange{0x1F6DC, 0x1F6DC}, prEmoji}, // E15.0  [1] (🛜)       wireless
+	{runeRange{0x1F6E0, 0x1F6E5}, prEmoji}, // E0.7   [6] (🛠️..🛥️)    hammer and wrench..motor boat
+	{runeRange{0x1F6EB, 0x1F6EC}, prEmoji}, // E1.0   [2] (🛫..🛬)    airplane departure..airplane arrival
+	{runeRange{0x1F6F3, 0x1F6F3}, prEmoji}, // E0.7   [1] (🛳️)       passenger ship
+	{runeRange{0x1F6F7, 0x1F6F8}, prEmoji}, // E5.0   [2] (🛷..🛸)    sled..flying saucer
+	{runeRange{0x1F6FA, 0x1F6FA}, prEmoji}, // E12.0  [1] (🛺)       auto rickshaw
+	{runeRange{0x1F7E0, 0x1F7EB}, prEmoji}, // E12.0 [12] (🟠..🟫)    orange circle..brown square
+	{runeRange{0x1F90C, 0x1F90C}, prEmoji}, // E13.0  [1] (🤌)       pinched fingers
+	{runeRange{0x1F910, 0x1F918}, prEmoji}, // E1.0   [9] (🤐..🤘)    zipper-mouth face..sign of the horns
+	{runeRange{0x1F91F, 0x1F91F}, prEmoji}, // E5.0   [1] (🤟)       love-you gesture
+	{runeRange{0x1F928, 0x1F92F}, prEmoji}, // E5.0   [8] (🤨..🤯)    face with raised eyebrow..exploding head
+	{runeRange{0x1F931, 0x1F932}, prEmoji}, // E5.0   [2] (🤱..🤲)    breast-feeding..palms up together
+	{runeRange{0x1F93C, 0x1F93E}, prEmoji}, // E3.0   [3] (🤼..🤾)    people wrestling..person playing handball
+	{runeRange{0x1F940, 0x1F945}, prEmoji}, // E3.0   [6] (🥀..🥅)    wilted flower..goal net
+	{runeRange{0x1F94C, 0x1F94C}, prEmoji}, // E5.0   [1] (🥌)       curling stone
+	{runeRange{0x1F950, 0x1F95E}, prEmoji}, // E3.0  [15] (🥐..🥞)    croissant..pancakes
+	{runeRange{0x1F96C, 0x1F970}, prEmoji}, // E11.0  [5] (🥬..🥰)    leafy green..smiling face with hearts
+	{runeRange{0x1F972, 0x1F972}, prEmoji}, // E13.0  [1] (🥲)       smiling face with tear
+	{runeRange{0x1F977, 0x1F978}, prEmoji}, // E13.0  [2] (🥷..🥸)    ninja..disguised face
+	{runeRange{0x1F97A, 0x1F97A}, prEmoji}, // E11.0  [1] (🥺)       pleading face
+	{runeRange{0x1F97C, 0x1F97F}, prEmoji}, // E11.0  [4] (🥼..🥿)    lab coat..flat shoe
+	{runeRange{0x1F985, 0x1F991}, prEmoji}, // E3.0  [13] (🦅..🦑)    eagle..squid
+	{runeRange{0x1F998, 0x1F9A2}, prEmoji}, // E11.0 [11] (🦘..🦢)    kangaroo..swan
+	{runeRange{0x1F9A5, 0x1F9AA}, prEmoji}, // E12.0  [6] (🦥..🦪)    sloth..oyster
+	{runeRange{0x1F9AE, 0x1F9AF}, prEmoji}, // E12.0  [2] (🦮..🦯)    guide dog..white cane
+	{runeRange{0x1F9BA, 0x1F9BF}, prEmoji}, // E12.0  [6] (🦺..🦿)    safety vest..mechanical leg
+	{runeRange{0x1F9C1, 0x1F9C2}, prEmoji}, // E11.0  [2] (🧁..🧂)    cupcake..salt
+	{runeRange{0x1F9CB, 0x1F9CB}, prEmoji}, // E13.0  [1] (🧋)       bubble tea
+	{runeRange{0x1F9CD, 0x1F9CF}, prEmoji}, // E12.0  [3] (🧍..🧏)    person standing..deaf person
+	{runeRange{0x1F9E7, 0x1F9FF}, prEmoji}, // E11.0 [25] (🧧..🧿)    red envelope..nazar amulet
+	{runeRange{0x1FA74, 0x1FA74}, prEmoji}, // E13.0  [1] (🩴)       thong sandal
+	{runeRange{0x1FA78, 0x1FA7A}, prEmoji}, // E12.0  [3] (🩸..🩺)    drop of blood..stethoscope
+	{runeRange{0x1FA80, 0x1FA82}, prEmoji}, // E12.0  [3] (🪀..🪂)    yo-yo..parachute
+	{runeRange{0x1FA87, 0x1FA88}, prEmoji}, // E15.0  [2] (🪇..🪈)    maracas..flute
+	{runeRange{0x1FA96, 0x1FAA8}, prEmoji}, // E13.0 [19] (🪖..🪨)    military helmet..rock
+	{runeRange{0x1FAAD, 0x1FAAF}, prEmoji}, // E15.0  [3] (🪭..🪯)    folding hand fan..khanda
+	{runeRange{0x1FAB7, 0x1FABA}, prEmoji}, // E14.0  [4] (🪷..🪺)    lotus..nest with eggs
+	{runeRange{0x1FABF, 0x1FABF}, prEmoji}, // E15.0  [1] (🪿)       goose
+	{runeRange{0x1FAC3, 0x1FAC5}, prEmoji}, // E14.0  [3] (🫃..🫅)    pregnant man..person with crown
+	{runeRange{0x1FAD0, 0x1FAD6}, prEmoji}, // E13.0  [7] (🫐..🫖)    blueberries..teapot
+	{runeRange{0x1FADA, 0x1FADB}, prEmoji}, // E15.0  [2] (🫚..🫛)    ginger root..pea pod
+	{runeRange{0x1FAE8, 0x1FAE8}, prEmoji}, // E15.0  [1] (🫨)       shaking face
 	{runeRange{0x1FAF7, 0x1FAF8}, prEmoji}, // E15.0  [2] (🫷..🫸)    leftwards pushing hand..rightwards pushing hand
+	{runeRange{0x0023, 0x0023}, prEmoji},   // E0.0   [1] (#️)       hash sign
+	{runeRange{0x0030, 0x0039}, prEmoji},   // E0.0  [10] (0️..9️)    digit zero..digit nine
+	{runeRange{0x00AE, 0x00AE}, prEmoji},   // E0.6   [1] (®️)       registered
+	{runeRange{0x2049, 0x2049}, prEmoji},   // E0.6   [1] (⁉️)       exclamation question mark
+	{runeRange{0x2139, 0x2139}, prEmoji},   // E0.6   [1] (ℹ️)       information
+	{runeRange{0x21A9, 0x21AA}, prEmoji},   // E0.6   [2] (↩️..↪️)    right arrow curving left..left arrow curving right
+	{runeRange{0x2328, 0x2328}, prEmoji},   // E1.0   [1] (⌨️)       keyboard
+	{runeRange{0x23E9, 0x23EC}, prEmoji},   // E0.6   [4] (⏩..⏬)    fast-forward button..fast down button
+	{runeRange{0x23EF, 0x23EF}, prEmoji},   // E1.0   [1] (⏯️)       play or pause button
+	{runeRange{0x23F1, 0x23F2}, prEmoji},   // E1.0   [2] (⏱️..⏲️)    stopwatch..timer clock
+	{runeRange{0x23F8, 0x23FA}, prEmoji},   // E0.7   [3] (⏸️..⏺️)    pause button..record button
+	{runeRange{0x25AA, 0x25AB}, prEmoji},   // E0.6   [2] (▪️..▫️)    black small square..white small square
+	{runeRange{0x25C0, 0x25C0}, prEmoji},   // E0.6   [1] (◀️)       reverse button
+	{runeRange{0x2600, 0x2601}, prEmoji},   // E0.6   [2] (☀️..☁️)    sun..cloud
+	{runeRange{0x2604, 0x2604}, prEmoji},   // E1.0   [1] (☄️)       comet
+	{runeRange{0x2611, 0x2611}, prEmoji},   // E0.6   [1] (☑️)       check box with check
+	{runeRange{0x2618, 0x2618}, prEmoji},   // E1.0   [1] (☘️)       shamrock
+	{runeRange{0x2620, 0x2620}, prEmoji},   // E1.0   [1] (☠️)       skull and crossbones
+	{runeRange{0x2626, 0x2626}, prEmoji},   // E1.0   [1] (☦️)       orthodox cross
+	{runeRange{0x262E, 0x262E}, prEmoji},   // E1.0   [1] (☮️)       peace symbol
+	{runeRange{0x2638, 0x2639}, prEmoji},   // E0.7   [2] (☸️..☹️)    wheel of dharma..frowning face
+	{runeRange{0x2640, 0x2640}, prEmoji},   // E4.0   [1] (♀️)       female sign
+	{runeRange{0x2648, 0x2653}, prEmoji},   // E0.6  [12] (♈..♓)    Aries..Pisces
+	{runeRange{0x2660, 0x2660}, prEmoji},   // E0.6   [1] (♠️)       spade suit
+	{runeRange{0x2665, 0x2666}, prEmoji},   // E0.6   [2] (♥️..♦️)    heart suit..diamond suit
+	{runeRange{0x267B, 0x267B}, prEmoji},   // E0.6   [1] (♻️)       recycling symbol
+	{runeRange{0x267F, 0x267F}, prEmoji},   // E0.6   [1] (♿)       wheelchair symbol
+	{runeRange{0x2693, 0x2693}, prEmoji},   // E0.6   [1] (⚓)       anchor
+	{runeRange{0x2695, 0x2695}, prEmoji},   // E4.0   [1] (⚕️)       medical symbol
+	{runeRange{0x2699, 0x2699}, prEmoji},   // E1.0   [1] (⚙️)       gear
+	{runeRange{0x26A0, 0x26A1}, prEmoji},   // E0.6   [2] (⚠️..⚡)    warning..high voltage
+	{runeRange{0x26AA, 0x26AB}, prEmoji},   // E0.6   [2] (⚪..⚫)    white circle..black circle
+	{runeRange{0x26BD, 0x26BE}, prEmoji},   // E0.6   [2] (⚽..⚾)    soccer ball..baseball
+	{runeRange{0x26C8, 0x26C8}, prEmoji},   // E0.7   [1] (⛈️)       cloud with lightning and rain
+	{runeRange{0x26CF, 0x26CF}, prEmoji},   // E0.7   [1] (⛏️)       pick
+	{runeRange{0x26D3, 0x26D3}, prEmoji},   // E0.7   [1] (⛓️)       chains
+	{runeRange{0x26E9, 0x26E9}, prEmoji},   // E0.7   [1] (⛩️)       shinto shrine
+	{runeRange{0x26F0, 0x26F1}, prEmoji},   // E0.7   [2] (⛰️..⛱️)    mountain..umbrella on ground
+	{runeRange{0x26F4, 0x26F4}, prEmoji},   // E0.7   [1] (⛴️)       ferry
+	{runeRange{0x26F7, 0x26F9}, prEmoji},   // E0.7   [3] (⛷️..⛹️)    skier..person bouncing ball
+	{runeRange{0x26FD, 0x26FD}, prEmoji},   // E0.6   [1] (⛽)       fuel pump
+	{runeRange{0x2705, 0x2705}, prEmoji},   // E0.6   [1] (✅)       check mark button
+	{runeRange{0x270D, 0x270D}, prEmoji},   // E0.7   [1] (✍️)       writing hand
+	{runeRange{0x2712, 0x2712}, prEmoji},   // E0.6   [1] (✒️)       black nib
+	{runeRange{0x2716, 0x2716}, prEmoji},   // E0.6   [1] (✖️)       multiply
+	{runeRange{0x2721, 0x2721}, prEmoji},   // E0.7   [1] (✡️)       star of David
+	{runeRange{0x2733, 0x2734}, prEmoji},   // E0.6   [2] (✳️..✴️)    eight-spoked asterisk..eight-pointed star
+	{runeRange{0x2747, 0x2747}, prEmoji},   // E0.6   [1] (❇️)       sparkle
+	{runeRange{0x274E, 0x274E}, prEmoji},   // E0.6   [1] (❎)       cross mark button
+	{runeRange{0x2757, 0x2757}, prEmoji},   // E0.6   [1] (❗)       red exclamation mark
+	{runeRange{0x2764, 0x2764}, prEmoji},   // E0.6   [1] (❤️)       red heart
+	{runeRange{0x27A1, 0x27A1}, prEmoji},   // E0.6   [1] (➡️)       right arrow
+	{runeRange{0x27BF, 0x27BF}, prEmoji},   // E1.0   [1] (➿)       double curly loop
+	{runeRange{0x2B05, 0x2B07}, prEmoji},   // E0.6   [3] (⬅️..⬇️)    left arrow..down arrow
+	{runeRange{0x2B50, 0x2B50}, prEmoji},   // E0.6   [1] (⭐)       star
+	{runeRange{0x3030, 0x3030}, prEmoji},   // E0.6   [1] (〰️)       wavy dash
+	{runeRange{0x3297, 0x3297}, prEmoji},   // E0.6   [1] (㊗️)       Japanese “congratulations” button
+	{runeRange{0x1F004, 0x1F004}, prEmoji}, // E0.6   [1] (🀄)       mahjong red dragon
+	{runeRange{0x1F170, 0x1F171}, prEmoji}, // E0.6   [2] (🅰️..🅱️)    A button (blood type)..B button (blood type)
+	{runeRange{0x1F18E, 0x1F18E}, prEmoji}, // E0.6   [1] (🆎)       AB button (blood type)
+	{runeRange{0x1F1E6, 0x1F1FF}, prEmoji}, // E0.0  [26] (🇦..🇿)    regional indicator symbol letter a..regional indicator symbol letter z
+	{runeRange{0x1F21A, 0x1F21A}, prEmoji}, // E0.6   [1] (🈚)       Japanese “free of charge” button
+	{runeRange{0x1F232, 0x1F23A}, prEmoji}, // E0.6   [9] (🈲..🈺)    Japanese “prohibited” button..Japanese “open for business” button
+	{runeRange{0x1F300, 0x1F30C}, prEmoji}, // E0.6  [13] (🌀..🌌)    cyclone..milky way
+	{runeRange{0x1F30F, 0x1F30F}, prEmoji}, // E0.6   [1] (🌏)       globe showing Asia-Australia
+	{runeRange{0x1F311, 0x1F311}, prEmoji}, // E0.6   [1] (🌑)       new moon
+	{runeRange{0x1F313, 0x1F315}, prEmoji}, // E0.6   [3] (🌓..🌕)    first quarter moon..full moon
+	{runeRange{0x1F319, 0x1F319}, prEmoji}, // E0.6   [1] (🌙)       crescent moon
+	{runeRange{0x1F31B, 0x1F31B}, prEmoji}, // E0.6   [1] (🌛)       first quarter moon face
+	{runeRange{0x1F31D, 0x1F31E}, prEmoji}, // E1.0   [2] (🌝..🌞)    full moon face..sun with face
+	{runeRange{0x1F321, 0x1F321}, prEmoji}, // E0.7   [1] (🌡️)       thermometer
+	{runeRange{0x1F32D, 0x1F32F}, prEmoji}, // E1.0   [3] (🌭..🌯)    hot dog..burrito
+	{runeRange{0x1F332, 0x1F333}, prEmoji}, // E1.0   [2] (🌲..🌳)    evergreen tree..deciduous tree
+	{runeRange{0x1F336, 0x1F336}, prEmoji}, // E0.7   [1] (🌶️)       hot pepper
+	{runeRange{0x1F34B, 0x1F34B}, prEmoji}, // E1.0   [1] (🍋)       lemon
+	{runeRange{0x1F350, 0x1F350}, prEmoji}, // E1.0   [1] (🍐)       pear
+	{runeRange{0x1F37C, 0x1F37C}, prEmoji}, // E1.0   [1] (🍼)       baby bottle
+	{runeRange{0x1F37E, 0x1F37F}, prEmoji}, // E1.0   [2] (🍾..🍿)    bottle with popping cork..popcorn
+	{runeRange{0x1F396, 0x1F397}, prEmoji}, // E0.7   [2] (🎖️..🎗️)    military medal..reminder ribbon
+	{runeRange{0x1F39E, 0x1F39F}, prEmoji}, // E0.7   [2] (🎞️..🎟️)    film frames..admission tickets
+	{runeRange{0x1F3C5, 0x1F3C5}, prEmoji}, // E1.0   [1] (🏅)       sports medal
+	{runeRange{0x1F3C7, 0x1F3C7}, prEmoji}, // E1.0   [1] (🏇)       horse racing
+	{runeRange{0x1F3C9, 0x1F3C9}, prEmoji}, // E1.0   [1] (🏉)       rugby football
+	{runeRange{0x1F3CB, 0x1F3CE}, prEmoji}, // E0.7   [4] (🏋️..🏎️)    person lifting weights..racing car
+	{runeRange{0x1F3D4, 0x1F3DF}, prEmoji}, // E0.7  [12] (🏔️..🏟️)    snow-capped mountain..stadium
+	{runeRange{0x1F3E4, 0x1F3E4}, prEmoji}, // E1.0   [1] (🏤)       post office
+	{runeRange{0x1F3F3, 0x1F3F3}, prEmoji}, // E0.7   [1] (🏳️)       white flag
+	{runeRange{0x1F3F5, 0x1F3F5}, prEmoji}, // E0.7   [1] (🏵️)       rosette
+	{runeRange{0x1F3F8, 0x1F407}, prEmoji}, // E1.0  [16] (🏸..🐇)    badminton..rabbit
+	{runeRange{0x1F409, 0x1F40B}, prEmoji}, // E1.0   [3] (🐉..🐋)    dragon..whale
+	{runeRange{0x1F40F, 0x1F410}, prEmoji}, // E1.0   [2] (🐏..🐐)    ram..goat
+	{runeRange{0x1F413, 0x1F413}, prEmoji}, // E1.0   [1] (🐓)       rooster
+	{runeRange{0x1F415, 0x1F415}, prEmoji}, // E0.7   [1] (🐕)       dog
+	{runeRange{0x1F417, 0x1F429}, prEmoji}, // E0.6  [19] (🐗..🐩)    boar..poodle
+	{runeRange{0x1F42B, 0x1F43E}, prEmoji}, // E0.6  [20] (🐫..🐾)    two-hump camel..paw prints
+	{runeRange{0x1F440, 0x1F440}, prEmoji}, // E0.6   [1] (👀)       eyes
+	{runeRange{0x1F442, 0x1F464}, prEmoji}, // E0.6  [35] (👂..👤)    ear..bust in silhouette
+	{runeRange{0x1F466, 0x1F46B}, prEmoji}, // E0.6   [6] (👦..👫)    boy..woman and man holding hands
+	{runeRange{0x1F46E, 0x1F4AC}, prEmoji}, // E0.6  [63] (👮..💬)    police officer..speech balloon
+	{runeRange{0x1F4AE, 0x1F4B5}, prEmoji}, // E0.6   [8] (💮..💵)    white flower..dollar banknote
+	{runeRange{0x1F4B8, 0x1F4EB}, prEmoji}, // E0.6  [52] (💸..📫)    money with wings..closed mailbox with raised flag
+	{runeRange{0x1F4EE, 0x1F4EE}, prEmoji}, // E0.6   [1] (📮)       postbox
+	{runeRange{0x1F4F0, 0x1F4F4}, prEmoji}, // E0.6   [5] (📰..📴)    newspaper..mobile phone off
+	{runeRange{0x1F4F6, 0x1F4F7}, prEmoji}, // E0.6   [2] (📶..📷)    antenna bars..camera
+	{runeRange{0x1F4F9, 0x1F4FC}, prEmoji}, // E0.6   [4] (📹..📼)    video camera..videocassette
+	{runeRange{0x1F4FF, 0x1F502}, prEmoji}, // E1.0   [4] (📿..🔂)    prayer beads..repeat single button
+	{runeRange{0x1F504, 0x1F507}, prEmoji}, // E1.0   [4] (🔄..🔇)    counterclockwise arrows button..muted speaker
+	{runeRange{0x1F509, 0x1F509}, prEmoji}, // E1.0   [1] (🔉)       speaker medium volume
+	{runeRange{0x1F515, 0x1F515}, prEmoji}, // E1.0   [1] (🔕)       bell with slash
+	{runeRange{0x1F52C, 0x1F52D}, prEmoji}, // E1.0   [2] (🔬..🔭)    microscope..telescope
+	{runeRange{0x1F549, 0x1F54A}, prEmoji}, // E0.7   [2] (🕉️..🕊️)    om..dove
+	{runeRange{0x1F550, 0x1F55B}, prEmoji}, // E0.6  [12] (🕐..🕛)    one o’clock..twelve o’clock
+	{runeRange{0x1F56F, 0x1F570}, prEmoji}, // E0.7   [2] (🕯️..🕰️)    candle..mantelpiece clock
+	{runeRange{0x1F57A, 0x1F57A}, prEmoji}, // E3.0   [1] (🕺)       man dancing
+	{runeRange{0x1F58A, 0x1F58D}, prEmoji}, // E0.7   [4] (🖊️..🖍️)    pen..crayon
+	{runeRange{0x1F595, 0x1F596}, prEmoji}, // E1.0   [2] (🖕..🖖)    middle finger..vulcan salute
+	{runeRange{0x1F5A5, 0x1F5A5}, prEmoji}, // E0.7   [1] (🖥️)       desktop computer
+	{runeRange{0x1F5B1, 0x1F5B2}, prEmoji}, // E0.7   [2] (🖱️..🖲️)    computer mouse..trackball
+	{runeRange{0x1F5C2, 0x1F5C4}, prEmoji}, // E0.7   [3] (🗂️..🗄️)    card index dividers..file cabinet
+	{runeRange{0x1F5DC, 0x1F5DE}, prEmoji}, // E0.7   [3] (🗜️..🗞️)    clamp..rolled-up newspaper
+	{runeRange{0x1F5E3, 0x1F5E3}, prEmoji}, // E0.7   [1] (🗣️)       speaking head
+	{runeRange{0x1F5EF, 0x1F5EF}, prEmoji}, // E0.7   [1] (🗯️)       right anger bubble
+	{runeRange{0x1F5FA, 0x1F5FA}, prEmoji}, // E0.7   [1] (🗺️)       world map
+	{runeRange{0x1F600, 0x1F600}, prEmoji}, // E1.0   [1] (😀)       grinning face
+	{runeRange{0x1F607, 0x1F608}, prEmoji}, // E1.0   [2] (😇..😈)    smiling face with halo..smiling face with horns
+	{runeRange{0x1F60E, 0x1F60E}, prEmoji}, // E1.0   [1] (😎)       smiling face with sunglasses
+	{runeRange{0x1F610, 0x1F610}, prEmoji}, // E0.7   [1] (😐)       neutral face
+	{runeRange{0x1F612, 0x1F614}, prEmoji}, // E0.6   [3] (😒..😔)    unamused face..pensive face
+	{runeRange{0x1F616, 0x1F616}, prEmoji}, // E0.6   [1] (😖)       confounded face
+	{runeRange{0x1F618, 0x1F618}, prEmoji}, // E0.6   [1] (😘)       face blowing a kiss
+	{runeRange{0x1F61A, 0x1F61A}, prEmoji}, // E0.6   [1] (😚)       kissing face with closed eyes
+	{runeRange{0x1F61C, 0x1F61E}, prEmoji}, // E0.6   [3] (😜..😞)    winking face with tongue..disappointed face
+	{runeRange{0x1F620, 0x1F625}, prEmoji}, // E0.6   [6] (😠..😥)    angry face..sad but relieved face
+	{runeRange{0x1F628, 0x1F62B}, prEmoji}, // E0.6   [4] (😨..😫)    fearful face..tired face
+	{runeRange{0x1F62D, 0x1F62D}, prEmoji}, // E0.6   [1] (😭)       loudly crying face
+	{runeRange{0x1F630, 0x1F633}, prEmoji}, // E0.6   [4] (😰..😳)    anxious face with sweat..flushed face
+	{runeRange{0x1F635, 0x1F635}, prEmoji}, // E0.6   [1] (😵)       face with crossed-out eyes
+	{runeRange{0x1F637, 0x1F640}, prEmoji}, // E0.6  [10] (😷..🙀)    face with medical mask..weary cat
+	{runeRange{0x1F645, 0x1F64F}, prEmoji}, // E0.6  [11] (🙅..🙏)    person gesturing NO..folded hands
+	{runeRange{0x1F681, 0x1F682}, prEmoji}, // E1.0   [2] (🚁..🚂)    helicopter..locomotive
+	{runeRange{0x1F686, 0x1F686}, prEmoji}, // E1.0   [1] (🚆)       train
+	{runeRange{0x1F688, 0x1F688}, prEmoji}, // E1.0   [1] (🚈)       light rail
+	{runeRange{0x1F68A, 0x1F68B}, prEmoji}, // E1.0   [2] (🚊..🚋)    tram..tram car
+	{runeRange{0x1F68D, 0x1F68D}, prEmoji}, // E0.7   [1] (🚍)       oncoming bus
+	{runeRange{0x1F68F, 0x1F68F}, prEmoji}, // E0.6   [1] (🚏)       bus stop
+	{runeRange{0x1F691, 0x1F693}, prEmoji}, // E0.6   [3] (🚑..🚓)    ambulance..police car
+	{runeRange{0x1F695, 0x1F695}, prEmoji}, // E0.6   [1] (🚕)       taxi
+	{runeRange{0x1F697, 0x1F697}, prEmoji}, // E0.6   [1] (🚗)       automobile
+	{runeRange{0x1F699, 0x1F69A}, prEmoji}, // E0.6   [2] (🚙..🚚)    sport utility vehicle..delivery truck
 }

--- a/emojipresentation.go
+++ b/emojipresentation.go
@@ -9,286 +9,286 @@ package uniseg
 // ("Extended_Pictographic" only)
 // See https://www.unicode.org/license.html for the Unicode license agreement.
 var emojiPresentation = dictionary[emojiProperty]{
-	{runeRange{0x231A, 0x231B}, prEmojiPresentation},   // E0.6   [2] (⌚..⌛)    watch..hourglass done
-	{runeRange{0x23E9, 0x23EC}, prEmojiPresentation},   // E0.6   [4] (⏩..⏬)    fast-forward button..fast down button
-	{runeRange{0x23F0, 0x23F0}, prEmojiPresentation},   // E0.6   [1] (⏰)       alarm clock
-	{runeRange{0x23F3, 0x23F3}, prEmojiPresentation},   // E0.6   [1] (⏳)       hourglass not done
-	{runeRange{0x25FD, 0x25FE}, prEmojiPresentation},   // E0.6   [2] (◽..◾)    white medium-small square..black medium-small square
-	{runeRange{0x2614, 0x2615}, prEmojiPresentation},   // E0.6   [2] (☔..☕)    umbrella with rain drops..hot beverage
-	{runeRange{0x2648, 0x2653}, prEmojiPresentation},   // E0.6  [12] (♈..♓)    Aries..Pisces
-	{runeRange{0x267F, 0x267F}, prEmojiPresentation},   // E0.6   [1] (♿)       wheelchair symbol
-	{runeRange{0x2693, 0x2693}, prEmojiPresentation},   // E0.6   [1] (⚓)       anchor
-	{runeRange{0x26A1, 0x26A1}, prEmojiPresentation},   // E0.6   [1] (⚡)       high voltage
-	{runeRange{0x26AA, 0x26AB}, prEmojiPresentation},   // E0.6   [2] (⚪..⚫)    white circle..black circle
-	{runeRange{0x26BD, 0x26BE}, prEmojiPresentation},   // E0.6   [2] (⚽..⚾)    soccer ball..baseball
-	{runeRange{0x26C4, 0x26C5}, prEmojiPresentation},   // E0.6   [2] (⛄..⛅)    snowman without snow..sun behind cloud
-	{runeRange{0x26CE, 0x26CE}, prEmojiPresentation},   // E0.6   [1] (⛎)       Ophiuchus
-	{runeRange{0x26D4, 0x26D4}, prEmojiPresentation},   // E0.6   [1] (⛔)       no entry
-	{runeRange{0x26EA, 0x26EA}, prEmojiPresentation},   // E0.6   [1] (⛪)       church
-	{runeRange{0x26F2, 0x26F3}, prEmojiPresentation},   // E0.6   [2] (⛲..⛳)    fountain..flag in hole
-	{runeRange{0x26F5, 0x26F5}, prEmojiPresentation},   // E0.6   [1] (⛵)       sailboat
-	{runeRange{0x26FA, 0x26FA}, prEmojiPresentation},   // E0.6   [1] (⛺)       tent
-	{runeRange{0x26FD, 0x26FD}, prEmojiPresentation},   // E0.6   [1] (⛽)       fuel pump
-	{runeRange{0x2705, 0x2705}, prEmojiPresentation},   // E0.6   [1] (✅)       check mark button
-	{runeRange{0x270A, 0x270B}, prEmojiPresentation},   // E0.6   [2] (✊..✋)    raised fist..raised hand
-	{runeRange{0x2728, 0x2728}, prEmojiPresentation},   // E0.6   [1] (✨)       sparkles
-	{runeRange{0x274C, 0x274C}, prEmojiPresentation},   // E0.6   [1] (❌)       cross mark
-	{runeRange{0x274E, 0x274E}, prEmojiPresentation},   // E0.6   [1] (❎)       cross mark button
-	{runeRange{0x2753, 0x2755}, prEmojiPresentation},   // E0.6   [3] (❓..❕)    red question mark..white exclamation mark
-	{runeRange{0x2757, 0x2757}, prEmojiPresentation},   // E0.6   [1] (❗)       red exclamation mark
-	{runeRange{0x2795, 0x2797}, prEmojiPresentation},   // E0.6   [3] (➕..➗)    plus..divide
-	{runeRange{0x27B0, 0x27B0}, prEmojiPresentation},   // E0.6   [1] (➰)       curly loop
-	{runeRange{0x27BF, 0x27BF}, prEmojiPresentation},   // E1.0   [1] (➿)       double curly loop
-	{runeRange{0x2B1B, 0x2B1C}, prEmojiPresentation},   // E0.6   [2] (⬛..⬜)    black large square..white large square
-	{runeRange{0x2B50, 0x2B50}, prEmojiPresentation},   // E0.6   [1] (⭐)       star
-	{runeRange{0x2B55, 0x2B55}, prEmojiPresentation},   // E0.6   [1] (⭕)       hollow red circle
-	{runeRange{0x1F004, 0x1F004}, prEmojiPresentation}, // E0.6   [1] (🀄)       mahjong red dragon
-	{runeRange{0x1F0CF, 0x1F0CF}, prEmojiPresentation}, // E0.6   [1] (🃏)       joker
-	{runeRange{0x1F18E, 0x1F18E}, prEmojiPresentation}, // E0.6   [1] (🆎)       AB button (blood type)
-	{runeRange{0x1F191, 0x1F19A}, prEmojiPresentation}, // E0.6  [10] (🆑..🆚)    CL button..VS button
-	{runeRange{0x1F1E6, 0x1F1FF}, prEmojiPresentation}, // E0.0  [26] (🇦..🇿)    regional indicator symbol letter a..regional indicator symbol letter z
-	{runeRange{0x1F201, 0x1F201}, prEmojiPresentation}, // E0.6   [1] (🈁)       Japanese “here” button
-	{runeRange{0x1F21A, 0x1F21A}, prEmojiPresentation}, // E0.6   [1] (🈚)       Japanese “free of charge” button
-	{runeRange{0x1F22F, 0x1F22F}, prEmojiPresentation}, // E0.6   [1] (🈯)       Japanese “reserved” button
-	{runeRange{0x1F232, 0x1F236}, prEmojiPresentation}, // E0.6   [5] (🈲..🈶)    Japanese “prohibited” button..Japanese “not free of charge” button
-	{runeRange{0x1F238, 0x1F23A}, prEmojiPresentation}, // E0.6   [3] (🈸..🈺)    Japanese “application” button..Japanese “open for business” button
-	{runeRange{0x1F250, 0x1F251}, prEmojiPresentation}, // E0.6   [2] (🉐..🉑)    Japanese “bargain” button..Japanese “acceptable” button
-	{runeRange{0x1F300, 0x1F30C}, prEmojiPresentation}, // E0.6  [13] (🌀..🌌)    cyclone..milky way
-	{runeRange{0x1F30D, 0x1F30E}, prEmojiPresentation}, // E0.7   [2] (🌍..🌎)    globe showing Europe-Africa..globe showing Americas
-	{runeRange{0x1F30F, 0x1F30F}, prEmojiPresentation}, // E0.6   [1] (🌏)       globe showing Asia-Australia
-	{runeRange{0x1F310, 0x1F310}, prEmojiPresentation}, // E1.0   [1] (🌐)       globe with meridians
-	{runeRange{0x1F311, 0x1F311}, prEmojiPresentation}, // E0.6   [1] (🌑)       new moon
-	{runeRange{0x1F312, 0x1F312}, prEmojiPresentation}, // E1.0   [1] (🌒)       waxing crescent moon
-	{runeRange{0x1F313, 0x1F315}, prEmojiPresentation}, // E0.6   [3] (🌓..🌕)    first quarter moon..full moon
-	{runeRange{0x1F316, 0x1F318}, prEmojiPresentation}, // E1.0   [3] (🌖..🌘)    waning gibbous moon..waning crescent moon
-	{runeRange{0x1F319, 0x1F319}, prEmojiPresentation}, // E0.6   [1] (🌙)       crescent moon
-	{runeRange{0x1F31A, 0x1F31A}, prEmojiPresentation}, // E1.0   [1] (🌚)       new moon face
-	{runeRange{0x1F31B, 0x1F31B}, prEmojiPresentation}, // E0.6   [1] (🌛)       first quarter moon face
-	{runeRange{0x1F31C, 0x1F31C}, prEmojiPresentation}, // E0.7   [1] (🌜)       last quarter moon face
-	{runeRange{0x1F31D, 0x1F31E}, prEmojiPresentation}, // E1.0   [2] (🌝..🌞)    full moon face..sun with face
-	{runeRange{0x1F31F, 0x1F320}, prEmojiPresentation}, // E0.6   [2] (🌟..🌠)    glowing star..shooting star
-	{runeRange{0x1F32D, 0x1F32F}, prEmojiPresentation}, // E1.0   [3] (🌭..🌯)    hot dog..burrito
-	{runeRange{0x1F330, 0x1F331}, prEmojiPresentation}, // E0.6   [2] (🌰..🌱)    chestnut..seedling
-	{runeRange{0x1F332, 0x1F333}, prEmojiPresentation}, // E1.0   [2] (🌲..🌳)    evergreen tree..deciduous tree
-	{runeRange{0x1F334, 0x1F335}, prEmojiPresentation}, // E0.6   [2] (🌴..🌵)    palm tree..cactus
-	{runeRange{0x1F337, 0x1F34A}, prEmojiPresentation}, // E0.6  [20] (🌷..🍊)    tulip..tangerine
-	{runeRange{0x1F34B, 0x1F34B}, prEmojiPresentation}, // E1.0   [1] (🍋)       lemon
-	{runeRange{0x1F34C, 0x1F34F}, prEmojiPresentation}, // E0.6   [4] (🍌..🍏)    banana..green apple
-	{runeRange{0x1F350, 0x1F350}, prEmojiPresentation}, // E1.0   [1] (🍐)       pear
-	{runeRange{0x1F351, 0x1F37B}, prEmojiPresentation}, // E0.6  [43] (🍑..🍻)    peach..clinking beer mugs
-	{runeRange{0x1F37C, 0x1F37C}, prEmojiPresentation}, // E1.0   [1] (🍼)       baby bottle
-	{runeRange{0x1F37E, 0x1F37F}, prEmojiPresentation}, // E1.0   [2] (🍾..🍿)    bottle with popping cork..popcorn
-	{runeRange{0x1F380, 0x1F393}, prEmojiPresentation}, // E0.6  [20] (🎀..🎓)    ribbon..graduation cap
-	{runeRange{0x1F3A0, 0x1F3C4}, prEmojiPresentation}, // E0.6  [37] (🎠..🏄)    carousel horse..person surfing
-	{runeRange{0x1F3C5, 0x1F3C5}, prEmojiPresentation}, // E1.0   [1] (🏅)       sports medal
-	{runeRange{0x1F3C6, 0x1F3C6}, prEmojiPresentation}, // E0.6   [1] (🏆)       trophy
-	{runeRange{0x1F3C7, 0x1F3C7}, prEmojiPresentation}, // E1.0   [1] (🏇)       horse racing
-	{runeRange{0x1F3C8, 0x1F3C8}, prEmojiPresentation}, // E0.6   [1] (🏈)       american football
-	{runeRange{0x1F3C9, 0x1F3C9}, prEmojiPresentation}, // E1.0   [1] (🏉)       rugby football
-	{runeRange{0x1F3CA, 0x1F3CA}, prEmojiPresentation}, // E0.6   [1] (🏊)       person swimming
-	{runeRange{0x1F3CF, 0x1F3D3}, prEmojiPresentation}, // E1.0   [5] (🏏..🏓)    cricket game..ping pong
-	{runeRange{0x1F3E0, 0x1F3E3}, prEmojiPresentation}, // E0.6   [4] (🏠..🏣)    house..Japanese post office
-	{runeRange{0x1F3E4, 0x1F3E4}, prEmojiPresentation}, // E1.0   [1] (🏤)       post office
-	{runeRange{0x1F3E5, 0x1F3F0}, prEmojiPresentation}, // E0.6  [12] (🏥..🏰)    hospital..castle
-	{runeRange{0x1F3F4, 0x1F3F4}, prEmojiPresentation}, // E1.0   [1] (🏴)       black flag
-	{runeRange{0x1F3F8, 0x1F407}, prEmojiPresentation}, // E1.0  [16] (🏸..🐇)    badminton..rabbit
-	{runeRange{0x1F408, 0x1F408}, prEmojiPresentation}, // E0.7   [1] (🐈)       cat
-	{runeRange{0x1F409, 0x1F40B}, prEmojiPresentation}, // E1.0   [3] (🐉..🐋)    dragon..whale
-	{runeRange{0x1F40C, 0x1F40E}, prEmojiPresentation}, // E0.6   [3] (🐌..🐎)    snail..horse
-	{runeRange{0x1F40F, 0x1F410}, prEmojiPresentation}, // E1.0   [2] (🐏..🐐)    ram..goat
-	{runeRange{0x1F411, 0x1F412}, prEmojiPresentation}, // E0.6   [2] (🐑..🐒)    ewe..monkey
-	{runeRange{0x1F413, 0x1F413}, prEmojiPresentation}, // E1.0   [1] (🐓)       rooster
-	{runeRange{0x1F414, 0x1F414}, prEmojiPresentation}, // E0.6   [1] (🐔)       chicken
-	{runeRange{0x1F415, 0x1F415}, prEmojiPresentation}, // E0.7   [1] (🐕)       dog
-	{runeRange{0x1F416, 0x1F416}, prEmojiPresentation}, // E1.0   [1] (🐖)       pig
-	{runeRange{0x1F417, 0x1F429}, prEmojiPresentation}, // E0.6  [19] (🐗..🐩)    boar..poodle
-	{runeRange{0x1F42A, 0x1F42A}, prEmojiPresentation}, // E1.0   [1] (🐪)       camel
-	{runeRange{0x1F42B, 0x1F43E}, prEmojiPresentation}, // E0.6  [20] (🐫..🐾)    two-hump camel..paw prints
-	{runeRange{0x1F440, 0x1F440}, prEmojiPresentation}, // E0.6   [1] (👀)       eyes
-	{runeRange{0x1F442, 0x1F464}, prEmojiPresentation}, // E0.6  [35] (👂..👤)    ear..bust in silhouette
-	{runeRange{0x1F465, 0x1F465}, prEmojiPresentation}, // E1.0   [1] (👥)       busts in silhouette
-	{runeRange{0x1F466, 0x1F46B}, prEmojiPresentation}, // E0.6   [6] (👦..👫)    boy..woman and man holding hands
-	{runeRange{0x1F46C, 0x1F46D}, prEmojiPresentation}, // E1.0   [2] (👬..👭)    men holding hands..women holding hands
-	{runeRange{0x1F46E, 0x1F4AC}, prEmojiPresentation}, // E0.6  [63] (👮..💬)    police officer..speech balloon
-	{runeRange{0x1F4AD, 0x1F4AD}, prEmojiPresentation}, // E1.0   [1] (💭)       thought balloon
-	{runeRange{0x1F4AE, 0x1F4B5}, prEmojiPresentation}, // E0.6   [8] (💮..💵)    white flower..dollar banknote
-	{runeRange{0x1F4B6, 0x1F4B7}, prEmojiPresentation}, // E1.0   [2] (💶..💷)    euro banknote..pound banknote
-	{runeRange{0x1F4B8, 0x1F4EB}, prEmojiPresentation}, // E0.6  [52] (💸..📫)    money with wings..closed mailbox with raised flag
-	{runeRange{0x1F4EC, 0x1F4ED}, prEmojiPresentation}, // E0.7   [2] (📬..📭)    open mailbox with raised flag..open mailbox with lowered flag
-	{runeRange{0x1F4EE, 0x1F4EE}, prEmojiPresentation}, // E0.6   [1] (📮)       postbox
-	{runeRange{0x1F4EF, 0x1F4EF}, prEmojiPresentation}, // E1.0   [1] (📯)       postal horn
-	{runeRange{0x1F4F0, 0x1F4F4}, prEmojiPresentation}, // E0.6   [5] (📰..📴)    newspaper..mobile phone off
-	{runeRange{0x1F4F5, 0x1F4F5}, prEmojiPresentation}, // E1.0   [1] (📵)       no mobile phones
-	{runeRange{0x1F4F6, 0x1F4F7}, prEmojiPresentation}, // E0.6   [2] (📶..📷)    antenna bars..camera
-	{runeRange{0x1F4F8, 0x1F4F8}, prEmojiPresentation}, // E1.0   [1] (📸)       camera with flash
-	{runeRange{0x1F4F9, 0x1F4FC}, prEmojiPresentation}, // E0.6   [4] (📹..📼)    video camera..videocassette
-	{runeRange{0x1F4FF, 0x1F502}, prEmojiPresentation}, // E1.0   [4] (📿..🔂)    prayer beads..repeat single button
-	{runeRange{0x1F503, 0x1F503}, prEmojiPresentation}, // E0.6   [1] (🔃)       clockwise vertical arrows
-	{runeRange{0x1F504, 0x1F507}, prEmojiPresentation}, // E1.0   [4] (🔄..🔇)    counterclockwise arrows button..muted speaker
-	{runeRange{0x1F508, 0x1F508}, prEmojiPresentation}, // E0.7   [1] (🔈)       speaker low volume
-	{runeRange{0x1F509, 0x1F509}, prEmojiPresentation}, // E1.0   [1] (🔉)       speaker medium volume
-	{runeRange{0x1F50A, 0x1F514}, prEmojiPresentation}, // E0.6  [11] (🔊..🔔)    speaker high volume..bell
-	{runeRange{0x1F515, 0x1F515}, prEmojiPresentation}, // E1.0   [1] (🔕)       bell with slash
-	{runeRange{0x1F516, 0x1F52B}, prEmojiPresentation}, // E0.6  [22] (🔖..🔫)    bookmark..water pistol
-	{runeRange{0x1F52C, 0x1F52D}, prEmojiPresentation}, // E1.0   [2] (🔬..🔭)    microscope..telescope
-	{runeRange{0x1F52E, 0x1F53D}, prEmojiPresentation}, // E0.6  [16] (🔮..🔽)    crystal ball..downwards button
-	{runeRange{0x1F54B, 0x1F54E}, prEmojiPresentation}, // E1.0   [4] (🕋..🕎)    kaaba..menorah
-	{runeRange{0x1F550, 0x1F55B}, prEmojiPresentation}, // E0.6  [12] (🕐..🕛)    one o’clock..twelve o’clock
-	{runeRange{0x1F55C, 0x1F567}, prEmojiPresentation}, // E0.7  [12] (🕜..🕧)    one-thirty..twelve-thirty
-	{runeRange{0x1F57A, 0x1F57A}, prEmojiPresentation}, // E3.0   [1] (🕺)       man dancing
-	{runeRange{0x1F595, 0x1F596}, prEmojiPresentation}, // E1.0   [2] (🖕..🖖)    middle finger..vulcan salute
-	{runeRange{0x1F5A4, 0x1F5A4}, prEmojiPresentation}, // E3.0   [1] (🖤)       black heart
-	{runeRange{0x1F5FB, 0x1F5FF}, prEmojiPresentation}, // E0.6   [5] (🗻..🗿)    mount fuji..moai
-	{runeRange{0x1F600, 0x1F600}, prEmojiPresentation}, // E1.0   [1] (😀)       grinning face
-	{runeRange{0x1F601, 0x1F606}, prEmojiPresentation}, // E0.6   [6] (😁..😆)    beaming face with smiling eyes..grinning squinting face
-	{runeRange{0x1F607, 0x1F608}, prEmojiPresentation}, // E1.0   [2] (😇..😈)    smiling face with halo..smiling face with horns
-	{runeRange{0x1F609, 0x1F60D}, prEmojiPresentation}, // E0.6   [5] (😉..😍)    winking face..smiling face with heart-eyes
-	{runeRange{0x1F60E, 0x1F60E}, prEmojiPresentation}, // E1.0   [1] (😎)       smiling face with sunglasses
-	{runeRange{0x1F60F, 0x1F60F}, prEmojiPresentation}, // E0.6   [1] (😏)       smirking face
-	{runeRange{0x1F610, 0x1F610}, prEmojiPresentation}, // E0.7   [1] (😐)       neutral face
-	{runeRange{0x1F611, 0x1F611}, prEmojiPresentation}, // E1.0   [1] (😑)       expressionless face
-	{runeRange{0x1F612, 0x1F614}, prEmojiPresentation}, // E0.6   [3] (😒..😔)    unamused face..pensive face
-	{runeRange{0x1F615, 0x1F615}, prEmojiPresentation}, // E1.0   [1] (😕)       confused face
-	{runeRange{0x1F616, 0x1F616}, prEmojiPresentation}, // E0.6   [1] (😖)       confounded face
-	{runeRange{0x1F617, 0x1F617}, prEmojiPresentation}, // E1.0   [1] (😗)       kissing face
-	{runeRange{0x1F618, 0x1F618}, prEmojiPresentation}, // E0.6   [1] (😘)       face blowing a kiss
-	{runeRange{0x1F619, 0x1F619}, prEmojiPresentation}, // E1.0   [1] (😙)       kissing face with smiling eyes
-	{runeRange{0x1F61A, 0x1F61A}, prEmojiPresentation}, // E0.6   [1] (😚)       kissing face with closed eyes
-	{runeRange{0x1F61B, 0x1F61B}, prEmojiPresentation}, // E1.0   [1] (😛)       face with tongue
-	{runeRange{0x1F61C, 0x1F61E}, prEmojiPresentation}, // E0.6   [3] (😜..😞)    winking face with tongue..disappointed face
-	{runeRange{0x1F61F, 0x1F61F}, prEmojiPresentation}, // E1.0   [1] (😟)       worried face
-	{runeRange{0x1F620, 0x1F625}, prEmojiPresentation}, // E0.6   [6] (😠..😥)    angry face..sad but relieved face
-	{runeRange{0x1F626, 0x1F627}, prEmojiPresentation}, // E1.0   [2] (😦..😧)    frowning face with open mouth..anguished face
-	{runeRange{0x1F628, 0x1F62B}, prEmojiPresentation}, // E0.6   [4] (😨..😫)    fearful face..tired face
-	{runeRange{0x1F62C, 0x1F62C}, prEmojiPresentation}, // E1.0   [1] (😬)       grimacing face
-	{runeRange{0x1F62D, 0x1F62D}, prEmojiPresentation}, // E0.6   [1] (😭)       loudly crying face
-	{runeRange{0x1F62E, 0x1F62F}, prEmojiPresentation}, // E1.0   [2] (😮..😯)    face with open mouth..hushed face
 	{runeRange{0x1F630, 0x1F633}, prEmojiPresentation}, // E0.6   [4] (😰..😳)    anxious face with sweat..flushed face
-	{runeRange{0x1F634, 0x1F634}, prEmojiPresentation}, // E1.0   [1] (😴)       sleeping face
-	{runeRange{0x1F635, 0x1F635}, prEmojiPresentation}, // E0.6   [1] (😵)       face with crossed-out eyes
-	{runeRange{0x1F636, 0x1F636}, prEmojiPresentation}, // E1.0   [1] (😶)       face without mouth
-	{runeRange{0x1F637, 0x1F640}, prEmojiPresentation}, // E0.6  [10] (😷..🙀)    face with medical mask..weary cat
-	{runeRange{0x1F641, 0x1F644}, prEmojiPresentation}, // E1.0   [4] (🙁..🙄)    slightly frowning face..face with rolling eyes
-	{runeRange{0x1F645, 0x1F64F}, prEmojiPresentation}, // E0.6  [11] (🙅..🙏)    person gesturing NO..folded hands
-	{runeRange{0x1F680, 0x1F680}, prEmojiPresentation}, // E0.6   [1] (🚀)       rocket
-	{runeRange{0x1F681, 0x1F682}, prEmojiPresentation}, // E1.0   [2] (🚁..🚂)    helicopter..locomotive
-	{runeRange{0x1F683, 0x1F685}, prEmojiPresentation}, // E0.6   [3] (🚃..🚅)    railway car..bullet train
-	{runeRange{0x1F686, 0x1F686}, prEmojiPresentation}, // E1.0   [1] (🚆)       train
-	{runeRange{0x1F687, 0x1F687}, prEmojiPresentation}, // E0.6   [1] (🚇)       metro
-	{runeRange{0x1F688, 0x1F688}, prEmojiPresentation}, // E1.0   [1] (🚈)       light rail
-	{runeRange{0x1F689, 0x1F689}, prEmojiPresentation}, // E0.6   [1] (🚉)       station
-	{runeRange{0x1F68A, 0x1F68B}, prEmojiPresentation}, // E1.0   [2] (🚊..🚋)    tram..tram car
-	{runeRange{0x1F68C, 0x1F68C}, prEmojiPresentation}, // E0.6   [1] (🚌)       bus
-	{runeRange{0x1F68D, 0x1F68D}, prEmojiPresentation}, // E0.7   [1] (🚍)       oncoming bus
-	{runeRange{0x1F68E, 0x1F68E}, prEmojiPresentation}, // E1.0   [1] (🚎)       trolleybus
-	{runeRange{0x1F68F, 0x1F68F}, prEmojiPresentation}, // E0.6   [1] (🚏)       bus stop
-	{runeRange{0x1F690, 0x1F690}, prEmojiPresentation}, // E1.0   [1] (🚐)       minibus
-	{runeRange{0x1F691, 0x1F693}, prEmojiPresentation}, // E0.6   [3] (🚑..🚓)    ambulance..police car
-	{runeRange{0x1F694, 0x1F694}, prEmojiPresentation}, // E0.7   [1] (🚔)       oncoming police car
-	{runeRange{0x1F695, 0x1F695}, prEmojiPresentation}, // E0.6   [1] (🚕)       taxi
-	{runeRange{0x1F696, 0x1F696}, prEmojiPresentation}, // E1.0   [1] (🚖)       oncoming taxi
-	{runeRange{0x1F697, 0x1F697}, prEmojiPresentation}, // E0.6   [1] (🚗)       automobile
-	{runeRange{0x1F698, 0x1F698}, prEmojiPresentation}, // E0.7   [1] (🚘)       oncoming automobile
-	{runeRange{0x1F699, 0x1F69A}, prEmojiPresentation}, // E0.6   [2] (🚙..🚚)    sport utility vehicle..delivery truck
-	{runeRange{0x1F69B, 0x1F6A1}, prEmojiPresentation}, // E1.0   [7] (🚛..🚡)    articulated lorry..aerial tramway
-	{runeRange{0x1F6A2, 0x1F6A2}, prEmojiPresentation}, // E0.6   [1] (🚢)       ship
-	{runeRange{0x1F6A3, 0x1F6A3}, prEmojiPresentation}, // E1.0   [1] (🚣)       person rowing boat
-	{runeRange{0x1F6A4, 0x1F6A5}, prEmojiPresentation}, // E0.6   [2] (🚤..🚥)    speedboat..horizontal traffic light
-	{runeRange{0x1F6A6, 0x1F6A6}, prEmojiPresentation}, // E1.0   [1] (🚦)       vertical traffic light
-	{runeRange{0x1F6A7, 0x1F6AD}, prEmojiPresentation}, // E0.6   [7] (🚧..🚭)    construction..no smoking
-	{runeRange{0x1F6AE, 0x1F6B1}, prEmojiPresentation}, // E1.0   [4] (🚮..🚱)    litter in bin sign..non-potable water
-	{runeRange{0x1F6B2, 0x1F6B2}, prEmojiPresentation}, // E0.6   [1] (🚲)       bicycle
-	{runeRange{0x1F6B3, 0x1F6B5}, prEmojiPresentation}, // E1.0   [3] (🚳..🚵)    no bicycles..person mountain biking
-	{runeRange{0x1F6B6, 0x1F6B6}, prEmojiPresentation}, // E0.6   [1] (🚶)       person walking
-	{runeRange{0x1F6B7, 0x1F6B8}, prEmojiPresentation}, // E1.0   [2] (🚷..🚸)    no pedestrians..children crossing
-	{runeRange{0x1F6B9, 0x1F6BE}, prEmojiPresentation}, // E0.6   [6] (🚹..🚾)    men’s room..water closet
-	{runeRange{0x1F6BF, 0x1F6BF}, prEmojiPresentation}, // E1.0   [1] (🚿)       shower
-	{runeRange{0x1F6C0, 0x1F6C0}, prEmojiPresentation}, // E0.6   [1] (🛀)       person taking bath
-	{runeRange{0x1F6C1, 0x1F6C5}, prEmojiPresentation}, // E1.0   [5] (🛁..🛅)    bathtub..left luggage
-	{runeRange{0x1F6CC, 0x1F6CC}, prEmojiPresentation}, // E1.0   [1] (🛌)       person in bed
-	{runeRange{0x1F6D0, 0x1F6D0}, prEmojiPresentation}, // E1.0   [1] (🛐)       place of worship
-	{runeRange{0x1F6D1, 0x1F6D2}, prEmojiPresentation}, // E3.0   [2] (🛑..🛒)    stop sign..shopping cart
-	{runeRange{0x1F6D5, 0x1F6D5}, prEmojiPresentation}, // E12.0  [1] (🛕)       hindu temple
-	{runeRange{0x1F6D6, 0x1F6D7}, prEmojiPresentation}, // E13.0  [2] (🛖..🛗)    hut..elevator
-	{runeRange{0x1F6DC, 0x1F6DC}, prEmojiPresentation}, // E15.0  [1] (🛜)       wireless
-	{runeRange{0x1F6DD, 0x1F6DF}, prEmojiPresentation}, // E14.0  [3] (🛝..🛟)    playground slide..ring buoy
-	{runeRange{0x1F6EB, 0x1F6EC}, prEmojiPresentation}, // E1.0   [2] (🛫..🛬)    airplane departure..airplane arrival
-	{runeRange{0x1F6F4, 0x1F6F6}, prEmojiPresentation}, // E3.0   [3] (🛴..🛶)    kick scooter..canoe
-	{runeRange{0x1F6F7, 0x1F6F8}, prEmojiPresentation}, // E5.0   [2] (🛷..🛸)    sled..flying saucer
-	{runeRange{0x1F6F9, 0x1F6F9}, prEmojiPresentation}, // E11.0  [1] (🛹)       skateboard
-	{runeRange{0x1F6FA, 0x1F6FA}, prEmojiPresentation}, // E12.0  [1] (🛺)       auto rickshaw
-	{runeRange{0x1F6FB, 0x1F6FC}, prEmojiPresentation}, // E13.0  [2] (🛻..🛼)    pickup truck..roller skate
-	{runeRange{0x1F7E0, 0x1F7EB}, prEmojiPresentation}, // E12.0 [12] (🟠..🟫)    orange circle..brown square
-	{runeRange{0x1F7F0, 0x1F7F0}, prEmojiPresentation}, // E14.0  [1] (🟰)       heavy equals sign
-	{runeRange{0x1F90C, 0x1F90C}, prEmojiPresentation}, // E13.0  [1] (🤌)       pinched fingers
-	{runeRange{0x1F90D, 0x1F90F}, prEmojiPresentation}, // E12.0  [3] (🤍..🤏)    white heart..pinching hand
-	{runeRange{0x1F910, 0x1F918}, prEmojiPresentation}, // E1.0   [9] (🤐..🤘)    zipper-mouth face..sign of the horns
-	{runeRange{0x1F919, 0x1F91E}, prEmojiPresentation}, // E3.0   [6] (🤙..🤞)    call me hand..crossed fingers
-	{runeRange{0x1F91F, 0x1F91F}, prEmojiPresentation}, // E5.0   [1] (🤟)       love-you gesture
-	{runeRange{0x1F920, 0x1F927}, prEmojiPresentation}, // E3.0   [8] (🤠..🤧)    cowboy hat face..sneezing face
-	{runeRange{0x1F928, 0x1F92F}, prEmojiPresentation}, // E5.0   [8] (🤨..🤯)    face with raised eyebrow..exploding head
+	{runeRange{0x1F415, 0x1F415}, prEmojiPresentation}, // E0.7   [1] (🐕)       dog
 	{runeRange{0x1F930, 0x1F930}, prEmojiPresentation}, // E3.0   [1] (🤰)       pregnant woman
-	{runeRange{0x1F931, 0x1F932}, prEmojiPresentation}, // E5.0   [2] (🤱..🤲)    breast-feeding..palms up together
-	{runeRange{0x1F933, 0x1F93A}, prEmojiPresentation}, // E3.0   [8] (🤳..🤺)    selfie..person fencing
-	{runeRange{0x1F93C, 0x1F93E}, prEmojiPresentation}, // E3.0   [3] (🤼..🤾)    people wrestling..person playing handball
-	{runeRange{0x1F93F, 0x1F93F}, prEmojiPresentation}, // E12.0  [1] (🤿)       diving mask
-	{runeRange{0x1F940, 0x1F945}, prEmojiPresentation}, // E3.0   [6] (🥀..🥅)    wilted flower..goal net
-	{runeRange{0x1F947, 0x1F94B}, prEmojiPresentation}, // E3.0   [5] (🥇..🥋)    1st place medal..martial arts uniform
-	{runeRange{0x1F94C, 0x1F94C}, prEmojiPresentation}, // E5.0   [1] (🥌)       curling stone
-	{runeRange{0x1F94D, 0x1F94F}, prEmojiPresentation}, // E11.0  [3] (🥍..🥏)    lacrosse..flying disc
-	{runeRange{0x1F950, 0x1F95E}, prEmojiPresentation}, // E3.0  [15] (🥐..🥞)    croissant..pancakes
-	{runeRange{0x1F95F, 0x1F96B}, prEmojiPresentation}, // E5.0  [13] (🥟..🥫)    dumpling..canned food
-	{runeRange{0x1F96C, 0x1F970}, prEmojiPresentation}, // E11.0  [5] (🥬..🥰)    leafy green..smiling face with hearts
-	{runeRange{0x1F971, 0x1F971}, prEmojiPresentation}, // E12.0  [1] (🥱)       yawning face
-	{runeRange{0x1F972, 0x1F972}, prEmojiPresentation}, // E13.0  [1] (🥲)       smiling face with tear
-	{runeRange{0x1F973, 0x1F976}, prEmojiPresentation}, // E11.0  [4] (🥳..🥶)    partying face..cold face
-	{runeRange{0x1F977, 0x1F978}, prEmojiPresentation}, // E13.0  [2] (🥷..🥸)    ninja..disguised face
-	{runeRange{0x1F979, 0x1F979}, prEmojiPresentation}, // E14.0  [1] (🥹)       face holding back tears
-	{runeRange{0x1F97A, 0x1F97A}, prEmojiPresentation}, // E11.0  [1] (🥺)       pleading face
-	{runeRange{0x1F97B, 0x1F97B}, prEmojiPresentation}, // E12.0  [1] (🥻)       sari
-	{runeRange{0x1F97C, 0x1F97F}, prEmojiPresentation}, // E11.0  [4] (🥼..🥿)    lab coat..flat shoe
-	{runeRange{0x1F980, 0x1F984}, prEmojiPresentation}, // E1.0   [5] (🦀..🦄)    crab..unicorn
-	{runeRange{0x1F985, 0x1F991}, prEmojiPresentation}, // E3.0  [13] (🦅..🦑)    eagle..squid
-	{runeRange{0x1F992, 0x1F997}, prEmojiPresentation}, // E5.0   [6] (🦒..🦗)    giraffe..cricket
-	{runeRange{0x1F998, 0x1F9A2}, prEmojiPresentation}, // E11.0 [11] (🦘..🦢)    kangaroo..swan
-	{runeRange{0x1F9A3, 0x1F9A4}, prEmojiPresentation}, // E13.0  [2] (🦣..🦤)    mammoth..dodo
-	{runeRange{0x1F9A5, 0x1F9AA}, prEmojiPresentation}, // E12.0  [6] (🦥..🦪)    sloth..oyster
-	{runeRange{0x1F9AB, 0x1F9AD}, prEmojiPresentation}, // E13.0  [3] (🦫..🦭)    beaver..seal
-	{runeRange{0x1F9AE, 0x1F9AF}, prEmojiPresentation}, // E12.0  [2] (🦮..🦯)    guide dog..white cane
-	{runeRange{0x1F9B0, 0x1F9B9}, prEmojiPresentation}, // E11.0 [10] (🦰..🦹)    red hair..supervillain
-	{runeRange{0x1F9BA, 0x1F9BF}, prEmojiPresentation}, // E12.0  [6] (🦺..🦿)    safety vest..mechanical leg
-	{runeRange{0x1F9C0, 0x1F9C0}, prEmojiPresentation}, // E1.0   [1] (🧀)       cheese wedge
-	{runeRange{0x1F9C1, 0x1F9C2}, prEmojiPresentation}, // E11.0  [2] (🧁..🧂)    cupcake..salt
+	{runeRange{0x1F32D, 0x1F32F}, prEmojiPresentation}, // E1.0   [3] (🌭..🌯)    hot dog..burrito
+	{runeRange{0x1F52E, 0x1F53D}, prEmojiPresentation}, // E0.6  [16] (🔮..🔽)    crystal ball..downwards button
+	{runeRange{0x1F6A7, 0x1F6AD}, prEmojiPresentation}, // E0.6   [7] (🚧..🚭)    construction..no smoking
 	{runeRange{0x1F9C3, 0x1F9CA}, prEmojiPresentation}, // E12.0  [8] (🧃..🧊)    beverage box..ice
-	{runeRange{0x1F9CB, 0x1F9CB}, prEmojiPresentation}, // E13.0  [1] (🧋)       bubble tea
-	{runeRange{0x1F9CC, 0x1F9CC}, prEmojiPresentation}, // E14.0  [1] (🧌)       troll
-	{runeRange{0x1F9CD, 0x1F9CF}, prEmojiPresentation}, // E12.0  [3] (🧍..🧏)    person standing..deaf person
-	{runeRange{0x1F9D0, 0x1F9E6}, prEmojiPresentation}, // E5.0  [23] (🧐..🧦)    face with monocle..socks
-	{runeRange{0x1F9E7, 0x1F9FF}, prEmojiPresentation}, // E11.0 [25] (🧧..🧿)    red envelope..nazar amulet
-	{runeRange{0x1FA70, 0x1FA73}, prEmojiPresentation}, // E12.0  [4] (🩰..🩳)    ballet shoes..shorts
-	{runeRange{0x1FA74, 0x1FA74}, prEmojiPresentation}, // E13.0  [1] (🩴)       thong sandal
-	{runeRange{0x1FA75, 0x1FA77}, prEmojiPresentation}, // E15.0  [3] (🩵..🩷)    light blue heart..pink heart
-	{runeRange{0x1FA78, 0x1FA7A}, prEmojiPresentation}, // E12.0  [3] (🩸..🩺)    drop of blood..stethoscope
-	{runeRange{0x1FA7B, 0x1FA7C}, prEmojiPresentation}, // E14.0  [2] (🩻..🩼)    x-ray..crutch
-	{runeRange{0x1FA80, 0x1FA82}, prEmojiPresentation}, // E12.0  [3] (🪀..🪂)    yo-yo..parachute
-	{runeRange{0x1FA83, 0x1FA86}, prEmojiPresentation}, // E13.0  [4] (🪃..🪆)    boomerang..nesting dolls
-	{runeRange{0x1FA87, 0x1FA88}, prEmojiPresentation}, // E15.0  [2] (🪇..🪈)    maracas..flute
-	{runeRange{0x1FA90, 0x1FA95}, prEmojiPresentation}, // E12.0  [6] (🪐..🪕)    ringed planet..banjo
-	{runeRange{0x1FA96, 0x1FAA8}, prEmojiPresentation}, // E13.0 [19] (🪖..🪨)    military helmet..rock
+	{runeRange{0x2B50, 0x2B50}, prEmojiPresentation},   // E0.6   [1] (⭐)       star
+	{runeRange{0x1F3C8, 0x1F3C8}, prEmojiPresentation}, // E0.6   [1] (🏈)       american football
+	{runeRange{0x1F4EE, 0x1F4EE}, prEmojiPresentation}, // E0.6   [1] (📮)       postbox
+	{runeRange{0x1F612, 0x1F614}, prEmojiPresentation}, // E0.6   [3] (😒..😔)    unamused face..pensive face
+	{runeRange{0x1F68D, 0x1F68D}, prEmojiPresentation}, // E0.7   [1] (🚍)       oncoming bus
+	{runeRange{0x1F6DD, 0x1F6DF}, prEmojiPresentation}, // E14.0  [3] (🛝..🛟)    playground slide..ring buoy
+	{runeRange{0x1F979, 0x1F979}, prEmojiPresentation}, // E14.0  [1] (🥹)       face holding back tears
 	{runeRange{0x1FAA9, 0x1FAAC}, prEmojiPresentation}, // E14.0  [4] (🪩..🪬)    mirror ball..hamsa
-	{runeRange{0x1FAAD, 0x1FAAF}, prEmojiPresentation}, // E15.0  [3] (🪭..🪯)    folding hand fan..khanda
-	{runeRange{0x1FAB0, 0x1FAB6}, prEmojiPresentation}, // E13.0  [7] (🪰..🪶)    fly..feather
-	{runeRange{0x1FAB7, 0x1FABA}, prEmojiPresentation}, // E14.0  [4] (🪷..🪺)    lotus..nest with eggs
-	{runeRange{0x1FABB, 0x1FABD}, prEmojiPresentation}, // E15.0  [3] (🪻..🪽)    hyacinth..wing
-	{runeRange{0x1FABF, 0x1FABF}, prEmojiPresentation}, // E15.0  [1] (🪿)       goose
-	{runeRange{0x1FAC0, 0x1FAC2}, prEmojiPresentation}, // E13.0  [3] (🫀..🫂)    anatomical heart..people hugging
-	{runeRange{0x1FAC3, 0x1FAC5}, prEmojiPresentation}, // E14.0  [3] (🫃..🫅)    pregnant man..person with crown
+	{runeRange{0x26EA, 0x26EA}, prEmojiPresentation},   // E0.6   [1] (⛪)       church
+	{runeRange{0x1F310, 0x1F310}, prEmojiPresentation}, // E1.0   [1] (🌐)       globe with meridians
+	{runeRange{0x1F351, 0x1F37B}, prEmojiPresentation}, // E0.6  [43] (🍑..🍻)    peach..clinking beer mugs
+	{runeRange{0x1F3F8, 0x1F407}, prEmojiPresentation}, // E1.0  [16] (🏸..🐇)    badminton..rabbit
+	{runeRange{0x1F466, 0x1F46B}, prEmojiPresentation}, // E0.6   [6] (👦..👫)    boy..woman and man holding hands
+	{runeRange{0x1F503, 0x1F503}, prEmojiPresentation}, // E0.6   [1] (🔃)       clockwise vertical arrows
+	{runeRange{0x1F600, 0x1F600}, prEmojiPresentation}, // E1.0   [1] (😀)       grinning face
+	{runeRange{0x1F61C, 0x1F61E}, prEmojiPresentation}, // E0.6   [3] (😜..😞)    winking face with tongue..disappointed face
+	{runeRange{0x1F681, 0x1F682}, prEmojiPresentation}, // E1.0   [2] (🚁..🚂)    helicopter..locomotive
+	{runeRange{0x1F697, 0x1F697}, prEmojiPresentation}, // E0.6   [1] (🚗)       automobile
+	{runeRange{0x1F6C0, 0x1F6C0}, prEmojiPresentation}, // E0.6   [1] (🛀)       person taking bath
+	{runeRange{0x1F7F0, 0x1F7F0}, prEmojiPresentation}, // E14.0  [1] (🟰)       heavy equals sign
+	{runeRange{0x1F94D, 0x1F94F}, prEmojiPresentation}, // E11.0  [3] (🥍..🥏)    lacrosse..flying disc
+	{runeRange{0x1F9A3, 0x1F9A4}, prEmojiPresentation}, // E13.0  [2] (🦣..🦤)    mammoth..dodo
+	{runeRange{0x1FA75, 0x1FA77}, prEmojiPresentation}, // E15.0  [3] (🩵..🩷)    light blue heart..pink heart
 	{runeRange{0x1FACE, 0x1FACF}, prEmojiPresentation}, // E15.0  [2] (🫎..🫏)    moose..donkey
-	{runeRange{0x1FAD0, 0x1FAD6}, prEmojiPresentation}, // E13.0  [7] (🫐..🫖)    blueberries..teapot
-	{runeRange{0x1FAD7, 0x1FAD9}, prEmojiPresentation}, // E14.0  [3] (🫗..🫙)    pouring liquid..jar
-	{runeRange{0x1FADA, 0x1FADB}, prEmojiPresentation}, // E15.0  [2] (🫚..🫛)    ginger root..pea pod
+	{runeRange{0x267F, 0x267F}, prEmojiPresentation},   // E0.6   [1] (♿)       wheelchair symbol
+	{runeRange{0x274C, 0x274C}, prEmojiPresentation},   // E0.6   [1] (❌)       cross mark
+	{runeRange{0x1F21A, 0x1F21A}, prEmojiPresentation}, // E0.6   [1] (🈚)       Japanese “free of charge” button
+	{runeRange{0x1F31B, 0x1F31B}, prEmojiPresentation}, // E0.6   [1] (🌛)       first quarter moon face
+	{runeRange{0x1F337, 0x1F34A}, prEmojiPresentation}, // E0.6  [20] (🌷..🍊)    tulip..tangerine
+	{runeRange{0x1F3A0, 0x1F3C4}, prEmojiPresentation}, // E0.6  [37] (🎠..🏄)    carousel horse..person surfing
+	{runeRange{0x1F3E0, 0x1F3E3}, prEmojiPresentation}, // E0.6   [4] (🏠..🏣)    house..Japanese post office
+	{runeRange{0x1F40F, 0x1F410}, prEmojiPresentation}, // E1.0   [2] (🐏..🐐)    ram..goat
+	{runeRange{0x1F42B, 0x1F43E}, prEmojiPresentation}, // E0.6  [20] (🐫..🐾)    two-hump camel..paw prints
+	{runeRange{0x1F4AE, 0x1F4B5}, prEmojiPresentation}, // E0.6   [8] (💮..💵)    white flower..dollar banknote
+	{runeRange{0x1F4F6, 0x1F4F7}, prEmojiPresentation}, // E0.6   [2] (📶..📷)    antenna bars..camera
+	{runeRange{0x1F50A, 0x1F514}, prEmojiPresentation}, // E0.6  [11] (🔊..🔔)    speaker high volume..bell
+	{runeRange{0x1F57A, 0x1F57A}, prEmojiPresentation}, // E3.0   [1] (🕺)       man dancing
+	{runeRange{0x1F60E, 0x1F60E}, prEmojiPresentation}, // E1.0   [1] (😎)       smiling face with sunglasses
+	{runeRange{0x1F618, 0x1F618}, prEmojiPresentation}, // E0.6   [1] (😘)       face blowing a kiss
+	{runeRange{0x1F628, 0x1F62B}, prEmojiPresentation}, // E0.6   [4] (😨..😫)    fearful face..tired face
+	{runeRange{0x1F637, 0x1F640}, prEmojiPresentation}, // E0.6  [10] (😷..🙀)    face with medical mask..weary cat
+	{runeRange{0x1F688, 0x1F688}, prEmojiPresentation}, // E1.0   [1] (🚈)       light rail
+	{runeRange{0x1F691, 0x1F693}, prEmojiPresentation}, // E0.6   [3] (🚑..🚓)    ambulance..police car
+	{runeRange{0x1F6A2, 0x1F6A2}, prEmojiPresentation}, // E0.6   [1] (🚢)       ship
+	{runeRange{0x1F6B6, 0x1F6B6}, prEmojiPresentation}, // E0.6   [1] (🚶)       person walking
+	{runeRange{0x1F6D1, 0x1F6D2}, prEmojiPresentation}, // E3.0   [2] (🛑..🛒)    stop sign..shopping cart
+	{runeRange{0x1F6F9, 0x1F6F9}, prEmojiPresentation}, // E11.0  [1] (🛹)       skateboard
+	{runeRange{0x1F919, 0x1F91E}, prEmojiPresentation}, // E3.0   [6] (🤙..🤞)    call me hand..crossed fingers
+	{runeRange{0x1F93F, 0x1F93F}, prEmojiPresentation}, // E12.0  [1] (🤿)       diving mask
+	{runeRange{0x1F971, 0x1F971}, prEmojiPresentation}, // E12.0  [1] (🥱)       yawning face
+	{runeRange{0x1F980, 0x1F984}, prEmojiPresentation}, // E1.0   [5] (🦀..🦄)    crab..unicorn
+	{runeRange{0x1F9B0, 0x1F9B9}, prEmojiPresentation}, // E11.0 [10] (🦰..🦹)    red hair..supervillain
+	{runeRange{0x1F9D0, 0x1F9E6}, prEmojiPresentation}, // E5.0  [23] (🧐..🧦)    face with monocle..socks
+	{runeRange{0x1FA83, 0x1FA86}, prEmojiPresentation}, // E13.0  [4] (🪃..🪆)    boomerang..nesting dolls
+	{runeRange{0x1FABB, 0x1FABD}, prEmojiPresentation}, // E15.0  [3] (🪻..🪽)    hyacinth..wing
 	{runeRange{0x1FAE0, 0x1FAE7}, prEmojiPresentation}, // E14.0  [8] (🫠..🫧)    melting face..bubbles
-	{runeRange{0x1FAE8, 0x1FAE8}, prEmojiPresentation}, // E15.0  [1] (🫨)       shaking face
+	{runeRange{0x23F3, 0x23F3}, prEmojiPresentation},   // E0.6   [1] (⏳)       hourglass not done
+	{runeRange{0x26BD, 0x26BE}, prEmojiPresentation},   // E0.6   [2] (⚽..⚾)    soccer ball..baseball
+	{runeRange{0x26FD, 0x26FD}, prEmojiPresentation},   // E0.6   [1] (⛽)       fuel pump
+	{runeRange{0x2795, 0x2797}, prEmojiPresentation},   // E0.6   [3] (➕..➗)    plus..divide
+	{runeRange{0x1F18E, 0x1F18E}, prEmojiPresentation}, // E0.6   [1] (🆎)       AB button (blood type)
+	{runeRange{0x1F250, 0x1F251}, prEmojiPresentation}, // E0.6   [2] (🉐..🉑)    Japanese “bargain” button..Japanese “acceptable” button
+	{runeRange{0x1F316, 0x1F318}, prEmojiPresentation}, // E1.0   [3] (🌖..🌘)    waning gibbous moon..waning crescent moon
+	{runeRange{0x1F31D, 0x1F31E}, prEmojiPresentation}, // E1.0   [2] (🌝..🌞)    full moon face..sun with face
+	{runeRange{0x1F332, 0x1F333}, prEmojiPresentation}, // E1.0   [2] (🌲..🌳)    evergreen tree..deciduous tree
+	{runeRange{0x1F34C, 0x1F34F}, prEmojiPresentation}, // E0.6   [4] (🍌..🍏)    banana..green apple
+	{runeRange{0x1F37E, 0x1F37F}, prEmojiPresentation}, // E1.0   [2] (🍾..🍿)    bottle with popping cork..popcorn
+	{runeRange{0x1F3C6, 0x1F3C6}, prEmojiPresentation}, // E0.6   [1] (🏆)       trophy
+	{runeRange{0x1F3CA, 0x1F3CA}, prEmojiPresentation}, // E0.6   [1] (🏊)       person swimming
+	{runeRange{0x1F3E5, 0x1F3F0}, prEmojiPresentation}, // E0.6  [12] (🏥..🏰)    hospital..castle
+	{runeRange{0x1F409, 0x1F40B}, prEmojiPresentation}, // E1.0   [3] (🐉..🐋)    dragon..whale
+	{runeRange{0x1F413, 0x1F413}, prEmojiPresentation}, // E1.0   [1] (🐓)       rooster
+	{runeRange{0x1F417, 0x1F429}, prEmojiPresentation}, // E0.6  [19] (🐗..🐩)    boar..poodle
+	{runeRange{0x1F442, 0x1F464}, prEmojiPresentation}, // E0.6  [35] (👂..👤)    ear..bust in silhouette
+	{runeRange{0x1F46E, 0x1F4AC}, prEmojiPresentation}, // E0.6  [63] (👮..💬)    police officer..speech balloon
+	{runeRange{0x1F4B8, 0x1F4EB}, prEmojiPresentation}, // E0.6  [52] (💸..📫)    money with wings..closed mailbox with raised flag
+	{runeRange{0x1F4F0, 0x1F4F4}, prEmojiPresentation}, // E0.6   [5] (📰..📴)    newspaper..mobile phone off
+	{runeRange{0x1F4F9, 0x1F4FC}, prEmojiPresentation}, // E0.6   [4] (📹..📼)    video camera..videocassette
+	{runeRange{0x1F508, 0x1F508}, prEmojiPresentation}, // E0.7   [1] (🔈)       speaker low volume
+	{runeRange{0x1F516, 0x1F52B}, prEmojiPresentation}, // E0.6  [22] (🔖..🔫)    bookmark..water pistol
+	{runeRange{0x1F550, 0x1F55B}, prEmojiPresentation}, // E0.6  [12] (🕐..🕛)    one o’clock..twelve o’clock
+	{runeRange{0x1F5A4, 0x1F5A4}, prEmojiPresentation}, // E3.0   [1] (🖤)       black heart
+	{runeRange{0x1F607, 0x1F608}, prEmojiPresentation}, // E1.0   [2] (😇..😈)    smiling face with halo..smiling face with horns
+	{runeRange{0x1F610, 0x1F610}, prEmojiPresentation}, // E0.7   [1] (😐)       neutral face
+	{runeRange{0x1F616, 0x1F616}, prEmojiPresentation}, // E0.6   [1] (😖)       confounded face
+	{runeRange{0x1F61A, 0x1F61A}, prEmojiPresentation}, // E0.6   [1] (😚)       kissing face with closed eyes
+	{runeRange{0x1F620, 0x1F625}, prEmojiPresentation}, // E0.6   [6] (😠..😥)    angry face..sad but relieved face
+	{runeRange{0x1F62D, 0x1F62D}, prEmojiPresentation}, // E0.6   [1] (😭)       loudly crying face
+	{runeRange{0x1F635, 0x1F635}, prEmojiPresentation}, // E0.6   [1] (😵)       face with crossed-out eyes
+	{runeRange{0x1F645, 0x1F64F}, prEmojiPresentation}, // E0.6  [11] (🙅..🙏)    person gesturing NO..folded hands
+	{runeRange{0x1F686, 0x1F686}, prEmojiPresentation}, // E1.0   [1] (🚆)       train
+	{runeRange{0x1F68A, 0x1F68B}, prEmojiPresentation}, // E1.0   [2] (🚊..🚋)    tram..tram car
+	{runeRange{0x1F68F, 0x1F68F}, prEmojiPresentation}, // E0.6   [1] (🚏)       bus stop
+	{runeRange{0x1F695, 0x1F695}, prEmojiPresentation}, // E0.6   [1] (🚕)       taxi
+	{runeRange{0x1F699, 0x1F69A}, prEmojiPresentation}, // E0.6   [2] (🚙..🚚)    sport utility vehicle..delivery truck
+	{runeRange{0x1F6A4, 0x1F6A5}, prEmojiPresentation}, // E0.6   [2] (🚤..🚥)    speedboat..horizontal traffic light
+	{runeRange{0x1F6B2, 0x1F6B2}, prEmojiPresentation}, // E0.6   [1] (🚲)       bicycle
+	{runeRange{0x1F6B9, 0x1F6BE}, prEmojiPresentation}, // E0.6   [6] (🚹..🚾)    men’s room..water closet
+	{runeRange{0x1F6CC, 0x1F6CC}, prEmojiPresentation}, // E1.0   [1] (🛌)       person in bed
+	{runeRange{0x1F6D6, 0x1F6D7}, prEmojiPresentation}, // E13.0  [2] (🛖..🛗)    hut..elevator
+	{runeRange{0x1F6F4, 0x1F6F6}, prEmojiPresentation}, // E3.0   [3] (🛴..🛶)    kick scooter..canoe
+	{runeRange{0x1F6FB, 0x1F6FC}, prEmojiPresentation}, // E13.0  [2] (🛻..🛼)    pickup truck..roller skate
+	{runeRange{0x1F90D, 0x1F90F}, prEmojiPresentation}, // E12.0  [3] (🤍..🤏)    white heart..pinching hand
+	{runeRange{0x1F920, 0x1F927}, prEmojiPresentation}, // E3.0   [8] (🤠..🤧)    cowboy hat face..sneezing face
+	{runeRange{0x1F933, 0x1F93A}, prEmojiPresentation}, // E3.0   [8] (🤳..🤺)    selfie..person fencing
+	{runeRange{0x1F947, 0x1F94B}, prEmojiPresentation}, // E3.0   [5] (🥇..🥋)    1st place medal..martial arts uniform
+	{runeRange{0x1F95F, 0x1F96B}, prEmojiPresentation}, // E5.0  [13] (🥟..🥫)    dumpling..canned food
+	{runeRange{0x1F973, 0x1F976}, prEmojiPresentation}, // E11.0  [4] (🥳..🥶)    partying face..cold face
+	{runeRange{0x1F97B, 0x1F97B}, prEmojiPresentation}, // E12.0  [1] (🥻)       sari
+	{runeRange{0x1F992, 0x1F997}, prEmojiPresentation}, // E5.0   [6] (🦒..🦗)    giraffe..cricket
+	{runeRange{0x1F9AB, 0x1F9AD}, prEmojiPresentation}, // E13.0  [3] (🦫..🦭)    beaver..seal
+	{runeRange{0x1F9C0, 0x1F9C0}, prEmojiPresentation}, // E1.0   [1] (🧀)       cheese wedge
+	{runeRange{0x1F9CC, 0x1F9CC}, prEmojiPresentation}, // E14.0  [1] (🧌)       troll
+	{runeRange{0x1FA70, 0x1FA73}, prEmojiPresentation}, // E12.0  [4] (🩰..🩳)    ballet shoes..shorts
+	{runeRange{0x1FA7B, 0x1FA7C}, prEmojiPresentation}, // E14.0  [2] (🩻..🩼)    x-ray..crutch
+	{runeRange{0x1FA90, 0x1FA95}, prEmojiPresentation}, // E12.0  [6] (🪐..🪕)    ringed planet..banjo
+	{runeRange{0x1FAB0, 0x1FAB6}, prEmojiPresentation}, // E13.0  [7] (🪰..🪶)    fly..feather
+	{runeRange{0x1FAC0, 0x1FAC2}, prEmojiPresentation}, // E13.0  [3] (🫀..🫂)    anatomical heart..people hugging
+	{runeRange{0x1FAD7, 0x1FAD9}, prEmojiPresentation}, // E14.0  [3] (🫗..🫙)    pouring liquid..jar
 	{runeRange{0x1FAF0, 0x1FAF6}, prEmojiPresentation}, // E14.0  [7] (🫰..🫶)    hand with index finger and thumb crossed..heart hands
+	{runeRange{0x23E9, 0x23EC}, prEmojiPresentation},   // E0.6   [4] (⏩..⏬)    fast-forward button..fast down button
+	{runeRange{0x2614, 0x2615}, prEmojiPresentation},   // E0.6   [2] (☔..☕)    umbrella with rain drops..hot beverage
+	{runeRange{0x26A1, 0x26A1}, prEmojiPresentation},   // E0.6   [1] (⚡)       high voltage
+	{runeRange{0x26CE, 0x26CE}, prEmojiPresentation},   // E0.6   [1] (⛎)       Ophiuchus
+	{runeRange{0x26F5, 0x26F5}, prEmojiPresentation},   // E0.6   [1] (⛵)       sailboat
+	{runeRange{0x270A, 0x270B}, prEmojiPresentation},   // E0.6   [2] (✊..✋)    raised fist..raised hand
+	{runeRange{0x2753, 0x2755}, prEmojiPresentation},   // E0.6   [3] (❓..❕)    red question mark..white exclamation mark
+	{runeRange{0x27BF, 0x27BF}, prEmojiPresentation},   // E1.0   [1] (➿)       double curly loop
+	{runeRange{0x1F004, 0x1F004}, prEmojiPresentation}, // E0.6   [1] (🀄)       mahjong red dragon
+	{runeRange{0x1F1E6, 0x1F1FF}, prEmojiPresentation}, // E0.0  [26] (🇦..🇿)    regional indicator symbol letter a..regional indicator symbol letter z
+	{runeRange{0x1F232, 0x1F236}, prEmojiPresentation}, // E0.6   [5] (🈲..🈶)    Japanese “prohibited” button..Japanese “not free of charge” button
+	{runeRange{0x1F30D, 0x1F30E}, prEmojiPresentation}, // E0.7   [2] (🌍..🌎)    globe showing Europe-Africa..globe showing Americas
+	{runeRange{0x1F312, 0x1F312}, prEmojiPresentation}, // E1.0   [1] (🌒)       waxing crescent moon
+	{runeRange{0x1F31A, 0x1F31A}, prEmojiPresentation}, // E1.0   [1] (🌚)       new moon face
+	{runeRange{0x1F31C, 0x1F31C}, prEmojiPresentation}, // E0.7   [1] (🌜)       last quarter moon face
+	{runeRange{0x1F31F, 0x1F320}, prEmojiPresentation}, // E0.6   [2] (🌟..🌠)    glowing star..shooting star
+	{runeRange{0x1F330, 0x1F331}, prEmojiPresentation}, // E0.6   [2] (🌰..🌱)    chestnut..seedling
+	{runeRange{0x1F334, 0x1F335}, prEmojiPresentation}, // E0.6   [2] (🌴..🌵)    palm tree..cactus
+	{runeRange{0x1F34B, 0x1F34B}, prEmojiPresentation}, // E1.0   [1] (🍋)       lemon
+	{runeRange{0x1F350, 0x1F350}, prEmojiPresentation}, // E1.0   [1] (🍐)       pear
+	{runeRange{0x1F37C, 0x1F37C}, prEmojiPresentation}, // E1.0   [1] (🍼)       baby bottle
+	{runeRange{0x1F380, 0x1F393}, prEmojiPresentation}, // E0.6  [20] (🎀..🎓)    ribbon..graduation cap
+	{runeRange{0x1F3C5, 0x1F3C5}, prEmojiPresentation}, // E1.0   [1] (🏅)       sports medal
+	{runeRange{0x1F3C7, 0x1F3C7}, prEmojiPresentation}, // E1.0   [1] (🏇)       horse racing
+	{runeRange{0x1F3C9, 0x1F3C9}, prEmojiPresentation}, // E1.0   [1] (🏉)       rugby football
+	{runeRange{0x1F3CF, 0x1F3D3}, prEmojiPresentation}, // E1.0   [5] (🏏..🏓)    cricket game..ping pong
+	{runeRange{0x1F3E4, 0x1F3E4}, prEmojiPresentation}, // E1.0   [1] (🏤)       post office
+	{runeRange{0x1F3F4, 0x1F3F4}, prEmojiPresentation}, // E1.0   [1] (🏴)       black flag
+	{runeRange{0x1F408, 0x1F408}, prEmojiPresentation}, // E0.7   [1] (🐈)       cat
+	{runeRange{0x1F40C, 0x1F40E}, prEmojiPresentation}, // E0.6   [3] (🐌..🐎)    snail..horse
+	{runeRange{0x1F411, 0x1F412}, prEmojiPresentation}, // E0.6   [2] (🐑..🐒)    ewe..monkey
+	{runeRange{0x1F414, 0x1F414}, prEmojiPresentation}, // E0.6   [1] (🐔)       chicken
+	{runeRange{0x1F416, 0x1F416}, prEmojiPresentation}, // E1.0   [1] (🐖)       pig
+	{runeRange{0x1F42A, 0x1F42A}, prEmojiPresentation}, // E1.0   [1] (🐪)       camel
+	{runeRange{0x1F440, 0x1F440}, prEmojiPresentation}, // E0.6   [1] (👀)       eyes
+	{runeRange{0x1F465, 0x1F465}, prEmojiPresentation}, // E1.0   [1] (👥)       busts in silhouette
+	{runeRange{0x1F46C, 0x1F46D}, prEmojiPresentation}, // E1.0   [2] (👬..👭)    men holding hands..women holding hands
+	{runeRange{0x1F4AD, 0x1F4AD}, prEmojiPresentation}, // E1.0   [1] (💭)       thought balloon
+	{runeRange{0x1F4B6, 0x1F4B7}, prEmojiPresentation}, // E1.0   [2] (💶..💷)    euro banknote..pound banknote
+	{runeRange{0x1F4EC, 0x1F4ED}, prEmojiPresentation}, // E0.7   [2] (📬..📭)    open mailbox with raised flag..open mailbox with lowered flag
+	{runeRange{0x1F4EF, 0x1F4EF}, prEmojiPresentation}, // E1.0   [1] (📯)       postal horn
+	{runeRange{0x1F4F5, 0x1F4F5}, prEmojiPresentation}, // E1.0   [1] (📵)       no mobile phones
+	{runeRange{0x1F4F8, 0x1F4F8}, prEmojiPresentation}, // E1.0   [1] (📸)       camera with flash
+	{runeRange{0x1F4FF, 0x1F502}, prEmojiPresentation}, // E1.0   [4] (📿..🔂)    prayer beads..repeat single button
+	{runeRange{0x1F504, 0x1F507}, prEmojiPresentation}, // E1.0   [4] (🔄..🔇)    counterclockwise arrows button..muted speaker
+	{runeRange{0x1F509, 0x1F509}, prEmojiPresentation}, // E1.0   [1] (🔉)       speaker medium volume
+	{runeRange{0x1F515, 0x1F515}, prEmojiPresentation}, // E1.0   [1] (🔕)       bell with slash
+	{runeRange{0x1F52C, 0x1F52D}, prEmojiPresentation}, // E1.0   [2] (🔬..🔭)    microscope..telescope
+	{runeRange{0x1F54B, 0x1F54E}, prEmojiPresentation}, // E1.0   [4] (🕋..🕎)    kaaba..menorah
+	{runeRange{0x1F55C, 0x1F567}, prEmojiPresentation}, // E0.7  [12] (🕜..🕧)    one-thirty..twelve-thirty
+	{runeRange{0x1F595, 0x1F596}, prEmojiPresentation}, // E1.0   [2] (🖕..🖖)    middle finger..vulcan salute
+	{runeRange{0x1F5FB, 0x1F5FF}, prEmojiPresentation}, // E0.6   [5] (🗻..🗿)    mount fuji..moai
+	{runeRange{0x1F601, 0x1F606}, prEmojiPresentation}, // E0.6   [6] (😁..😆)    beaming face with smiling eyes..grinning squinting face
+	{runeRange{0x1F609, 0x1F60D}, prEmojiPresentation}, // E0.6   [5] (😉..😍)    winking face..smiling face with heart-eyes
+	{runeRange{0x1F60F, 0x1F60F}, prEmojiPresentation}, // E0.6   [1] (😏)       smirking face
+	{runeRange{0x1F611, 0x1F611}, prEmojiPresentation}, // E1.0   [1] (😑)       expressionless face
+	{runeRange{0x1F615, 0x1F615}, prEmojiPresentation}, // E1.0   [1] (😕)       confused face
+	{runeRange{0x1F617, 0x1F617}, prEmojiPresentation}, // E1.0   [1] (😗)       kissing face
+	{runeRange{0x1F619, 0x1F619}, prEmojiPresentation}, // E1.0   [1] (😙)       kissing face with smiling eyes
+	{runeRange{0x1F61B, 0x1F61B}, prEmojiPresentation}, // E1.0   [1] (😛)       face with tongue
+	{runeRange{0x1F61F, 0x1F61F}, prEmojiPresentation}, // E1.0   [1] (😟)       worried face
+	{runeRange{0x1F626, 0x1F627}, prEmojiPresentation}, // E1.0   [2] (😦..😧)    frowning face with open mouth..anguished face
+	{runeRange{0x1F62C, 0x1F62C}, prEmojiPresentation}, // E1.0   [1] (😬)       grimacing face
+	{runeRange{0x1F62E, 0x1F62F}, prEmojiPresentation}, // E1.0   [2] (😮..😯)    face with open mouth..hushed face
+	{runeRange{0x1F634, 0x1F634}, prEmojiPresentation}, // E1.0   [1] (😴)       sleeping face
+	{runeRange{0x1F636, 0x1F636}, prEmojiPresentation}, // E1.0   [1] (😶)       face without mouth
+	{runeRange{0x1F641, 0x1F644}, prEmojiPresentation}, // E1.0   [4] (🙁..🙄)    slightly frowning face..face with rolling eyes
+	{runeRange{0x1F680, 0x1F680}, prEmojiPresentation}, // E0.6   [1] (🚀)       rocket
+	{runeRange{0x1F683, 0x1F685}, prEmojiPresentation}, // E0.6   [3] (🚃..🚅)    railway car..bullet train
+	{runeRange{0x1F687, 0x1F687}, prEmojiPresentation}, // E0.6   [1] (🚇)       metro
+	{runeRange{0x1F689, 0x1F689}, prEmojiPresentation}, // E0.6   [1] (🚉)       station
+	{runeRange{0x1F68C, 0x1F68C}, prEmojiPresentation}, // E0.6   [1] (🚌)       bus
+	{runeRange{0x1F68E, 0x1F68E}, prEmojiPresentation}, // E1.0   [1] (🚎)       trolleybus
+	{runeRange{0x1F690, 0x1F690}, prEmojiPresentation}, // E1.0   [1] (🚐)       minibus
+	{runeRange{0x1F694, 0x1F694}, prEmojiPresentation}, // E0.7   [1] (🚔)       oncoming police car
+	{runeRange{0x1F696, 0x1F696}, prEmojiPresentation}, // E1.0   [1] (🚖)       oncoming taxi
+	{runeRange{0x1F698, 0x1F698}, prEmojiPresentation}, // E0.7   [1] (🚘)       oncoming automobile
+	{runeRange{0x1F69B, 0x1F6A1}, prEmojiPresentation}, // E1.0   [7] (🚛..🚡)    articulated lorry..aerial tramway
+	{runeRange{0x1F6A3, 0x1F6A3}, prEmojiPresentation}, // E1.0   [1] (🚣)       person rowing boat
+	{runeRange{0x1F6A6, 0x1F6A6}, prEmojiPresentation}, // E1.0   [1] (🚦)       vertical traffic light
+	{runeRange{0x1F6AE, 0x1F6B1}, prEmojiPresentation}, // E1.0   [4] (🚮..🚱)    litter in bin sign..non-potable water
+	{runeRange{0x1F6B3, 0x1F6B5}, prEmojiPresentation}, // E1.0   [3] (🚳..🚵)    no bicycles..person mountain biking
+	{runeRange{0x1F6B7, 0x1F6B8}, prEmojiPresentation}, // E1.0   [2] (🚷..🚸)    no pedestrians..children crossing
+	{runeRange{0x1F6BF, 0x1F6BF}, prEmojiPresentation}, // E1.0   [1] (🚿)       shower
+	{runeRange{0x1F6C1, 0x1F6C5}, prEmojiPresentation}, // E1.0   [5] (🛁..🛅)    bathtub..left luggage
+	{runeRange{0x1F6D0, 0x1F6D0}, prEmojiPresentation}, // E1.0   [1] (🛐)       place of worship
+	{runeRange{0x1F6D5, 0x1F6D5}, prEmojiPresentation}, // E12.0  [1] (🛕)       hindu temple
+	{runeRange{0x1F6DC, 0x1F6DC}, prEmojiPresentation}, // E15.0  [1] (🛜)       wireless
+	{runeRange{0x1F6EB, 0x1F6EC}, prEmojiPresentation}, // E1.0   [2] (🛫..🛬)    airplane departure..airplane arrival
+	{runeRange{0x1F6F7, 0x1F6F8}, prEmojiPresentation}, // E5.0   [2] (🛷..🛸)    sled..flying saucer
+	{runeRange{0x1F6FA, 0x1F6FA}, prEmojiPresentation}, // E12.0  [1] (🛺)       auto rickshaw
+	{runeRange{0x1F7E0, 0x1F7EB}, prEmojiPresentation}, // E12.0 [12] (🟠..🟫)    orange circle..brown square
+	{runeRange{0x1F90C, 0x1F90C}, prEmojiPresentation}, // E13.0  [1] (🤌)       pinched fingers
+	{runeRange{0x1F910, 0x1F918}, prEmojiPresentation}, // E1.0   [9] (🤐..🤘)    zipper-mouth face..sign of the horns
+	{runeRange{0x1F91F, 0x1F91F}, prEmojiPresentation}, // E5.0   [1] (🤟)       love-you gesture
+	{runeRange{0x1F928, 0x1F92F}, prEmojiPresentation}, // E5.0   [8] (🤨..🤯)    face with raised eyebrow..exploding head
+	{runeRange{0x1F931, 0x1F932}, prEmojiPresentation}, // E5.0   [2] (🤱..🤲)    breast-feeding..palms up together
+	{runeRange{0x1F93C, 0x1F93E}, prEmojiPresentation}, // E3.0   [3] (🤼..🤾)    people wrestling..person playing handball
+	{runeRange{0x1F940, 0x1F945}, prEmojiPresentation}, // E3.0   [6] (🥀..🥅)    wilted flower..goal net
+	{runeRange{0x1F94C, 0x1F94C}, prEmojiPresentation}, // E5.0   [1] (🥌)       curling stone
+	{runeRange{0x1F950, 0x1F95E}, prEmojiPresentation}, // E3.0  [15] (🥐..🥞)    croissant..pancakes
+	{runeRange{0x1F96C, 0x1F970}, prEmojiPresentation}, // E11.0  [5] (🥬..🥰)    leafy green..smiling face with hearts
+	{runeRange{0x1F972, 0x1F972}, prEmojiPresentation}, // E13.0  [1] (🥲)       smiling face with tear
+	{runeRange{0x1F977, 0x1F978}, prEmojiPresentation}, // E13.0  [2] (🥷..🥸)    ninja..disguised face
+	{runeRange{0x1F97A, 0x1F97A}, prEmojiPresentation}, // E11.0  [1] (🥺)       pleading face
+	{runeRange{0x1F97C, 0x1F97F}, prEmojiPresentation}, // E11.0  [4] (🥼..🥿)    lab coat..flat shoe
+	{runeRange{0x1F985, 0x1F991}, prEmojiPresentation}, // E3.0  [13] (🦅..🦑)    eagle..squid
+	{runeRange{0x1F998, 0x1F9A2}, prEmojiPresentation}, // E11.0 [11] (🦘..🦢)    kangaroo..swan
+	{runeRange{0x1F9A5, 0x1F9AA}, prEmojiPresentation}, // E12.0  [6] (🦥..🦪)    sloth..oyster
+	{runeRange{0x1F9AE, 0x1F9AF}, prEmojiPresentation}, // E12.0  [2] (🦮..🦯)    guide dog..white cane
+	{runeRange{0x1F9BA, 0x1F9BF}, prEmojiPresentation}, // E12.0  [6] (🦺..🦿)    safety vest..mechanical leg
+	{runeRange{0x1F9C1, 0x1F9C2}, prEmojiPresentation}, // E11.0  [2] (🧁..🧂)    cupcake..salt
+	{runeRange{0x1F9CB, 0x1F9CB}, prEmojiPresentation}, // E13.0  [1] (🧋)       bubble tea
+	{runeRange{0x1F9CD, 0x1F9CF}, prEmojiPresentation}, // E12.0  [3] (🧍..🧏)    person standing..deaf person
+	{runeRange{0x1F9E7, 0x1F9FF}, prEmojiPresentation}, // E11.0 [25] (🧧..🧿)    red envelope..nazar amulet
+	{runeRange{0x1FA74, 0x1FA74}, prEmojiPresentation}, // E13.0  [1] (🩴)       thong sandal
+	{runeRange{0x1FA78, 0x1FA7A}, prEmojiPresentation}, // E12.0  [3] (🩸..🩺)    drop of blood..stethoscope
+	{runeRange{0x1FA80, 0x1FA82}, prEmojiPresentation}, // E12.0  [3] (🪀..🪂)    yo-yo..parachute
+	{runeRange{0x1FA87, 0x1FA88}, prEmojiPresentation}, // E15.0  [2] (🪇..🪈)    maracas..flute
+	{runeRange{0x1FA96, 0x1FAA8}, prEmojiPresentation}, // E13.0 [19] (🪖..🪨)    military helmet..rock
+	{runeRange{0x1FAAD, 0x1FAAF}, prEmojiPresentation}, // E15.0  [3] (🪭..🪯)    folding hand fan..khanda
+	{runeRange{0x1FAB7, 0x1FABA}, prEmojiPresentation}, // E14.0  [4] (🪷..🪺)    lotus..nest with eggs
+	{runeRange{0x1FABF, 0x1FABF}, prEmojiPresentation}, // E15.0  [1] (🪿)       goose
+	{runeRange{0x1FAC3, 0x1FAC5}, prEmojiPresentation}, // E14.0  [3] (🫃..🫅)    pregnant man..person with crown
+	{runeRange{0x1FAD0, 0x1FAD6}, prEmojiPresentation}, // E13.0  [7] (🫐..🫖)    blueberries..teapot
+	{runeRange{0x1FADA, 0x1FADB}, prEmojiPresentation}, // E15.0  [2] (🫚..🫛)    ginger root..pea pod
+	{runeRange{0x1FAE8, 0x1FAE8}, prEmojiPresentation}, // E15.0  [1] (🫨)       shaking face
 	{runeRange{0x1FAF7, 0x1FAF8}, prEmojiPresentation}, // E15.0  [2] (🫷..🫸)    leftwards pushing hand..rightwards pushing hand
+	{runeRange{0x231A, 0x231B}, prEmojiPresentation},   // E0.6   [2] (⌚..⌛)    watch..hourglass done
+	{runeRange{0x23F0, 0x23F0}, prEmojiPresentation},   // E0.6   [1] (⏰)       alarm clock
+	{runeRange{0x25FD, 0x25FE}, prEmojiPresentation},   // E0.6   [2] (◽..◾)    white medium-small square..black medium-small square
+	{runeRange{0x2648, 0x2653}, prEmojiPresentation},   // E0.6  [12] (♈..♓)    Aries..Pisces
+	{runeRange{0x2693, 0x2693}, prEmojiPresentation},   // E0.6   [1] (⚓)       anchor
+	{runeRange{0x26AA, 0x26AB}, prEmojiPresentation},   // E0.6   [2] (⚪..⚫)    white circle..black circle
+	{runeRange{0x26C4, 0x26C5}, prEmojiPresentation},   // E0.6   [2] (⛄..⛅)    snowman without snow..sun behind cloud
+	{runeRange{0x26D4, 0x26D4}, prEmojiPresentation},   // E0.6   [1] (⛔)       no entry
+	{runeRange{0x26F2, 0x26F3}, prEmojiPresentation},   // E0.6   [2] (⛲..⛳)    fountain..flag in hole
+	{runeRange{0x26FA, 0x26FA}, prEmojiPresentation},   // E0.6   [1] (⛺)       tent
+	{runeRange{0x2705, 0x2705}, prEmojiPresentation},   // E0.6   [1] (✅)       check mark button
+	{runeRange{0x2728, 0x2728}, prEmojiPresentation},   // E0.6   [1] (✨)       sparkles
+	{runeRange{0x274E, 0x274E}, prEmojiPresentation},   // E0.6   [1] (❎)       cross mark button
+	{runeRange{0x2757, 0x2757}, prEmojiPresentation},   // E0.6   [1] (❗)       red exclamation mark
+	{runeRange{0x27B0, 0x27B0}, prEmojiPresentation},   // E0.6   [1] (➰)       curly loop
+	{runeRange{0x2B1B, 0x2B1C}, prEmojiPresentation},   // E0.6   [2] (⬛..⬜)    black large square..white large square
+	{runeRange{0x2B55, 0x2B55}, prEmojiPresentation},   // E0.6   [1] (⭕)       hollow red circle
+	{runeRange{0x1F0CF, 0x1F0CF}, prEmojiPresentation}, // E0.6   [1] (🃏)       joker
+	{runeRange{0x1F191, 0x1F19A}, prEmojiPresentation}, // E0.6  [10] (🆑..🆚)    CL button..VS button
+	{runeRange{0x1F201, 0x1F201}, prEmojiPresentation}, // E0.6   [1] (🈁)       Japanese “here” button
+	{runeRange{0x1F22F, 0x1F22F}, prEmojiPresentation}, // E0.6   [1] (🈯)       Japanese “reserved” button
+	{runeRange{0x1F238, 0x1F23A}, prEmojiPresentation}, // E0.6   [3] (🈸..🈺)    Japanese “application” button..Japanese “open for business” button
+	{runeRange{0x1F300, 0x1F30C}, prEmojiPresentation}, // E0.6  [13] (🌀..🌌)    cyclone..milky way
+	{runeRange{0x1F30F, 0x1F30F}, prEmojiPresentation}, // E0.6   [1] (🌏)       globe showing Asia-Australia
+	{runeRange{0x1F311, 0x1F311}, prEmojiPresentation}, // E0.6   [1] (🌑)       new moon
+	{runeRange{0x1F313, 0x1F315}, prEmojiPresentation}, // E0.6   [3] (🌓..🌕)    first quarter moon..full moon
+	{runeRange{0x1F319, 0x1F319}, prEmojiPresentation}, // E0.6   [1] (🌙)       crescent moon
 }

--- a/graphemeproperties.go
+++ b/graphemeproperties.go
@@ -9,1906 +9,1906 @@ package uniseg
 // ("Extended_Pictographic" only)
 // See https://www.unicode.org/license.html for the Unicode license agreement.
 var graphemeCodePoints = dictionary[property]{
-	{runeRange{0x0000, 0x0009}, prControl},                // Cc  [10] <control-0000>..<control-0009>
-	{runeRange{0x000A, 0x000A}, prLF},                     // Cc       <control-000A>
-	{runeRange{0x000B, 0x000C}, prControl},                // Cc   [2] <control-000B>..<control-000C>
-	{runeRange{0x000D, 0x000D}, prCR},                     // Cc       <control-000D>
-	{runeRange{0x000E, 0x001F}, prControl},                // Cc  [18] <control-000E>..<control-001F>
-	{runeRange{0x007F, 0x009F}, prControl},                // Cc  [33] <control-007F>..<control-009F>
-	{runeRange{0x00A9, 0x00A9}, prExtendedPictographic},   // E0.6   [1] (©️)       copyright
-	{runeRange{0x00AD, 0x00AD}, prControl},                // Cf       SOFT HYPHEN
-	{runeRange{0x00AE, 0x00AE}, prExtendedPictographic},   // E0.6   [1] (®️)       registered
-	{runeRange{0x0300, 0x036F}, prExtend},                 // Mn [112] COMBINING GRAVE ACCENT..COMBINING LATIN SMALL LETTER X
-	{runeRange{0x0483, 0x0487}, prExtend},                 // Mn   [5] COMBINING CYRILLIC TITLO..COMBINING CYRILLIC POKRYTIE
-	{runeRange{0x0488, 0x0489}, prExtend},                 // Me   [2] COMBINING CYRILLIC HUNDRED THOUSANDS SIGN..COMBINING CYRILLIC MILLIONS SIGN
-	{runeRange{0x0591, 0x05BD}, prExtend},                 // Mn  [45] HEBREW ACCENT ETNAHTA..HEBREW POINT METEG
-	{runeRange{0x05BF, 0x05BF}, prExtend},                 // Mn       HEBREW POINT RAFE
-	{runeRange{0x05C1, 0x05C2}, prExtend},                 // Mn   [2] HEBREW POINT SHIN DOT..HEBREW POINT SIN DOT
-	{runeRange{0x05C4, 0x05C5}, prExtend},                 // Mn   [2] HEBREW MARK UPPER DOT..HEBREW MARK LOWER DOT
-	{runeRange{0x05C7, 0x05C7}, prExtend},                 // Mn       HEBREW POINT QAMATS QATAN
-	{runeRange{0x0600, 0x0605}, prPrepend},                // Cf   [6] ARABIC NUMBER SIGN..ARABIC NUMBER MARK ABOVE
-	{runeRange{0x0610, 0x061A}, prExtend},                 // Mn  [11] ARABIC SIGN SALLALLAHOU ALAYHE WASSALLAM..ARABIC SMALL KASRA
-	{runeRange{0x061C, 0x061C}, prControl},                // Cf       ARABIC LETTER MARK
-	{runeRange{0x064B, 0x065F}, prExtend},                 // Mn  [21] ARABIC FATHATAN..ARABIC WAVY HAMZA BELOW
-	{runeRange{0x0670, 0x0670}, prExtend},                 // Mn       ARABIC LETTER SUPERSCRIPT ALEF
-	{runeRange{0x06D6, 0x06DC}, prExtend},                 // Mn   [7] ARABIC SMALL HIGH LIGATURE SAD WITH LAM WITH ALEF MAKSURA..ARABIC SMALL HIGH SEEN
-	{runeRange{0x06DD, 0x06DD}, prPrepend},                // Cf       ARABIC END OF AYAH
-	{runeRange{0x06DF, 0x06E4}, prExtend},                 // Mn   [6] ARABIC SMALL HIGH ROUNDED ZERO..ARABIC SMALL HIGH MADDA
-	{runeRange{0x06E7, 0x06E8}, prExtend},                 // Mn   [2] ARABIC SMALL HIGH YEH..ARABIC SMALL HIGH NOON
-	{runeRange{0x06EA, 0x06ED}, prExtend},                 // Mn   [4] ARABIC EMPTY CENTRE LOW STOP..ARABIC SMALL LOW MEEM
-	{runeRange{0x070F, 0x070F}, prPrepend},                // Cf       SYRIAC ABBREVIATION MARK
-	{runeRange{0x0711, 0x0711}, prExtend},                 // Mn       SYRIAC LETTER SUPERSCRIPT ALAPH
-	{runeRange{0x0730, 0x074A}, prExtend},                 // Mn  [27] SYRIAC PTHAHA ABOVE..SYRIAC BARREKH
-	{runeRange{0x07A6, 0x07B0}, prExtend},                 // Mn  [11] THAANA ABAFILI..THAANA SUKUN
-	{runeRange{0x07EB, 0x07F3}, prExtend},                 // Mn   [9] NKO COMBINING SHORT HIGH TONE..NKO COMBINING DOUBLE DOT ABOVE
-	{runeRange{0x07FD, 0x07FD}, prExtend},                 // Mn       NKO DANTAYALAN
-	{runeRange{0x0816, 0x0819}, prExtend},                 // Mn   [4] SAMARITAN MARK IN..SAMARITAN MARK DAGESH
-	{runeRange{0x081B, 0x0823}, prExtend},                 // Mn   [9] SAMARITAN MARK EPENTHETIC YUT..SAMARITAN VOWEL SIGN A
-	{runeRange{0x0825, 0x0827}, prExtend},                 // Mn   [3] SAMARITAN VOWEL SIGN SHORT A..SAMARITAN VOWEL SIGN U
-	{runeRange{0x0829, 0x082D}, prExtend},                 // Mn   [5] SAMARITAN VOWEL SIGN LONG I..SAMARITAN MARK NEQUDAA
-	{runeRange{0x0859, 0x085B}, prExtend},                 // Mn   [3] MANDAIC AFFRICATION MARK..MANDAIC GEMINATION MARK
-	{runeRange{0x0890, 0x0891}, prPrepend},                // Cf   [2] ARABIC POUND MARK ABOVE..ARABIC PIASTRE MARK ABOVE
-	{runeRange{0x0898, 0x089F}, prExtend},                 // Mn   [8] ARABIC SMALL HIGH WORD AL-JUZ..ARABIC HALF MADDA OVER MADDA
-	{runeRange{0x08CA, 0x08E1}, prExtend},                 // Mn  [24] ARABIC SMALL HIGH FARSI YEH..ARABIC SMALL HIGH SIGN SAFHA
-	{runeRange{0x08E2, 0x08E2}, prPrepend},                // Cf       ARABIC DISPUTED END OF AYAH
-	{runeRange{0x08E3, 0x0902}, prExtend},                 // Mn  [32] ARABIC TURNED DAMMA BELOW..DEVANAGARI SIGN ANUSVARA
-	{runeRange{0x0903, 0x0903}, prSpacingMark},            // Mc       DEVANAGARI SIGN VISARGA
-	{runeRange{0x093A, 0x093A}, prExtend},                 // Mn       DEVANAGARI VOWEL SIGN OE
-	{runeRange{0x093B, 0x093B}, prSpacingMark},            // Mc       DEVANAGARI VOWEL SIGN OOE
-	{runeRange{0x093C, 0x093C}, prExtend},                 // Mn       DEVANAGARI SIGN NUKTA
-	{runeRange{0x093E, 0x0940}, prSpacingMark},            // Mc   [3] DEVANAGARI VOWEL SIGN AA..DEVANAGARI VOWEL SIGN II
-	{runeRange{0x0941, 0x0948}, prExtend},                 // Mn   [8] DEVANAGARI VOWEL SIGN U..DEVANAGARI VOWEL SIGN AI
-	{runeRange{0x0949, 0x094C}, prSpacingMark},            // Mc   [4] DEVANAGARI VOWEL SIGN CANDRA O..DEVANAGARI VOWEL SIGN AU
-	{runeRange{0x094D, 0x094D}, prExtend},                 // Mn       DEVANAGARI SIGN VIRAMA
-	{runeRange{0x094E, 0x094F}, prSpacingMark},            // Mc   [2] DEVANAGARI VOWEL SIGN PRISHTHAMATRA E..DEVANAGARI VOWEL SIGN AW
-	{runeRange{0x0951, 0x0957}, prExtend},                 // Mn   [7] DEVANAGARI STRESS SIGN UDATTA..DEVANAGARI VOWEL SIGN UUE
-	{runeRange{0x0962, 0x0963}, prExtend},                 // Mn   [2] DEVANAGARI VOWEL SIGN VOCALIC L..DEVANAGARI VOWEL SIGN VOCALIC LL
-	{runeRange{0x0981, 0x0981}, prExtend},                 // Mn       BENGALI SIGN CANDRABINDU
-	{runeRange{0x0982, 0x0983}, prSpacingMark},            // Mc   [2] BENGALI SIGN ANUSVARA..BENGALI SIGN VISARGA
-	{runeRange{0x09BC, 0x09BC}, prExtend},                 // Mn       BENGALI SIGN NUKTA
-	{runeRange{0x09BE, 0x09BE}, prExtend},                 // Mc       BENGALI VOWEL SIGN AA
-	{runeRange{0x09BF, 0x09C0}, prSpacingMark},            // Mc   [2] BENGALI VOWEL SIGN I..BENGALI VOWEL SIGN II
-	{runeRange{0x09C1, 0x09C4}, prExtend},                 // Mn   [4] BENGALI VOWEL SIGN U..BENGALI VOWEL SIGN VOCALIC RR
-	{runeRange{0x09C7, 0x09C8}, prSpacingMark},            // Mc   [2] BENGALI VOWEL SIGN E..BENGALI VOWEL SIGN AI
-	{runeRange{0x09CB, 0x09CC}, prSpacingMark},            // Mc   [2] BENGALI VOWEL SIGN O..BENGALI VOWEL SIGN AU
-	{runeRange{0x09CD, 0x09CD}, prExtend},                 // Mn       BENGALI SIGN VIRAMA
-	{runeRange{0x09D7, 0x09D7}, prExtend},                 // Mc       BENGALI AU LENGTH MARK
-	{runeRange{0x09E2, 0x09E3}, prExtend},                 // Mn   [2] BENGALI VOWEL SIGN VOCALIC L..BENGALI VOWEL SIGN VOCALIC LL
-	{runeRange{0x09FE, 0x09FE}, prExtend},                 // Mn       BENGALI SANDHI MARK
-	{runeRange{0x0A01, 0x0A02}, prExtend},                 // Mn   [2] GURMUKHI SIGN ADAK BINDI..GURMUKHI SIGN BINDI
-	{runeRange{0x0A03, 0x0A03}, prSpacingMark},            // Mc       GURMUKHI SIGN VISARGA
-	{runeRange{0x0A3C, 0x0A3C}, prExtend},                 // Mn       GURMUKHI SIGN NUKTA
-	{runeRange{0x0A3E, 0x0A40}, prSpacingMark},            // Mc   [3] GURMUKHI VOWEL SIGN AA..GURMUKHI VOWEL SIGN II
-	{runeRange{0x0A41, 0x0A42}, prExtend},                 // Mn   [2] GURMUKHI VOWEL SIGN U..GURMUKHI VOWEL SIGN UU
-	{runeRange{0x0A47, 0x0A48}, prExtend},                 // Mn   [2] GURMUKHI VOWEL SIGN EE..GURMUKHI VOWEL SIGN AI
-	{runeRange{0x0A4B, 0x0A4D}, prExtend},                 // Mn   [3] GURMUKHI VOWEL SIGN OO..GURMUKHI SIGN VIRAMA
-	{runeRange{0x0A51, 0x0A51}, prExtend},                 // Mn       GURMUKHI SIGN UDAAT
-	{runeRange{0x0A70, 0x0A71}, prExtend},                 // Mn   [2] GURMUKHI TIPPI..GURMUKHI ADDAK
-	{runeRange{0x0A75, 0x0A75}, prExtend},                 // Mn       GURMUKHI SIGN YAKASH
-	{runeRange{0x0A81, 0x0A82}, prExtend},                 // Mn   [2] GUJARATI SIGN CANDRABINDU..GUJARATI SIGN ANUSVARA
-	{runeRange{0x0A83, 0x0A83}, prSpacingMark},            // Mc       GUJARATI SIGN VISARGA
-	{runeRange{0x0ABC, 0x0ABC}, prExtend},                 // Mn       GUJARATI SIGN NUKTA
-	{runeRange{0x0ABE, 0x0AC0}, prSpacingMark},            // Mc   [3] GUJARATI VOWEL SIGN AA..GUJARATI VOWEL SIGN II
-	{runeRange{0x0AC1, 0x0AC5}, prExtend},                 // Mn   [5] GUJARATI VOWEL SIGN U..GUJARATI VOWEL SIGN CANDRA E
-	{runeRange{0x0AC7, 0x0AC8}, prExtend},                 // Mn   [2] GUJARATI VOWEL SIGN E..GUJARATI VOWEL SIGN AI
-	{runeRange{0x0AC9, 0x0AC9}, prSpacingMark},            // Mc       GUJARATI VOWEL SIGN CANDRA O
-	{runeRange{0x0ACB, 0x0ACC}, prSpacingMark},            // Mc   [2] GUJARATI VOWEL SIGN O..GUJARATI VOWEL SIGN AU
-	{runeRange{0x0ACD, 0x0ACD}, prExtend},                 // Mn       GUJARATI SIGN VIRAMA
-	{runeRange{0x0AE2, 0x0AE3}, prExtend},                 // Mn   [2] GUJARATI VOWEL SIGN VOCALIC L..GUJARATI VOWEL SIGN VOCALIC LL
-	{runeRange{0x0AFA, 0x0AFF}, prExtend},                 // Mn   [6] GUJARATI SIGN SUKUN..GUJARATI SIGN TWO-CIRCLE NUKTA ABOVE
-	{runeRange{0x0B01, 0x0B01}, prExtend},                 // Mn       ORIYA SIGN CANDRABINDU
-	{runeRange{0x0B02, 0x0B03}, prSpacingMark},            // Mc   [2] ORIYA SIGN ANUSVARA..ORIYA SIGN VISARGA
-	{runeRange{0x0B3C, 0x0B3C}, prExtend},                 // Mn       ORIYA SIGN NUKTA
-	{runeRange{0x0B3E, 0x0B3E}, prExtend},                 // Mc       ORIYA VOWEL SIGN AA
-	{runeRange{0x0B3F, 0x0B3F}, prExtend},                 // Mn       ORIYA VOWEL SIGN I
-	{runeRange{0x0B40, 0x0B40}, prSpacingMark},            // Mc       ORIYA VOWEL SIGN II
-	{runeRange{0x0B41, 0x0B44}, prExtend},                 // Mn   [4] ORIYA VOWEL SIGN U..ORIYA VOWEL SIGN VOCALIC RR
-	{runeRange{0x0B47, 0x0B48}, prSpacingMark},            // Mc   [2] ORIYA VOWEL SIGN E..ORIYA VOWEL SIGN AI
-	{runeRange{0x0B4B, 0x0B4C}, prSpacingMark},            // Mc   [2] ORIYA VOWEL SIGN O..ORIYA VOWEL SIGN AU
-	{runeRange{0x0B4D, 0x0B4D}, prExtend},                 // Mn       ORIYA SIGN VIRAMA
-	{runeRange{0x0B55, 0x0B56}, prExtend},                 // Mn   [2] ORIYA SIGN OVERLINE..ORIYA AI LENGTH MARK
-	{runeRange{0x0B57, 0x0B57}, prExtend},                 // Mc       ORIYA AU LENGTH MARK
-	{runeRange{0x0B62, 0x0B63}, prExtend},                 // Mn   [2] ORIYA VOWEL SIGN VOCALIC L..ORIYA VOWEL SIGN VOCALIC LL
-	{runeRange{0x0B82, 0x0B82}, prExtend},                 // Mn       TAMIL SIGN ANUSVARA
-	{runeRange{0x0BBE, 0x0BBE}, prExtend},                 // Mc       TAMIL VOWEL SIGN AA
-	{runeRange{0x0BBF, 0x0BBF}, prSpacingMark},            // Mc       TAMIL VOWEL SIGN I
-	{runeRange{0x0BC0, 0x0BC0}, prExtend},                 // Mn       TAMIL VOWEL SIGN II
-	{runeRange{0x0BC1, 0x0BC2}, prSpacingMark},            // Mc   [2] TAMIL VOWEL SIGN U..TAMIL VOWEL SIGN UU
-	{runeRange{0x0BC6, 0x0BC8}, prSpacingMark},            // Mc   [3] TAMIL VOWEL SIGN E..TAMIL VOWEL SIGN AI
-	{runeRange{0x0BCA, 0x0BCC}, prSpacingMark},            // Mc   [3] TAMIL VOWEL SIGN O..TAMIL VOWEL SIGN AU
-	{runeRange{0x0BCD, 0x0BCD}, prExtend},                 // Mn       TAMIL SIGN VIRAMA
-	{runeRange{0x0BD7, 0x0BD7}, prExtend},                 // Mc       TAMIL AU LENGTH MARK
-	{runeRange{0x0C00, 0x0C00}, prExtend},                 // Mn       TELUGU SIGN COMBINING CANDRABINDU ABOVE
-	{runeRange{0x0C01, 0x0C03}, prSpacingMark},            // Mc   [3] TELUGU SIGN CANDRABINDU..TELUGU SIGN VISARGA
-	{runeRange{0x0C04, 0x0C04}, prExtend},                 // Mn       TELUGU SIGN COMBINING ANUSVARA ABOVE
-	{runeRange{0x0C3C, 0x0C3C}, prExtend},                 // Mn       TELUGU SIGN NUKTA
-	{runeRange{0x0C3E, 0x0C40}, prExtend},                 // Mn   [3] TELUGU VOWEL SIGN AA..TELUGU VOWEL SIGN II
-	{runeRange{0x0C41, 0x0C44}, prSpacingMark},            // Mc   [4] TELUGU VOWEL SIGN U..TELUGU VOWEL SIGN VOCALIC RR
-	{runeRange{0x0C46, 0x0C48}, prExtend},                 // Mn   [3] TELUGU VOWEL SIGN E..TELUGU VOWEL SIGN AI
-	{runeRange{0x0C4A, 0x0C4D}, prExtend},                 // Mn   [4] TELUGU VOWEL SIGN O..TELUGU SIGN VIRAMA
-	{runeRange{0x0C55, 0x0C56}, prExtend},                 // Mn   [2] TELUGU LENGTH MARK..TELUGU AI LENGTH MARK
-	{runeRange{0x0C62, 0x0C63}, prExtend},                 // Mn   [2] TELUGU VOWEL SIGN VOCALIC L..TELUGU VOWEL SIGN VOCALIC LL
-	{runeRange{0x0C81, 0x0C81}, prExtend},                 // Mn       KANNADA SIGN CANDRABINDU
-	{runeRange{0x0C82, 0x0C83}, prSpacingMark},            // Mc   [2] KANNADA SIGN ANUSVARA..KANNADA SIGN VISARGA
-	{runeRange{0x0CBC, 0x0CBC}, prExtend},                 // Mn       KANNADA SIGN NUKTA
-	{runeRange{0x0CBE, 0x0CBE}, prSpacingMark},            // Mc       KANNADA VOWEL SIGN AA
-	{runeRange{0x0CBF, 0x0CBF}, prExtend},                 // Mn       KANNADA VOWEL SIGN I
-	{runeRange{0x0CC0, 0x0CC1}, prSpacingMark},            // Mc   [2] KANNADA VOWEL SIGN II..KANNADA VOWEL SIGN U
-	{runeRange{0x0CC2, 0x0CC2}, prExtend},                 // Mc       KANNADA VOWEL SIGN UU
-	{runeRange{0x0CC3, 0x0CC4}, prSpacingMark},            // Mc   [2] KANNADA VOWEL SIGN VOCALIC R..KANNADA VOWEL SIGN VOCALIC RR
-	{runeRange{0x0CC6, 0x0CC6}, prExtend},                 // Mn       KANNADA VOWEL SIGN E
-	{runeRange{0x0CC7, 0x0CC8}, prSpacingMark},            // Mc   [2] KANNADA VOWEL SIGN EE..KANNADA VOWEL SIGN AI
-	{runeRange{0x0CCA, 0x0CCB}, prSpacingMark},            // Mc   [2] KANNADA VOWEL SIGN O..KANNADA VOWEL SIGN OO
-	{runeRange{0x0CCC, 0x0CCD}, prExtend},                 // Mn   [2] KANNADA VOWEL SIGN AU..KANNADA SIGN VIRAMA
-	{runeRange{0x0CD5, 0x0CD6}, prExtend},                 // Mc   [2] KANNADA LENGTH MARK..KANNADA AI LENGTH MARK
-	{runeRange{0x0CE2, 0x0CE3}, prExtend},                 // Mn   [2] KANNADA VOWEL SIGN VOCALIC L..KANNADA VOWEL SIGN VOCALIC LL
-	{runeRange{0x0CF3, 0x0CF3}, prSpacingMark},            // Mc       KANNADA SIGN COMBINING ANUSVARA ABOVE RIGHT
-	{runeRange{0x0D00, 0x0D01}, prExtend},                 // Mn   [2] MALAYALAM SIGN COMBINING ANUSVARA ABOVE..MALAYALAM SIGN CANDRABINDU
-	{runeRange{0x0D02, 0x0D03}, prSpacingMark},            // Mc   [2] MALAYALAM SIGN ANUSVARA..MALAYALAM SIGN VISARGA
-	{runeRange{0x0D3B, 0x0D3C}, prExtend},                 // Mn   [2] MALAYALAM SIGN VERTICAL BAR VIRAMA..MALAYALAM SIGN CIRCULAR VIRAMA
-	{runeRange{0x0D3E, 0x0D3E}, prExtend},                 // Mc       MALAYALAM VOWEL SIGN AA
-	{runeRange{0x0D3F, 0x0D40}, prSpacingMark},            // Mc   [2] MALAYALAM VOWEL SIGN I..MALAYALAM VOWEL SIGN II
-	{runeRange{0x0D41, 0x0D44}, prExtend},                 // Mn   [4] MALAYALAM VOWEL SIGN U..MALAYALAM VOWEL SIGN VOCALIC RR
-	{runeRange{0x0D46, 0x0D48}, prSpacingMark},            // Mc   [3] MALAYALAM VOWEL SIGN E..MALAYALAM VOWEL SIGN AI
-	{runeRange{0x0D4A, 0x0D4C}, prSpacingMark},            // Mc   [3] MALAYALAM VOWEL SIGN O..MALAYALAM VOWEL SIGN AU
-	{runeRange{0x0D4D, 0x0D4D}, prExtend},                 // Mn       MALAYALAM SIGN VIRAMA
-	{runeRange{0x0D4E, 0x0D4E}, prPrepend},                // Lo       MALAYALAM LETTER DOT REPH
-	{runeRange{0x0D57, 0x0D57}, prExtend},                 // Mc       MALAYALAM AU LENGTH MARK
-	{runeRange{0x0D62, 0x0D63}, prExtend},                 // Mn   [2] MALAYALAM VOWEL SIGN VOCALIC L..MALAYALAM VOWEL SIGN VOCALIC LL
-	{runeRange{0x0D81, 0x0D81}, prExtend},                 // Mn       SINHALA SIGN CANDRABINDU
-	{runeRange{0x0D82, 0x0D83}, prSpacingMark},            // Mc   [2] SINHALA SIGN ANUSVARAYA..SINHALA SIGN VISARGAYA
-	{runeRange{0x0DCA, 0x0DCA}, prExtend},                 // Mn       SINHALA SIGN AL-LAKUNA
-	{runeRange{0x0DCF, 0x0DCF}, prExtend},                 // Mc       SINHALA VOWEL SIGN AELA-PILLA
-	{runeRange{0x0DD0, 0x0DD1}, prSpacingMark},            // Mc   [2] SINHALA VOWEL SIGN KETTI AEDA-PILLA..SINHALA VOWEL SIGN DIGA AEDA-PILLA
-	{runeRange{0x0DD2, 0x0DD4}, prExtend},                 // Mn   [3] SINHALA VOWEL SIGN KETTI IS-PILLA..SINHALA VOWEL SIGN KETTI PAA-PILLA
-	{runeRange{0x0DD6, 0x0DD6}, prExtend},                 // Mn       SINHALA VOWEL SIGN DIGA PAA-PILLA
-	{runeRange{0x0DD8, 0x0DDE}, prSpacingMark},            // Mc   [7] SINHALA VOWEL SIGN GAETTA-PILLA..SINHALA VOWEL SIGN KOMBUVA HAA GAYANUKITTA
-	{runeRange{0x0DDF, 0x0DDF}, prExtend},                 // Mc       SINHALA VOWEL SIGN GAYANUKITTA
-	{runeRange{0x0DF2, 0x0DF3}, prSpacingMark},            // Mc   [2] SINHALA VOWEL SIGN DIGA GAETTA-PILLA..SINHALA VOWEL SIGN DIGA GAYANUKITTA
-	{runeRange{0x0E31, 0x0E31}, prExtend},                 // Mn       THAI CHARACTER MAI HAN-AKAT
-	{runeRange{0x0E33, 0x0E33}, prSpacingMark},            // Lo       THAI CHARACTER SARA AM
-	{runeRange{0x0E34, 0x0E3A}, prExtend},                 // Mn   [7] THAI CHARACTER SARA I..THAI CHARACTER PHINTHU
-	{runeRange{0x0E47, 0x0E4E}, prExtend},                 // Mn   [8] THAI CHARACTER MAITAIKHU..THAI CHARACTER YAMAKKAN
-	{runeRange{0x0EB1, 0x0EB1}, prExtend},                 // Mn       LAO VOWEL SIGN MAI KAN
-	{runeRange{0x0EB3, 0x0EB3}, prSpacingMark},            // Lo       LAO VOWEL SIGN AM
-	{runeRange{0x0EB4, 0x0EBC}, prExtend},                 // Mn   [9] LAO VOWEL SIGN I..LAO SEMIVOWEL SIGN LO
-	{runeRange{0x0EC8, 0x0ECE}, prExtend},                 // Mn   [7] LAO TONE MAI EK..LAO YAMAKKAN
-	{runeRange{0x0F18, 0x0F19}, prExtend},                 // Mn   [2] TIBETAN ASTROLOGICAL SIGN -KHYUD PA..TIBETAN ASTROLOGICAL SIGN SDONG TSHUGS
-	{runeRange{0x0F35, 0x0F35}, prExtend},                 // Mn       TIBETAN MARK NGAS BZUNG NYI ZLA
-	{runeRange{0x0F37, 0x0F37}, prExtend},                 // Mn       TIBETAN MARK NGAS BZUNG SGOR RTAGS
-	{runeRange{0x0F39, 0x0F39}, prExtend},                 // Mn       TIBETAN MARK TSA -PHRU
-	{runeRange{0x0F3E, 0x0F3F}, prSpacingMark},            // Mc   [2] TIBETAN SIGN YAR TSHES..TIBETAN SIGN MAR TSHES
-	{runeRange{0x0F71, 0x0F7E}, prExtend},                 // Mn  [14] TIBETAN VOWEL SIGN AA..TIBETAN SIGN RJES SU NGA RO
-	{runeRange{0x0F7F, 0x0F7F}, prSpacingMark},            // Mc       TIBETAN SIGN RNAM BCAD
-	{runeRange{0x0F80, 0x0F84}, prExtend},                 // Mn   [5] TIBETAN VOWEL SIGN REVERSED I..TIBETAN MARK HALANTA
-	{runeRange{0x0F86, 0x0F87}, prExtend},                 // Mn   [2] TIBETAN SIGN LCI RTAGS..TIBETAN SIGN YANG RTAGS
-	{runeRange{0x0F8D, 0x0F97}, prExtend},                 // Mn  [11] TIBETAN SUBJOINED SIGN LCE TSA CAN..TIBETAN SUBJOINED LETTER JA
-	{runeRange{0x0F99, 0x0FBC}, prExtend},                 // Mn  [36] TIBETAN SUBJOINED LETTER NYA..TIBETAN SUBJOINED LETTER FIXED-FORM RA
-	{runeRange{0x0FC6, 0x0FC6}, prExtend},                 // Mn       TIBETAN SYMBOL PADMA GDAN
-	{runeRange{0x102D, 0x1030}, prExtend},                 // Mn   [4] MYANMAR VOWEL SIGN I..MYANMAR VOWEL SIGN UU
-	{runeRange{0x1031, 0x1031}, prSpacingMark},            // Mc       MYANMAR VOWEL SIGN E
-	{runeRange{0x1032, 0x1037}, prExtend},                 // Mn   [6] MYANMAR VOWEL SIGN AI..MYANMAR SIGN DOT BELOW
-	{runeRange{0x1039, 0x103A}, prExtend},                 // Mn   [2] MYANMAR SIGN VIRAMA..MYANMAR SIGN ASAT
-	{runeRange{0x103B, 0x103C}, prSpacingMark},            // Mc   [2] MYANMAR CONSONANT SIGN MEDIAL YA..MYANMAR CONSONANT SIGN MEDIAL RA
-	{runeRange{0x103D, 0x103E}, prExtend},                 // Mn   [2] MYANMAR CONSONANT SIGN MEDIAL WA..MYANMAR CONSONANT SIGN MEDIAL HA
-	{runeRange{0x1056, 0x1057}, prSpacingMark},            // Mc   [2] MYANMAR VOWEL SIGN VOCALIC R..MYANMAR VOWEL SIGN VOCALIC RR
-	{runeRange{0x1058, 0x1059}, prExtend},                 // Mn   [2] MYANMAR VOWEL SIGN VOCALIC L..MYANMAR VOWEL SIGN VOCALIC LL
-	{runeRange{0x105E, 0x1060}, prExtend},                 // Mn   [3] MYANMAR CONSONANT SIGN MON MEDIAL NA..MYANMAR CONSONANT SIGN MON MEDIAL LA
-	{runeRange{0x1071, 0x1074}, prExtend},                 // Mn   [4] MYANMAR VOWEL SIGN GEBA KAREN I..MYANMAR VOWEL SIGN KAYAH EE
-	{runeRange{0x1082, 0x1082}, prExtend},                 // Mn       MYANMAR CONSONANT SIGN SHAN MEDIAL WA
-	{runeRange{0x1084, 0x1084}, prSpacingMark},            // Mc       MYANMAR VOWEL SIGN SHAN E
-	{runeRange{0x1085, 0x1086}, prExtend},                 // Mn   [2] MYANMAR VOWEL SIGN SHAN E ABOVE..MYANMAR VOWEL SIGN SHAN FINAL Y
-	{runeRange{0x108D, 0x108D}, prExtend},                 // Mn       MYANMAR SIGN SHAN COUNCIL EMPHATIC TONE
-	{runeRange{0x109D, 0x109D}, prExtend},                 // Mn       MYANMAR VOWEL SIGN AITON AI
-	{runeRange{0x1100, 0x115F}, prL},                      // Lo  [96] HANGUL CHOSEONG KIYEOK..HANGUL CHOSEONG FILLER
-	{runeRange{0x1160, 0x11A7}, prV},                      // Lo  [72] HANGUL JUNGSEONG FILLER..HANGUL JUNGSEONG O-YAE
-	{runeRange{0x11A8, 0x11FF}, prT},                      // Lo  [88] HANGUL JONGSEONG KIYEOK..HANGUL JONGSEONG SSANGNIEUN
-	{runeRange{0x135D, 0x135F}, prExtend},                 // Mn   [3] ETHIOPIC COMBINING GEMINATION AND VOWEL LENGTH MARK..ETHIOPIC COMBINING GEMINATION MARK
-	{runeRange{0x1712, 0x1714}, prExtend},                 // Mn   [3] TAGALOG VOWEL SIGN I..TAGALOG SIGN VIRAMA
-	{runeRange{0x1715, 0x1715}, prSpacingMark},            // Mc       TAGALOG SIGN PAMUDPOD
-	{runeRange{0x1732, 0x1733}, prExtend},                 // Mn   [2] HANUNOO VOWEL SIGN I..HANUNOO VOWEL SIGN U
-	{runeRange{0x1734, 0x1734}, prSpacingMark},            // Mc       HANUNOO SIGN PAMUDPOD
-	{runeRange{0x1752, 0x1753}, prExtend},                 // Mn   [2] BUHID VOWEL SIGN I..BUHID VOWEL SIGN U
-	{runeRange{0x1772, 0x1773}, prExtend},                 // Mn   [2] TAGBANWA VOWEL SIGN I..TAGBANWA VOWEL SIGN U
-	{runeRange{0x17B4, 0x17B5}, prExtend},                 // Mn   [2] KHMER VOWEL INHERENT AQ..KHMER VOWEL INHERENT AA
-	{runeRange{0x17B6, 0x17B6}, prSpacingMark},            // Mc       KHMER VOWEL SIGN AA
-	{runeRange{0x17B7, 0x17BD}, prExtend},                 // Mn   [7] KHMER VOWEL SIGN I..KHMER VOWEL SIGN UA
-	{runeRange{0x17BE, 0x17C5}, prSpacingMark},            // Mc   [8] KHMER VOWEL SIGN OE..KHMER VOWEL SIGN AU
-	{runeRange{0x17C6, 0x17C6}, prExtend},                 // Mn       KHMER SIGN NIKAHIT
-	{runeRange{0x17C7, 0x17C8}, prSpacingMark},            // Mc   [2] KHMER SIGN REAHMUK..KHMER SIGN YUUKALEAPINTU
-	{runeRange{0x17C9, 0x17D3}, prExtend},                 // Mn  [11] KHMER SIGN MUUSIKATOAN..KHMER SIGN BATHAMASAT
-	{runeRange{0x17DD, 0x17DD}, prExtend},                 // Mn       KHMER SIGN ATTHACAN
-	{runeRange{0x180B, 0x180D}, prExtend},                 // Mn   [3] MONGOLIAN FREE VARIATION SELECTOR ONE..MONGOLIAN FREE VARIATION SELECTOR THREE
-	{runeRange{0x180E, 0x180E}, prControl},                // Cf       MONGOLIAN VOWEL SEPARATOR
-	{runeRange{0x180F, 0x180F}, prExtend},                 // Mn       MONGOLIAN FREE VARIATION SELECTOR FOUR
-	{runeRange{0x1885, 0x1886}, prExtend},                 // Mn   [2] MONGOLIAN LETTER ALI GALI BALUDA..MONGOLIAN LETTER ALI GALI THREE BALUDA
-	{runeRange{0x18A9, 0x18A9}, prExtend},                 // Mn       MONGOLIAN LETTER ALI GALI DAGALGA
-	{runeRange{0x1920, 0x1922}, prExtend},                 // Mn   [3] LIMBU VOWEL SIGN A..LIMBU VOWEL SIGN U
-	{runeRange{0x1923, 0x1926}, prSpacingMark},            // Mc   [4] LIMBU VOWEL SIGN EE..LIMBU VOWEL SIGN AU
-	{runeRange{0x1927, 0x1928}, prExtend},                 // Mn   [2] LIMBU VOWEL SIGN E..LIMBU VOWEL SIGN O
-	{runeRange{0x1929, 0x192B}, prSpacingMark},            // Mc   [3] LIMBU SUBJOINED LETTER YA..LIMBU SUBJOINED LETTER WA
-	{runeRange{0x1930, 0x1931}, prSpacingMark},            // Mc   [2] LIMBU SMALL LETTER KA..LIMBU SMALL LETTER NGA
-	{runeRange{0x1932, 0x1932}, prExtend},                 // Mn       LIMBU SMALL LETTER ANUSVARA
-	{runeRange{0x1933, 0x1938}, prSpacingMark},            // Mc   [6] LIMBU SMALL LETTER TA..LIMBU SMALL LETTER LA
-	{runeRange{0x1939, 0x193B}, prExtend},                 // Mn   [3] LIMBU SIGN MUKPHRENG..LIMBU SIGN SA-I
-	{runeRange{0x1A17, 0x1A18}, prExtend},                 // Mn   [2] BUGINESE VOWEL SIGN I..BUGINESE VOWEL SIGN U
-	{runeRange{0x1A19, 0x1A1A}, prSpacingMark},            // Mc   [2] BUGINESE VOWEL SIGN E..BUGINESE VOWEL SIGN O
-	{runeRange{0x1A1B, 0x1A1B}, prExtend},                 // Mn       BUGINESE VOWEL SIGN AE
-	{runeRange{0x1A55, 0x1A55}, prSpacingMark},            // Mc       TAI THAM CONSONANT SIGN MEDIAL RA
-	{runeRange{0x1A56, 0x1A56}, prExtend},                 // Mn       TAI THAM CONSONANT SIGN MEDIAL LA
-	{runeRange{0x1A57, 0x1A57}, prSpacingMark},            // Mc       TAI THAM CONSONANT SIGN LA TANG LAI
-	{runeRange{0x1A58, 0x1A5E}, prExtend},                 // Mn   [7] TAI THAM SIGN MAI KANG LAI..TAI THAM CONSONANT SIGN SA
-	{runeRange{0x1A60, 0x1A60}, prExtend},                 // Mn       TAI THAM SIGN SAKOT
-	{runeRange{0x1A62, 0x1A62}, prExtend},                 // Mn       TAI THAM VOWEL SIGN MAI SAT
-	{runeRange{0x1A65, 0x1A6C}, prExtend},                 // Mn   [8] TAI THAM VOWEL SIGN I..TAI THAM VOWEL SIGN OA BELOW
-	{runeRange{0x1A6D, 0x1A72}, prSpacingMark},            // Mc   [6] TAI THAM VOWEL SIGN OY..TAI THAM VOWEL SIGN THAM AI
-	{runeRange{0x1A73, 0x1A7C}, prExtend},                 // Mn  [10] TAI THAM VOWEL SIGN OA ABOVE..TAI THAM SIGN KHUEN-LUE KARAN
-	{runeRange{0x1A7F, 0x1A7F}, prExtend},                 // Mn       TAI THAM COMBINING CRYPTOGRAMMIC DOT
-	{runeRange{0x1AB0, 0x1ABD}, prExtend},                 // Mn  [14] COMBINING DOUBLED CIRCUMFLEX ACCENT..COMBINING PARENTHESES BELOW
-	{runeRange{0x1ABE, 0x1ABE}, prExtend},                 // Me       COMBINING PARENTHESES OVERLAY
-	{runeRange{0x1ABF, 0x1ACE}, prExtend},                 // Mn  [16] COMBINING LATIN SMALL LETTER W BELOW..COMBINING LATIN SMALL LETTER INSULAR T
-	{runeRange{0x1B00, 0x1B03}, prExtend},                 // Mn   [4] BALINESE SIGN ULU RICEM..BALINESE SIGN SURANG
-	{runeRange{0x1B04, 0x1B04}, prSpacingMark},            // Mc       BALINESE SIGN BISAH
-	{runeRange{0x1B34, 0x1B34}, prExtend},                 // Mn       BALINESE SIGN REREKAN
-	{runeRange{0x1B35, 0x1B35}, prExtend},                 // Mc       BALINESE VOWEL SIGN TEDUNG
-	{runeRange{0x1B36, 0x1B3A}, prExtend},                 // Mn   [5] BALINESE VOWEL SIGN ULU..BALINESE VOWEL SIGN RA REPA
-	{runeRange{0x1B3B, 0x1B3B}, prSpacingMark},            // Mc       BALINESE VOWEL SIGN RA REPA TEDUNG
-	{runeRange{0x1B3C, 0x1B3C}, prExtend},                 // Mn       BALINESE VOWEL SIGN LA LENGA
-	{runeRange{0x1B3D, 0x1B41}, prSpacingMark},            // Mc   [5] BALINESE VOWEL SIGN LA LENGA TEDUNG..BALINESE VOWEL SIGN TALING REPA TEDUNG
-	{runeRange{0x1B42, 0x1B42}, prExtend},                 // Mn       BALINESE VOWEL SIGN PEPET
-	{runeRange{0x1B43, 0x1B44}, prSpacingMark},            // Mc   [2] BALINESE VOWEL SIGN PEPET TEDUNG..BALINESE ADEG ADEG
-	{runeRange{0x1B6B, 0x1B73}, prExtend},                 // Mn   [9] BALINESE MUSICAL SYMBOL COMBINING TEGEH..BALINESE MUSICAL SYMBOL COMBINING GONG
-	{runeRange{0x1B80, 0x1B81}, prExtend},                 // Mn   [2] SUNDANESE SIGN PANYECEK..SUNDANESE SIGN PANGLAYAR
-	{runeRange{0x1B82, 0x1B82}, prSpacingMark},            // Mc       SUNDANESE SIGN PANGWISAD
-	{runeRange{0x1BA1, 0x1BA1}, prSpacingMark},            // Mc       SUNDANESE CONSONANT SIGN PAMINGKAL
-	{runeRange{0x1BA2, 0x1BA5}, prExtend},                 // Mn   [4] SUNDANESE CONSONANT SIGN PANYAKRA..SUNDANESE VOWEL SIGN PANYUKU
-	{runeRange{0x1BA6, 0x1BA7}, prSpacingMark},            // Mc   [2] SUNDANESE VOWEL SIGN PANAELAENG..SUNDANESE VOWEL SIGN PANOLONG
-	{runeRange{0x1BA8, 0x1BA9}, prExtend},                 // Mn   [2] SUNDANESE VOWEL SIGN PAMEPET..SUNDANESE VOWEL SIGN PANEULEUNG
-	{runeRange{0x1BAA, 0x1BAA}, prSpacingMark},            // Mc       SUNDANESE SIGN PAMAAEH
-	{runeRange{0x1BAB, 0x1BAD}, prExtend},                 // Mn   [3] SUNDANESE SIGN VIRAMA..SUNDANESE CONSONANT SIGN PASANGAN WA
-	{runeRange{0x1BE6, 0x1BE6}, prExtend},                 // Mn       BATAK SIGN TOMPI
-	{runeRange{0x1BE7, 0x1BE7}, prSpacingMark},            // Mc       BATAK VOWEL SIGN E
-	{runeRange{0x1BE8, 0x1BE9}, prExtend},                 // Mn   [2] BATAK VOWEL SIGN PAKPAK E..BATAK VOWEL SIGN EE
-	{runeRange{0x1BEA, 0x1BEC}, prSpacingMark},            // Mc   [3] BATAK VOWEL SIGN I..BATAK VOWEL SIGN O
-	{runeRange{0x1BED, 0x1BED}, prExtend},                 // Mn       BATAK VOWEL SIGN KARO O
-	{runeRange{0x1BEE, 0x1BEE}, prSpacingMark},            // Mc       BATAK VOWEL SIGN U
-	{runeRange{0x1BEF, 0x1BF1}, prExtend},                 // Mn   [3] BATAK VOWEL SIGN U FOR SIMALUNGUN SA..BATAK CONSONANT SIGN H
-	{runeRange{0x1BF2, 0x1BF3}, prSpacingMark},            // Mc   [2] BATAK PANGOLAT..BATAK PANONGONAN
-	{runeRange{0x1C24, 0x1C2B}, prSpacingMark},            // Mc   [8] LEPCHA SUBJOINED LETTER YA..LEPCHA VOWEL SIGN UU
-	{runeRange{0x1C2C, 0x1C33}, prExtend},                 // Mn   [8] LEPCHA VOWEL SIGN E..LEPCHA CONSONANT SIGN T
-	{runeRange{0x1C34, 0x1C35}, prSpacingMark},            // Mc   [2] LEPCHA CONSONANT SIGN NYIN-DO..LEPCHA CONSONANT SIGN KANG
-	{runeRange{0x1C36, 0x1C37}, prExtend},                 // Mn   [2] LEPCHA SIGN RAN..LEPCHA SIGN NUKTA
-	{runeRange{0x1CD0, 0x1CD2}, prExtend},                 // Mn   [3] VEDIC TONE KARSHANA..VEDIC TONE PRENKHA
-	{runeRange{0x1CD4, 0x1CE0}, prExtend},                 // Mn  [13] VEDIC SIGN YAJURVEDIC MIDLINE SVARITA..VEDIC TONE RIGVEDIC KASHMIRI INDEPENDENT SVARITA
-	{runeRange{0x1CE1, 0x1CE1}, prSpacingMark},            // Mc       VEDIC TONE ATHARVAVEDIC INDEPENDENT SVARITA
-	{runeRange{0x1CE2, 0x1CE8}, prExtend},                 // Mn   [7] VEDIC SIGN VISARGA SVARITA..VEDIC SIGN VISARGA ANUDATTA WITH TAIL
-	{runeRange{0x1CED, 0x1CED}, prExtend},                 // Mn       VEDIC SIGN TIRYAK
-	{runeRange{0x1CF4, 0x1CF4}, prExtend},                 // Mn       VEDIC TONE CANDRA ABOVE
-	{runeRange{0x1CF7, 0x1CF7}, prSpacingMark},            // Mc       VEDIC SIGN ATIKRAMA
-	{runeRange{0x1CF8, 0x1CF9}, prExtend},                 // Mn   [2] VEDIC TONE RING ABOVE..VEDIC TONE DOUBLE RING ABOVE
-	{runeRange{0x1DC0, 0x1DFF}, prExtend},                 // Mn  [64] COMBINING DOTTED GRAVE ACCENT..COMBINING RIGHT ARROWHEAD AND DOWN ARROWHEAD BELOW
-	{runeRange{0x200B, 0x200B}, prControl},                // Cf       ZERO WIDTH SPACE
-	{runeRange{0x200C, 0x200C}, prExtend},                 // Cf       ZERO WIDTH NON-JOINER
-	{runeRange{0x200D, 0x200D}, prZWJ},                    // Cf       ZERO WIDTH JOINER
-	{runeRange{0x200E, 0x200F}, prControl},                // Cf   [2] LEFT-TO-RIGHT MARK..RIGHT-TO-LEFT MARK
-	{runeRange{0x2028, 0x2028}, prControl},                // Zl       LINE SEPARATOR
-	{runeRange{0x2029, 0x2029}, prControl},                // Zp       PARAGRAPH SEPARATOR
-	{runeRange{0x202A, 0x202E}, prControl},                // Cf   [5] LEFT-TO-RIGHT EMBEDDING..RIGHT-TO-LEFT OVERRIDE
-	{runeRange{0x203C, 0x203C}, prExtendedPictographic},   // E0.6   [1] (‼️)       double exclamation mark
-	{runeRange{0x2049, 0x2049}, prExtendedPictographic},   // E0.6   [1] (⁉️)       exclamation question mark
-	{runeRange{0x2060, 0x2064}, prControl},                // Cf   [5] WORD JOINER..INVISIBLE PLUS
-	{runeRange{0x2065, 0x2065}, prControl},                // Cn       <reserved-2065>
-	{runeRange{0x2066, 0x206F}, prControl},                // Cf  [10] LEFT-TO-RIGHT ISOLATE..NOMINAL DIGIT SHAPES
-	{runeRange{0x20D0, 0x20DC}, prExtend},                 // Mn  [13] COMBINING LEFT HARPOON ABOVE..COMBINING FOUR DOTS ABOVE
-	{runeRange{0x20DD, 0x20E0}, prExtend},                 // Me   [4] COMBINING ENCLOSING CIRCLE..COMBINING ENCLOSING CIRCLE BACKSLASH
-	{runeRange{0x20E1, 0x20E1}, prExtend},                 // Mn       COMBINING LEFT RIGHT ARROW ABOVE
-	{runeRange{0x20E2, 0x20E4}, prExtend},                 // Me   [3] COMBINING ENCLOSING SCREEN..COMBINING ENCLOSING UPWARD POINTING TRIANGLE
-	{runeRange{0x20E5, 0x20F0}, prExtend},                 // Mn  [12] COMBINING REVERSE SOLIDUS OVERLAY..COMBINING ASTERISK ABOVE
-	{runeRange{0x2122, 0x2122}, prExtendedPictographic},   // E0.6   [1] (™️)       trade mark
-	{runeRange{0x2139, 0x2139}, prExtendedPictographic},   // E0.6   [1] (ℹ️)       information
-	{runeRange{0x2194, 0x2199}, prExtendedPictographic},   // E0.6   [6] (↔️..↙️)    left-right arrow..down-left arrow
-	{runeRange{0x21A9, 0x21AA}, prExtendedPictographic},   // E0.6   [2] (↩️..↪️)    right arrow curving left..left arrow curving right
-	{runeRange{0x231A, 0x231B}, prExtendedPictographic},   // E0.6   [2] (⌚..⌛)    watch..hourglass done
-	{runeRange{0x2328, 0x2328}, prExtendedPictographic},   // E1.0   [1] (⌨️)       keyboard
-	{runeRange{0x2388, 0x2388}, prExtendedPictographic},   // E0.0   [1] (⎈)       HELM SYMBOL
-	{runeRange{0x23CF, 0x23CF}, prExtendedPictographic},   // E1.0   [1] (⏏️)       eject button
-	{runeRange{0x23E9, 0x23EC}, prExtendedPictographic},   // E0.6   [4] (⏩..⏬)    fast-forward button..fast down button
-	{runeRange{0x23ED, 0x23EE}, prExtendedPictographic},   // E0.7   [2] (⏭️..⏮️)    next track button..last track button
-	{runeRange{0x23EF, 0x23EF}, prExtendedPictographic},   // E1.0   [1] (⏯️)       play or pause button
-	{runeRange{0x23F0, 0x23F0}, prExtendedPictographic},   // E0.6   [1] (⏰)       alarm clock
-	{runeRange{0x23F1, 0x23F2}, prExtendedPictographic},   // E1.0   [2] (⏱️..⏲️)    stopwatch..timer clock
-	{runeRange{0x23F3, 0x23F3}, prExtendedPictographic},   // E0.6   [1] (⏳)       hourglass not done
-	{runeRange{0x23F8, 0x23FA}, prExtendedPictographic},   // E0.7   [3] (⏸️..⏺️)    pause button..record button
-	{runeRange{0x24C2, 0x24C2}, prExtendedPictographic},   // E0.6   [1] (Ⓜ️)       circled M
-	{runeRange{0x25AA, 0x25AB}, prExtendedPictographic},   // E0.6   [2] (▪️..▫️)    black small square..white small square
-	{runeRange{0x25B6, 0x25B6}, prExtendedPictographic},   // E0.6   [1] (▶️)       play button
-	{runeRange{0x25C0, 0x25C0}, prExtendedPictographic},   // E0.6   [1] (◀️)       reverse button
-	{runeRange{0x25FB, 0x25FE}, prExtendedPictographic},   // E0.6   [4] (◻️..◾)    white medium square..black medium-small square
-	{runeRange{0x2600, 0x2601}, prExtendedPictographic},   // E0.6   [2] (☀️..☁️)    sun..cloud
-	{runeRange{0x2602, 0x2603}, prExtendedPictographic},   // E0.7   [2] (☂️..☃️)    umbrella..snowman
-	{runeRange{0x2604, 0x2604}, prExtendedPictographic},   // E1.0   [1] (☄️)       comet
-	{runeRange{0x2605, 0x2605}, prExtendedPictographic},   // E0.0   [1] (★)       BLACK STAR
-	{runeRange{0x2607, 0x260D}, prExtendedPictographic},   // E0.0   [7] (☇..☍)    LIGHTNING..OPPOSITION
-	{runeRange{0x260E, 0x260E}, prExtendedPictographic},   // E0.6   [1] (☎️)       telephone
-	{runeRange{0x260F, 0x2610}, prExtendedPictographic},   // E0.0   [2] (☏..☐)    WHITE TELEPHONE..BALLOT BOX
-	{runeRange{0x2611, 0x2611}, prExtendedPictographic},   // E0.6   [1] (☑️)       check box with check
-	{runeRange{0x2612, 0x2612}, prExtendedPictographic},   // E0.0   [1] (☒)       BALLOT BOX WITH X
-	{runeRange{0x2614, 0x2615}, prExtendedPictographic},   // E0.6   [2] (☔..☕)    umbrella with rain drops..hot beverage
-	{runeRange{0x2616, 0x2617}, prExtendedPictographic},   // E0.0   [2] (☖..☗)    WHITE SHOGI PIECE..BLACK SHOGI PIECE
-	{runeRange{0x2618, 0x2618}, prExtendedPictographic},   // E1.0   [1] (☘️)       shamrock
-	{runeRange{0x2619, 0x261C}, prExtendedPictographic},   // E0.0   [4] (☙..☜)    REVERSED ROTATED FLORAL HEART BULLET..WHITE LEFT POINTING INDEX
-	{runeRange{0x261D, 0x261D}, prExtendedPictographic},   // E0.6   [1] (☝️)       index pointing up
-	{runeRange{0x261E, 0x261F}, prExtendedPictographic},   // E0.0   [2] (☞..☟)    WHITE RIGHT POINTING INDEX..WHITE DOWN POINTING INDEX
-	{runeRange{0x2620, 0x2620}, prExtendedPictographic},   // E1.0   [1] (☠️)       skull and crossbones
-	{runeRange{0x2621, 0x2621}, prExtendedPictographic},   // E0.0   [1] (☡)       CAUTION SIGN
-	{runeRange{0x2622, 0x2623}, prExtendedPictographic},   // E1.0   [2] (☢️..☣️)    radioactive..biohazard
-	{runeRange{0x2624, 0x2625}, prExtendedPictographic},   // E0.0   [2] (☤..☥)    CADUCEUS..ANKH
-	{runeRange{0x2626, 0x2626}, prExtendedPictographic},   // E1.0   [1] (☦️)       orthodox cross
-	{runeRange{0x2627, 0x2629}, prExtendedPictographic},   // E0.0   [3] (☧..☩)    CHI RHO..CROSS OF JERUSALEM
-	{runeRange{0x262A, 0x262A}, prExtendedPictographic},   // E0.7   [1] (☪️)       star and crescent
-	{runeRange{0x262B, 0x262D}, prExtendedPictographic},   // E0.0   [3] (☫..☭)    FARSI SYMBOL..HAMMER AND SICKLE
-	{runeRange{0x262E, 0x262E}, prExtendedPictographic},   // E1.0   [1] (☮️)       peace symbol
-	{runeRange{0x262F, 0x262F}, prExtendedPictographic},   // E0.7   [1] (☯️)       yin yang
-	{runeRange{0x2630, 0x2637}, prExtendedPictographic},   // E0.0   [8] (☰..☷)    TRIGRAM FOR HEAVEN..TRIGRAM FOR EARTH
-	{runeRange{0x2638, 0x2639}, prExtendedPictographic},   // E0.7   [2] (☸️..☹️)    wheel of dharma..frowning face
-	{runeRange{0x263A, 0x263A}, prExtendedPictographic},   // E0.6   [1] (☺️)       smiling face
-	{runeRange{0x263B, 0x263F}, prExtendedPictographic},   // E0.0   [5] (☻..☿)    BLACK SMILING FACE..MERCURY
-	{runeRange{0x2640, 0x2640}, prExtendedPictographic},   // E4.0   [1] (♀️)       female sign
-	{runeRange{0x2641, 0x2641}, prExtendedPictographic},   // E0.0   [1] (♁)       EARTH
-	{runeRange{0x2642, 0x2642}, prExtendedPictographic},   // E4.0   [1] (♂️)       male sign
-	{runeRange{0x2643, 0x2647}, prExtendedPictographic},   // E0.0   [5] (♃..♇)    JUPITER..PLUTO
-	{runeRange{0x2648, 0x2653}, prExtendedPictographic},   // E0.6  [12] (♈..♓)    Aries..Pisces
-	{runeRange{0x2654, 0x265E}, prExtendedPictographic},   // E0.0  [11] (♔..♞)    WHITE CHESS KING..BLACK CHESS KNIGHT
-	{runeRange{0x265F, 0x265F}, prExtendedPictographic},   // E11.0  [1] (♟️)       chess pawn
-	{runeRange{0x2660, 0x2660}, prExtendedPictographic},   // E0.6   [1] (♠️)       spade suit
-	{runeRange{0x2661, 0x2662}, prExtendedPictographic},   // E0.0   [2] (♡..♢)    WHITE HEART SUIT..WHITE DIAMOND SUIT
-	{runeRange{0x2663, 0x2663}, prExtendedPictographic},   // E0.6   [1] (♣️)       club suit
-	{runeRange{0x2664, 0x2664}, prExtendedPictographic},   // E0.0   [1] (♤)       WHITE SPADE SUIT
-	{runeRange{0x2665, 0x2666}, prExtendedPictographic},   // E0.6   [2] (♥️..♦️)    heart suit..diamond suit
-	{runeRange{0x2667, 0x2667}, prExtendedPictographic},   // E0.0   [1] (♧)       WHITE CLUB SUIT
-	{runeRange{0x2668, 0x2668}, prExtendedPictographic},   // E0.6   [1] (♨️)       hot springs
-	{runeRange{0x2669, 0x267A}, prExtendedPictographic},   // E0.0  [18] (♩..♺)    QUARTER NOTE..RECYCLING SYMBOL FOR GENERIC MATERIALS
-	{runeRange{0x267B, 0x267B}, prExtendedPictographic},   // E0.6   [1] (♻️)       recycling symbol
-	{runeRange{0x267C, 0x267D}, prExtendedPictographic},   // E0.0   [2] (♼..♽)    RECYCLED PAPER SYMBOL..PARTIALLY-RECYCLED PAPER SYMBOL
-	{runeRange{0x267E, 0x267E}, prExtendedPictographic},   // E11.0  [1] (♾️)       infinity
-	{runeRange{0x267F, 0x267F}, prExtendedPictographic},   // E0.6   [1] (♿)       wheelchair symbol
-	{runeRange{0x2680, 0x2685}, prExtendedPictographic},   // E0.0   [6] (⚀..⚅)    DIE FACE-1..DIE FACE-6
-	{runeRange{0x2690, 0x2691}, prExtendedPictographic},   // E0.0   [2] (⚐..⚑)    WHITE FLAG..BLACK FLAG
-	{runeRange{0x2692, 0x2692}, prExtendedPictographic},   // E1.0   [1] (⚒️)       hammer and pick
-	{runeRange{0x2693, 0x2693}, prExtendedPictographic},   // E0.6   [1] (⚓)       anchor
-	{runeRange{0x2694, 0x2694}, prExtendedPictographic},   // E1.0   [1] (⚔️)       crossed swords
-	{runeRange{0x2695, 0x2695}, prExtendedPictographic},   // E4.0   [1] (⚕️)       medical symbol
-	{runeRange{0x2696, 0x2697}, prExtendedPictographic},   // E1.0   [2] (⚖️..⚗️)    balance scale..alembic
-	{runeRange{0x2698, 0x2698}, prExtendedPictographic},   // E0.0   [1] (⚘)       FLOWER
-	{runeRange{0x2699, 0x2699}, prExtendedPictographic},   // E1.0   [1] (⚙️)       gear
-	{runeRange{0x269A, 0x269A}, prExtendedPictographic},   // E0.0   [1] (⚚)       STAFF OF HERMES
-	{runeRange{0x269B, 0x269C}, prExtendedPictographic},   // E1.0   [2] (⚛️..⚜️)    atom symbol..fleur-de-lis
-	{runeRange{0x269D, 0x269F}, prExtendedPictographic},   // E0.0   [3] (⚝..⚟)    OUTLINED WHITE STAR..THREE LINES CONVERGING LEFT
-	{runeRange{0x26A0, 0x26A1}, prExtendedPictographic},   // E0.6   [2] (⚠️..⚡)    warning..high voltage
-	{runeRange{0x26A2, 0x26A6}, prExtendedPictographic},   // E0.0   [5] (⚢..⚦)    DOUBLED FEMALE SIGN..MALE WITH STROKE SIGN
-	{runeRange{0x26A7, 0x26A7}, prExtendedPictographic},   // E13.0  [1] (⚧️)       transgender symbol
-	{runeRange{0x26A8, 0x26A9}, prExtendedPictographic},   // E0.0   [2] (⚨..⚩)    VERTICAL MALE WITH STROKE SIGN..HORIZONTAL MALE WITH STROKE SIGN
-	{runeRange{0x26AA, 0x26AB}, prExtendedPictographic},   // E0.6   [2] (⚪..⚫)    white circle..black circle
-	{runeRange{0x26AC, 0x26AF}, prExtendedPictographic},   // E0.0   [4] (⚬..⚯)    MEDIUM SMALL WHITE CIRCLE..UNMARRIED PARTNERSHIP SYMBOL
-	{runeRange{0x26B0, 0x26B1}, prExtendedPictographic},   // E1.0   [2] (⚰️..⚱️)    coffin..funeral urn
-	{runeRange{0x26B2, 0x26BC}, prExtendedPictographic},   // E0.0  [11] (⚲..⚼)    NEUTER..SESQUIQUADRATE
-	{runeRange{0x26BD, 0x26BE}, prExtendedPictographic},   // E0.6   [2] (⚽..⚾)    soccer ball..baseball
-	{runeRange{0x26BF, 0x26C3}, prExtendedPictographic},   // E0.0   [5] (⚿..⛃)    SQUARED KEY..BLACK DRAUGHTS KING
-	{runeRange{0x26C4, 0x26C5}, prExtendedPictographic},   // E0.6   [2] (⛄..⛅)    snowman without snow..sun behind cloud
-	{runeRange{0x26C6, 0x26C7}, prExtendedPictographic},   // E0.0   [2] (⛆..⛇)    RAIN..BLACK SNOWMAN
-	{runeRange{0x26C8, 0x26C8}, prExtendedPictographic},   // E0.7   [1] (⛈️)       cloud with lightning and rain
-	{runeRange{0x26C9, 0x26CD}, prExtendedPictographic},   // E0.0   [5] (⛉..⛍)    TURNED WHITE SHOGI PIECE..DISABLED CAR
-	{runeRange{0x26CE, 0x26CE}, prExtendedPictographic},   // E0.6   [1] (⛎)       Ophiuchus
-	{runeRange{0x26CF, 0x26CF}, prExtendedPictographic},   // E0.7   [1] (⛏️)       pick
-	{runeRange{0x26D0, 0x26D0}, prExtendedPictographic},   // E0.0   [1] (⛐)       CAR SLIDING
-	{runeRange{0x26D1, 0x26D1}, prExtendedPictographic},   // E0.7   [1] (⛑️)       rescue worker’s helmet
-	{runeRange{0x26D2, 0x26D2}, prExtendedPictographic},   // E0.0   [1] (⛒)       CIRCLED CROSSING LANES
-	{runeRange{0x26D3, 0x26D3}, prExtendedPictographic},   // E0.7   [1] (⛓️)       chains
-	{runeRange{0x26D4, 0x26D4}, prExtendedPictographic},   // E0.6   [1] (⛔)       no entry
-	{runeRange{0x26D5, 0x26E8}, prExtendedPictographic},   // E0.0  [20] (⛕..⛨)    ALTERNATE ONE-WAY LEFT WAY TRAFFIC..BLACK CROSS ON SHIELD
-	{runeRange{0x26E9, 0x26E9}, prExtendedPictographic},   // E0.7   [1] (⛩️)       shinto shrine
-	{runeRange{0x26EA, 0x26EA}, prExtendedPictographic},   // E0.6   [1] (⛪)       church
-	{runeRange{0x26EB, 0x26EF}, prExtendedPictographic},   // E0.0   [5] (⛫..⛯)    CASTLE..MAP SYMBOL FOR LIGHTHOUSE
-	{runeRange{0x26F0, 0x26F1}, prExtendedPictographic},   // E0.7   [2] (⛰️..⛱️)    mountain..umbrella on ground
-	{runeRange{0x26F2, 0x26F3}, prExtendedPictographic},   // E0.6   [2] (⛲..⛳)    fountain..flag in hole
-	{runeRange{0x26F4, 0x26F4}, prExtendedPictographic},   // E0.7   [1] (⛴️)       ferry
-	{runeRange{0x26F5, 0x26F5}, prExtendedPictographic},   // E0.6   [1] (⛵)       sailboat
-	{runeRange{0x26F6, 0x26F6}, prExtendedPictographic},   // E0.0   [1] (⛶)       SQUARE FOUR CORNERS
-	{runeRange{0x26F7, 0x26F9}, prExtendedPictographic},   // E0.7   [3] (⛷️..⛹️)    skier..person bouncing ball
-	{runeRange{0x26FA, 0x26FA}, prExtendedPictographic},   // E0.6   [1] (⛺)       tent
-	{runeRange{0x26FB, 0x26FC}, prExtendedPictographic},   // E0.0   [2] (⛻..⛼)    JAPANESE BANK SYMBOL..HEADSTONE GRAVEYARD SYMBOL
-	{runeRange{0x26FD, 0x26FD}, prExtendedPictographic},   // E0.6   [1] (⛽)       fuel pump
-	{runeRange{0x26FE, 0x2701}, prExtendedPictographic},   // E0.0   [4] (⛾..✁)    CUP ON BLACK SQUARE..UPPER BLADE SCISSORS
-	{runeRange{0x2702, 0x2702}, prExtendedPictographic},   // E0.6   [1] (✂️)       scissors
-	{runeRange{0x2703, 0x2704}, prExtendedPictographic},   // E0.0   [2] (✃..✄)    LOWER BLADE SCISSORS..WHITE SCISSORS
-	{runeRange{0x2705, 0x2705}, prExtendedPictographic},   // E0.6   [1] (✅)       check mark button
-	{runeRange{0x2708, 0x270C}, prExtendedPictographic},   // E0.6   [5] (✈️..✌️)    airplane..victory hand
-	{runeRange{0x270D, 0x270D}, prExtendedPictographic},   // E0.7   [1] (✍️)       writing hand
-	{runeRange{0x270E, 0x270E}, prExtendedPictographic},   // E0.0   [1] (✎)       LOWER RIGHT PENCIL
-	{runeRange{0x270F, 0x270F}, prExtendedPictographic},   // E0.6   [1] (✏️)       pencil
-	{runeRange{0x2710, 0x2711}, prExtendedPictographic},   // E0.0   [2] (✐..✑)    UPPER RIGHT PENCIL..WHITE NIB
-	{runeRange{0x2712, 0x2712}, prExtendedPictographic},   // E0.6   [1] (✒️)       black nib
-	{runeRange{0x2714, 0x2714}, prExtendedPictographic},   // E0.6   [1] (✔️)       check mark
-	{runeRange{0x2716, 0x2716}, prExtendedPictographic},   // E0.6   [1] (✖️)       multiply
-	{runeRange{0x271D, 0x271D}, prExtendedPictographic},   // E0.7   [1] (✝️)       latin cross
-	{runeRange{0x2721, 0x2721}, prExtendedPictographic},   // E0.7   [1] (✡️)       star of David
-	{runeRange{0x2728, 0x2728}, prExtendedPictographic},   // E0.6   [1] (✨)       sparkles
-	{runeRange{0x2733, 0x2734}, prExtendedPictographic},   // E0.6   [2] (✳️..✴️)    eight-spoked asterisk..eight-pointed star
-	{runeRange{0x2744, 0x2744}, prExtendedPictographic},   // E0.6   [1] (❄️)       snowflake
-	{runeRange{0x2747, 0x2747}, prExtendedPictographic},   // E0.6   [1] (❇️)       sparkle
-	{runeRange{0x274C, 0x274C}, prExtendedPictographic},   // E0.6   [1] (❌)       cross mark
-	{runeRange{0x274E, 0x274E}, prExtendedPictographic},   // E0.6   [1] (❎)       cross mark button
-	{runeRange{0x2753, 0x2755}, prExtendedPictographic},   // E0.6   [3] (❓..❕)    red question mark..white exclamation mark
-	{runeRange{0x2757, 0x2757}, prExtendedPictographic},   // E0.6   [1] (❗)       red exclamation mark
-	{runeRange{0x2763, 0x2763}, prExtendedPictographic},   // E1.0   [1] (❣️)       heart exclamation
-	{runeRange{0x2764, 0x2764}, prExtendedPictographic},   // E0.6   [1] (❤️)       red heart
-	{runeRange{0x2765, 0x2767}, prExtendedPictographic},   // E0.0   [3] (❥..❧)    ROTATED HEAVY BLACK HEART BULLET..ROTATED FLORAL HEART BULLET
-	{runeRange{0x2795, 0x2797}, prExtendedPictographic},   // E0.6   [3] (➕..➗)    plus..divide
-	{runeRange{0x27A1, 0x27A1}, prExtendedPictographic},   // E0.6   [1] (➡️)       right arrow
-	{runeRange{0x27B0, 0x27B0}, prExtendedPictographic},   // E0.6   [1] (➰)       curly loop
-	{runeRange{0x27BF, 0x27BF}, prExtendedPictographic},   // E1.0   [1] (➿)       double curly loop
-	{runeRange{0x2934, 0x2935}, prExtendedPictographic},   // E0.6   [2] (⤴️..⤵️)    right arrow curving up..right arrow curving down
-	{runeRange{0x2B05, 0x2B07}, prExtendedPictographic},   // E0.6   [3] (⬅️..⬇️)    left arrow..down arrow
-	{runeRange{0x2B1B, 0x2B1C}, prExtendedPictographic},   // E0.6   [2] (⬛..⬜)    black large square..white large square
-	{runeRange{0x2B50, 0x2B50}, prExtendedPictographic},   // E0.6   [1] (⭐)       star
-	{runeRange{0x2B55, 0x2B55}, prExtendedPictographic},   // E0.6   [1] (⭕)       hollow red circle
-	{runeRange{0x2CEF, 0x2CF1}, prExtend},                 // Mn   [3] COPTIC COMBINING NI ABOVE..COPTIC COMBINING SPIRITUS LENIS
-	{runeRange{0x2D7F, 0x2D7F}, prExtend},                 // Mn       TIFINAGH CONSONANT JOINER
-	{runeRange{0x2DE0, 0x2DFF}, prExtend},                 // Mn  [32] COMBINING CYRILLIC LETTER BE..COMBINING CYRILLIC LETTER IOTIFIED BIG YUS
-	{runeRange{0x302A, 0x302D}, prExtend},                 // Mn   [4] IDEOGRAPHIC LEVEL TONE MARK..IDEOGRAPHIC ENTERING TONE MARK
-	{runeRange{0x302E, 0x302F}, prExtend},                 // Mc   [2] HANGUL SINGLE DOT TONE MARK..HANGUL DOUBLE DOT TONE MARK
-	{runeRange{0x3030, 0x3030}, prExtendedPictographic},   // E0.6   [1] (〰️)       wavy dash
-	{runeRange{0x303D, 0x303D}, prExtendedPictographic},   // E0.6   [1] (〽️)       part alternation mark
-	{runeRange{0x3099, 0x309A}, prExtend},                 // Mn   [2] COMBINING KATAKANA-HIRAGANA VOICED SOUND MARK..COMBINING KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK
-	{runeRange{0x3297, 0x3297}, prExtendedPictographic},   // E0.6   [1] (㊗️)       Japanese “congratulations” button
-	{runeRange{0x3299, 0x3299}, prExtendedPictographic},   // E0.6   [1] (㊙️)       Japanese “secret” button
-	{runeRange{0xA66F, 0xA66F}, prExtend},                 // Mn       COMBINING CYRILLIC VZMET
-	{runeRange{0xA670, 0xA672}, prExtend},                 // Me   [3] COMBINING CYRILLIC TEN MILLIONS SIGN..COMBINING CYRILLIC THOUSAND MILLIONS SIGN
-	{runeRange{0xA674, 0xA67D}, prExtend},                 // Mn  [10] COMBINING CYRILLIC LETTER UKRAINIAN IE..COMBINING CYRILLIC PAYEROK
-	{runeRange{0xA69E, 0xA69F}, prExtend},                 // Mn   [2] COMBINING CYRILLIC LETTER EF..COMBINING CYRILLIC LETTER IOTIFIED E
-	{runeRange{0xA6F0, 0xA6F1}, prExtend},                 // Mn   [2] BAMUM COMBINING MARK KOQNDON..BAMUM COMBINING MARK TUKWENTIS
-	{runeRange{0xA802, 0xA802}, prExtend},                 // Mn       SYLOTI NAGRI SIGN DVISVARA
-	{runeRange{0xA806, 0xA806}, prExtend},                 // Mn       SYLOTI NAGRI SIGN HASANTA
-	{runeRange{0xA80B, 0xA80B}, prExtend},                 // Mn       SYLOTI NAGRI SIGN ANUSVARA
-	{runeRange{0xA823, 0xA824}, prSpacingMark},            // Mc   [2] SYLOTI NAGRI VOWEL SIGN A..SYLOTI NAGRI VOWEL SIGN I
-	{runeRange{0xA825, 0xA826}, prExtend},                 // Mn   [2] SYLOTI NAGRI VOWEL SIGN U..SYLOTI NAGRI VOWEL SIGN E
-	{runeRange{0xA827, 0xA827}, prSpacingMark},            // Mc       SYLOTI NAGRI VOWEL SIGN OO
-	{runeRange{0xA82C, 0xA82C}, prExtend},                 // Mn       SYLOTI NAGRI SIGN ALTERNATE HASANTA
-	{runeRange{0xA880, 0xA881}, prSpacingMark},            // Mc   [2] SAURASHTRA SIGN ANUSVARA..SAURASHTRA SIGN VISARGA
-	{runeRange{0xA8B4, 0xA8C3}, prSpacingMark},            // Mc  [16] SAURASHTRA CONSONANT SIGN HAARU..SAURASHTRA VOWEL SIGN AU
-	{runeRange{0xA8C4, 0xA8C5}, prExtend},                 // Mn   [2] SAURASHTRA SIGN VIRAMA..SAURASHTRA SIGN CANDRABINDU
-	{runeRange{0xA8E0, 0xA8F1}, prExtend},                 // Mn  [18] COMBINING DEVANAGARI DIGIT ZERO..COMBINING DEVANAGARI SIGN AVAGRAHA
-	{runeRange{0xA8FF, 0xA8FF}, prExtend},                 // Mn       DEVANAGARI VOWEL SIGN AY
-	{runeRange{0xA926, 0xA92D}, prExtend},                 // Mn   [8] KAYAH LI VOWEL UE..KAYAH LI TONE CALYA PLOPHU
-	{runeRange{0xA947, 0xA951}, prExtend},                 // Mn  [11] REJANG VOWEL SIGN I..REJANG CONSONANT SIGN R
-	{runeRange{0xA952, 0xA953}, prSpacingMark},            // Mc   [2] REJANG CONSONANT SIGN H..REJANG VIRAMA
-	{runeRange{0xA960, 0xA97C}, prL},                      // Lo  [29] HANGUL CHOSEONG TIKEUT-MIEUM..HANGUL CHOSEONG SSANGYEORINHIEUH
-	{runeRange{0xA980, 0xA982}, prExtend},                 // Mn   [3] JAVANESE SIGN PANYANGGA..JAVANESE SIGN LAYAR
-	{runeRange{0xA983, 0xA983}, prSpacingMark},            // Mc       JAVANESE SIGN WIGNYAN
-	{runeRange{0xA9B3, 0xA9B3}, prExtend},                 // Mn       JAVANESE SIGN CECAK TELU
-	{runeRange{0xA9B4, 0xA9B5}, prSpacingMark},            // Mc   [2] JAVANESE VOWEL SIGN TARUNG..JAVANESE VOWEL SIGN TOLONG
-	{runeRange{0xA9B6, 0xA9B9}, prExtend},                 // Mn   [4] JAVANESE VOWEL SIGN WULU..JAVANESE VOWEL SIGN SUKU MENDUT
-	{runeRange{0xA9BA, 0xA9BB}, prSpacingMark},            // Mc   [2] JAVANESE VOWEL SIGN TALING..JAVANESE VOWEL SIGN DIRGA MURE
-	{runeRange{0xA9BC, 0xA9BD}, prExtend},                 // Mn   [2] JAVANESE VOWEL SIGN PEPET..JAVANESE CONSONANT SIGN KERET
-	{runeRange{0xA9BE, 0xA9C0}, prSpacingMark},            // Mc   [3] JAVANESE CONSONANT SIGN PENGKAL..JAVANESE PANGKON
-	{runeRange{0xA9E5, 0xA9E5}, prExtend},                 // Mn       MYANMAR SIGN SHAN SAW
-	{runeRange{0xAA29, 0xAA2E}, prExtend},                 // Mn   [6] CHAM VOWEL SIGN AA..CHAM VOWEL SIGN OE
-	{runeRange{0xAA2F, 0xAA30}, prSpacingMark},            // Mc   [2] CHAM VOWEL SIGN O..CHAM VOWEL SIGN AI
-	{runeRange{0xAA31, 0xAA32}, prExtend},                 // Mn   [2] CHAM VOWEL SIGN AU..CHAM VOWEL SIGN UE
-	{runeRange{0xAA33, 0xAA34}, prSpacingMark},            // Mc   [2] CHAM CONSONANT SIGN YA..CHAM CONSONANT SIGN RA
-	{runeRange{0xAA35, 0xAA36}, prExtend},                 // Mn   [2] CHAM CONSONANT SIGN LA..CHAM CONSONANT SIGN WA
-	{runeRange{0xAA43, 0xAA43}, prExtend},                 // Mn       CHAM CONSONANT SIGN FINAL NG
-	{runeRange{0xAA4C, 0xAA4C}, prExtend},                 // Mn       CHAM CONSONANT SIGN FINAL M
-	{runeRange{0xAA4D, 0xAA4D}, prSpacingMark},            // Mc       CHAM CONSONANT SIGN FINAL H
-	{runeRange{0xAA7C, 0xAA7C}, prExtend},                 // Mn       MYANMAR SIGN TAI LAING TONE-2
-	{runeRange{0xAAB0, 0xAAB0}, prExtend},                 // Mn       TAI VIET MAI KANG
-	{runeRange{0xAAB2, 0xAAB4}, prExtend},                 // Mn   [3] TAI VIET VOWEL I..TAI VIET VOWEL U
-	{runeRange{0xAAB7, 0xAAB8}, prExtend},                 // Mn   [2] TAI VIET MAI KHIT..TAI VIET VOWEL IA
-	{runeRange{0xAABE, 0xAABF}, prExtend},                 // Mn   [2] TAI VIET VOWEL AM..TAI VIET TONE MAI EK
-	{runeRange{0xAAC1, 0xAAC1}, prExtend},                 // Mn       TAI VIET TONE MAI THO
-	{runeRange{0xAAEB, 0xAAEB}, prSpacingMark},            // Mc       MEETEI MAYEK VOWEL SIGN II
-	{runeRange{0xAAEC, 0xAAED}, prExtend},                 // Mn   [2] MEETEI MAYEK VOWEL SIGN UU..MEETEI MAYEK VOWEL SIGN AAI
-	{runeRange{0xAAEE, 0xAAEF}, prSpacingMark},            // Mc   [2] MEETEI MAYEK VOWEL SIGN AU..MEETEI MAYEK VOWEL SIGN AAU
-	{runeRange{0xAAF5, 0xAAF5}, prSpacingMark},            // Mc       MEETEI MAYEK VOWEL SIGN VISARGA
-	{runeRange{0xAAF6, 0xAAF6}, prExtend},                 // Mn       MEETEI MAYEK VIRAMA
-	{runeRange{0xABE3, 0xABE4}, prSpacingMark},            // Mc   [2] MEETEI MAYEK VOWEL SIGN ONAP..MEETEI MAYEK VOWEL SIGN INAP
-	{runeRange{0xABE5, 0xABE5}, prExtend},                 // Mn       MEETEI MAYEK VOWEL SIGN ANAP
-	{runeRange{0xABE6, 0xABE7}, prSpacingMark},            // Mc   [2] MEETEI MAYEK VOWEL SIGN YENAP..MEETEI MAYEK VOWEL SIGN SOUNAP
-	{runeRange{0xABE8, 0xABE8}, prExtend},                 // Mn       MEETEI MAYEK VOWEL SIGN UNAP
-	{runeRange{0xABE9, 0xABEA}, prSpacingMark},            // Mc   [2] MEETEI MAYEK VOWEL SIGN CHEINAP..MEETEI MAYEK VOWEL SIGN NUNG
-	{runeRange{0xABEC, 0xABEC}, prSpacingMark},            // Mc       MEETEI MAYEK LUM IYEK
-	{runeRange{0xABED, 0xABED}, prExtend},                 // Mn       MEETEI MAYEK APUN IYEK
-	{runeRange{0xAC00, 0xAC00}, prLV},                     // Lo       HANGUL SYLLABLE GA
-	{runeRange{0xAC01, 0xAC1B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GAG..HANGUL SYLLABLE GAH
-	{runeRange{0xAC1C, 0xAC1C}, prLV},                     // Lo       HANGUL SYLLABLE GAE
-	{runeRange{0xAC1D, 0xAC37}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GAEG..HANGUL SYLLABLE GAEH
-	{runeRange{0xAC38, 0xAC38}, prLV},                     // Lo       HANGUL SYLLABLE GYA
-	{runeRange{0xAC39, 0xAC53}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GYAG..HANGUL SYLLABLE GYAH
-	{runeRange{0xAC54, 0xAC54}, prLV},                     // Lo       HANGUL SYLLABLE GYAE
-	{runeRange{0xAC55, 0xAC6F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GYAEG..HANGUL SYLLABLE GYAEH
-	{runeRange{0xAC70, 0xAC70}, prLV},                     // Lo       HANGUL SYLLABLE GEO
-	{runeRange{0xAC71, 0xAC8B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GEOG..HANGUL SYLLABLE GEOH
-	{runeRange{0xAC8C, 0xAC8C}, prLV},                     // Lo       HANGUL SYLLABLE GE
-	{runeRange{0xAC8D, 0xACA7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GEG..HANGUL SYLLABLE GEH
-	{runeRange{0xACA8, 0xACA8}, prLV},                     // Lo       HANGUL SYLLABLE GYEO
-	{runeRange{0xACA9, 0xACC3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GYEOG..HANGUL SYLLABLE GYEOH
-	{runeRange{0xACC4, 0xACC4}, prLV},                     // Lo       HANGUL SYLLABLE GYE
-	{runeRange{0xACC5, 0xACDF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GYEG..HANGUL SYLLABLE GYEH
-	{runeRange{0xACE0, 0xACE0}, prLV},                     // Lo       HANGUL SYLLABLE GO
-	{runeRange{0xACE1, 0xACFB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GOG..HANGUL SYLLABLE GOH
-	{runeRange{0xACFC, 0xACFC}, prLV},                     // Lo       HANGUL SYLLABLE GWA
-	{runeRange{0xACFD, 0xAD17}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GWAG..HANGUL SYLLABLE GWAH
-	{runeRange{0xAD18, 0xAD18}, prLV},                     // Lo       HANGUL SYLLABLE GWAE
-	{runeRange{0xAD19, 0xAD33}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GWAEG..HANGUL SYLLABLE GWAEH
-	{runeRange{0xAD34, 0xAD34}, prLV},                     // Lo       HANGUL SYLLABLE GOE
-	{runeRange{0xAD35, 0xAD4F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GOEG..HANGUL SYLLABLE GOEH
-	{runeRange{0xAD50, 0xAD50}, prLV},                     // Lo       HANGUL SYLLABLE GYO
-	{runeRange{0xAD51, 0xAD6B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GYOG..HANGUL SYLLABLE GYOH
-	{runeRange{0xAD6C, 0xAD6C}, prLV},                     // Lo       HANGUL SYLLABLE GU
-	{runeRange{0xAD6D, 0xAD87}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GUG..HANGUL SYLLABLE GUH
-	{runeRange{0xAD88, 0xAD88}, prLV},                     // Lo       HANGUL SYLLABLE GWEO
-	{runeRange{0xAD89, 0xADA3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GWEOG..HANGUL SYLLABLE GWEOH
-	{runeRange{0xADA4, 0xADA4}, prLV},                     // Lo       HANGUL SYLLABLE GWE
-	{runeRange{0xADA5, 0xADBF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GWEG..HANGUL SYLLABLE GWEH
-	{runeRange{0xADC0, 0xADC0}, prLV},                     // Lo       HANGUL SYLLABLE GWI
-	{runeRange{0xADC1, 0xADDB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GWIG..HANGUL SYLLABLE GWIH
-	{runeRange{0xADDC, 0xADDC}, prLV},                     // Lo       HANGUL SYLLABLE GYU
-	{runeRange{0xADDD, 0xADF7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GYUG..HANGUL SYLLABLE GYUH
-	{runeRange{0xADF8, 0xADF8}, prLV},                     // Lo       HANGUL SYLLABLE GEU
-	{runeRange{0xADF9, 0xAE13}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GEUG..HANGUL SYLLABLE GEUH
-	{runeRange{0xAE14, 0xAE14}, prLV},                     // Lo       HANGUL SYLLABLE GYI
-	{runeRange{0xAE15, 0xAE2F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GYIG..HANGUL SYLLABLE GYIH
-	{runeRange{0xAE30, 0xAE30}, prLV},                     // Lo       HANGUL SYLLABLE GI
-	{runeRange{0xAE31, 0xAE4B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GIG..HANGUL SYLLABLE GIH
-	{runeRange{0xAE4C, 0xAE4C}, prLV},                     // Lo       HANGUL SYLLABLE GGA
-	{runeRange{0xAE4D, 0xAE67}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGAG..HANGUL SYLLABLE GGAH
-	{runeRange{0xAE68, 0xAE68}, prLV},                     // Lo       HANGUL SYLLABLE GGAE
-	{runeRange{0xAE69, 0xAE83}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGAEG..HANGUL SYLLABLE GGAEH
-	{runeRange{0xAE84, 0xAE84}, prLV},                     // Lo       HANGUL SYLLABLE GGYA
-	{runeRange{0xAE85, 0xAE9F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGYAG..HANGUL SYLLABLE GGYAH
-	{runeRange{0xAEA0, 0xAEA0}, prLV},                     // Lo       HANGUL SYLLABLE GGYAE
-	{runeRange{0xAEA1, 0xAEBB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGYAEG..HANGUL SYLLABLE GGYAEH
-	{runeRange{0xAEBC, 0xAEBC}, prLV},                     // Lo       HANGUL SYLLABLE GGEO
-	{runeRange{0xAEBD, 0xAED7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGEOG..HANGUL SYLLABLE GGEOH
-	{runeRange{0xAED8, 0xAED8}, prLV},                     // Lo       HANGUL SYLLABLE GGE
-	{runeRange{0xAED9, 0xAEF3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGEG..HANGUL SYLLABLE GGEH
-	{runeRange{0xAEF4, 0xAEF4}, prLV},                     // Lo       HANGUL SYLLABLE GGYEO
-	{runeRange{0xAEF5, 0xAF0F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGYEOG..HANGUL SYLLABLE GGYEOH
-	{runeRange{0xAF10, 0xAF10}, prLV},                     // Lo       HANGUL SYLLABLE GGYE
-	{runeRange{0xAF11, 0xAF2B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGYEG..HANGUL SYLLABLE GGYEH
-	{runeRange{0xAF2C, 0xAF2C}, prLV},                     // Lo       HANGUL SYLLABLE GGO
-	{runeRange{0xAF2D, 0xAF47}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGOG..HANGUL SYLLABLE GGOH
-	{runeRange{0xAF48, 0xAF48}, prLV},                     // Lo       HANGUL SYLLABLE GGWA
-	{runeRange{0xAF49, 0xAF63}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGWAG..HANGUL SYLLABLE GGWAH
-	{runeRange{0xAF64, 0xAF64}, prLV},                     // Lo       HANGUL SYLLABLE GGWAE
-	{runeRange{0xAF65, 0xAF7F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGWAEG..HANGUL SYLLABLE GGWAEH
-	{runeRange{0xAF80, 0xAF80}, prLV},                     // Lo       HANGUL SYLLABLE GGOE
-	{runeRange{0xAF81, 0xAF9B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGOEG..HANGUL SYLLABLE GGOEH
-	{runeRange{0xAF9C, 0xAF9C}, prLV},                     // Lo       HANGUL SYLLABLE GGYO
-	{runeRange{0xAF9D, 0xAFB7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGYOG..HANGUL SYLLABLE GGYOH
-	{runeRange{0xAFB8, 0xAFB8}, prLV},                     // Lo       HANGUL SYLLABLE GGU
-	{runeRange{0xAFB9, 0xAFD3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGUG..HANGUL SYLLABLE GGUH
-	{runeRange{0xAFD4, 0xAFD4}, prLV},                     // Lo       HANGUL SYLLABLE GGWEO
-	{runeRange{0xAFD5, 0xAFEF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGWEOG..HANGUL SYLLABLE GGWEOH
-	{runeRange{0xAFF0, 0xAFF0}, prLV},                     // Lo       HANGUL SYLLABLE GGWE
-	{runeRange{0xAFF1, 0xB00B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGWEG..HANGUL SYLLABLE GGWEH
-	{runeRange{0xB00C, 0xB00C}, prLV},                     // Lo       HANGUL SYLLABLE GGWI
-	{runeRange{0xB00D, 0xB027}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGWIG..HANGUL SYLLABLE GGWIH
-	{runeRange{0xB028, 0xB028}, prLV},                     // Lo       HANGUL SYLLABLE GGYU
-	{runeRange{0xB029, 0xB043}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGYUG..HANGUL SYLLABLE GGYUH
-	{runeRange{0xB044, 0xB044}, prLV},                     // Lo       HANGUL SYLLABLE GGEU
-	{runeRange{0xB045, 0xB05F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGEUG..HANGUL SYLLABLE GGEUH
-	{runeRange{0xB060, 0xB060}, prLV},                     // Lo       HANGUL SYLLABLE GGYI
-	{runeRange{0xB061, 0xB07B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGYIG..HANGUL SYLLABLE GGYIH
-	{runeRange{0xB07C, 0xB07C}, prLV},                     // Lo       HANGUL SYLLABLE GGI
-	{runeRange{0xB07D, 0xB097}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGIG..HANGUL SYLLABLE GGIH
-	{runeRange{0xB098, 0xB098}, prLV},                     // Lo       HANGUL SYLLABLE NA
-	{runeRange{0xB099, 0xB0B3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NAG..HANGUL SYLLABLE NAH
-	{runeRange{0xB0B4, 0xB0B4}, prLV},                     // Lo       HANGUL SYLLABLE NAE
-	{runeRange{0xB0B5, 0xB0CF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NAEG..HANGUL SYLLABLE NAEH
-	{runeRange{0xB0D0, 0xB0D0}, prLV},                     // Lo       HANGUL SYLLABLE NYA
-	{runeRange{0xB0D1, 0xB0EB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NYAG..HANGUL SYLLABLE NYAH
-	{runeRange{0xB0EC, 0xB0EC}, prLV},                     // Lo       HANGUL SYLLABLE NYAE
-	{runeRange{0xB0ED, 0xB107}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NYAEG..HANGUL SYLLABLE NYAEH
-	{runeRange{0xB108, 0xB108}, prLV},                     // Lo       HANGUL SYLLABLE NEO
-	{runeRange{0xB109, 0xB123}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NEOG..HANGUL SYLLABLE NEOH
-	{runeRange{0xB124, 0xB124}, prLV},                     // Lo       HANGUL SYLLABLE NE
-	{runeRange{0xB125, 0xB13F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NEG..HANGUL SYLLABLE NEH
-	{runeRange{0xB140, 0xB140}, prLV},                     // Lo       HANGUL SYLLABLE NYEO
-	{runeRange{0xB141, 0xB15B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NYEOG..HANGUL SYLLABLE NYEOH
-	{runeRange{0xB15C, 0xB15C}, prLV},                     // Lo       HANGUL SYLLABLE NYE
-	{runeRange{0xB15D, 0xB177}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NYEG..HANGUL SYLLABLE NYEH
-	{runeRange{0xB178, 0xB178}, prLV},                     // Lo       HANGUL SYLLABLE NO
-	{runeRange{0xB179, 0xB193}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NOG..HANGUL SYLLABLE NOH
-	{runeRange{0xB194, 0xB194}, prLV},                     // Lo       HANGUL SYLLABLE NWA
-	{runeRange{0xB195, 0xB1AF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NWAG..HANGUL SYLLABLE NWAH
-	{runeRange{0xB1B0, 0xB1B0}, prLV},                     // Lo       HANGUL SYLLABLE NWAE
-	{runeRange{0xB1B1, 0xB1CB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NWAEG..HANGUL SYLLABLE NWAEH
-	{runeRange{0xB1CC, 0xB1CC}, prLV},                     // Lo       HANGUL SYLLABLE NOE
-	{runeRange{0xB1CD, 0xB1E7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NOEG..HANGUL SYLLABLE NOEH
-	{runeRange{0xB1E8, 0xB1E8}, prLV},                     // Lo       HANGUL SYLLABLE NYO
-	{runeRange{0xB1E9, 0xB203}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NYOG..HANGUL SYLLABLE NYOH
-	{runeRange{0xB204, 0xB204}, prLV},                     // Lo       HANGUL SYLLABLE NU
-	{runeRange{0xB205, 0xB21F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NUG..HANGUL SYLLABLE NUH
-	{runeRange{0xB220, 0xB220}, prLV},                     // Lo       HANGUL SYLLABLE NWEO
-	{runeRange{0xB221, 0xB23B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NWEOG..HANGUL SYLLABLE NWEOH
-	{runeRange{0xB23C, 0xB23C}, prLV},                     // Lo       HANGUL SYLLABLE NWE
-	{runeRange{0xB23D, 0xB257}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NWEG..HANGUL SYLLABLE NWEH
-	{runeRange{0xB258, 0xB258}, prLV},                     // Lo       HANGUL SYLLABLE NWI
-	{runeRange{0xB259, 0xB273}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NWIG..HANGUL SYLLABLE NWIH
-	{runeRange{0xB274, 0xB274}, prLV},                     // Lo       HANGUL SYLLABLE NYU
-	{runeRange{0xB275, 0xB28F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NYUG..HANGUL SYLLABLE NYUH
-	{runeRange{0xB290, 0xB290}, prLV},                     // Lo       HANGUL SYLLABLE NEU
-	{runeRange{0xB291, 0xB2AB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NEUG..HANGUL SYLLABLE NEUH
-	{runeRange{0xB2AC, 0xB2AC}, prLV},                     // Lo       HANGUL SYLLABLE NYI
-	{runeRange{0xB2AD, 0xB2C7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NYIG..HANGUL SYLLABLE NYIH
-	{runeRange{0xB2C8, 0xB2C8}, prLV},                     // Lo       HANGUL SYLLABLE NI
-	{runeRange{0xB2C9, 0xB2E3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NIG..HANGUL SYLLABLE NIH
-	{runeRange{0xB2E4, 0xB2E4}, prLV},                     // Lo       HANGUL SYLLABLE DA
-	{runeRange{0xB2E5, 0xB2FF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DAG..HANGUL SYLLABLE DAH
-	{runeRange{0xB300, 0xB300}, prLV},                     // Lo       HANGUL SYLLABLE DAE
-	{runeRange{0xB301, 0xB31B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DAEG..HANGUL SYLLABLE DAEH
-	{runeRange{0xB31C, 0xB31C}, prLV},                     // Lo       HANGUL SYLLABLE DYA
-	{runeRange{0xB31D, 0xB337}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DYAG..HANGUL SYLLABLE DYAH
-	{runeRange{0xB338, 0xB338}, prLV},                     // Lo       HANGUL SYLLABLE DYAE
-	{runeRange{0xB339, 0xB353}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DYAEG..HANGUL SYLLABLE DYAEH
-	{runeRange{0xB354, 0xB354}, prLV},                     // Lo       HANGUL SYLLABLE DEO
-	{runeRange{0xB355, 0xB36F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DEOG..HANGUL SYLLABLE DEOH
-	{runeRange{0xB370, 0xB370}, prLV},                     // Lo       HANGUL SYLLABLE DE
-	{runeRange{0xB371, 0xB38B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DEG..HANGUL SYLLABLE DEH
-	{runeRange{0xB38C, 0xB38C}, prLV},                     // Lo       HANGUL SYLLABLE DYEO
-	{runeRange{0xB38D, 0xB3A7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DYEOG..HANGUL SYLLABLE DYEOH
-	{runeRange{0xB3A8, 0xB3A8}, prLV},                     // Lo       HANGUL SYLLABLE DYE
-	{runeRange{0xB3A9, 0xB3C3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DYEG..HANGUL SYLLABLE DYEH
-	{runeRange{0xB3C4, 0xB3C4}, prLV},                     // Lo       HANGUL SYLLABLE DO
-	{runeRange{0xB3C5, 0xB3DF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DOG..HANGUL SYLLABLE DOH
-	{runeRange{0xB3E0, 0xB3E0}, prLV},                     // Lo       HANGUL SYLLABLE DWA
-	{runeRange{0xB3E1, 0xB3FB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DWAG..HANGUL SYLLABLE DWAH
-	{runeRange{0xB3FC, 0xB3FC}, prLV},                     // Lo       HANGUL SYLLABLE DWAE
-	{runeRange{0xB3FD, 0xB417}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DWAEG..HANGUL SYLLABLE DWAEH
-	{runeRange{0xB418, 0xB418}, prLV},                     // Lo       HANGUL SYLLABLE DOE
-	{runeRange{0xB419, 0xB433}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DOEG..HANGUL SYLLABLE DOEH
-	{runeRange{0xB434, 0xB434}, prLV},                     // Lo       HANGUL SYLLABLE DYO
-	{runeRange{0xB435, 0xB44F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DYOG..HANGUL SYLLABLE DYOH
-	{runeRange{0xB450, 0xB450}, prLV},                     // Lo       HANGUL SYLLABLE DU
-	{runeRange{0xB451, 0xB46B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DUG..HANGUL SYLLABLE DUH
-	{runeRange{0xB46C, 0xB46C}, prLV},                     // Lo       HANGUL SYLLABLE DWEO
-	{runeRange{0xB46D, 0xB487}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DWEOG..HANGUL SYLLABLE DWEOH
-	{runeRange{0xB488, 0xB488}, prLV},                     // Lo       HANGUL SYLLABLE DWE
-	{runeRange{0xB489, 0xB4A3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DWEG..HANGUL SYLLABLE DWEH
-	{runeRange{0xB4A4, 0xB4A4}, prLV},                     // Lo       HANGUL SYLLABLE DWI
-	{runeRange{0xB4A5, 0xB4BF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DWIG..HANGUL SYLLABLE DWIH
-	{runeRange{0xB4C0, 0xB4C0}, prLV},                     // Lo       HANGUL SYLLABLE DYU
-	{runeRange{0xB4C1, 0xB4DB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DYUG..HANGUL SYLLABLE DYUH
-	{runeRange{0xB4DC, 0xB4DC}, prLV},                     // Lo       HANGUL SYLLABLE DEU
-	{runeRange{0xB4DD, 0xB4F7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DEUG..HANGUL SYLLABLE DEUH
-	{runeRange{0xB4F8, 0xB4F8}, prLV},                     // Lo       HANGUL SYLLABLE DYI
-	{runeRange{0xB4F9, 0xB513}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DYIG..HANGUL SYLLABLE DYIH
-	{runeRange{0xB514, 0xB514}, prLV},                     // Lo       HANGUL SYLLABLE DI
-	{runeRange{0xB515, 0xB52F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DIG..HANGUL SYLLABLE DIH
-	{runeRange{0xB530, 0xB530}, prLV},                     // Lo       HANGUL SYLLABLE DDA
-	{runeRange{0xB531, 0xB54B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDAG..HANGUL SYLLABLE DDAH
-	{runeRange{0xB54C, 0xB54C}, prLV},                     // Lo       HANGUL SYLLABLE DDAE
-	{runeRange{0xB54D, 0xB567}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDAEG..HANGUL SYLLABLE DDAEH
-	{runeRange{0xB568, 0xB568}, prLV},                     // Lo       HANGUL SYLLABLE DDYA
-	{runeRange{0xB569, 0xB583}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDYAG..HANGUL SYLLABLE DDYAH
-	{runeRange{0xB584, 0xB584}, prLV},                     // Lo       HANGUL SYLLABLE DDYAE
-	{runeRange{0xB585, 0xB59F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDYAEG..HANGUL SYLLABLE DDYAEH
-	{runeRange{0xB5A0, 0xB5A0}, prLV},                     // Lo       HANGUL SYLLABLE DDEO
-	{runeRange{0xB5A1, 0xB5BB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDEOG..HANGUL SYLLABLE DDEOH
-	{runeRange{0xB5BC, 0xB5BC}, prLV},                     // Lo       HANGUL SYLLABLE DDE
-	{runeRange{0xB5BD, 0xB5D7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDEG..HANGUL SYLLABLE DDEH
-	{runeRange{0xB5D8, 0xB5D8}, prLV},                     // Lo       HANGUL SYLLABLE DDYEO
-	{runeRange{0xB5D9, 0xB5F3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDYEOG..HANGUL SYLLABLE DDYEOH
-	{runeRange{0xB5F4, 0xB5F4}, prLV},                     // Lo       HANGUL SYLLABLE DDYE
-	{runeRange{0xB5F5, 0xB60F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDYEG..HANGUL SYLLABLE DDYEH
-	{runeRange{0xB610, 0xB610}, prLV},                     // Lo       HANGUL SYLLABLE DDO
-	{runeRange{0xB611, 0xB62B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDOG..HANGUL SYLLABLE DDOH
-	{runeRange{0xB62C, 0xB62C}, prLV},                     // Lo       HANGUL SYLLABLE DDWA
-	{runeRange{0xB62D, 0xB647}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDWAG..HANGUL SYLLABLE DDWAH
-	{runeRange{0xB648, 0xB648}, prLV},                     // Lo       HANGUL SYLLABLE DDWAE
-	{runeRange{0xB649, 0xB663}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDWAEG..HANGUL SYLLABLE DDWAEH
-	{runeRange{0xB664, 0xB664}, prLV},                     // Lo       HANGUL SYLLABLE DDOE
-	{runeRange{0xB665, 0xB67F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDOEG..HANGUL SYLLABLE DDOEH
-	{runeRange{0xB680, 0xB680}, prLV},                     // Lo       HANGUL SYLLABLE DDYO
-	{runeRange{0xB681, 0xB69B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDYOG..HANGUL SYLLABLE DDYOH
-	{runeRange{0xB69C, 0xB69C}, prLV},                     // Lo       HANGUL SYLLABLE DDU
-	{runeRange{0xB69D, 0xB6B7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDUG..HANGUL SYLLABLE DDUH
-	{runeRange{0xB6B8, 0xB6B8}, prLV},                     // Lo       HANGUL SYLLABLE DDWEO
-	{runeRange{0xB6B9, 0xB6D3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDWEOG..HANGUL SYLLABLE DDWEOH
-	{runeRange{0xB6D4, 0xB6D4}, prLV},                     // Lo       HANGUL SYLLABLE DDWE
-	{runeRange{0xB6D5, 0xB6EF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDWEG..HANGUL SYLLABLE DDWEH
-	{runeRange{0xB6F0, 0xB6F0}, prLV},                     // Lo       HANGUL SYLLABLE DDWI
-	{runeRange{0xB6F1, 0xB70B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDWIG..HANGUL SYLLABLE DDWIH
-	{runeRange{0xB70C, 0xB70C}, prLV},                     // Lo       HANGUL SYLLABLE DDYU
-	{runeRange{0xB70D, 0xB727}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDYUG..HANGUL SYLLABLE DDYUH
-	{runeRange{0xB728, 0xB728}, prLV},                     // Lo       HANGUL SYLLABLE DDEU
-	{runeRange{0xB729, 0xB743}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDEUG..HANGUL SYLLABLE DDEUH
-	{runeRange{0xB744, 0xB744}, prLV},                     // Lo       HANGUL SYLLABLE DDYI
-	{runeRange{0xB745, 0xB75F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDYIG..HANGUL SYLLABLE DDYIH
-	{runeRange{0xB760, 0xB760}, prLV},                     // Lo       HANGUL SYLLABLE DDI
-	{runeRange{0xB761, 0xB77B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDIG..HANGUL SYLLABLE DDIH
-	{runeRange{0xB77C, 0xB77C}, prLV},                     // Lo       HANGUL SYLLABLE RA
-	{runeRange{0xB77D, 0xB797}, prLVT},                    // Lo  [27] HANGUL SYLLABLE RAG..HANGUL SYLLABLE RAH
-	{runeRange{0xB798, 0xB798}, prLV},                     // Lo       HANGUL SYLLABLE RAE
-	{runeRange{0xB799, 0xB7B3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE RAEG..HANGUL SYLLABLE RAEH
-	{runeRange{0xB7B4, 0xB7B4}, prLV},                     // Lo       HANGUL SYLLABLE RYA
-	{runeRange{0xB7B5, 0xB7CF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE RYAG..HANGUL SYLLABLE RYAH
-	{runeRange{0xB7D0, 0xB7D0}, prLV},                     // Lo       HANGUL SYLLABLE RYAE
-	{runeRange{0xB7D1, 0xB7EB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE RYAEG..HANGUL SYLLABLE RYAEH
-	{runeRange{0xB7EC, 0xB7EC}, prLV},                     // Lo       HANGUL SYLLABLE REO
-	{runeRange{0xB7ED, 0xB807}, prLVT},                    // Lo  [27] HANGUL SYLLABLE REOG..HANGUL SYLLABLE REOH
-	{runeRange{0xB808, 0xB808}, prLV},                     // Lo       HANGUL SYLLABLE RE
-	{runeRange{0xB809, 0xB823}, prLVT},                    // Lo  [27] HANGUL SYLLABLE REG..HANGUL SYLLABLE REH
-	{runeRange{0xB824, 0xB824}, prLV},                     // Lo       HANGUL SYLLABLE RYEO
-	{runeRange{0xB825, 0xB83F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE RYEOG..HANGUL SYLLABLE RYEOH
-	{runeRange{0xB840, 0xB840}, prLV},                     // Lo       HANGUL SYLLABLE RYE
-	{runeRange{0xB841, 0xB85B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE RYEG..HANGUL SYLLABLE RYEH
-	{runeRange{0xB85C, 0xB85C}, prLV},                     // Lo       HANGUL SYLLABLE RO
-	{runeRange{0xB85D, 0xB877}, prLVT},                    // Lo  [27] HANGUL SYLLABLE ROG..HANGUL SYLLABLE ROH
-	{runeRange{0xB878, 0xB878}, prLV},                     // Lo       HANGUL SYLLABLE RWA
-	{runeRange{0xB879, 0xB893}, prLVT},                    // Lo  [27] HANGUL SYLLABLE RWAG..HANGUL SYLLABLE RWAH
-	{runeRange{0xB894, 0xB894}, prLV},                     // Lo       HANGUL SYLLABLE RWAE
-	{runeRange{0xB895, 0xB8AF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE RWAEG..HANGUL SYLLABLE RWAEH
-	{runeRange{0xB8B0, 0xB8B0}, prLV},                     // Lo       HANGUL SYLLABLE ROE
-	{runeRange{0xB8B1, 0xB8CB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE ROEG..HANGUL SYLLABLE ROEH
-	{runeRange{0xB8CC, 0xB8CC}, prLV},                     // Lo       HANGUL SYLLABLE RYO
-	{runeRange{0xB8CD, 0xB8E7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE RYOG..HANGUL SYLLABLE RYOH
-	{runeRange{0xB8E8, 0xB8E8}, prLV},                     // Lo       HANGUL SYLLABLE RU
-	{runeRange{0xB8E9, 0xB903}, prLVT},                    // Lo  [27] HANGUL SYLLABLE RUG..HANGUL SYLLABLE RUH
-	{runeRange{0xB904, 0xB904}, prLV},                     // Lo       HANGUL SYLLABLE RWEO
-	{runeRange{0xB905, 0xB91F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE RWEOG..HANGUL SYLLABLE RWEOH
-	{runeRange{0xB920, 0xB920}, prLV},                     // Lo       HANGUL SYLLABLE RWE
-	{runeRange{0xB921, 0xB93B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE RWEG..HANGUL SYLLABLE RWEH
-	{runeRange{0xB93C, 0xB93C}, prLV},                     // Lo       HANGUL SYLLABLE RWI
-	{runeRange{0xB93D, 0xB957}, prLVT},                    // Lo  [27] HANGUL SYLLABLE RWIG..HANGUL SYLLABLE RWIH
-	{runeRange{0xB958, 0xB958}, prLV},                     // Lo       HANGUL SYLLABLE RYU
-	{runeRange{0xB959, 0xB973}, prLVT},                    // Lo  [27] HANGUL SYLLABLE RYUG..HANGUL SYLLABLE RYUH
-	{runeRange{0xB974, 0xB974}, prLV},                     // Lo       HANGUL SYLLABLE REU
-	{runeRange{0xB975, 0xB98F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE REUG..HANGUL SYLLABLE REUH
-	{runeRange{0xB990, 0xB990}, prLV},                     // Lo       HANGUL SYLLABLE RYI
-	{runeRange{0xB991, 0xB9AB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE RYIG..HANGUL SYLLABLE RYIH
-	{runeRange{0xB9AC, 0xB9AC}, prLV},                     // Lo       HANGUL SYLLABLE RI
-	{runeRange{0xB9AD, 0xB9C7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE RIG..HANGUL SYLLABLE RIH
-	{runeRange{0xB9C8, 0xB9C8}, prLV},                     // Lo       HANGUL SYLLABLE MA
-	{runeRange{0xB9C9, 0xB9E3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MAG..HANGUL SYLLABLE MAH
-	{runeRange{0xB9E4, 0xB9E4}, prLV},                     // Lo       HANGUL SYLLABLE MAE
-	{runeRange{0xB9E5, 0xB9FF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MAEG..HANGUL SYLLABLE MAEH
-	{runeRange{0xBA00, 0xBA00}, prLV},                     // Lo       HANGUL SYLLABLE MYA
-	{runeRange{0xBA01, 0xBA1B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MYAG..HANGUL SYLLABLE MYAH
-	{runeRange{0xBA1C, 0xBA1C}, prLV},                     // Lo       HANGUL SYLLABLE MYAE
-	{runeRange{0xBA1D, 0xBA37}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MYAEG..HANGUL SYLLABLE MYAEH
-	{runeRange{0xBA38, 0xBA38}, prLV},                     // Lo       HANGUL SYLLABLE MEO
-	{runeRange{0xBA39, 0xBA53}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MEOG..HANGUL SYLLABLE MEOH
-	{runeRange{0xBA54, 0xBA54}, prLV},                     // Lo       HANGUL SYLLABLE ME
-	{runeRange{0xBA55, 0xBA6F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MEG..HANGUL SYLLABLE MEH
-	{runeRange{0xBA70, 0xBA70}, prLV},                     // Lo       HANGUL SYLLABLE MYEO
-	{runeRange{0xBA71, 0xBA8B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MYEOG..HANGUL SYLLABLE MYEOH
-	{runeRange{0xBA8C, 0xBA8C}, prLV},                     // Lo       HANGUL SYLLABLE MYE
-	{runeRange{0xBA8D, 0xBAA7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MYEG..HANGUL SYLLABLE MYEH
-	{runeRange{0xBAA8, 0xBAA8}, prLV},                     // Lo       HANGUL SYLLABLE MO
-	{runeRange{0xBAA9, 0xBAC3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MOG..HANGUL SYLLABLE MOH
-	{runeRange{0xBAC4, 0xBAC4}, prLV},                     // Lo       HANGUL SYLLABLE MWA
-	{runeRange{0xBAC5, 0xBADF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MWAG..HANGUL SYLLABLE MWAH
-	{runeRange{0xBAE0, 0xBAE0}, prLV},                     // Lo       HANGUL SYLLABLE MWAE
-	{runeRange{0xBAE1, 0xBAFB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MWAEG..HANGUL SYLLABLE MWAEH
-	{runeRange{0xBAFC, 0xBAFC}, prLV},                     // Lo       HANGUL SYLLABLE MOE
-	{runeRange{0xBAFD, 0xBB17}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MOEG..HANGUL SYLLABLE MOEH
-	{runeRange{0xBB18, 0xBB18}, prLV},                     // Lo       HANGUL SYLLABLE MYO
-	{runeRange{0xBB19, 0xBB33}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MYOG..HANGUL SYLLABLE MYOH
-	{runeRange{0xBB34, 0xBB34}, prLV},                     // Lo       HANGUL SYLLABLE MU
-	{runeRange{0xBB35, 0xBB4F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MUG..HANGUL SYLLABLE MUH
-	{runeRange{0xBB50, 0xBB50}, prLV},                     // Lo       HANGUL SYLLABLE MWEO
-	{runeRange{0xBB51, 0xBB6B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MWEOG..HANGUL SYLLABLE MWEOH
-	{runeRange{0xBB6C, 0xBB6C}, prLV},                     // Lo       HANGUL SYLLABLE MWE
-	{runeRange{0xBB6D, 0xBB87}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MWEG..HANGUL SYLLABLE MWEH
-	{runeRange{0xBB88, 0xBB88}, prLV},                     // Lo       HANGUL SYLLABLE MWI
-	{runeRange{0xBB89, 0xBBA3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MWIG..HANGUL SYLLABLE MWIH
-	{runeRange{0xBBA4, 0xBBA4}, prLV},                     // Lo       HANGUL SYLLABLE MYU
-	{runeRange{0xBBA5, 0xBBBF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MYUG..HANGUL SYLLABLE MYUH
-	{runeRange{0xBBC0, 0xBBC0}, prLV},                     // Lo       HANGUL SYLLABLE MEU
-	{runeRange{0xBBC1, 0xBBDB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MEUG..HANGUL SYLLABLE MEUH
-	{runeRange{0xBBDC, 0xBBDC}, prLV},                     // Lo       HANGUL SYLLABLE MYI
-	{runeRange{0xBBDD, 0xBBF7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MYIG..HANGUL SYLLABLE MYIH
-	{runeRange{0xBBF8, 0xBBF8}, prLV},                     // Lo       HANGUL SYLLABLE MI
-	{runeRange{0xBBF9, 0xBC13}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MIG..HANGUL SYLLABLE MIH
-	{runeRange{0xBC14, 0xBC14}, prLV},                     // Lo       HANGUL SYLLABLE BA
-	{runeRange{0xBC15, 0xBC2F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BAG..HANGUL SYLLABLE BAH
-	{runeRange{0xBC30, 0xBC30}, prLV},                     // Lo       HANGUL SYLLABLE BAE
-	{runeRange{0xBC31, 0xBC4B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BAEG..HANGUL SYLLABLE BAEH
-	{runeRange{0xBC4C, 0xBC4C}, prLV},                     // Lo       HANGUL SYLLABLE BYA
-	{runeRange{0xBC4D, 0xBC67}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BYAG..HANGUL SYLLABLE BYAH
-	{runeRange{0xBC68, 0xBC68}, prLV},                     // Lo       HANGUL SYLLABLE BYAE
-	{runeRange{0xBC69, 0xBC83}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BYAEG..HANGUL SYLLABLE BYAEH
-	{runeRange{0xBC84, 0xBC84}, prLV},                     // Lo       HANGUL SYLLABLE BEO
-	{runeRange{0xBC85, 0xBC9F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BEOG..HANGUL SYLLABLE BEOH
-	{runeRange{0xBCA0, 0xBCA0}, prLV},                     // Lo       HANGUL SYLLABLE BE
-	{runeRange{0xBCA1, 0xBCBB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BEG..HANGUL SYLLABLE BEH
-	{runeRange{0xBCBC, 0xBCBC}, prLV},                     // Lo       HANGUL SYLLABLE BYEO
-	{runeRange{0xBCBD, 0xBCD7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BYEOG..HANGUL SYLLABLE BYEOH
-	{runeRange{0xBCD8, 0xBCD8}, prLV},                     // Lo       HANGUL SYLLABLE BYE
-	{runeRange{0xBCD9, 0xBCF3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BYEG..HANGUL SYLLABLE BYEH
-	{runeRange{0xBCF4, 0xBCF4}, prLV},                     // Lo       HANGUL SYLLABLE BO
-	{runeRange{0xBCF5, 0xBD0F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BOG..HANGUL SYLLABLE BOH
-	{runeRange{0xBD10, 0xBD10}, prLV},                     // Lo       HANGUL SYLLABLE BWA
-	{runeRange{0xBD11, 0xBD2B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BWAG..HANGUL SYLLABLE BWAH
-	{runeRange{0xBD2C, 0xBD2C}, prLV},                     // Lo       HANGUL SYLLABLE BWAE
-	{runeRange{0xBD2D, 0xBD47}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BWAEG..HANGUL SYLLABLE BWAEH
-	{runeRange{0xBD48, 0xBD48}, prLV},                     // Lo       HANGUL SYLLABLE BOE
-	{runeRange{0xBD49, 0xBD63}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BOEG..HANGUL SYLLABLE BOEH
-	{runeRange{0xBD64, 0xBD64}, prLV},                     // Lo       HANGUL SYLLABLE BYO
-	{runeRange{0xBD65, 0xBD7F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BYOG..HANGUL SYLLABLE BYOH
-	{runeRange{0xBD80, 0xBD80}, prLV},                     // Lo       HANGUL SYLLABLE BU
-	{runeRange{0xBD81, 0xBD9B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BUG..HANGUL SYLLABLE BUH
-	{runeRange{0xBD9C, 0xBD9C}, prLV},                     // Lo       HANGUL SYLLABLE BWEO
-	{runeRange{0xBD9D, 0xBDB7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BWEOG..HANGUL SYLLABLE BWEOH
-	{runeRange{0xBDB8, 0xBDB8}, prLV},                     // Lo       HANGUL SYLLABLE BWE
-	{runeRange{0xBDB9, 0xBDD3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BWEG..HANGUL SYLLABLE BWEH
-	{runeRange{0xBDD4, 0xBDD4}, prLV},                     // Lo       HANGUL SYLLABLE BWI
-	{runeRange{0xBDD5, 0xBDEF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BWIG..HANGUL SYLLABLE BWIH
-	{runeRange{0xBDF0, 0xBDF0}, prLV},                     // Lo       HANGUL SYLLABLE BYU
-	{runeRange{0xBDF1, 0xBE0B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BYUG..HANGUL SYLLABLE BYUH
-	{runeRange{0xBE0C, 0xBE0C}, prLV},                     // Lo       HANGUL SYLLABLE BEU
-	{runeRange{0xBE0D, 0xBE27}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BEUG..HANGUL SYLLABLE BEUH
-	{runeRange{0xBE28, 0xBE28}, prLV},                     // Lo       HANGUL SYLLABLE BYI
-	{runeRange{0xBE29, 0xBE43}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BYIG..HANGUL SYLLABLE BYIH
-	{runeRange{0xBE44, 0xBE44}, prLV},                     // Lo       HANGUL SYLLABLE BI
-	{runeRange{0xBE45, 0xBE5F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BIG..HANGUL SYLLABLE BIH
-	{runeRange{0xBE60, 0xBE60}, prLV},                     // Lo       HANGUL SYLLABLE BBA
-	{runeRange{0xBE61, 0xBE7B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBAG..HANGUL SYLLABLE BBAH
-	{runeRange{0xBE7C, 0xBE7C}, prLV},                     // Lo       HANGUL SYLLABLE BBAE
-	{runeRange{0xBE7D, 0xBE97}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBAEG..HANGUL SYLLABLE BBAEH
-	{runeRange{0xBE98, 0xBE98}, prLV},                     // Lo       HANGUL SYLLABLE BBYA
-	{runeRange{0xBE99, 0xBEB3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBYAG..HANGUL SYLLABLE BBYAH
-	{runeRange{0xBEB4, 0xBEB4}, prLV},                     // Lo       HANGUL SYLLABLE BBYAE
-	{runeRange{0xBEB5, 0xBECF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBYAEG..HANGUL SYLLABLE BBYAEH
-	{runeRange{0xBED0, 0xBED0}, prLV},                     // Lo       HANGUL SYLLABLE BBEO
-	{runeRange{0xBED1, 0xBEEB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBEOG..HANGUL SYLLABLE BBEOH
-	{runeRange{0xBEEC, 0xBEEC}, prLV},                     // Lo       HANGUL SYLLABLE BBE
-	{runeRange{0xBEED, 0xBF07}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBEG..HANGUL SYLLABLE BBEH
-	{runeRange{0xBF08, 0xBF08}, prLV},                     // Lo       HANGUL SYLLABLE BBYEO
-	{runeRange{0xBF09, 0xBF23}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBYEOG..HANGUL SYLLABLE BBYEOH
-	{runeRange{0xBF24, 0xBF24}, prLV},                     // Lo       HANGUL SYLLABLE BBYE
-	{runeRange{0xBF25, 0xBF3F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBYEG..HANGUL SYLLABLE BBYEH
-	{runeRange{0xBF40, 0xBF40}, prLV},                     // Lo       HANGUL SYLLABLE BBO
-	{runeRange{0xBF41, 0xBF5B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBOG..HANGUL SYLLABLE BBOH
-	{runeRange{0xBF5C, 0xBF5C}, prLV},                     // Lo       HANGUL SYLLABLE BBWA
-	{runeRange{0xBF5D, 0xBF77}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBWAG..HANGUL SYLLABLE BBWAH
-	{runeRange{0xBF78, 0xBF78}, prLV},                     // Lo       HANGUL SYLLABLE BBWAE
-	{runeRange{0xBF79, 0xBF93}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBWAEG..HANGUL SYLLABLE BBWAEH
-	{runeRange{0xBF94, 0xBF94}, prLV},                     // Lo       HANGUL SYLLABLE BBOE
-	{runeRange{0xBF95, 0xBFAF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBOEG..HANGUL SYLLABLE BBOEH
-	{runeRange{0xBFB0, 0xBFB0}, prLV},                     // Lo       HANGUL SYLLABLE BBYO
-	{runeRange{0xBFB1, 0xBFCB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBYOG..HANGUL SYLLABLE BBYOH
-	{runeRange{0xBFCC, 0xBFCC}, prLV},                     // Lo       HANGUL SYLLABLE BBU
-	{runeRange{0xBFCD, 0xBFE7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBUG..HANGUL SYLLABLE BBUH
-	{runeRange{0xBFE8, 0xBFE8}, prLV},                     // Lo       HANGUL SYLLABLE BBWEO
-	{runeRange{0xBFE9, 0xC003}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBWEOG..HANGUL SYLLABLE BBWEOH
-	{runeRange{0xC004, 0xC004}, prLV},                     // Lo       HANGUL SYLLABLE BBWE
-	{runeRange{0xC005, 0xC01F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBWEG..HANGUL SYLLABLE BBWEH
-	{runeRange{0xC020, 0xC020}, prLV},                     // Lo       HANGUL SYLLABLE BBWI
-	{runeRange{0xC021, 0xC03B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBWIG..HANGUL SYLLABLE BBWIH
-	{runeRange{0xC03C, 0xC03C}, prLV},                     // Lo       HANGUL SYLLABLE BBYU
-	{runeRange{0xC03D, 0xC057}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBYUG..HANGUL SYLLABLE BBYUH
-	{runeRange{0xC058, 0xC058}, prLV},                     // Lo       HANGUL SYLLABLE BBEU
-	{runeRange{0xC059, 0xC073}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBEUG..HANGUL SYLLABLE BBEUH
-	{runeRange{0xC074, 0xC074}, prLV},                     // Lo       HANGUL SYLLABLE BBYI
-	{runeRange{0xC075, 0xC08F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBYIG..HANGUL SYLLABLE BBYIH
-	{runeRange{0xC090, 0xC090}, prLV},                     // Lo       HANGUL SYLLABLE BBI
-	{runeRange{0xC091, 0xC0AB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBIG..HANGUL SYLLABLE BBIH
-	{runeRange{0xC0AC, 0xC0AC}, prLV},                     // Lo       HANGUL SYLLABLE SA
-	{runeRange{0xC0AD, 0xC0C7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SAG..HANGUL SYLLABLE SAH
-	{runeRange{0xC0C8, 0xC0C8}, prLV},                     // Lo       HANGUL SYLLABLE SAE
-	{runeRange{0xC0C9, 0xC0E3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SAEG..HANGUL SYLLABLE SAEH
-	{runeRange{0xC0E4, 0xC0E4}, prLV},                     // Lo       HANGUL SYLLABLE SYA
-	{runeRange{0xC0E5, 0xC0FF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SYAG..HANGUL SYLLABLE SYAH
-	{runeRange{0xC100, 0xC100}, prLV},                     // Lo       HANGUL SYLLABLE SYAE
-	{runeRange{0xC101, 0xC11B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SYAEG..HANGUL SYLLABLE SYAEH
-	{runeRange{0xC11C, 0xC11C}, prLV},                     // Lo       HANGUL SYLLABLE SEO
-	{runeRange{0xC11D, 0xC137}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SEOG..HANGUL SYLLABLE SEOH
-	{runeRange{0xC138, 0xC138}, prLV},                     // Lo       HANGUL SYLLABLE SE
-	{runeRange{0xC139, 0xC153}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SEG..HANGUL SYLLABLE SEH
-	{runeRange{0xC154, 0xC154}, prLV},                     // Lo       HANGUL SYLLABLE SYEO
-	{runeRange{0xC155, 0xC16F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SYEOG..HANGUL SYLLABLE SYEOH
-	{runeRange{0xC170, 0xC170}, prLV},                     // Lo       HANGUL SYLLABLE SYE
-	{runeRange{0xC171, 0xC18B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SYEG..HANGUL SYLLABLE SYEH
-	{runeRange{0xC18C, 0xC18C}, prLV},                     // Lo       HANGUL SYLLABLE SO
-	{runeRange{0xC18D, 0xC1A7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SOG..HANGUL SYLLABLE SOH
-	{runeRange{0xC1A8, 0xC1A8}, prLV},                     // Lo       HANGUL SYLLABLE SWA
-	{runeRange{0xC1A9, 0xC1C3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SWAG..HANGUL SYLLABLE SWAH
-	{runeRange{0xC1C4, 0xC1C4}, prLV},                     // Lo       HANGUL SYLLABLE SWAE
-	{runeRange{0xC1C5, 0xC1DF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SWAEG..HANGUL SYLLABLE SWAEH
-	{runeRange{0xC1E0, 0xC1E0}, prLV},                     // Lo       HANGUL SYLLABLE SOE
-	{runeRange{0xC1E1, 0xC1FB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SOEG..HANGUL SYLLABLE SOEH
-	{runeRange{0xC1FC, 0xC1FC}, prLV},                     // Lo       HANGUL SYLLABLE SYO
-	{runeRange{0xC1FD, 0xC217}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SYOG..HANGUL SYLLABLE SYOH
-	{runeRange{0xC218, 0xC218}, prLV},                     // Lo       HANGUL SYLLABLE SU
-	{runeRange{0xC219, 0xC233}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SUG..HANGUL SYLLABLE SUH
-	{runeRange{0xC234, 0xC234}, prLV},                     // Lo       HANGUL SYLLABLE SWEO
-	{runeRange{0xC235, 0xC24F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SWEOG..HANGUL SYLLABLE SWEOH
-	{runeRange{0xC250, 0xC250}, prLV},                     // Lo       HANGUL SYLLABLE SWE
-	{runeRange{0xC251, 0xC26B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SWEG..HANGUL SYLLABLE SWEH
-	{runeRange{0xC26C, 0xC26C}, prLV},                     // Lo       HANGUL SYLLABLE SWI
-	{runeRange{0xC26D, 0xC287}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SWIG..HANGUL SYLLABLE SWIH
-	{runeRange{0xC288, 0xC288}, prLV},                     // Lo       HANGUL SYLLABLE SYU
-	{runeRange{0xC289, 0xC2A3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SYUG..HANGUL SYLLABLE SYUH
-	{runeRange{0xC2A4, 0xC2A4}, prLV},                     // Lo       HANGUL SYLLABLE SEU
-	{runeRange{0xC2A5, 0xC2BF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SEUG..HANGUL SYLLABLE SEUH
-	{runeRange{0xC2C0, 0xC2C0}, prLV},                     // Lo       HANGUL SYLLABLE SYI
-	{runeRange{0xC2C1, 0xC2DB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SYIG..HANGUL SYLLABLE SYIH
-	{runeRange{0xC2DC, 0xC2DC}, prLV},                     // Lo       HANGUL SYLLABLE SI
-	{runeRange{0xC2DD, 0xC2F7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SIG..HANGUL SYLLABLE SIH
-	{runeRange{0xC2F8, 0xC2F8}, prLV},                     // Lo       HANGUL SYLLABLE SSA
-	{runeRange{0xC2F9, 0xC313}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSAG..HANGUL SYLLABLE SSAH
-	{runeRange{0xC314, 0xC314}, prLV},                     // Lo       HANGUL SYLLABLE SSAE
-	{runeRange{0xC315, 0xC32F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSAEG..HANGUL SYLLABLE SSAEH
-	{runeRange{0xC330, 0xC330}, prLV},                     // Lo       HANGUL SYLLABLE SSYA
-	{runeRange{0xC331, 0xC34B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSYAG..HANGUL SYLLABLE SSYAH
-	{runeRange{0xC34C, 0xC34C}, prLV},                     // Lo       HANGUL SYLLABLE SSYAE
-	{runeRange{0xC34D, 0xC367}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSYAEG..HANGUL SYLLABLE SSYAEH
-	{runeRange{0xC368, 0xC368}, prLV},                     // Lo       HANGUL SYLLABLE SSEO
-	{runeRange{0xC369, 0xC383}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSEOG..HANGUL SYLLABLE SSEOH
-	{runeRange{0xC384, 0xC384}, prLV},                     // Lo       HANGUL SYLLABLE SSE
-	{runeRange{0xC385, 0xC39F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSEG..HANGUL SYLLABLE SSEH
-	{runeRange{0xC3A0, 0xC3A0}, prLV},                     // Lo       HANGUL SYLLABLE SSYEO
-	{runeRange{0xC3A1, 0xC3BB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSYEOG..HANGUL SYLLABLE SSYEOH
-	{runeRange{0xC3BC, 0xC3BC}, prLV},                     // Lo       HANGUL SYLLABLE SSYE
-	{runeRange{0xC3BD, 0xC3D7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSYEG..HANGUL SYLLABLE SSYEH
-	{runeRange{0xC3D8, 0xC3D8}, prLV},                     // Lo       HANGUL SYLLABLE SSO
-	{runeRange{0xC3D9, 0xC3F3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSOG..HANGUL SYLLABLE SSOH
-	{runeRange{0xC3F4, 0xC3F4}, prLV},                     // Lo       HANGUL SYLLABLE SSWA
-	{runeRange{0xC3F5, 0xC40F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSWAG..HANGUL SYLLABLE SSWAH
-	{runeRange{0xC410, 0xC410}, prLV},                     // Lo       HANGUL SYLLABLE SSWAE
-	{runeRange{0xC411, 0xC42B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSWAEG..HANGUL SYLLABLE SSWAEH
-	{runeRange{0xC42C, 0xC42C}, prLV},                     // Lo       HANGUL SYLLABLE SSOE
-	{runeRange{0xC42D, 0xC447}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSOEG..HANGUL SYLLABLE SSOEH
-	{runeRange{0xC448, 0xC448}, prLV},                     // Lo       HANGUL SYLLABLE SSYO
-	{runeRange{0xC449, 0xC463}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSYOG..HANGUL SYLLABLE SSYOH
-	{runeRange{0xC464, 0xC464}, prLV},                     // Lo       HANGUL SYLLABLE SSU
-	{runeRange{0xC465, 0xC47F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSUG..HANGUL SYLLABLE SSUH
-	{runeRange{0xC480, 0xC480}, prLV},                     // Lo       HANGUL SYLLABLE SSWEO
-	{runeRange{0xC481, 0xC49B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSWEOG..HANGUL SYLLABLE SSWEOH
-	{runeRange{0xC49C, 0xC49C}, prLV},                     // Lo       HANGUL SYLLABLE SSWE
-	{runeRange{0xC49D, 0xC4B7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSWEG..HANGUL SYLLABLE SSWEH
-	{runeRange{0xC4B8, 0xC4B8}, prLV},                     // Lo       HANGUL SYLLABLE SSWI
-	{runeRange{0xC4B9, 0xC4D3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSWIG..HANGUL SYLLABLE SSWIH
-	{runeRange{0xC4D4, 0xC4D4}, prLV},                     // Lo       HANGUL SYLLABLE SSYU
-	{runeRange{0xC4D5, 0xC4EF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSYUG..HANGUL SYLLABLE SSYUH
-	{runeRange{0xC4F0, 0xC4F0}, prLV},                     // Lo       HANGUL SYLLABLE SSEU
-	{runeRange{0xC4F1, 0xC50B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSEUG..HANGUL SYLLABLE SSEUH
-	{runeRange{0xC50C, 0xC50C}, prLV},                     // Lo       HANGUL SYLLABLE SSYI
-	{runeRange{0xC50D, 0xC527}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSYIG..HANGUL SYLLABLE SSYIH
-	{runeRange{0xC528, 0xC528}, prLV},                     // Lo       HANGUL SYLLABLE SSI
-	{runeRange{0xC529, 0xC543}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSIG..HANGUL SYLLABLE SSIH
-	{runeRange{0xC544, 0xC544}, prLV},                     // Lo       HANGUL SYLLABLE A
-	{runeRange{0xC545, 0xC55F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE AG..HANGUL SYLLABLE AH
-	{runeRange{0xC560, 0xC560}, prLV},                     // Lo       HANGUL SYLLABLE AE
-	{runeRange{0xC561, 0xC57B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE AEG..HANGUL SYLLABLE AEH
-	{runeRange{0xC57C, 0xC57C}, prLV},                     // Lo       HANGUL SYLLABLE YA
-	{runeRange{0xC57D, 0xC597}, prLVT},                    // Lo  [27] HANGUL SYLLABLE YAG..HANGUL SYLLABLE YAH
-	{runeRange{0xC598, 0xC598}, prLV},                     // Lo       HANGUL SYLLABLE YAE
-	{runeRange{0xC599, 0xC5B3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE YAEG..HANGUL SYLLABLE YAEH
-	{runeRange{0xC5B4, 0xC5B4}, prLV},                     // Lo       HANGUL SYLLABLE EO
-	{runeRange{0xC5B5, 0xC5CF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE EOG..HANGUL SYLLABLE EOH
-	{runeRange{0xC5D0, 0xC5D0}, prLV},                     // Lo       HANGUL SYLLABLE E
-	{runeRange{0xC5D1, 0xC5EB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE EG..HANGUL SYLLABLE EH
-	{runeRange{0xC5EC, 0xC5EC}, prLV},                     // Lo       HANGUL SYLLABLE YEO
-	{runeRange{0xC5ED, 0xC607}, prLVT},                    // Lo  [27] HANGUL SYLLABLE YEOG..HANGUL SYLLABLE YEOH
-	{runeRange{0xC608, 0xC608}, prLV},                     // Lo       HANGUL SYLLABLE YE
-	{runeRange{0xC609, 0xC623}, prLVT},                    // Lo  [27] HANGUL SYLLABLE YEG..HANGUL SYLLABLE YEH
-	{runeRange{0xC624, 0xC624}, prLV},                     // Lo       HANGUL SYLLABLE O
-	{runeRange{0xC625, 0xC63F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE OG..HANGUL SYLLABLE OH
-	{runeRange{0xC640, 0xC640}, prLV},                     // Lo       HANGUL SYLLABLE WA
-	{runeRange{0xC641, 0xC65B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE WAG..HANGUL SYLLABLE WAH
-	{runeRange{0xC65C, 0xC65C}, prLV},                     // Lo       HANGUL SYLLABLE WAE
-	{runeRange{0xC65D, 0xC677}, prLVT},                    // Lo  [27] HANGUL SYLLABLE WAEG..HANGUL SYLLABLE WAEH
-	{runeRange{0xC678, 0xC678}, prLV},                     // Lo       HANGUL SYLLABLE OE
-	{runeRange{0xC679, 0xC693}, prLVT},                    // Lo  [27] HANGUL SYLLABLE OEG..HANGUL SYLLABLE OEH
-	{runeRange{0xC694, 0xC694}, prLV},                     // Lo       HANGUL SYLLABLE YO
-	{runeRange{0xC695, 0xC6AF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE YOG..HANGUL SYLLABLE YOH
-	{runeRange{0xC6B0, 0xC6B0}, prLV},                     // Lo       HANGUL SYLLABLE U
-	{runeRange{0xC6B1, 0xC6CB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE UG..HANGUL SYLLABLE UH
-	{runeRange{0xC6CC, 0xC6CC}, prLV},                     // Lo       HANGUL SYLLABLE WEO
-	{runeRange{0xC6CD, 0xC6E7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE WEOG..HANGUL SYLLABLE WEOH
-	{runeRange{0xC6E8, 0xC6E8}, prLV},                     // Lo       HANGUL SYLLABLE WE
-	{runeRange{0xC6E9, 0xC703}, prLVT},                    // Lo  [27] HANGUL SYLLABLE WEG..HANGUL SYLLABLE WEH
-	{runeRange{0xC704, 0xC704}, prLV},                     // Lo       HANGUL SYLLABLE WI
-	{runeRange{0xC705, 0xC71F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE WIG..HANGUL SYLLABLE WIH
-	{runeRange{0xC720, 0xC720}, prLV},                     // Lo       HANGUL SYLLABLE YU
-	{runeRange{0xC721, 0xC73B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE YUG..HANGUL SYLLABLE YUH
-	{runeRange{0xC73C, 0xC73C}, prLV},                     // Lo       HANGUL SYLLABLE EU
-	{runeRange{0xC73D, 0xC757}, prLVT},                    // Lo  [27] HANGUL SYLLABLE EUG..HANGUL SYLLABLE EUH
-	{runeRange{0xC758, 0xC758}, prLV},                     // Lo       HANGUL SYLLABLE YI
-	{runeRange{0xC759, 0xC773}, prLVT},                    // Lo  [27] HANGUL SYLLABLE YIG..HANGUL SYLLABLE YIH
-	{runeRange{0xC774, 0xC774}, prLV},                     // Lo       HANGUL SYLLABLE I
-	{runeRange{0xC775, 0xC78F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE IG..HANGUL SYLLABLE IH
-	{runeRange{0xC790, 0xC790}, prLV},                     // Lo       HANGUL SYLLABLE JA
-	{runeRange{0xC791, 0xC7AB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JAG..HANGUL SYLLABLE JAH
-	{runeRange{0xC7AC, 0xC7AC}, prLV},                     // Lo       HANGUL SYLLABLE JAE
-	{runeRange{0xC7AD, 0xC7C7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JAEG..HANGUL SYLLABLE JAEH
-	{runeRange{0xC7C8, 0xC7C8}, prLV},                     // Lo       HANGUL SYLLABLE JYA
-	{runeRange{0xC7C9, 0xC7E3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JYAG..HANGUL SYLLABLE JYAH
-	{runeRange{0xC7E4, 0xC7E4}, prLV},                     // Lo       HANGUL SYLLABLE JYAE
-	{runeRange{0xC7E5, 0xC7FF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JYAEG..HANGUL SYLLABLE JYAEH
-	{runeRange{0xC800, 0xC800}, prLV},                     // Lo       HANGUL SYLLABLE JEO
-	{runeRange{0xC801, 0xC81B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JEOG..HANGUL SYLLABLE JEOH
 	{runeRange{0xC81C, 0xC81C}, prLV},                     // Lo       HANGUL SYLLABLE JE
-	{runeRange{0xC81D, 0xC837}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JEG..HANGUL SYLLABLE JEH
-	{runeRange{0xC838, 0xC838}, prLV},                     // Lo       HANGUL SYLLABLE JYEO
-	{runeRange{0xC839, 0xC853}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JYEOG..HANGUL SYLLABLE JYEOH
-	{runeRange{0xC854, 0xC854}, prLV},                     // Lo       HANGUL SYLLABLE JYE
-	{runeRange{0xC855, 0xC86F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JYEG..HANGUL SYLLABLE JYEH
-	{runeRange{0xC870, 0xC870}, prLV},                     // Lo       HANGUL SYLLABLE JO
-	{runeRange{0xC871, 0xC88B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JOG..HANGUL SYLLABLE JOH
-	{runeRange{0xC88C, 0xC88C}, prLV},                     // Lo       HANGUL SYLLABLE JWA
-	{runeRange{0xC88D, 0xC8A7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JWAG..HANGUL SYLLABLE JWAH
-	{runeRange{0xC8A8, 0xC8A8}, prLV},                     // Lo       HANGUL SYLLABLE JWAE
-	{runeRange{0xC8A9, 0xC8C3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JWAEG..HANGUL SYLLABLE JWAEH
-	{runeRange{0xC8C4, 0xC8C4}, prLV},                     // Lo       HANGUL SYLLABLE JOE
-	{runeRange{0xC8C5, 0xC8DF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JOEG..HANGUL SYLLABLE JOEH
-	{runeRange{0xC8E0, 0xC8E0}, prLV},                     // Lo       HANGUL SYLLABLE JYO
-	{runeRange{0xC8E1, 0xC8FB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JYOG..HANGUL SYLLABLE JYOH
-	{runeRange{0xC8FC, 0xC8FC}, prLV},                     // Lo       HANGUL SYLLABLE JU
-	{runeRange{0xC8FD, 0xC917}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JUG..HANGUL SYLLABLE JUH
-	{runeRange{0xC918, 0xC918}, prLV},                     // Lo       HANGUL SYLLABLE JWEO
-	{runeRange{0xC919, 0xC933}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JWEOG..HANGUL SYLLABLE JWEOH
-	{runeRange{0xC934, 0xC934}, prLV},                     // Lo       HANGUL SYLLABLE JWE
-	{runeRange{0xC935, 0xC94F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JWEG..HANGUL SYLLABLE JWEH
-	{runeRange{0xC950, 0xC950}, prLV},                     // Lo       HANGUL SYLLABLE JWI
-	{runeRange{0xC951, 0xC96B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JWIG..HANGUL SYLLABLE JWIH
-	{runeRange{0xC96C, 0xC96C}, prLV},                     // Lo       HANGUL SYLLABLE JYU
-	{runeRange{0xC96D, 0xC987}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JYUG..HANGUL SYLLABLE JYUH
-	{runeRange{0xC988, 0xC988}, prLV},                     // Lo       HANGUL SYLLABLE JEU
-	{runeRange{0xC989, 0xC9A3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JEUG..HANGUL SYLLABLE JEUH
-	{runeRange{0xC9A4, 0xC9A4}, prLV},                     // Lo       HANGUL SYLLABLE JYI
-	{runeRange{0xC9A5, 0xC9BF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JYIG..HANGUL SYLLABLE JYIH
-	{runeRange{0xC9C0, 0xC9C0}, prLV},                     // Lo       HANGUL SYLLABLE JI
-	{runeRange{0xC9C1, 0xC9DB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JIG..HANGUL SYLLABLE JIH
-	{runeRange{0xC9DC, 0xC9DC}, prLV},                     // Lo       HANGUL SYLLABLE JJA
-	{runeRange{0xC9DD, 0xC9F7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJAG..HANGUL SYLLABLE JJAH
-	{runeRange{0xC9F8, 0xC9F8}, prLV},                     // Lo       HANGUL SYLLABLE JJAE
-	{runeRange{0xC9F9, 0xCA13}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJAEG..HANGUL SYLLABLE JJAEH
-	{runeRange{0xCA14, 0xCA14}, prLV},                     // Lo       HANGUL SYLLABLE JJYA
-	{runeRange{0xCA15, 0xCA2F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJYAG..HANGUL SYLLABLE JJYAH
-	{runeRange{0xCA30, 0xCA30}, prLV},                     // Lo       HANGUL SYLLABLE JJYAE
-	{runeRange{0xCA31, 0xCA4B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJYAEG..HANGUL SYLLABLE JJYAEH
-	{runeRange{0xCA4C, 0xCA4C}, prLV},                     // Lo       HANGUL SYLLABLE JJEO
-	{runeRange{0xCA4D, 0xCA67}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJEOG..HANGUL SYLLABLE JJEOH
-	{runeRange{0xCA68, 0xCA68}, prLV},                     // Lo       HANGUL SYLLABLE JJE
-	{runeRange{0xCA69, 0xCA83}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJEG..HANGUL SYLLABLE JJEH
-	{runeRange{0xCA84, 0xCA84}, prLV},                     // Lo       HANGUL SYLLABLE JJYEO
-	{runeRange{0xCA85, 0xCA9F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJYEOG..HANGUL SYLLABLE JJYEOH
-	{runeRange{0xCAA0, 0xCAA0}, prLV},                     // Lo       HANGUL SYLLABLE JJYE
-	{runeRange{0xCAA1, 0xCABB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJYEG..HANGUL SYLLABLE JJYEH
-	{runeRange{0xCABC, 0xCABC}, prLV},                     // Lo       HANGUL SYLLABLE JJO
-	{runeRange{0xCABD, 0xCAD7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJOG..HANGUL SYLLABLE JJOH
-	{runeRange{0xCAD8, 0xCAD8}, prLV},                     // Lo       HANGUL SYLLABLE JJWA
-	{runeRange{0xCAD9, 0xCAF3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJWAG..HANGUL SYLLABLE JJWAH
-	{runeRange{0xCAF4, 0xCAF4}, prLV},                     // Lo       HANGUL SYLLABLE JJWAE
-	{runeRange{0xCAF5, 0xCB0F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJWAEG..HANGUL SYLLABLE JJWAEH
-	{runeRange{0xCB10, 0xCB10}, prLV},                     // Lo       HANGUL SYLLABLE JJOE
-	{runeRange{0xCB11, 0xCB2B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJOEG..HANGUL SYLLABLE JJOEH
-	{runeRange{0xCB2C, 0xCB2C}, prLV},                     // Lo       HANGUL SYLLABLE JJYO
-	{runeRange{0xCB2D, 0xCB47}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJYOG..HANGUL SYLLABLE JJYOH
-	{runeRange{0xCB48, 0xCB48}, prLV},                     // Lo       HANGUL SYLLABLE JJU
-	{runeRange{0xCB49, 0xCB63}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJUG..HANGUL SYLLABLE JJUH
-	{runeRange{0xCB64, 0xCB64}, prLV},                     // Lo       HANGUL SYLLABLE JJWEO
-	{runeRange{0xCB65, 0xCB7F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJWEOG..HANGUL SYLLABLE JJWEOH
-	{runeRange{0xCB80, 0xCB80}, prLV},                     // Lo       HANGUL SYLLABLE JJWE
-	{runeRange{0xCB81, 0xCB9B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJWEG..HANGUL SYLLABLE JJWEH
-	{runeRange{0xCB9C, 0xCB9C}, prLV},                     // Lo       HANGUL SYLLABLE JJWI
-	{runeRange{0xCB9D, 0xCBB7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJWIG..HANGUL SYLLABLE JJWIH
-	{runeRange{0xCBB8, 0xCBB8}, prLV},                     // Lo       HANGUL SYLLABLE JJYU
-	{runeRange{0xCBB9, 0xCBD3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJYUG..HANGUL SYLLABLE JJYUH
-	{runeRange{0xCBD4, 0xCBD4}, prLV},                     // Lo       HANGUL SYLLABLE JJEU
-	{runeRange{0xCBD5, 0xCBEF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJEUG..HANGUL SYLLABLE JJEUH
-	{runeRange{0xCBF0, 0xCBF0}, prLV},                     // Lo       HANGUL SYLLABLE JJYI
-	{runeRange{0xCBF1, 0xCC0B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJYIG..HANGUL SYLLABLE JJYIH
-	{runeRange{0xCC0C, 0xCC0C}, prLV},                     // Lo       HANGUL SYLLABLE JJI
-	{runeRange{0xCC0D, 0xCC27}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJIG..HANGUL SYLLABLE JJIH
-	{runeRange{0xCC28, 0xCC28}, prLV},                     // Lo       HANGUL SYLLABLE CA
-	{runeRange{0xCC29, 0xCC43}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CAG..HANGUL SYLLABLE CAH
-	{runeRange{0xCC44, 0xCC44}, prLV},                     // Lo       HANGUL SYLLABLE CAE
-	{runeRange{0xCC45, 0xCC5F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CAEG..HANGUL SYLLABLE CAEH
-	{runeRange{0xCC60, 0xCC60}, prLV},                     // Lo       HANGUL SYLLABLE CYA
-	{runeRange{0xCC61, 0xCC7B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CYAG..HANGUL SYLLABLE CYAH
-	{runeRange{0xCC7C, 0xCC7C}, prLV},                     // Lo       HANGUL SYLLABLE CYAE
-	{runeRange{0xCC7D, 0xCC97}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CYAEG..HANGUL SYLLABLE CYAEH
-	{runeRange{0xCC98, 0xCC98}, prLV},                     // Lo       HANGUL SYLLABLE CEO
-	{runeRange{0xCC99, 0xCCB3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CEOG..HANGUL SYLLABLE CEOH
-	{runeRange{0xCCB4, 0xCCB4}, prLV},                     // Lo       HANGUL SYLLABLE CE
-	{runeRange{0xCCB5, 0xCCCF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CEG..HANGUL SYLLABLE CEH
-	{runeRange{0xCCD0, 0xCCD0}, prLV},                     // Lo       HANGUL SYLLABLE CYEO
-	{runeRange{0xCCD1, 0xCCEB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CYEOG..HANGUL SYLLABLE CYEOH
-	{runeRange{0xCCEC, 0xCCEC}, prLV},                     // Lo       HANGUL SYLLABLE CYE
-	{runeRange{0xCCED, 0xCD07}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CYEG..HANGUL SYLLABLE CYEH
-	{runeRange{0xCD08, 0xCD08}, prLV},                     // Lo       HANGUL SYLLABLE CO
-	{runeRange{0xCD09, 0xCD23}, prLVT},                    // Lo  [27] HANGUL SYLLABLE COG..HANGUL SYLLABLE COH
-	{runeRange{0xCD24, 0xCD24}, prLV},                     // Lo       HANGUL SYLLABLE CWA
-	{runeRange{0xCD25, 0xCD3F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CWAG..HANGUL SYLLABLE CWAH
-	{runeRange{0xCD40, 0xCD40}, prLV},                     // Lo       HANGUL SYLLABLE CWAE
-	{runeRange{0xCD41, 0xCD5B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CWAEG..HANGUL SYLLABLE CWAEH
-	{runeRange{0xCD5C, 0xCD5C}, prLV},                     // Lo       HANGUL SYLLABLE COE
-	{runeRange{0xCD5D, 0xCD77}, prLVT},                    // Lo  [27] HANGUL SYLLABLE COEG..HANGUL SYLLABLE COEH
-	{runeRange{0xCD78, 0xCD78}, prLV},                     // Lo       HANGUL SYLLABLE CYO
-	{runeRange{0xCD79, 0xCD93}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CYOG..HANGUL SYLLABLE CYOH
-	{runeRange{0xCD94, 0xCD94}, prLV},                     // Lo       HANGUL SYLLABLE CU
-	{runeRange{0xCD95, 0xCDAF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CUG..HANGUL SYLLABLE CUH
-	{runeRange{0xCDB0, 0xCDB0}, prLV},                     // Lo       HANGUL SYLLABLE CWEO
-	{runeRange{0xCDB1, 0xCDCB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CWEOG..HANGUL SYLLABLE CWEOH
-	{runeRange{0xCDCC, 0xCDCC}, prLV},                     // Lo       HANGUL SYLLABLE CWE
-	{runeRange{0xCDCD, 0xCDE7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CWEG..HANGUL SYLLABLE CWEH
-	{runeRange{0xCDE8, 0xCDE8}, prLV},                     // Lo       HANGUL SYLLABLE CWI
-	{runeRange{0xCDE9, 0xCE03}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CWIG..HANGUL SYLLABLE CWIH
-	{runeRange{0xCE04, 0xCE04}, prLV},                     // Lo       HANGUL SYLLABLE CYU
-	{runeRange{0xCE05, 0xCE1F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CYUG..HANGUL SYLLABLE CYUH
-	{runeRange{0xCE20, 0xCE20}, prLV},                     // Lo       HANGUL SYLLABLE CEU
-	{runeRange{0xCE21, 0xCE3B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CEUG..HANGUL SYLLABLE CEUH
-	{runeRange{0xCE3C, 0xCE3C}, prLV},                     // Lo       HANGUL SYLLABLE CYI
-	{runeRange{0xCE3D, 0xCE57}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CYIG..HANGUL SYLLABLE CYIH
-	{runeRange{0xCE58, 0xCE58}, prLV},                     // Lo       HANGUL SYLLABLE CI
-	{runeRange{0xCE59, 0xCE73}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CIG..HANGUL SYLLABLE CIH
-	{runeRange{0xCE74, 0xCE74}, prLV},                     // Lo       HANGUL SYLLABLE KA
-	{runeRange{0xCE75, 0xCE8F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KAG..HANGUL SYLLABLE KAH
-	{runeRange{0xCE90, 0xCE90}, prLV},                     // Lo       HANGUL SYLLABLE KAE
-	{runeRange{0xCE91, 0xCEAB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KAEG..HANGUL SYLLABLE KAEH
-	{runeRange{0xCEAC, 0xCEAC}, prLV},                     // Lo       HANGUL SYLLABLE KYA
-	{runeRange{0xCEAD, 0xCEC7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KYAG..HANGUL SYLLABLE KYAH
-	{runeRange{0xCEC8, 0xCEC8}, prLV},                     // Lo       HANGUL SYLLABLE KYAE
-	{runeRange{0xCEC9, 0xCEE3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KYAEG..HANGUL SYLLABLE KYAEH
-	{runeRange{0xCEE4, 0xCEE4}, prLV},                     // Lo       HANGUL SYLLABLE KEO
-	{runeRange{0xCEE5, 0xCEFF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KEOG..HANGUL SYLLABLE KEOH
-	{runeRange{0xCF00, 0xCF00}, prLV},                     // Lo       HANGUL SYLLABLE KE
-	{runeRange{0xCF01, 0xCF1B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KEG..HANGUL SYLLABLE KEH
-	{runeRange{0xCF1C, 0xCF1C}, prLV},                     // Lo       HANGUL SYLLABLE KYEO
-	{runeRange{0xCF1D, 0xCF37}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KYEOG..HANGUL SYLLABLE KYEOH
-	{runeRange{0xCF38, 0xCF38}, prLV},                     // Lo       HANGUL SYLLABLE KYE
-	{runeRange{0xCF39, 0xCF53}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KYEG..HANGUL SYLLABLE KYEH
-	{runeRange{0xCF54, 0xCF54}, prLV},                     // Lo       HANGUL SYLLABLE KO
-	{runeRange{0xCF55, 0xCF6F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KOG..HANGUL SYLLABLE KOH
-	{runeRange{0xCF70, 0xCF70}, prLV},                     // Lo       HANGUL SYLLABLE KWA
-	{runeRange{0xCF71, 0xCF8B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KWAG..HANGUL SYLLABLE KWAH
-	{runeRange{0xCF8C, 0xCF8C}, prLV},                     // Lo       HANGUL SYLLABLE KWAE
-	{runeRange{0xCF8D, 0xCFA7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KWAEG..HANGUL SYLLABLE KWAEH
-	{runeRange{0xCFA8, 0xCFA8}, prLV},                     // Lo       HANGUL SYLLABLE KOE
-	{runeRange{0xCFA9, 0xCFC3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KOEG..HANGUL SYLLABLE KOEH
-	{runeRange{0xCFC4, 0xCFC4}, prLV},                     // Lo       HANGUL SYLLABLE KYO
-	{runeRange{0xCFC5, 0xCFDF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KYOG..HANGUL SYLLABLE KYOH
-	{runeRange{0xCFE0, 0xCFE0}, prLV},                     // Lo       HANGUL SYLLABLE KU
-	{runeRange{0xCFE1, 0xCFFB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KUG..HANGUL SYLLABLE KUH
-	{runeRange{0xCFFC, 0xCFFC}, prLV},                     // Lo       HANGUL SYLLABLE KWEO
-	{runeRange{0xCFFD, 0xD017}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KWEOG..HANGUL SYLLABLE KWEOH
-	{runeRange{0xD018, 0xD018}, prLV},                     // Lo       HANGUL SYLLABLE KWE
-	{runeRange{0xD019, 0xD033}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KWEG..HANGUL SYLLABLE KWEH
-	{runeRange{0xD034, 0xD034}, prLV},                     // Lo       HANGUL SYLLABLE KWI
-	{runeRange{0xD035, 0xD04F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KWIG..HANGUL SYLLABLE KWIH
-	{runeRange{0xD050, 0xD050}, prLV},                     // Lo       HANGUL SYLLABLE KYU
-	{runeRange{0xD051, 0xD06B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KYUG..HANGUL SYLLABLE KYUH
-	{runeRange{0xD06C, 0xD06C}, prLV},                     // Lo       HANGUL SYLLABLE KEU
-	{runeRange{0xD06D, 0xD087}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KEUG..HANGUL SYLLABLE KEUH
-	{runeRange{0xD088, 0xD088}, prLV},                     // Lo       HANGUL SYLLABLE KYI
-	{runeRange{0xD089, 0xD0A3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KYIG..HANGUL SYLLABLE KYIH
-	{runeRange{0xD0A4, 0xD0A4}, prLV},                     // Lo       HANGUL SYLLABLE KI
-	{runeRange{0xD0A5, 0xD0BF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KIG..HANGUL SYLLABLE KIH
-	{runeRange{0xD0C0, 0xD0C0}, prLV},                     // Lo       HANGUL SYLLABLE TA
-	{runeRange{0xD0C1, 0xD0DB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TAG..HANGUL SYLLABLE TAH
-	{runeRange{0xD0DC, 0xD0DC}, prLV},                     // Lo       HANGUL SYLLABLE TAE
-	{runeRange{0xD0DD, 0xD0F7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TAEG..HANGUL SYLLABLE TAEH
-	{runeRange{0xD0F8, 0xD0F8}, prLV},                     // Lo       HANGUL SYLLABLE TYA
-	{runeRange{0xD0F9, 0xD113}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TYAG..HANGUL SYLLABLE TYAH
-	{runeRange{0xD114, 0xD114}, prLV},                     // Lo       HANGUL SYLLABLE TYAE
-	{runeRange{0xD115, 0xD12F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TYAEG..HANGUL SYLLABLE TYAEH
-	{runeRange{0xD130, 0xD130}, prLV},                     // Lo       HANGUL SYLLABLE TEO
-	{runeRange{0xD131, 0xD14B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TEOG..HANGUL SYLLABLE TEOH
-	{runeRange{0xD14C, 0xD14C}, prLV},                     // Lo       HANGUL SYLLABLE TE
-	{runeRange{0xD14D, 0xD167}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TEG..HANGUL SYLLABLE TEH
-	{runeRange{0xD168, 0xD168}, prLV},                     // Lo       HANGUL SYLLABLE TYEO
-	{runeRange{0xD169, 0xD183}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TYEOG..HANGUL SYLLABLE TYEOH
-	{runeRange{0xD184, 0xD184}, prLV},                     // Lo       HANGUL SYLLABLE TYE
-	{runeRange{0xD185, 0xD19F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TYEG..HANGUL SYLLABLE TYEH
-	{runeRange{0xD1A0, 0xD1A0}, prLV},                     // Lo       HANGUL SYLLABLE TO
-	{runeRange{0xD1A1, 0xD1BB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TOG..HANGUL SYLLABLE TOH
-	{runeRange{0xD1BC, 0xD1BC}, prLV},                     // Lo       HANGUL SYLLABLE TWA
-	{runeRange{0xD1BD, 0xD1D7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TWAG..HANGUL SYLLABLE TWAH
-	{runeRange{0xD1D8, 0xD1D8}, prLV},                     // Lo       HANGUL SYLLABLE TWAE
-	{runeRange{0xD1D9, 0xD1F3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TWAEG..HANGUL SYLLABLE TWAEH
-	{runeRange{0xD1F4, 0xD1F4}, prLV},                     // Lo       HANGUL SYLLABLE TOE
-	{runeRange{0xD1F5, 0xD20F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TOEG..HANGUL SYLLABLE TOEH
-	{runeRange{0xD210, 0xD210}, prLV},                     // Lo       HANGUL SYLLABLE TYO
-	{runeRange{0xD211, 0xD22B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TYOG..HANGUL SYLLABLE TYOH
-	{runeRange{0xD22C, 0xD22C}, prLV},                     // Lo       HANGUL SYLLABLE TU
-	{runeRange{0xD22D, 0xD247}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TUG..HANGUL SYLLABLE TUH
-	{runeRange{0xD248, 0xD248}, prLV},                     // Lo       HANGUL SYLLABLE TWEO
-	{runeRange{0xD249, 0xD263}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TWEOG..HANGUL SYLLABLE TWEOH
-	{runeRange{0xD264, 0xD264}, prLV},                     // Lo       HANGUL SYLLABLE TWE
-	{runeRange{0xD265, 0xD27F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TWEG..HANGUL SYLLABLE TWEH
-	{runeRange{0xD280, 0xD280}, prLV},                     // Lo       HANGUL SYLLABLE TWI
-	{runeRange{0xD281, 0xD29B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TWIG..HANGUL SYLLABLE TWIH
-	{runeRange{0xD29C, 0xD29C}, prLV},                     // Lo       HANGUL SYLLABLE TYU
-	{runeRange{0xD29D, 0xD2B7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TYUG..HANGUL SYLLABLE TYUH
-	{runeRange{0xD2B8, 0xD2B8}, prLV},                     // Lo       HANGUL SYLLABLE TEU
-	{runeRange{0xD2B9, 0xD2D3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TEUG..HANGUL SYLLABLE TEUH
-	{runeRange{0xD2D4, 0xD2D4}, prLV},                     // Lo       HANGUL SYLLABLE TYI
-	{runeRange{0xD2D5, 0xD2EF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TYIG..HANGUL SYLLABLE TYIH
-	{runeRange{0xD2F0, 0xD2F0}, prLV},                     // Lo       HANGUL SYLLABLE TI
-	{runeRange{0xD2F1, 0xD30B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TIG..HANGUL SYLLABLE TIH
-	{runeRange{0xD30C, 0xD30C}, prLV},                     // Lo       HANGUL SYLLABLE PA
-	{runeRange{0xD30D, 0xD327}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PAG..HANGUL SYLLABLE PAH
-	{runeRange{0xD328, 0xD328}, prLV},                     // Lo       HANGUL SYLLABLE PAE
-	{runeRange{0xD329, 0xD343}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PAEG..HANGUL SYLLABLE PAEH
-	{runeRange{0xD344, 0xD344}, prLV},                     // Lo       HANGUL SYLLABLE PYA
-	{runeRange{0xD345, 0xD35F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PYAG..HANGUL SYLLABLE PYAH
-	{runeRange{0xD360, 0xD360}, prLV},                     // Lo       HANGUL SYLLABLE PYAE
-	{runeRange{0xD361, 0xD37B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PYAEG..HANGUL SYLLABLE PYAEH
-	{runeRange{0xD37C, 0xD37C}, prLV},                     // Lo       HANGUL SYLLABLE PEO
-	{runeRange{0xD37D, 0xD397}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PEOG..HANGUL SYLLABLE PEOH
-	{runeRange{0xD398, 0xD398}, prLV},                     // Lo       HANGUL SYLLABLE PE
-	{runeRange{0xD399, 0xD3B3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PEG..HANGUL SYLLABLE PEH
-	{runeRange{0xD3B4, 0xD3B4}, prLV},                     // Lo       HANGUL SYLLABLE PYEO
-	{runeRange{0xD3B5, 0xD3CF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PYEOG..HANGUL SYLLABLE PYEOH
-	{runeRange{0xD3D0, 0xD3D0}, prLV},                     // Lo       HANGUL SYLLABLE PYE
-	{runeRange{0xD3D1, 0xD3EB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PYEG..HANGUL SYLLABLE PYEH
-	{runeRange{0xD3EC, 0xD3EC}, prLV},                     // Lo       HANGUL SYLLABLE PO
-	{runeRange{0xD3ED, 0xD407}, prLVT},                    // Lo  [27] HANGUL SYLLABLE POG..HANGUL SYLLABLE POH
-	{runeRange{0xD408, 0xD408}, prLV},                     // Lo       HANGUL SYLLABLE PWA
-	{runeRange{0xD409, 0xD423}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PWAG..HANGUL SYLLABLE PWAH
-	{runeRange{0xD424, 0xD424}, prLV},                     // Lo       HANGUL SYLLABLE PWAE
-	{runeRange{0xD425, 0xD43F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PWAEG..HANGUL SYLLABLE PWAEH
-	{runeRange{0xD440, 0xD440}, prLV},                     // Lo       HANGUL SYLLABLE POE
-	{runeRange{0xD441, 0xD45B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE POEG..HANGUL SYLLABLE POEH
-	{runeRange{0xD45C, 0xD45C}, prLV},                     // Lo       HANGUL SYLLABLE PYO
-	{runeRange{0xD45D, 0xD477}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PYOG..HANGUL SYLLABLE PYOH
-	{runeRange{0xD478, 0xD478}, prLV},                     // Lo       HANGUL SYLLABLE PU
-	{runeRange{0xD479, 0xD493}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PUG..HANGUL SYLLABLE PUH
-	{runeRange{0xD494, 0xD494}, prLV},                     // Lo       HANGUL SYLLABLE PWEO
-	{runeRange{0xD495, 0xD4AF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PWEOG..HANGUL SYLLABLE PWEOH
-	{runeRange{0xD4B0, 0xD4B0}, prLV},                     // Lo       HANGUL SYLLABLE PWE
-	{runeRange{0xD4B1, 0xD4CB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PWEG..HANGUL SYLLABLE PWEH
-	{runeRange{0xD4CC, 0xD4CC}, prLV},                     // Lo       HANGUL SYLLABLE PWI
-	{runeRange{0xD4CD, 0xD4E7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PWIG..HANGUL SYLLABLE PWIH
-	{runeRange{0xD4E8, 0xD4E8}, prLV},                     // Lo       HANGUL SYLLABLE PYU
-	{runeRange{0xD4E9, 0xD503}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PYUG..HANGUL SYLLABLE PYUH
-	{runeRange{0xD504, 0xD504}, prLV},                     // Lo       HANGUL SYLLABLE PEU
-	{runeRange{0xD505, 0xD51F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PEUG..HANGUL SYLLABLE PEUH
-	{runeRange{0xD520, 0xD520}, prLV},                     // Lo       HANGUL SYLLABLE PYI
-	{runeRange{0xD521, 0xD53B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PYIG..HANGUL SYLLABLE PYIH
-	{runeRange{0xD53C, 0xD53C}, prLV},                     // Lo       HANGUL SYLLABLE PI
-	{runeRange{0xD53D, 0xD557}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PIG..HANGUL SYLLABLE PIH
-	{runeRange{0xD558, 0xD558}, prLV},                     // Lo       HANGUL SYLLABLE HA
-	{runeRange{0xD559, 0xD573}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HAG..HANGUL SYLLABLE HAH
-	{runeRange{0xD574, 0xD574}, prLV},                     // Lo       HANGUL SYLLABLE HAE
-	{runeRange{0xD575, 0xD58F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HAEG..HANGUL SYLLABLE HAEH
-	{runeRange{0xD590, 0xD590}, prLV},                     // Lo       HANGUL SYLLABLE HYA
-	{runeRange{0xD591, 0xD5AB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HYAG..HANGUL SYLLABLE HYAH
-	{runeRange{0xD5AC, 0xD5AC}, prLV},                     // Lo       HANGUL SYLLABLE HYAE
-	{runeRange{0xD5AD, 0xD5C7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HYAEG..HANGUL SYLLABLE HYAEH
-	{runeRange{0xD5C8, 0xD5C8}, prLV},                     // Lo       HANGUL SYLLABLE HEO
-	{runeRange{0xD5C9, 0xD5E3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HEOG..HANGUL SYLLABLE HEOH
-	{runeRange{0xD5E4, 0xD5E4}, prLV},                     // Lo       HANGUL SYLLABLE HE
-	{runeRange{0xD5E5, 0xD5FF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HEG..HANGUL SYLLABLE HEH
-	{runeRange{0xD600, 0xD600}, prLV},                     // Lo       HANGUL SYLLABLE HYEO
-	{runeRange{0xD601, 0xD61B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HYEOG..HANGUL SYLLABLE HYEOH
-	{runeRange{0xD61C, 0xD61C}, prLV},                     // Lo       HANGUL SYLLABLE HYE
-	{runeRange{0xD61D, 0xD637}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HYEG..HANGUL SYLLABLE HYEH
-	{runeRange{0xD638, 0xD638}, prLV},                     // Lo       HANGUL SYLLABLE HO
-	{runeRange{0xD639, 0xD653}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HOG..HANGUL SYLLABLE HOH
-	{runeRange{0xD654, 0xD654}, prLV},                     // Lo       HANGUL SYLLABLE HWA
-	{runeRange{0xD655, 0xD66F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HWAG..HANGUL SYLLABLE HWAH
-	{runeRange{0xD670, 0xD670}, prLV},                     // Lo       HANGUL SYLLABLE HWAE
-	{runeRange{0xD671, 0xD68B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HWAEG..HANGUL SYLLABLE HWAEH
-	{runeRange{0xD68C, 0xD68C}, prLV},                     // Lo       HANGUL SYLLABLE HOE
-	{runeRange{0xD68D, 0xD6A7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HOEG..HANGUL SYLLABLE HOEH
-	{runeRange{0xD6A8, 0xD6A8}, prLV},                     // Lo       HANGUL SYLLABLE HYO
-	{runeRange{0xD6A9, 0xD6C3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HYOG..HANGUL SYLLABLE HYOH
-	{runeRange{0xD6C4, 0xD6C4}, prLV},                     // Lo       HANGUL SYLLABLE HU
-	{runeRange{0xD6C5, 0xD6DF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HUG..HANGUL SYLLABLE HUH
-	{runeRange{0xD6E0, 0xD6E0}, prLV},                     // Lo       HANGUL SYLLABLE HWEO
-	{runeRange{0xD6E1, 0xD6FB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HWEOG..HANGUL SYLLABLE HWEOH
-	{runeRange{0xD6FC, 0xD6FC}, prLV},                     // Lo       HANGUL SYLLABLE HWE
-	{runeRange{0xD6FD, 0xD717}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HWEG..HANGUL SYLLABLE HWEH
-	{runeRange{0xD718, 0xD718}, prLV},                     // Lo       HANGUL SYLLABLE HWI
-	{runeRange{0xD719, 0xD733}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HWIG..HANGUL SYLLABLE HWIH
-	{runeRange{0xD734, 0xD734}, prLV},                     // Lo       HANGUL SYLLABLE HYU
-	{runeRange{0xD735, 0xD74F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HYUG..HANGUL SYLLABLE HYUH
-	{runeRange{0xD750, 0xD750}, prLV},                     // Lo       HANGUL SYLLABLE HEU
-	{runeRange{0xD751, 0xD76B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HEUG..HANGUL SYLLABLE HEUH
-	{runeRange{0xD76C, 0xD76C}, prLV},                     // Lo       HANGUL SYLLABLE HYI
-	{runeRange{0xD76D, 0xD787}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HYIG..HANGUL SYLLABLE HYIH
-	{runeRange{0xD788, 0xD788}, prLV},                     // Lo       HANGUL SYLLABLE HI
-	{runeRange{0xD789, 0xD7A3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HIG..HANGUL SYLLABLE HIH
-	{runeRange{0xD7B0, 0xD7C6}, prV},                      // Lo  [23] HANGUL JUNGSEONG O-YEO..HANGUL JUNGSEONG ARAEA-E
-	{runeRange{0xD7CB, 0xD7FB}, prT},                      // Lo  [49] HANGUL JONGSEONG NIEUN-RIEUL..HANGUL JONGSEONG PHIEUPH-THIEUTH
-	{runeRange{0xFB1E, 0xFB1E}, prExtend},                 // Mn       HEBREW POINT JUDEO-SPANISH VARIKA
-	{runeRange{0xFE00, 0xFE0F}, prExtend},                 // Mn  [16] VARIATION SELECTOR-1..VARIATION SELECTOR-16
-	{runeRange{0xFE20, 0xFE2F}, prExtend},                 // Mn  [16] COMBINING LIGATURE LEFT HALF..COMBINING CYRILLIC TITLO RIGHT HALF
-	{runeRange{0xFEFF, 0xFEFF}, prControl},                // Cf       ZERO WIDTH NO-BREAK SPACE
-	{runeRange{0xFF9E, 0xFF9F}, prExtend},                 // Lm   [2] HALFWIDTH KATAKANA VOICED SOUND MARK..HALFWIDTH KATAKANA SEMI-VOICED SOUND MARK
-	{runeRange{0xFFF0, 0xFFF8}, prControl},                // Cn   [9] <reserved-FFF0>..<reserved-FFF8>
-	{runeRange{0xFFF9, 0xFFFB}, prControl},                // Cf   [3] INTERLINEAR ANNOTATION ANCHOR..INTERLINEAR ANNOTATION TERMINATOR
-	{runeRange{0x101FD, 0x101FD}, prExtend},               // Mn       PHAISTOS DISC SIGN COMBINING OBLIQUE STROKE
-	{runeRange{0x102E0, 0x102E0}, prExtend},               // Mn       COPTIC EPACT THOUSANDS MARK
-	{runeRange{0x10376, 0x1037A}, prExtend},               // Mn   [5] COMBINING OLD PERMIC LETTER AN..COMBINING OLD PERMIC LETTER SII
-	{runeRange{0x10A01, 0x10A03}, prExtend},               // Mn   [3] KHAROSHTHI VOWEL SIGN I..KHAROSHTHI VOWEL SIGN VOCALIC R
-	{runeRange{0x10A05, 0x10A06}, prExtend},               // Mn   [2] KHAROSHTHI VOWEL SIGN E..KHAROSHTHI VOWEL SIGN O
-	{runeRange{0x10A0C, 0x10A0F}, prExtend},               // Mn   [4] KHAROSHTHI VOWEL LENGTH MARK..KHAROSHTHI SIGN VISARGA
-	{runeRange{0x10A38, 0x10A3A}, prExtend},               // Mn   [3] KHAROSHTHI SIGN BAR ABOVE..KHAROSHTHI SIGN DOT BELOW
-	{runeRange{0x10A3F, 0x10A3F}, prExtend},               // Mn       KHAROSHTHI VIRAMA
-	{runeRange{0x10AE5, 0x10AE6}, prExtend},               // Mn   [2] MANICHAEAN ABBREVIATION MARK ABOVE..MANICHAEAN ABBREVIATION MARK BELOW
-	{runeRange{0x10D24, 0x10D27}, prExtend},               // Mn   [4] HANIFI ROHINGYA SIGN HARBAHAY..HANIFI ROHINGYA SIGN TASSI
-	{runeRange{0x10EAB, 0x10EAC}, prExtend},               // Mn   [2] YEZIDI COMBINING HAMZA MARK..YEZIDI COMBINING MADDA MARK
-	{runeRange{0x10EFD, 0x10EFF}, prExtend},               // Mn   [3] ARABIC SMALL LOW WORD SAKTA..ARABIC SMALL LOW WORD MADDA
-	{runeRange{0x10F46, 0x10F50}, prExtend},               // Mn  [11] SOGDIAN COMBINING DOT BELOW..SOGDIAN COMBINING STROKE BELOW
-	{runeRange{0x10F82, 0x10F85}, prExtend},               // Mn   [4] OLD UYGHUR COMBINING DOT ABOVE..OLD UYGHUR COMBINING TWO DOTS BELOW
-	{runeRange{0x11000, 0x11000}, prSpacingMark},          // Mc       BRAHMI SIGN CANDRABINDU
-	{runeRange{0x11001, 0x11001}, prExtend},               // Mn       BRAHMI SIGN ANUSVARA
-	{runeRange{0x11002, 0x11002}, prSpacingMark},          // Mc       BRAHMI SIGN VISARGA
-	{runeRange{0x11038, 0x11046}, prExtend},               // Mn  [15] BRAHMI VOWEL SIGN AA..BRAHMI VIRAMA
-	{runeRange{0x11070, 0x11070}, prExtend},               // Mn       BRAHMI SIGN OLD TAMIL VIRAMA
-	{runeRange{0x11073, 0x11074}, prExtend},               // Mn   [2] BRAHMI VOWEL SIGN OLD TAMIL SHORT E..BRAHMI VOWEL SIGN OLD TAMIL SHORT O
-	{runeRange{0x1107F, 0x11081}, prExtend},               // Mn   [3] BRAHMI NUMBER JOINER..KAITHI SIGN ANUSVARA
-	{runeRange{0x11082, 0x11082}, prSpacingMark},          // Mc       KAITHI SIGN VISARGA
-	{runeRange{0x110B0, 0x110B2}, prSpacingMark},          // Mc   [3] KAITHI VOWEL SIGN AA..KAITHI VOWEL SIGN II
-	{runeRange{0x110B3, 0x110B6}, prExtend},               // Mn   [4] KAITHI VOWEL SIGN U..KAITHI VOWEL SIGN AI
-	{runeRange{0x110B7, 0x110B8}, prSpacingMark},          // Mc   [2] KAITHI VOWEL SIGN O..KAITHI VOWEL SIGN AU
-	{runeRange{0x110B9, 0x110BA}, prExtend},               // Mn   [2] KAITHI SIGN VIRAMA..KAITHI SIGN NUKTA
-	{runeRange{0x110BD, 0x110BD}, prPrepend},              // Cf       KAITHI NUMBER SIGN
-	{runeRange{0x110C2, 0x110C2}, prExtend},               // Mn       KAITHI VOWEL SIGN VOCALIC R
-	{runeRange{0x110CD, 0x110CD}, prPrepend},              // Cf       KAITHI NUMBER SIGN ABOVE
-	{runeRange{0x11100, 0x11102}, prExtend},               // Mn   [3] CHAKMA SIGN CANDRABINDU..CHAKMA SIGN VISARGA
-	{runeRange{0x11127, 0x1112B}, prExtend},               // Mn   [5] CHAKMA VOWEL SIGN A..CHAKMA VOWEL SIGN UU
-	{runeRange{0x1112C, 0x1112C}, prSpacingMark},          // Mc       CHAKMA VOWEL SIGN E
-	{runeRange{0x1112D, 0x11134}, prExtend},               // Mn   [8] CHAKMA VOWEL SIGN AI..CHAKMA MAAYYAA
-	{runeRange{0x11145, 0x11146}, prSpacingMark},          // Mc   [2] CHAKMA VOWEL SIGN AA..CHAKMA VOWEL SIGN EI
-	{runeRange{0x11173, 0x11173}, prExtend},               // Mn       MAHAJANI SIGN NUKTA
-	{runeRange{0x11180, 0x11181}, prExtend},               // Mn   [2] SHARADA SIGN CANDRABINDU..SHARADA SIGN ANUSVARA
-	{runeRange{0x11182, 0x11182}, prSpacingMark},          // Mc       SHARADA SIGN VISARGA
-	{runeRange{0x111B3, 0x111B5}, prSpacingMark},          // Mc   [3] SHARADA VOWEL SIGN AA..SHARADA VOWEL SIGN II
-	{runeRange{0x111B6, 0x111BE}, prExtend},               // Mn   [9] SHARADA VOWEL SIGN U..SHARADA VOWEL SIGN O
-	{runeRange{0x111BF, 0x111C0}, prSpacingMark},          // Mc   [2] SHARADA VOWEL SIGN AU..SHARADA SIGN VIRAMA
-	{runeRange{0x111C2, 0x111C3}, prPrepend},              // Lo   [2] SHARADA SIGN JIHVAMULIYA..SHARADA SIGN UPADHMANIYA
-	{runeRange{0x111C9, 0x111CC}, prExtend},               // Mn   [4] SHARADA SANDHI MARK..SHARADA EXTRA SHORT VOWEL MARK
-	{runeRange{0x111CE, 0x111CE}, prSpacingMark},          // Mc       SHARADA VOWEL SIGN PRISHTHAMATRA E
-	{runeRange{0x111CF, 0x111CF}, prExtend},               // Mn       SHARADA SIGN INVERTED CANDRABINDU
-	{runeRange{0x1122C, 0x1122E}, prSpacingMark},          // Mc   [3] KHOJKI VOWEL SIGN AA..KHOJKI VOWEL SIGN II
-	{runeRange{0x1122F, 0x11231}, prExtend},               // Mn   [3] KHOJKI VOWEL SIGN U..KHOJKI VOWEL SIGN AI
-	{runeRange{0x11232, 0x11233}, prSpacingMark},          // Mc   [2] KHOJKI VOWEL SIGN O..KHOJKI VOWEL SIGN AU
-	{runeRange{0x11234, 0x11234}, prExtend},               // Mn       KHOJKI SIGN ANUSVARA
-	{runeRange{0x11235, 0x11235}, prSpacingMark},          // Mc       KHOJKI SIGN VIRAMA
-	{runeRange{0x11236, 0x11237}, prExtend},               // Mn   [2] KHOJKI SIGN NUKTA..KHOJKI SIGN SHADDA
-	{runeRange{0x1123E, 0x1123E}, prExtend},               // Mn       KHOJKI SIGN SUKUN
-	{runeRange{0x11241, 0x11241}, prExtend},               // Mn       KHOJKI VOWEL SIGN VOCALIC R
-	{runeRange{0x112DF, 0x112DF}, prExtend},               // Mn       KHUDAWADI SIGN ANUSVARA
-	{runeRange{0x112E0, 0x112E2}, prSpacingMark},          // Mc   [3] KHUDAWADI VOWEL SIGN AA..KHUDAWADI VOWEL SIGN II
-	{runeRange{0x112E3, 0x112EA}, prExtend},               // Mn   [8] KHUDAWADI VOWEL SIGN U..KHUDAWADI SIGN VIRAMA
-	{runeRange{0x11300, 0x11301}, prExtend},               // Mn   [2] GRANTHA SIGN COMBINING ANUSVARA ABOVE..GRANTHA SIGN CANDRABINDU
-	{runeRange{0x11302, 0x11303}, prSpacingMark},          // Mc   [2] GRANTHA SIGN ANUSVARA..GRANTHA SIGN VISARGA
-	{runeRange{0x1133B, 0x1133C}, prExtend},               // Mn   [2] COMBINING BINDU BELOW..GRANTHA SIGN NUKTA
-	{runeRange{0x1133E, 0x1133E}, prExtend},               // Mc       GRANTHA VOWEL SIGN AA
-	{runeRange{0x1133F, 0x1133F}, prSpacingMark},          // Mc       GRANTHA VOWEL SIGN I
-	{runeRange{0x11340, 0x11340}, prExtend},               // Mn       GRANTHA VOWEL SIGN II
-	{runeRange{0x11341, 0x11344}, prSpacingMark},          // Mc   [4] GRANTHA VOWEL SIGN U..GRANTHA VOWEL SIGN VOCALIC RR
-	{runeRange{0x11347, 0x11348}, prSpacingMark},          // Mc   [2] GRANTHA VOWEL SIGN EE..GRANTHA VOWEL SIGN AI
-	{runeRange{0x1134B, 0x1134D}, prSpacingMark},          // Mc   [3] GRANTHA VOWEL SIGN OO..GRANTHA SIGN VIRAMA
-	{runeRange{0x11357, 0x11357}, prExtend},               // Mc       GRANTHA AU LENGTH MARK
-	{runeRange{0x11362, 0x11363}, prSpacingMark},          // Mc   [2] GRANTHA VOWEL SIGN VOCALIC L..GRANTHA VOWEL SIGN VOCALIC LL
-	{runeRange{0x11366, 0x1136C}, prExtend},               // Mn   [7] COMBINING GRANTHA DIGIT ZERO..COMBINING GRANTHA DIGIT SIX
-	{runeRange{0x11370, 0x11374}, prExtend},               // Mn   [5] COMBINING GRANTHA LETTER A..COMBINING GRANTHA LETTER PA
-	{runeRange{0x11435, 0x11437}, prSpacingMark},          // Mc   [3] NEWA VOWEL SIGN AA..NEWA VOWEL SIGN II
-	{runeRange{0x11438, 0x1143F}, prExtend},               // Mn   [8] NEWA VOWEL SIGN U..NEWA VOWEL SIGN AI
-	{runeRange{0x11440, 0x11441}, prSpacingMark},          // Mc   [2] NEWA VOWEL SIGN O..NEWA VOWEL SIGN AU
-	{runeRange{0x11442, 0x11444}, prExtend},               // Mn   [3] NEWA SIGN VIRAMA..NEWA SIGN ANUSVARA
-	{runeRange{0x11445, 0x11445}, prSpacingMark},          // Mc       NEWA SIGN VISARGA
-	{runeRange{0x11446, 0x11446}, prExtend},               // Mn       NEWA SIGN NUKTA
-	{runeRange{0x1145E, 0x1145E}, prExtend},               // Mn       NEWA SANDHI MARK
-	{runeRange{0x114B0, 0x114B0}, prExtend},               // Mc       TIRHUTA VOWEL SIGN AA
-	{runeRange{0x114B1, 0x114B2}, prSpacingMark},          // Mc   [2] TIRHUTA VOWEL SIGN I..TIRHUTA VOWEL SIGN II
-	{runeRange{0x114B3, 0x114B8}, prExtend},               // Mn   [6] TIRHUTA VOWEL SIGN U..TIRHUTA VOWEL SIGN VOCALIC LL
-	{runeRange{0x114B9, 0x114B9}, prSpacingMark},          // Mc       TIRHUTA VOWEL SIGN E
-	{runeRange{0x114BA, 0x114BA}, prExtend},               // Mn       TIRHUTA VOWEL SIGN SHORT E
-	{runeRange{0x114BB, 0x114BC}, prSpacingMark},          // Mc   [2] TIRHUTA VOWEL SIGN AI..TIRHUTA VOWEL SIGN O
-	{runeRange{0x114BD, 0x114BD}, prExtend},               // Mc       TIRHUTA VOWEL SIGN SHORT O
-	{runeRange{0x114BE, 0x114BE}, prSpacingMark},          // Mc       TIRHUTA VOWEL SIGN AU
-	{runeRange{0x114BF, 0x114C0}, prExtend},               // Mn   [2] TIRHUTA SIGN CANDRABINDU..TIRHUTA SIGN ANUSVARA
-	{runeRange{0x114C1, 0x114C1}, prSpacingMark},          // Mc       TIRHUTA SIGN VISARGA
-	{runeRange{0x114C2, 0x114C3}, prExtend},               // Mn   [2] TIRHUTA SIGN VIRAMA..TIRHUTA SIGN NUKTA
-	{runeRange{0x115AF, 0x115AF}, prExtend},               // Mc       SIDDHAM VOWEL SIGN AA
-	{runeRange{0x115B0, 0x115B1}, prSpacingMark},          // Mc   [2] SIDDHAM VOWEL SIGN I..SIDDHAM VOWEL SIGN II
-	{runeRange{0x115B2, 0x115B5}, prExtend},               // Mn   [4] SIDDHAM VOWEL SIGN U..SIDDHAM VOWEL SIGN VOCALIC RR
-	{runeRange{0x115B8, 0x115BB}, prSpacingMark},          // Mc   [4] SIDDHAM VOWEL SIGN E..SIDDHAM VOWEL SIGN AU
-	{runeRange{0x115BC, 0x115BD}, prExtend},               // Mn   [2] SIDDHAM SIGN CANDRABINDU..SIDDHAM SIGN ANUSVARA
-	{runeRange{0x115BE, 0x115BE}, prSpacingMark},          // Mc       SIDDHAM SIGN VISARGA
-	{runeRange{0x115BF, 0x115C0}, prExtend},               // Mn   [2] SIDDHAM SIGN VIRAMA..SIDDHAM SIGN NUKTA
-	{runeRange{0x115DC, 0x115DD}, prExtend},               // Mn   [2] SIDDHAM VOWEL SIGN ALTERNATE U..SIDDHAM VOWEL SIGN ALTERNATE UU
-	{runeRange{0x11630, 0x11632}, prSpacingMark},          // Mc   [3] MODI VOWEL SIGN AA..MODI VOWEL SIGN II
-	{runeRange{0x11633, 0x1163A}, prExtend},               // Mn   [8] MODI VOWEL SIGN U..MODI VOWEL SIGN AI
-	{runeRange{0x1163B, 0x1163C}, prSpacingMark},          // Mc   [2] MODI VOWEL SIGN O..MODI VOWEL SIGN AU
-	{runeRange{0x1163D, 0x1163D}, prExtend},               // Mn       MODI SIGN ANUSVARA
-	{runeRange{0x1163E, 0x1163E}, prSpacingMark},          // Mc       MODI SIGN VISARGA
-	{runeRange{0x1163F, 0x11640}, prExtend},               // Mn   [2] MODI SIGN VIRAMA..MODI SIGN ARDHACANDRA
-	{runeRange{0x116AB, 0x116AB}, prExtend},               // Mn       TAKRI SIGN ANUSVARA
-	{runeRange{0x116AC, 0x116AC}, prSpacingMark},          // Mc       TAKRI SIGN VISARGA
-	{runeRange{0x116AD, 0x116AD}, prExtend},               // Mn       TAKRI VOWEL SIGN AA
-	{runeRange{0x116AE, 0x116AF}, prSpacingMark},          // Mc   [2] TAKRI VOWEL SIGN I..TAKRI VOWEL SIGN II
-	{runeRange{0x116B0, 0x116B5}, prExtend},               // Mn   [6] TAKRI VOWEL SIGN U..TAKRI VOWEL SIGN AU
-	{runeRange{0x116B6, 0x116B6}, prSpacingMark},          // Mc       TAKRI SIGN VIRAMA
-	{runeRange{0x116B7, 0x116B7}, prExtend},               // Mn       TAKRI SIGN NUKTA
-	{runeRange{0x1171D, 0x1171F}, prExtend},               // Mn   [3] AHOM CONSONANT SIGN MEDIAL LA..AHOM CONSONANT SIGN MEDIAL LIGATING RA
-	{runeRange{0x11722, 0x11725}, prExtend},               // Mn   [4] AHOM VOWEL SIGN I..AHOM VOWEL SIGN UU
-	{runeRange{0x11726, 0x11726}, prSpacingMark},          // Mc       AHOM VOWEL SIGN E
-	{runeRange{0x11727, 0x1172B}, prExtend},               // Mn   [5] AHOM VOWEL SIGN AW..AHOM SIGN KILLER
-	{runeRange{0x1182C, 0x1182E}, prSpacingMark},          // Mc   [3] DOGRA VOWEL SIGN AA..DOGRA VOWEL SIGN II
-	{runeRange{0x1182F, 0x11837}, prExtend},               // Mn   [9] DOGRA VOWEL SIGN U..DOGRA SIGN ANUSVARA
-	{runeRange{0x11838, 0x11838}, prSpacingMark},          // Mc       DOGRA SIGN VISARGA
-	{runeRange{0x11839, 0x1183A}, prExtend},               // Mn   [2] DOGRA SIGN VIRAMA..DOGRA SIGN NUKTA
-	{runeRange{0x11930, 0x11930}, prExtend},               // Mc       DIVES AKURU VOWEL SIGN AA
-	{runeRange{0x11931, 0x11935}, prSpacingMark},          // Mc   [5] DIVES AKURU VOWEL SIGN I..DIVES AKURU VOWEL SIGN E
-	{runeRange{0x11937, 0x11938}, prSpacingMark},          // Mc   [2] DIVES AKURU VOWEL SIGN AI..DIVES AKURU VOWEL SIGN O
-	{runeRange{0x1193B, 0x1193C}, prExtend},               // Mn   [2] DIVES AKURU SIGN ANUSVARA..DIVES AKURU SIGN CANDRABINDU
-	{runeRange{0x1193D, 0x1193D}, prSpacingMark},          // Mc       DIVES AKURU SIGN HALANTA
-	{runeRange{0x1193E, 0x1193E}, prExtend},               // Mn       DIVES AKURU VIRAMA
-	{runeRange{0x1193F, 0x1193F}, prPrepend},              // Lo       DIVES AKURU PREFIXED NASAL SIGN
-	{runeRange{0x11940, 0x11940}, prSpacingMark},          // Mc       DIVES AKURU MEDIAL YA
-	{runeRange{0x11941, 0x11941}, prPrepend},              // Lo       DIVES AKURU INITIAL RA
-	{runeRange{0x11942, 0x11942}, prSpacingMark},          // Mc       DIVES AKURU MEDIAL RA
-	{runeRange{0x11943, 0x11943}, prExtend},               // Mn       DIVES AKURU SIGN NUKTA
-	{runeRange{0x119D1, 0x119D3}, prSpacingMark},          // Mc   [3] NANDINAGARI VOWEL SIGN AA..NANDINAGARI VOWEL SIGN II
-	{runeRange{0x119D4, 0x119D7}, prExtend},               // Mn   [4] NANDINAGARI VOWEL SIGN U..NANDINAGARI VOWEL SIGN VOCALIC RR
-	{runeRange{0x119DA, 0x119DB}, prExtend},               // Mn   [2] NANDINAGARI VOWEL SIGN E..NANDINAGARI VOWEL SIGN AI
-	{runeRange{0x119DC, 0x119DF}, prSpacingMark},          // Mc   [4] NANDINAGARI VOWEL SIGN O..NANDINAGARI SIGN VISARGA
-	{runeRange{0x119E0, 0x119E0}, prExtend},               // Mn       NANDINAGARI SIGN VIRAMA
-	{runeRange{0x119E4, 0x119E4}, prSpacingMark},          // Mc       NANDINAGARI VOWEL SIGN PRISHTHAMATRA E
-	{runeRange{0x11A01, 0x11A0A}, prExtend},               // Mn  [10] ZANABAZAR SQUARE VOWEL SIGN I..ZANABAZAR SQUARE VOWEL LENGTH MARK
-	{runeRange{0x11A33, 0x11A38}, prExtend},               // Mn   [6] ZANABAZAR SQUARE FINAL CONSONANT MARK..ZANABAZAR SQUARE SIGN ANUSVARA
-	{runeRange{0x11A39, 0x11A39}, prSpacingMark},          // Mc       ZANABAZAR SQUARE SIGN VISARGA
-	{runeRange{0x11A3A, 0x11A3A}, prPrepend},              // Lo       ZANABAZAR SQUARE CLUSTER-INITIAL LETTER RA
-	{runeRange{0x11A3B, 0x11A3E}, prExtend},               // Mn   [4] ZANABAZAR SQUARE CLUSTER-FINAL LETTER YA..ZANABAZAR SQUARE CLUSTER-FINAL LETTER VA
-	{runeRange{0x11A47, 0x11A47}, prExtend},               // Mn       ZANABAZAR SQUARE SUBJOINER
-	{runeRange{0x11A51, 0x11A56}, prExtend},               // Mn   [6] SOYOMBO VOWEL SIGN I..SOYOMBO VOWEL SIGN OE
-	{runeRange{0x11A57, 0x11A58}, prSpacingMark},          // Mc   [2] SOYOMBO VOWEL SIGN AI..SOYOMBO VOWEL SIGN AU
-	{runeRange{0x11A59, 0x11A5B}, prExtend},               // Mn   [3] SOYOMBO VOWEL SIGN VOCALIC R..SOYOMBO VOWEL LENGTH MARK
-	{runeRange{0x11A84, 0x11A89}, prPrepend},              // Lo   [6] SOYOMBO SIGN JIHVAMULIYA..SOYOMBO CLUSTER-INITIAL LETTER SA
-	{runeRange{0x11A8A, 0x11A96}, prExtend},               // Mn  [13] SOYOMBO FINAL CONSONANT SIGN G..SOYOMBO SIGN ANUSVARA
-	{runeRange{0x11A97, 0x11A97}, prSpacingMark},          // Mc       SOYOMBO SIGN VISARGA
-	{runeRange{0x11A98, 0x11A99}, prExtend},               // Mn   [2] SOYOMBO GEMINATION MARK..SOYOMBO SUBJOINER
-	{runeRange{0x11C2F, 0x11C2F}, prSpacingMark},          // Mc       BHAIKSUKI VOWEL SIGN AA
-	{runeRange{0x11C30, 0x11C36}, prExtend},               // Mn   [7] BHAIKSUKI VOWEL SIGN I..BHAIKSUKI VOWEL SIGN VOCALIC L
-	{runeRange{0x11C38, 0x11C3D}, prExtend},               // Mn   [6] BHAIKSUKI VOWEL SIGN E..BHAIKSUKI SIGN ANUSVARA
-	{runeRange{0x11C3E, 0x11C3E}, prSpacingMark},          // Mc       BHAIKSUKI SIGN VISARGA
-	{runeRange{0x11C3F, 0x11C3F}, prExtend},               // Mn       BHAIKSUKI SIGN VIRAMA
-	{runeRange{0x11C92, 0x11CA7}, prExtend},               // Mn  [22] MARCHEN SUBJOINED LETTER KA..MARCHEN SUBJOINED LETTER ZA
-	{runeRange{0x11CA9, 0x11CA9}, prSpacingMark},          // Mc       MARCHEN SUBJOINED LETTER YA
-	{runeRange{0x11CAA, 0x11CB0}, prExtend},               // Mn   [7] MARCHEN SUBJOINED LETTER RA..MARCHEN VOWEL SIGN AA
-	{runeRange{0x11CB1, 0x11CB1}, prSpacingMark},          // Mc       MARCHEN VOWEL SIGN I
-	{runeRange{0x11CB2, 0x11CB3}, prExtend},               // Mn   [2] MARCHEN VOWEL SIGN U..MARCHEN VOWEL SIGN E
-	{runeRange{0x11CB4, 0x11CB4}, prSpacingMark},          // Mc       MARCHEN VOWEL SIGN O
-	{runeRange{0x11CB5, 0x11CB6}, prExtend},               // Mn   [2] MARCHEN SIGN ANUSVARA..MARCHEN SIGN CANDRABINDU
-	{runeRange{0x11D31, 0x11D36}, prExtend},               // Mn   [6] MASARAM GONDI VOWEL SIGN AA..MASARAM GONDI VOWEL SIGN VOCALIC R
-	{runeRange{0x11D3A, 0x11D3A}, prExtend},               // Mn       MASARAM GONDI VOWEL SIGN E
-	{runeRange{0x11D3C, 0x11D3D}, prExtend},               // Mn   [2] MASARAM GONDI VOWEL SIGN AI..MASARAM GONDI VOWEL SIGN O
-	{runeRange{0x11D3F, 0x11D45}, prExtend},               // Mn   [7] MASARAM GONDI VOWEL SIGN AU..MASARAM GONDI VIRAMA
-	{runeRange{0x11D46, 0x11D46}, prPrepend},              // Lo       MASARAM GONDI REPHA
-	{runeRange{0x11D47, 0x11D47}, prExtend},               // Mn       MASARAM GONDI RA-KARA
-	{runeRange{0x11D8A, 0x11D8E}, prSpacingMark},          // Mc   [5] GUNJALA GONDI VOWEL SIGN AA..GUNJALA GONDI VOWEL SIGN UU
-	{runeRange{0x11D90, 0x11D91}, prExtend},               // Mn   [2] GUNJALA GONDI VOWEL SIGN EE..GUNJALA GONDI VOWEL SIGN AI
-	{runeRange{0x11D93, 0x11D94}, prSpacingMark},          // Mc   [2] GUNJALA GONDI VOWEL SIGN OO..GUNJALA GONDI VOWEL SIGN AU
-	{runeRange{0x11D95, 0x11D95}, prExtend},               // Mn       GUNJALA GONDI SIGN ANUSVARA
-	{runeRange{0x11D96, 0x11D96}, prSpacingMark},          // Mc       GUNJALA GONDI SIGN VISARGA
-	{runeRange{0x11D97, 0x11D97}, prExtend},               // Mn       GUNJALA GONDI VIRAMA
-	{runeRange{0x11EF3, 0x11EF4}, prExtend},               // Mn   [2] MAKASAR VOWEL SIGN I..MAKASAR VOWEL SIGN U
-	{runeRange{0x11EF5, 0x11EF6}, prSpacingMark},          // Mc   [2] MAKASAR VOWEL SIGN E..MAKASAR VOWEL SIGN O
-	{runeRange{0x11F00, 0x11F01}, prExtend},               // Mn   [2] KAWI SIGN CANDRABINDU..KAWI SIGN ANUSVARA
-	{runeRange{0x11F02, 0x11F02}, prPrepend},              // Lo       KAWI SIGN REPHA
-	{runeRange{0x11F03, 0x11F03}, prSpacingMark},          // Mc       KAWI SIGN VISARGA
-	{runeRange{0x11F34, 0x11F35}, prSpacingMark},          // Mc   [2] KAWI VOWEL SIGN AA..KAWI VOWEL SIGN ALTERNATE AA
-	{runeRange{0x11F36, 0x11F3A}, prExtend},               // Mn   [5] KAWI VOWEL SIGN I..KAWI VOWEL SIGN VOCALIC R
-	{runeRange{0x11F3E, 0x11F3F}, prSpacingMark},          // Mc   [2] KAWI VOWEL SIGN E..KAWI VOWEL SIGN AI
-	{runeRange{0x11F40, 0x11F40}, prExtend},               // Mn       KAWI VOWEL SIGN EU
-	{runeRange{0x11F41, 0x11F41}, prSpacingMark},          // Mc       KAWI SIGN KILLER
-	{runeRange{0x11F42, 0x11F42}, prExtend},               // Mn       KAWI CONJOINER
-	{runeRange{0x13430, 0x1343F}, prControl},              // Cf  [16] EGYPTIAN HIEROGLYPH VERTICAL JOINER..EGYPTIAN HIEROGLYPH END WALLED ENCLOSURE
-	{runeRange{0x13440, 0x13440}, prExtend},               // Mn       EGYPTIAN HIEROGLYPH MIRROR HORIZONTALLY
-	{runeRange{0x13447, 0x13455}, prExtend},               // Mn  [15] EGYPTIAN HIEROGLYPH MODIFIER DAMAGED AT TOP START..EGYPTIAN HIEROGLYPH MODIFIER DAMAGED
-	{runeRange{0x16AF0, 0x16AF4}, prExtend},               // Mn   [5] BASSA VAH COMBINING HIGH TONE..BASSA VAH COMBINING HIGH-LOW TONE
-	{runeRange{0x16B30, 0x16B36}, prExtend},               // Mn   [7] PAHAWH HMONG MARK CIM TUB..PAHAWH HMONG MARK CIM TAUM
-	{runeRange{0x16F4F, 0x16F4F}, prExtend},               // Mn       MIAO SIGN CONSONANT MODIFIER BAR
-	{runeRange{0x16F51, 0x16F87}, prSpacingMark},          // Mc  [55] MIAO SIGN ASPIRATION..MIAO VOWEL SIGN UI
-	{runeRange{0x16F8F, 0x16F92}, prExtend},               // Mn   [4] MIAO TONE RIGHT..MIAO TONE BELOW
-	{runeRange{0x16FE4, 0x16FE4}, prExtend},               // Mn       KHITAN SMALL SCRIPT FILLER
-	{runeRange{0x16FF0, 0x16FF1}, prSpacingMark},          // Mc   [2] VIETNAMESE ALTERNATE READING MARK CA..VIETNAMESE ALTERNATE READING MARK NHAY
-	{runeRange{0x1BC9D, 0x1BC9E}, prExtend},               // Mn   [2] DUPLOYAN THICK LETTER SELECTOR..DUPLOYAN DOUBLE MARK
-	{runeRange{0x1BCA0, 0x1BCA3}, prControl},              // Cf   [4] SHORTHAND FORMAT LETTER OVERLAP..SHORTHAND FORMAT UP STEP
-	{runeRange{0x1CF00, 0x1CF2D}, prExtend},               // Mn  [46] ZNAMENNY COMBINING MARK GORAZDO NIZKO S KRYZHEM ON LEFT..ZNAMENNY COMBINING MARK KRYZH ON LEFT
-	{runeRange{0x1CF30, 0x1CF46}, prExtend},               // Mn  [23] ZNAMENNY COMBINING TONAL RANGE MARK MRACHNO..ZNAMENNY PRIZNAK MODIFIER ROG
-	{runeRange{0x1D165, 0x1D165}, prExtend},               // Mc       MUSICAL SYMBOL COMBINING STEM
-	{runeRange{0x1D166, 0x1D166}, prSpacingMark},          // Mc       MUSICAL SYMBOL COMBINING SPRECHGESANG STEM
-	{runeRange{0x1D167, 0x1D169}, prExtend},               // Mn   [3] MUSICAL SYMBOL COMBINING TREMOLO-1..MUSICAL SYMBOL COMBINING TREMOLO-3
-	{runeRange{0x1D16D, 0x1D16D}, prSpacingMark},          // Mc       MUSICAL SYMBOL COMBINING AUGMENTATION DOT
-	{runeRange{0x1D16E, 0x1D172}, prExtend},               // Mc   [5] MUSICAL SYMBOL COMBINING FLAG-1..MUSICAL SYMBOL COMBINING FLAG-5
-	{runeRange{0x1D173, 0x1D17A}, prControl},              // Cf   [8] MUSICAL SYMBOL BEGIN BEAM..MUSICAL SYMBOL END PHRASE
-	{runeRange{0x1D17B, 0x1D182}, prExtend},               // Mn   [8] MUSICAL SYMBOL COMBINING ACCENT..MUSICAL SYMBOL COMBINING LOURE
-	{runeRange{0x1D185, 0x1D18B}, prExtend},               // Mn   [7] MUSICAL SYMBOL COMBINING DOIT..MUSICAL SYMBOL COMBINING TRIPLE TONGUE
-	{runeRange{0x1D1AA, 0x1D1AD}, prExtend},               // Mn   [4] MUSICAL SYMBOL COMBINING DOWN BOW..MUSICAL SYMBOL COMBINING SNAP PIZZICATO
-	{runeRange{0x1D242, 0x1D244}, prExtend},               // Mn   [3] COMBINING GREEK MUSICAL TRISEME..COMBINING GREEK MUSICAL PENTASEME
-	{runeRange{0x1DA00, 0x1DA36}, prExtend},               // Mn  [55] SIGNWRITING HEAD RIM..SIGNWRITING AIR SUCKING IN
-	{runeRange{0x1DA3B, 0x1DA6C}, prExtend},               // Mn  [50] SIGNWRITING MOUTH CLOSED NEUTRAL..SIGNWRITING EXCITEMENT
-	{runeRange{0x1DA75, 0x1DA75}, prExtend},               // Mn       SIGNWRITING UPPER BODY TILTING FROM HIP JOINTS
-	{runeRange{0x1DA84, 0x1DA84}, prExtend},               // Mn       SIGNWRITING LOCATION HEAD NECK
-	{runeRange{0x1DA9B, 0x1DA9F}, prExtend},               // Mn   [5] SIGNWRITING FILL MODIFIER-2..SIGNWRITING FILL MODIFIER-6
-	{runeRange{0x1DAA1, 0x1DAAF}, prExtend},               // Mn  [15] SIGNWRITING ROTATION MODIFIER-2..SIGNWRITING ROTATION MODIFIER-16
-	{runeRange{0x1E000, 0x1E006}, prExtend},               // Mn   [7] COMBINING GLAGOLITIC LETTER AZU..COMBINING GLAGOLITIC LETTER ZHIVETE
-	{runeRange{0x1E008, 0x1E018}, prExtend},               // Mn  [17] COMBINING GLAGOLITIC LETTER ZEMLJA..COMBINING GLAGOLITIC LETTER HERU
-	{runeRange{0x1E01B, 0x1E021}, prExtend},               // Mn   [7] COMBINING GLAGOLITIC LETTER SHTA..COMBINING GLAGOLITIC LETTER YATI
-	{runeRange{0x1E023, 0x1E024}, prExtend},               // Mn   [2] COMBINING GLAGOLITIC LETTER YU..COMBINING GLAGOLITIC LETTER SMALL YUS
-	{runeRange{0x1E026, 0x1E02A}, prExtend},               // Mn   [5] COMBINING GLAGOLITIC LETTER YO..COMBINING GLAGOLITIC LETTER FITA
-	{runeRange{0x1E08F, 0x1E08F}, prExtend},               // Mn       COMBINING CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I
-	{runeRange{0x1E130, 0x1E136}, prExtend},               // Mn   [7] NYIAKENG PUACHUE HMONG TONE-B..NYIAKENG PUACHUE HMONG TONE-D
-	{runeRange{0x1E2AE, 0x1E2AE}, prExtend},               // Mn       TOTO SIGN RISING TONE
-	{runeRange{0x1E2EC, 0x1E2EF}, prExtend},               // Mn   [4] WANCHO TONE TUP..WANCHO TONE KOINI
+	{runeRange{0xAC1C, 0xAC1C}, prLV},                     // Lo       HANGUL SYLLABLE GAE
 	{runeRange{0x1E4EC, 0x1E4EF}, prExtend},               // Mn   [4] NAG MUNDARI SIGN MUHOR..NAG MUNDARI SIGN SUTUH
-	{runeRange{0x1E8D0, 0x1E8D6}, prExtend},               // Mn   [7] MENDE KIKAKUI COMBINING NUMBER TEENS..MENDE KIKAKUI COMBINING NUMBER MILLIONS
-	{runeRange{0x1E944, 0x1E94A}, prExtend},               // Mn   [7] ADLAM ALIF LENGTHENER..ADLAM NUKTA
-	{runeRange{0x1F000, 0x1F003}, prExtendedPictographic}, // E0.0   [4] (🀀..🀃)    MAHJONG TILE EAST WIND..MAHJONG TILE NORTH WIND
-	{runeRange{0x1F004, 0x1F004}, prExtendedPictographic}, // E0.6   [1] (🀄)       mahjong red dragon
-	{runeRange{0x1F005, 0x1F0CE}, prExtendedPictographic}, // E0.0 [202] (🀅..🃎)    MAHJONG TILE GREEN DRAGON..PLAYING CARD KING OF DIAMONDS
-	{runeRange{0x1F0CF, 0x1F0CF}, prExtendedPictographic}, // E0.6   [1] (🃏)       joker
-	{runeRange{0x1F0D0, 0x1F0FF}, prExtendedPictographic}, // E0.0  [48] (🃐..🃿)    <reserved-1F0D0>..<reserved-1F0FF>
-	{runeRange{0x1F10D, 0x1F10F}, prExtendedPictographic}, // E0.0   [3] (🄍..🄏)    CIRCLED ZERO WITH SLASH..CIRCLED DOLLAR SIGN WITH OVERLAID BACKSLASH
-	{runeRange{0x1F12F, 0x1F12F}, prExtendedPictographic}, // E0.0   [1] (🄯)       COPYLEFT SYMBOL
-	{runeRange{0x1F16C, 0x1F16F}, prExtendedPictographic}, // E0.0   [4] (🅬..🅯)    RAISED MR SIGN..CIRCLED HUMAN FIGURE
-	{runeRange{0x1F170, 0x1F171}, prExtendedPictographic}, // E0.6   [2] (🅰️..🅱️)    A button (blood type)..B button (blood type)
-	{runeRange{0x1F17E, 0x1F17F}, prExtendedPictographic}, // E0.6   [2] (🅾️..🅿️)    O button (blood type)..P button
-	{runeRange{0x1F18E, 0x1F18E}, prExtendedPictographic}, // E0.6   [1] (🆎)       AB button (blood type)
-	{runeRange{0x1F191, 0x1F19A}, prExtendedPictographic}, // E0.6  [10] (🆑..🆚)    CL button..VS button
-	{runeRange{0x1F1AD, 0x1F1E5}, prExtendedPictographic}, // E0.0  [57] (🆭..🇥)    MASK WORK SYMBOL..<reserved-1F1E5>
-	{runeRange{0x1F1E6, 0x1F1FF}, prRegionalIndicator},    // So  [26] REGIONAL INDICATOR SYMBOL LETTER A..REGIONAL INDICATOR SYMBOL LETTER Z
-	{runeRange{0x1F201, 0x1F202}, prExtendedPictographic}, // E0.6   [2] (🈁..🈂️)    Japanese “here” button..Japanese “service charge” button
-	{runeRange{0x1F203, 0x1F20F}, prExtendedPictographic}, // E0.0  [13] (🈃..🈏)    <reserved-1F203>..<reserved-1F20F>
-	{runeRange{0x1F21A, 0x1F21A}, prExtendedPictographic}, // E0.6   [1] (🈚)       Japanese “free of charge” button
-	{runeRange{0x1F22F, 0x1F22F}, prExtendedPictographic}, // E0.6   [1] (🈯)       Japanese “reserved” button
-	{runeRange{0x1F232, 0x1F23A}, prExtendedPictographic}, // E0.6   [9] (🈲..🈺)    Japanese “prohibited” button..Japanese “open for business” button
-	{runeRange{0x1F23C, 0x1F23F}, prExtendedPictographic}, // E0.0   [4] (🈼..🈿)    <reserved-1F23C>..<reserved-1F23F>
-	{runeRange{0x1F249, 0x1F24F}, prExtendedPictographic}, // E0.0   [7] (🉉..🉏)    <reserved-1F249>..<reserved-1F24F>
-	{runeRange{0x1F250, 0x1F251}, prExtendedPictographic}, // E0.6   [2] (🉐..🉑)    Japanese “bargain” button..Japanese “acceptable” button
-	{runeRange{0x1F252, 0x1F2FF}, prExtendedPictographic}, // E0.0 [174] (🉒..🋿)    <reserved-1F252>..<reserved-1F2FF>
-	{runeRange{0x1F300, 0x1F30C}, prExtendedPictographic}, // E0.6  [13] (🌀..🌌)    cyclone..milky way
-	{runeRange{0x1F30D, 0x1F30E}, prExtendedPictographic}, // E0.7   [2] (🌍..🌎)    globe showing Europe-Africa..globe showing Americas
-	{runeRange{0x1F30F, 0x1F30F}, prExtendedPictographic}, // E0.6   [1] (🌏)       globe showing Asia-Australia
-	{runeRange{0x1F310, 0x1F310}, prExtendedPictographic}, // E1.0   [1] (🌐)       globe with meridians
-	{runeRange{0x1F311, 0x1F311}, prExtendedPictographic}, // E0.6   [1] (🌑)       new moon
-	{runeRange{0x1F312, 0x1F312}, prExtendedPictographic}, // E1.0   [1] (🌒)       waxing crescent moon
-	{runeRange{0x1F313, 0x1F315}, prExtendedPictographic}, // E0.6   [3] (🌓..🌕)    first quarter moon..full moon
-	{runeRange{0x1F316, 0x1F318}, prExtendedPictographic}, // E1.0   [3] (🌖..🌘)    waning gibbous moon..waning crescent moon
-	{runeRange{0x1F319, 0x1F319}, prExtendedPictographic}, // E0.6   [1] (🌙)       crescent moon
-	{runeRange{0x1F31A, 0x1F31A}, prExtendedPictographic}, // E1.0   [1] (🌚)       new moon face
-	{runeRange{0x1F31B, 0x1F31B}, prExtendedPictographic}, // E0.6   [1] (🌛)       first quarter moon face
-	{runeRange{0x1F31C, 0x1F31C}, prExtendedPictographic}, // E0.7   [1] (🌜)       last quarter moon face
-	{runeRange{0x1F31D, 0x1F31E}, prExtendedPictographic}, // E1.0   [2] (🌝..🌞)    full moon face..sun with face
-	{runeRange{0x1F31F, 0x1F320}, prExtendedPictographic}, // E0.6   [2] (🌟..🌠)    glowing star..shooting star
-	{runeRange{0x1F321, 0x1F321}, prExtendedPictographic}, // E0.7   [1] (🌡️)       thermometer
-	{runeRange{0x1F322, 0x1F323}, prExtendedPictographic}, // E0.0   [2] (🌢..🌣)    BLACK DROPLET..WHITE SUN
-	{runeRange{0x1F324, 0x1F32C}, prExtendedPictographic}, // E0.7   [9] (🌤️..🌬️)    sun behind small cloud..wind face
-	{runeRange{0x1F32D, 0x1F32F}, prExtendedPictographic}, // E1.0   [3] (🌭..🌯)    hot dog..burrito
-	{runeRange{0x1F330, 0x1F331}, prExtendedPictographic}, // E0.6   [2] (🌰..🌱)    chestnut..seedling
-	{runeRange{0x1F332, 0x1F333}, prExtendedPictographic}, // E1.0   [2] (🌲..🌳)    evergreen tree..deciduous tree
-	{runeRange{0x1F334, 0x1F335}, prExtendedPictographic}, // E0.6   [2] (🌴..🌵)    palm tree..cactus
-	{runeRange{0x1F336, 0x1F336}, prExtendedPictographic}, // E0.7   [1] (🌶️)       hot pepper
-	{runeRange{0x1F337, 0x1F34A}, prExtendedPictographic}, // E0.6  [20] (🌷..🍊)    tulip..tangerine
-	{runeRange{0x1F34B, 0x1F34B}, prExtendedPictographic}, // E1.0   [1] (🍋)       lemon
-	{runeRange{0x1F34C, 0x1F34F}, prExtendedPictographic}, // E0.6   [4] (🍌..🍏)    banana..green apple
-	{runeRange{0x1F350, 0x1F350}, prExtendedPictographic}, // E1.0   [1] (🍐)       pear
-	{runeRange{0x1F351, 0x1F37B}, prExtendedPictographic}, // E0.6  [43] (🍑..🍻)    peach..clinking beer mugs
-	{runeRange{0x1F37C, 0x1F37C}, prExtendedPictographic}, // E1.0   [1] (🍼)       baby bottle
-	{runeRange{0x1F37D, 0x1F37D}, prExtendedPictographic}, // E0.7   [1] (🍽️)       fork and knife with plate
-	{runeRange{0x1F37E, 0x1F37F}, prExtendedPictographic}, // E1.0   [2] (🍾..🍿)    bottle with popping cork..popcorn
-	{runeRange{0x1F380, 0x1F393}, prExtendedPictographic}, // E0.6  [20] (🎀..🎓)    ribbon..graduation cap
-	{runeRange{0x1F394, 0x1F395}, prExtendedPictographic}, // E0.0   [2] (🎔..🎕)    HEART WITH TIP ON THE LEFT..BOUQUET OF FLOWERS
-	{runeRange{0x1F396, 0x1F397}, prExtendedPictographic}, // E0.7   [2] (🎖️..🎗️)    military medal..reminder ribbon
-	{runeRange{0x1F398, 0x1F398}, prExtendedPictographic}, // E0.0   [1] (🎘)       MUSICAL KEYBOARD WITH JACKS
-	{runeRange{0x1F399, 0x1F39B}, prExtendedPictographic}, // E0.7   [3] (🎙️..🎛️)    studio microphone..control knobs
-	{runeRange{0x1F39C, 0x1F39D}, prExtendedPictographic}, // E0.0   [2] (🎜..🎝)    BEAMED ASCENDING MUSICAL NOTES..BEAMED DESCENDING MUSICAL NOTES
-	{runeRange{0x1F39E, 0x1F39F}, prExtendedPictographic}, // E0.7   [2] (🎞️..🎟️)    film frames..admission tickets
-	{runeRange{0x1F3A0, 0x1F3C4}, prExtendedPictographic}, // E0.6  [37] (🎠..🏄)    carousel horse..person surfing
-	{runeRange{0x1F3C5, 0x1F3C5}, prExtendedPictographic}, // E1.0   [1] (🏅)       sports medal
-	{runeRange{0x1F3C6, 0x1F3C6}, prExtendedPictographic}, // E0.6   [1] (🏆)       trophy
-	{runeRange{0x1F3C7, 0x1F3C7}, prExtendedPictographic}, // E1.0   [1] (🏇)       horse racing
-	{runeRange{0x1F3C8, 0x1F3C8}, prExtendedPictographic}, // E0.6   [1] (🏈)       american football
-	{runeRange{0x1F3C9, 0x1F3C9}, prExtendedPictographic}, // E1.0   [1] (🏉)       rugby football
-	{runeRange{0x1F3CA, 0x1F3CA}, prExtendedPictographic}, // E0.6   [1] (🏊)       person swimming
-	{runeRange{0x1F3CB, 0x1F3CE}, prExtendedPictographic}, // E0.7   [4] (🏋️..🏎️)    person lifting weights..racing car
-	{runeRange{0x1F3CF, 0x1F3D3}, prExtendedPictographic}, // E1.0   [5] (🏏..🏓)    cricket game..ping pong
-	{runeRange{0x1F3D4, 0x1F3DF}, prExtendedPictographic}, // E0.7  [12] (🏔️..🏟️)    snow-capped mountain..stadium
-	{runeRange{0x1F3E0, 0x1F3E3}, prExtendedPictographic}, // E0.6   [4] (🏠..🏣)    house..Japanese post office
-	{runeRange{0x1F3E4, 0x1F3E4}, prExtendedPictographic}, // E1.0   [1] (🏤)       post office
-	{runeRange{0x1F3E5, 0x1F3F0}, prExtendedPictographic}, // E0.6  [12] (🏥..🏰)    hospital..castle
-	{runeRange{0x1F3F1, 0x1F3F2}, prExtendedPictographic}, // E0.0   [2] (🏱..🏲)    WHITE PENNANT..BLACK PENNANT
-	{runeRange{0x1F3F3, 0x1F3F3}, prExtendedPictographic}, // E0.7   [1] (🏳️)       white flag
-	{runeRange{0x1F3F4, 0x1F3F4}, prExtendedPictographic}, // E1.0   [1] (🏴)       black flag
-	{runeRange{0x1F3F5, 0x1F3F5}, prExtendedPictographic}, // E0.7   [1] (🏵️)       rosette
-	{runeRange{0x1F3F6, 0x1F3F6}, prExtendedPictographic}, // E0.0   [1] (🏶)       BLACK ROSETTE
-	{runeRange{0x1F3F7, 0x1F3F7}, prExtendedPictographic}, // E0.7   [1] (🏷️)       label
-	{runeRange{0x1F3F8, 0x1F3FA}, prExtendedPictographic}, // E1.0   [3] (🏸..🏺)    badminton..amphora
-	{runeRange{0x1F3FB, 0x1F3FF}, prExtend},               // Sk   [5] EMOJI MODIFIER FITZPATRICK TYPE-1-2..EMOJI MODIFIER FITZPATRICK TYPE-6
-	{runeRange{0x1F400, 0x1F407}, prExtendedPictographic}, // E1.0   [8] (🐀..🐇)    rat..rabbit
-	{runeRange{0x1F408, 0x1F408}, prExtendedPictographic}, // E0.7   [1] (🐈)       cat
-	{runeRange{0x1F409, 0x1F40B}, prExtendedPictographic}, // E1.0   [3] (🐉..🐋)    dragon..whale
-	{runeRange{0x1F40C, 0x1F40E}, prExtendedPictographic}, // E0.6   [3] (🐌..🐎)    snail..horse
-	{runeRange{0x1F40F, 0x1F410}, prExtendedPictographic}, // E1.0   [2] (🐏..🐐)    ram..goat
-	{runeRange{0x1F411, 0x1F412}, prExtendedPictographic}, // E0.6   [2] (🐑..🐒)    ewe..monkey
-	{runeRange{0x1F413, 0x1F413}, prExtendedPictographic}, // E1.0   [1] (🐓)       rooster
-	{runeRange{0x1F414, 0x1F414}, prExtendedPictographic}, // E0.6   [1] (🐔)       chicken
-	{runeRange{0x1F415, 0x1F415}, prExtendedPictographic}, // E0.7   [1] (🐕)       dog
-	{runeRange{0x1F416, 0x1F416}, prExtendedPictographic}, // E1.0   [1] (🐖)       pig
-	{runeRange{0x1F417, 0x1F429}, prExtendedPictographic}, // E0.6  [19] (🐗..🐩)    boar..poodle
-	{runeRange{0x1F42A, 0x1F42A}, prExtendedPictographic}, // E1.0   [1] (🐪)       camel
-	{runeRange{0x1F42B, 0x1F43E}, prExtendedPictographic}, // E0.6  [20] (🐫..🐾)    two-hump camel..paw prints
-	{runeRange{0x1F43F, 0x1F43F}, prExtendedPictographic}, // E0.7   [1] (🐿️)       chipmunk
-	{runeRange{0x1F440, 0x1F440}, prExtendedPictographic}, // E0.6   [1] (👀)       eyes
-	{runeRange{0x1F441, 0x1F441}, prExtendedPictographic}, // E0.7   [1] (👁️)       eye
-	{runeRange{0x1F442, 0x1F464}, prExtendedPictographic}, // E0.6  [35] (👂..👤)    ear..bust in silhouette
-	{runeRange{0x1F465, 0x1F465}, prExtendedPictographic}, // E1.0   [1] (👥)       busts in silhouette
-	{runeRange{0x1F466, 0x1F46B}, prExtendedPictographic}, // E0.6   [6] (👦..👫)    boy..woman and man holding hands
-	{runeRange{0x1F46C, 0x1F46D}, prExtendedPictographic}, // E1.0   [2] (👬..👭)    men holding hands..women holding hands
-	{runeRange{0x1F46E, 0x1F4AC}, prExtendedPictographic}, // E0.6  [63] (👮..💬)    police officer..speech balloon
-	{runeRange{0x1F4AD, 0x1F4AD}, prExtendedPictographic}, // E1.0   [1] (💭)       thought balloon
-	{runeRange{0x1F4AE, 0x1F4B5}, prExtendedPictographic}, // E0.6   [8] (💮..💵)    white flower..dollar banknote
-	{runeRange{0x1F4B6, 0x1F4B7}, prExtendedPictographic}, // E1.0   [2] (💶..💷)    euro banknote..pound banknote
-	{runeRange{0x1F4B8, 0x1F4EB}, prExtendedPictographic}, // E0.6  [52] (💸..📫)    money with wings..closed mailbox with raised flag
-	{runeRange{0x1F4EC, 0x1F4ED}, prExtendedPictographic}, // E0.7   [2] (📬..📭)    open mailbox with raised flag..open mailbox with lowered flag
-	{runeRange{0x1F4EE, 0x1F4EE}, prExtendedPictographic}, // E0.6   [1] (📮)       postbox
-	{runeRange{0x1F4EF, 0x1F4EF}, prExtendedPictographic}, // E1.0   [1] (📯)       postal horn
-	{runeRange{0x1F4F0, 0x1F4F4}, prExtendedPictographic}, // E0.6   [5] (📰..📴)    newspaper..mobile phone off
-	{runeRange{0x1F4F5, 0x1F4F5}, prExtendedPictographic}, // E1.0   [1] (📵)       no mobile phones
-	{runeRange{0x1F4F6, 0x1F4F7}, prExtendedPictographic}, // E0.6   [2] (📶..📷)    antenna bars..camera
-	{runeRange{0x1F4F8, 0x1F4F8}, prExtendedPictographic}, // E1.0   [1] (📸)       camera with flash
-	{runeRange{0x1F4F9, 0x1F4FC}, prExtendedPictographic}, // E0.6   [4] (📹..📼)    video camera..videocassette
-	{runeRange{0x1F4FD, 0x1F4FD}, prExtendedPictographic}, // E0.7   [1] (📽️)       film projector
-	{runeRange{0x1F4FE, 0x1F4FE}, prExtendedPictographic}, // E0.0   [1] (📾)       PORTABLE STEREO
-	{runeRange{0x1F4FF, 0x1F502}, prExtendedPictographic}, // E1.0   [4] (📿..🔂)    prayer beads..repeat single button
-	{runeRange{0x1F503, 0x1F503}, prExtendedPictographic}, // E0.6   [1] (🔃)       clockwise vertical arrows
-	{runeRange{0x1F504, 0x1F507}, prExtendedPictographic}, // E1.0   [4] (🔄..🔇)    counterclockwise arrows button..muted speaker
-	{runeRange{0x1F508, 0x1F508}, prExtendedPictographic}, // E0.7   [1] (🔈)       speaker low volume
-	{runeRange{0x1F509, 0x1F509}, prExtendedPictographic}, // E1.0   [1] (🔉)       speaker medium volume
-	{runeRange{0x1F50A, 0x1F514}, prExtendedPictographic}, // E0.6  [11] (🔊..🔔)    speaker high volume..bell
-	{runeRange{0x1F515, 0x1F515}, prExtendedPictographic}, // E1.0   [1] (🔕)       bell with slash
-	{runeRange{0x1F516, 0x1F52B}, prExtendedPictographic}, // E0.6  [22] (🔖..🔫)    bookmark..water pistol
-	{runeRange{0x1F52C, 0x1F52D}, prExtendedPictographic}, // E1.0   [2] (🔬..🔭)    microscope..telescope
-	{runeRange{0x1F52E, 0x1F53D}, prExtendedPictographic}, // E0.6  [16] (🔮..🔽)    crystal ball..downwards button
-	{runeRange{0x1F546, 0x1F548}, prExtendedPictographic}, // E0.0   [3] (🕆..🕈)    WHITE LATIN CROSS..CELTIC CROSS
-	{runeRange{0x1F549, 0x1F54A}, prExtendedPictographic}, // E0.7   [2] (🕉️..🕊️)    om..dove
-	{runeRange{0x1F54B, 0x1F54E}, prExtendedPictographic}, // E1.0   [4] (🕋..🕎)    kaaba..menorah
-	{runeRange{0x1F54F, 0x1F54F}, prExtendedPictographic}, // E0.0   [1] (🕏)       BOWL OF HYGIEIA
-	{runeRange{0x1F550, 0x1F55B}, prExtendedPictographic}, // E0.6  [12] (🕐..🕛)    one o’clock..twelve o’clock
-	{runeRange{0x1F55C, 0x1F567}, prExtendedPictographic}, // E0.7  [12] (🕜..🕧)    one-thirty..twelve-thirty
-	{runeRange{0x1F568, 0x1F56E}, prExtendedPictographic}, // E0.0   [7] (🕨..🕮)    RIGHT SPEAKER..BOOK
-	{runeRange{0x1F56F, 0x1F570}, prExtendedPictographic}, // E0.7   [2] (🕯️..🕰️)    candle..mantelpiece clock
-	{runeRange{0x1F571, 0x1F572}, prExtendedPictographic}, // E0.0   [2] (🕱..🕲)    BLACK SKULL AND CROSSBONES..NO PIRACY
-	{runeRange{0x1F573, 0x1F579}, prExtendedPictographic}, // E0.7   [7] (🕳️..🕹️)    hole..joystick
-	{runeRange{0x1F57A, 0x1F57A}, prExtendedPictographic}, // E3.0   [1] (🕺)       man dancing
-	{runeRange{0x1F57B, 0x1F586}, prExtendedPictographic}, // E0.0  [12] (🕻..🖆)    LEFT HAND TELEPHONE RECEIVER..PEN OVER STAMPED ENVELOPE
-	{runeRange{0x1F587, 0x1F587}, prExtendedPictographic}, // E0.7   [1] (🖇️)       linked paperclips
-	{runeRange{0x1F588, 0x1F589}, prExtendedPictographic}, // E0.0   [2] (🖈..🖉)    BLACK PUSHPIN..LOWER LEFT PENCIL
-	{runeRange{0x1F58A, 0x1F58D}, prExtendedPictographic}, // E0.7   [4] (🖊️..🖍️)    pen..crayon
-	{runeRange{0x1F58E, 0x1F58F}, prExtendedPictographic}, // E0.0   [2] (🖎..🖏)    LEFT WRITING HAND..TURNED OK HAND SIGN
-	{runeRange{0x1F590, 0x1F590}, prExtendedPictographic}, // E0.7   [1] (🖐️)       hand with fingers splayed
-	{runeRange{0x1F591, 0x1F594}, prExtendedPictographic}, // E0.0   [4] (🖑..🖔)    REVERSED RAISED HAND WITH FINGERS SPLAYED..REVERSED VICTORY HAND
-	{runeRange{0x1F595, 0x1F596}, prExtendedPictographic}, // E1.0   [2] (🖕..🖖)    middle finger..vulcan salute
-	{runeRange{0x1F597, 0x1F5A3}, prExtendedPictographic}, // E0.0  [13] (🖗..🖣)    WHITE DOWN POINTING LEFT HAND INDEX..BLACK DOWN POINTING BACKHAND INDEX
-	{runeRange{0x1F5A4, 0x1F5A4}, prExtendedPictographic}, // E3.0   [1] (🖤)       black heart
-	{runeRange{0x1F5A5, 0x1F5A5}, prExtendedPictographic}, // E0.7   [1] (🖥️)       desktop computer
-	{runeRange{0x1F5A6, 0x1F5A7}, prExtendedPictographic}, // E0.0   [2] (🖦..🖧)    KEYBOARD AND MOUSE..THREE NETWORKED COMPUTERS
-	{runeRange{0x1F5A8, 0x1F5A8}, prExtendedPictographic}, // E0.7   [1] (🖨️)       printer
-	{runeRange{0x1F5A9, 0x1F5B0}, prExtendedPictographic}, // E0.0   [8] (🖩..🖰)    POCKET CALCULATOR..TWO BUTTON MOUSE
-	{runeRange{0x1F5B1, 0x1F5B2}, prExtendedPictographic}, // E0.7   [2] (🖱️..🖲️)    computer mouse..trackball
-	{runeRange{0x1F5B3, 0x1F5BB}, prExtendedPictographic}, // E0.0   [9] (🖳..🖻)    OLD PERSONAL COMPUTER..DOCUMENT WITH PICTURE
-	{runeRange{0x1F5BC, 0x1F5BC}, prExtendedPictographic}, // E0.7   [1] (🖼️)       framed picture
-	{runeRange{0x1F5BD, 0x1F5C1}, prExtendedPictographic}, // E0.0   [5] (🖽..🗁)    FRAME WITH TILES..OPEN FOLDER
-	{runeRange{0x1F5C2, 0x1F5C4}, prExtendedPictographic}, // E0.7   [3] (🗂️..🗄️)    card index dividers..file cabinet
-	{runeRange{0x1F5C5, 0x1F5D0}, prExtendedPictographic}, // E0.0  [12] (🗅..🗐)    EMPTY NOTE..PAGES
-	{runeRange{0x1F5D1, 0x1F5D3}, prExtendedPictographic}, // E0.7   [3] (🗑️..🗓️)    wastebasket..spiral calendar
-	{runeRange{0x1F5D4, 0x1F5DB}, prExtendedPictographic}, // E0.0   [8] (🗔..🗛)    DESKTOP WINDOW..DECREASE FONT SIZE SYMBOL
-	{runeRange{0x1F5DC, 0x1F5DE}, prExtendedPictographic}, // E0.7   [3] (🗜️..🗞️)    clamp..rolled-up newspaper
-	{runeRange{0x1F5DF, 0x1F5E0}, prExtendedPictographic}, // E0.0   [2] (🗟..🗠)    PAGE WITH CIRCLED TEXT..STOCK CHART
-	{runeRange{0x1F5E1, 0x1F5E1}, prExtendedPictographic}, // E0.7   [1] (🗡️)       dagger
-	{runeRange{0x1F5E2, 0x1F5E2}, prExtendedPictographic}, // E0.0   [1] (🗢)       LIPS
-	{runeRange{0x1F5E3, 0x1F5E3}, prExtendedPictographic}, // E0.7   [1] (🗣️)       speaking head
-	{runeRange{0x1F5E4, 0x1F5E7}, prExtendedPictographic}, // E0.0   [4] (🗤..🗧)    THREE RAYS ABOVE..THREE RAYS RIGHT
-	{runeRange{0x1F5E8, 0x1F5E8}, prExtendedPictographic}, // E2.0   [1] (🗨️)       left speech bubble
-	{runeRange{0x1F5E9, 0x1F5EE}, prExtendedPictographic}, // E0.0   [6] (🗩..🗮)    RIGHT SPEECH BUBBLE..LEFT ANGER BUBBLE
-	{runeRange{0x1F5EF, 0x1F5EF}, prExtendedPictographic}, // E0.7   [1] (🗯️)       right anger bubble
-	{runeRange{0x1F5F0, 0x1F5F2}, prExtendedPictographic}, // E0.0   [3] (🗰..🗲)    MOOD BUBBLE..LIGHTNING MOOD
-	{runeRange{0x1F5F3, 0x1F5F3}, prExtendedPictographic}, // E0.7   [1] (🗳️)       ballot box with ballot
-	{runeRange{0x1F5F4, 0x1F5F9}, prExtendedPictographic}, // E0.0   [6] (🗴..🗹)    BALLOT SCRIPT X..BALLOT BOX WITH BOLD CHECK
-	{runeRange{0x1F5FA, 0x1F5FA}, prExtendedPictographic}, // E0.7   [1] (🗺️)       world map
-	{runeRange{0x1F5FB, 0x1F5FF}, prExtendedPictographic}, // E0.6   [5] (🗻..🗿)    mount fuji..moai
-	{runeRange{0x1F600, 0x1F600}, prExtendedPictographic}, // E1.0   [1] (😀)       grinning face
-	{runeRange{0x1F601, 0x1F606}, prExtendedPictographic}, // E0.6   [6] (😁..😆)    beaming face with smiling eyes..grinning squinting face
-	{runeRange{0x1F607, 0x1F608}, prExtendedPictographic}, // E1.0   [2] (😇..😈)    smiling face with halo..smiling face with horns
-	{runeRange{0x1F609, 0x1F60D}, prExtendedPictographic}, // E0.6   [5] (😉..😍)    winking face..smiling face with heart-eyes
-	{runeRange{0x1F60E, 0x1F60E}, prExtendedPictographic}, // E1.0   [1] (😎)       smiling face with sunglasses
-	{runeRange{0x1F60F, 0x1F60F}, prExtendedPictographic}, // E0.6   [1] (😏)       smirking face
-	{runeRange{0x1F610, 0x1F610}, prExtendedPictographic}, // E0.7   [1] (😐)       neutral face
-	{runeRange{0x1F611, 0x1F611}, prExtendedPictographic}, // E1.0   [1] (😑)       expressionless face
-	{runeRange{0x1F612, 0x1F614}, prExtendedPictographic}, // E0.6   [3] (😒..😔)    unamused face..pensive face
-	{runeRange{0x1F615, 0x1F615}, prExtendedPictographic}, // E1.0   [1] (😕)       confused face
-	{runeRange{0x1F616, 0x1F616}, prExtendedPictographic}, // E0.6   [1] (😖)       confounded face
-	{runeRange{0x1F617, 0x1F617}, prExtendedPictographic}, // E1.0   [1] (😗)       kissing face
-	{runeRange{0x1F618, 0x1F618}, prExtendedPictographic}, // E0.6   [1] (😘)       face blowing a kiss
-	{runeRange{0x1F619, 0x1F619}, prExtendedPictographic}, // E1.0   [1] (😙)       kissing face with smiling eyes
-	{runeRange{0x1F61A, 0x1F61A}, prExtendedPictographic}, // E0.6   [1] (😚)       kissing face with closed eyes
-	{runeRange{0x1F61B, 0x1F61B}, prExtendedPictographic}, // E1.0   [1] (😛)       face with tongue
-	{runeRange{0x1F61C, 0x1F61E}, prExtendedPictographic}, // E0.6   [3] (😜..😞)    winking face with tongue..disappointed face
-	{runeRange{0x1F61F, 0x1F61F}, prExtendedPictographic}, // E1.0   [1] (😟)       worried face
-	{runeRange{0x1F620, 0x1F625}, prExtendedPictographic}, // E0.6   [6] (😠..😥)    angry face..sad but relieved face
-	{runeRange{0x1F626, 0x1F627}, prExtendedPictographic}, // E1.0   [2] (😦..😧)    frowning face with open mouth..anguished face
-	{runeRange{0x1F628, 0x1F62B}, prExtendedPictographic}, // E0.6   [4] (😨..😫)    fearful face..tired face
-	{runeRange{0x1F62C, 0x1F62C}, prExtendedPictographic}, // E1.0   [1] (😬)       grimacing face
-	{runeRange{0x1F62D, 0x1F62D}, prExtendedPictographic}, // E0.6   [1] (😭)       loudly crying face
-	{runeRange{0x1F62E, 0x1F62F}, prExtendedPictographic}, // E1.0   [2] (😮..😯)    face with open mouth..hushed face
-	{runeRange{0x1F630, 0x1F633}, prExtendedPictographic}, // E0.6   [4] (😰..😳)    anxious face with sweat..flushed face
-	{runeRange{0x1F634, 0x1F634}, prExtendedPictographic}, // E1.0   [1] (😴)       sleeping face
-	{runeRange{0x1F635, 0x1F635}, prExtendedPictographic}, // E0.6   [1] (😵)       face with crossed-out eyes
-	{runeRange{0x1F636, 0x1F636}, prExtendedPictographic}, // E1.0   [1] (😶)       face without mouth
-	{runeRange{0x1F637, 0x1F640}, prExtendedPictographic}, // E0.6  [10] (😷..🙀)    face with medical mask..weary cat
-	{runeRange{0x1F641, 0x1F644}, prExtendedPictographic}, // E1.0   [4] (🙁..🙄)    slightly frowning face..face with rolling eyes
-	{runeRange{0x1F645, 0x1F64F}, prExtendedPictographic}, // E0.6  [11] (🙅..🙏)    person gesturing NO..folded hands
-	{runeRange{0x1F680, 0x1F680}, prExtendedPictographic}, // E0.6   [1] (🚀)       rocket
-	{runeRange{0x1F681, 0x1F682}, prExtendedPictographic}, // E1.0   [2] (🚁..🚂)    helicopter..locomotive
-	{runeRange{0x1F683, 0x1F685}, prExtendedPictographic}, // E0.6   [3] (🚃..🚅)    railway car..bullet train
-	{runeRange{0x1F686, 0x1F686}, prExtendedPictographic}, // E1.0   [1] (🚆)       train
-	{runeRange{0x1F687, 0x1F687}, prExtendedPictographic}, // E0.6   [1] (🚇)       metro
-	{runeRange{0x1F688, 0x1F688}, prExtendedPictographic}, // E1.0   [1] (🚈)       light rail
-	{runeRange{0x1F689, 0x1F689}, prExtendedPictographic}, // E0.6   [1] (🚉)       station
-	{runeRange{0x1F68A, 0x1F68B}, prExtendedPictographic}, // E1.0   [2] (🚊..🚋)    tram..tram car
-	{runeRange{0x1F68C, 0x1F68C}, prExtendedPictographic}, // E0.6   [1] (🚌)       bus
-	{runeRange{0x1F68D, 0x1F68D}, prExtendedPictographic}, // E0.7   [1] (🚍)       oncoming bus
-	{runeRange{0x1F68E, 0x1F68E}, prExtendedPictographic}, // E1.0   [1] (🚎)       trolleybus
-	{runeRange{0x1F68F, 0x1F68F}, prExtendedPictographic}, // E0.6   [1] (🚏)       bus stop
-	{runeRange{0x1F690, 0x1F690}, prExtendedPictographic}, // E1.0   [1] (🚐)       minibus
-	{runeRange{0x1F691, 0x1F693}, prExtendedPictographic}, // E0.6   [3] (🚑..🚓)    ambulance..police car
-	{runeRange{0x1F694, 0x1F694}, prExtendedPictographic}, // E0.7   [1] (🚔)       oncoming police car
-	{runeRange{0x1F695, 0x1F695}, prExtendedPictographic}, // E0.6   [1] (🚕)       taxi
-	{runeRange{0x1F696, 0x1F696}, prExtendedPictographic}, // E1.0   [1] (🚖)       oncoming taxi
-	{runeRange{0x1F697, 0x1F697}, prExtendedPictographic}, // E0.6   [1] (🚗)       automobile
-	{runeRange{0x1F698, 0x1F698}, prExtendedPictographic}, // E0.7   [1] (🚘)       oncoming automobile
-	{runeRange{0x1F699, 0x1F69A}, prExtendedPictographic}, // E0.6   [2] (🚙..🚚)    sport utility vehicle..delivery truck
-	{runeRange{0x1F69B, 0x1F6A1}, prExtendedPictographic}, // E1.0   [7] (🚛..🚡)    articulated lorry..aerial tramway
-	{runeRange{0x1F6A2, 0x1F6A2}, prExtendedPictographic}, // E0.6   [1] (🚢)       ship
-	{runeRange{0x1F6A3, 0x1F6A3}, prExtendedPictographic}, // E1.0   [1] (🚣)       person rowing boat
-	{runeRange{0x1F6A4, 0x1F6A5}, prExtendedPictographic}, // E0.6   [2] (🚤..🚥)    speedboat..horizontal traffic light
-	{runeRange{0x1F6A6, 0x1F6A6}, prExtendedPictographic}, // E1.0   [1] (🚦)       vertical traffic light
-	{runeRange{0x1F6A7, 0x1F6AD}, prExtendedPictographic}, // E0.6   [7] (🚧..🚭)    construction..no smoking
-	{runeRange{0x1F6AE, 0x1F6B1}, prExtendedPictographic}, // E1.0   [4] (🚮..🚱)    litter in bin sign..non-potable water
-	{runeRange{0x1F6B2, 0x1F6B2}, prExtendedPictographic}, // E0.6   [1] (🚲)       bicycle
-	{runeRange{0x1F6B3, 0x1F6B5}, prExtendedPictographic}, // E1.0   [3] (🚳..🚵)    no bicycles..person mountain biking
-	{runeRange{0x1F6B6, 0x1F6B6}, prExtendedPictographic}, // E0.6   [1] (🚶)       person walking
-	{runeRange{0x1F6B7, 0x1F6B8}, prExtendedPictographic}, // E1.0   [2] (🚷..🚸)    no pedestrians..children crossing
-	{runeRange{0x1F6B9, 0x1F6BE}, prExtendedPictographic}, // E0.6   [6] (🚹..🚾)    men’s room..water closet
+	{runeRange{0x1BAA, 0x1BAA}, prSpacingMark},            // Mc       SUNDANESE SIGN PAMAAEH
+	{runeRange{0xBA1C, 0xBA1C}, prLV},                     // Lo       HANGUL SYLLABLE MYAE
+	{runeRange{0xD61C, 0xD61C}, prLV},                     // Lo       HANGUL SYLLABLE HYE
 	{runeRange{0x1F6BF, 0x1F6BF}, prExtendedPictographic}, // E1.0   [1] (🚿)       shower
-	{runeRange{0x1F6C0, 0x1F6C0}, prExtendedPictographic}, // E0.6   [1] (🛀)       person taking bath
-	{runeRange{0x1F6C1, 0x1F6C5}, prExtendedPictographic}, // E1.0   [5] (🛁..🛅)    bathtub..left luggage
-	{runeRange{0x1F6C6, 0x1F6CA}, prExtendedPictographic}, // E0.0   [5] (🛆..🛊)    TRIANGLE WITH ROUNDED CORNERS..GIRLS SYMBOL
-	{runeRange{0x1F6CB, 0x1F6CB}, prExtendedPictographic}, // E0.7   [1] (🛋️)       couch and lamp
-	{runeRange{0x1F6CC, 0x1F6CC}, prExtendedPictographic}, // E1.0   [1] (🛌)       person in bed
-	{runeRange{0x1F6CD, 0x1F6CF}, prExtendedPictographic}, // E0.7   [3] (🛍️..🛏️)    shopping bags..bed
-	{runeRange{0x1F6D0, 0x1F6D0}, prExtendedPictographic}, // E1.0   [1] (🛐)       place of worship
-	{runeRange{0x1F6D1, 0x1F6D2}, prExtendedPictographic}, // E3.0   [2] (🛑..🛒)    stop sign..shopping cart
-	{runeRange{0x1F6D3, 0x1F6D4}, prExtendedPictographic}, // E0.0   [2] (🛓..🛔)    STUPA..PAGODA
-	{runeRange{0x1F6D5, 0x1F6D5}, prExtendedPictographic}, // E12.0  [1] (🛕)       hindu temple
-	{runeRange{0x1F6D6, 0x1F6D7}, prExtendedPictographic}, // E13.0  [2] (🛖..🛗)    hut..elevator
-	{runeRange{0x1F6D8, 0x1F6DB}, prExtendedPictographic}, // E0.0   [4] (🛘..🛛)    <reserved-1F6D8>..<reserved-1F6DB>
-	{runeRange{0x1F6DC, 0x1F6DC}, prExtendedPictographic}, // E15.0  [1] (🛜)       wireless
-	{runeRange{0x1F6DD, 0x1F6DF}, prExtendedPictographic}, // E14.0  [3] (🛝..🛟)    playground slide..ring buoy
-	{runeRange{0x1F6E0, 0x1F6E5}, prExtendedPictographic}, // E0.7   [6] (🛠️..🛥️)    hammer and wrench..motor boat
-	{runeRange{0x1F6E6, 0x1F6E8}, prExtendedPictographic}, // E0.0   [3] (🛦..🛨)    UP-POINTING MILITARY AIRPLANE..UP-POINTING SMALL AIRPLANE
-	{runeRange{0x1F6E9, 0x1F6E9}, prExtendedPictographic}, // E0.7   [1] (🛩️)       small airplane
-	{runeRange{0x1F6EA, 0x1F6EA}, prExtendedPictographic}, // E0.0   [1] (🛪)       NORTHEAST-POINTING AIRPLANE
-	{runeRange{0x1F6EB, 0x1F6EC}, prExtendedPictographic}, // E1.0   [2] (🛫..🛬)    airplane departure..airplane arrival
-	{runeRange{0x1F6ED, 0x1F6EF}, prExtendedPictographic}, // E0.0   [3] (🛭..🛯)    <reserved-1F6ED>..<reserved-1F6EF>
-	{runeRange{0x1F6F0, 0x1F6F0}, prExtendedPictographic}, // E0.7   [1] (🛰️)       satellite
-	{runeRange{0x1F6F1, 0x1F6F2}, prExtendedPictographic}, // E0.0   [2] (🛱..🛲)    ONCOMING FIRE ENGINE..DIESEL LOCOMOTIVE
-	{runeRange{0x1F6F3, 0x1F6F3}, prExtendedPictographic}, // E0.7   [1] (🛳️)       passenger ship
-	{runeRange{0x1F6F4, 0x1F6F6}, prExtendedPictographic}, // E3.0   [3] (🛴..🛶)    kick scooter..canoe
-	{runeRange{0x1F6F7, 0x1F6F8}, prExtendedPictographic}, // E5.0   [2] (🛷..🛸)    sled..flying saucer
-	{runeRange{0x1F6F9, 0x1F6F9}, prExtendedPictographic}, // E11.0  [1] (🛹)       skateboard
-	{runeRange{0x1F6FA, 0x1F6FA}, prExtendedPictographic}, // E12.0  [1] (🛺)       auto rickshaw
-	{runeRange{0x1F6FB, 0x1F6FC}, prExtendedPictographic}, // E13.0  [2] (🛻..🛼)    pickup truck..roller skate
-	{runeRange{0x1F6FD, 0x1F6FF}, prExtendedPictographic}, // E0.0   [3] (🛽..🛿)    <reserved-1F6FD>..<reserved-1F6FF>
-	{runeRange{0x1F774, 0x1F77F}, prExtendedPictographic}, // E0.0  [12] (🝴..🝿)    LOT OF FORTUNE..ORCUS
-	{runeRange{0x1F7D5, 0x1F7DF}, prExtendedPictographic}, // E0.0  [11] (🟕..🟟)    CIRCLED TRIANGLE..<reserved-1F7DF>
-	{runeRange{0x1F7E0, 0x1F7EB}, prExtendedPictographic}, // E12.0 [12] (🟠..🟫)    orange circle..brown square
-	{runeRange{0x1F7EC, 0x1F7EF}, prExtendedPictographic}, // E0.0   [4] (🟬..🟯)    <reserved-1F7EC>..<reserved-1F7EF>
-	{runeRange{0x1F7F0, 0x1F7F0}, prExtendedPictographic}, // E14.0  [1] (🟰)       heavy equals sign
-	{runeRange{0x1F7F1, 0x1F7FF}, prExtendedPictographic}, // E0.0  [15] (🟱..🟿)    <reserved-1F7F1>..<reserved-1F7FF>
-	{runeRange{0x1F80C, 0x1F80F}, prExtendedPictographic}, // E0.0   [4] (🠌..🠏)    <reserved-1F80C>..<reserved-1F80F>
-	{runeRange{0x1F848, 0x1F84F}, prExtendedPictographic}, // E0.0   [8] (🡈..🡏)    <reserved-1F848>..<reserved-1F84F>
-	{runeRange{0x1F85A, 0x1F85F}, prExtendedPictographic}, // E0.0   [6] (🡚..🡟)    <reserved-1F85A>..<reserved-1F85F>
-	{runeRange{0x1F888, 0x1F88F}, prExtendedPictographic}, // E0.0   [8] (🢈..🢏)    <reserved-1F888>..<reserved-1F88F>
-	{runeRange{0x1F8AE, 0x1F8FF}, prExtendedPictographic}, // E0.0  [82] (🢮..🣿)    <reserved-1F8AE>..<reserved-1F8FF>
-	{runeRange{0x1F90C, 0x1F90C}, prExtendedPictographic}, // E13.0  [1] (🤌)       pinched fingers
-	{runeRange{0x1F90D, 0x1F90F}, prExtendedPictographic}, // E12.0  [3] (🤍..🤏)    white heart..pinching hand
-	{runeRange{0x1F910, 0x1F918}, prExtendedPictographic}, // E1.0   [9] (🤐..🤘)    zipper-mouth face..sign of the horns
-	{runeRange{0x1F919, 0x1F91E}, prExtendedPictographic}, // E3.0   [6] (🤙..🤞)    call me hand..crossed fingers
-	{runeRange{0x1F91F, 0x1F91F}, prExtendedPictographic}, // E5.0   [1] (🤟)       love-you gesture
-	{runeRange{0x1F920, 0x1F927}, prExtendedPictographic}, // E3.0   [8] (🤠..🤧)    cowboy hat face..sneezing face
-	{runeRange{0x1F928, 0x1F92F}, prExtendedPictographic}, // E5.0   [8] (🤨..🤯)    face with raised eyebrow..exploding head
-	{runeRange{0x1F930, 0x1F930}, prExtendedPictographic}, // E3.0   [1] (🤰)       pregnant woman
-	{runeRange{0x1F931, 0x1F932}, prExtendedPictographic}, // E5.0   [2] (🤱..🤲)    breast-feeding..palms up together
-	{runeRange{0x1F933, 0x1F93A}, prExtendedPictographic}, // E3.0   [8] (🤳..🤺)    selfie..person fencing
-	{runeRange{0x1F93C, 0x1F93E}, prExtendedPictographic}, // E3.0   [3] (🤼..🤾)    people wrestling..person playing handball
-	{runeRange{0x1F93F, 0x1F93F}, prExtendedPictographic}, // E12.0  [1] (🤿)       diving mask
-	{runeRange{0x1F940, 0x1F945}, prExtendedPictographic}, // E3.0   [6] (🥀..🥅)    wilted flower..goal net
-	{runeRange{0x1F947, 0x1F94B}, prExtendedPictographic}, // E3.0   [5] (🥇..🥋)    1st place medal..martial arts uniform
-	{runeRange{0x1F94C, 0x1F94C}, prExtendedPictographic}, // E5.0   [1] (🥌)       curling stone
-	{runeRange{0x1F94D, 0x1F94F}, prExtendedPictographic}, // E11.0  [3] (🥍..🥏)    lacrosse..flying disc
-	{runeRange{0x1F950, 0x1F95E}, prExtendedPictographic}, // E3.0  [15] (🥐..🥞)    croissant..pancakes
-	{runeRange{0x1F95F, 0x1F96B}, prExtendedPictographic}, // E5.0  [13] (🥟..🥫)    dumpling..canned food
-	{runeRange{0x1F96C, 0x1F970}, prExtendedPictographic}, // E11.0  [5] (🥬..🥰)    leafy green..smiling face with hearts
-	{runeRange{0x1F971, 0x1F971}, prExtendedPictographic}, // E12.0  [1] (🥱)       yawning face
-	{runeRange{0x1F972, 0x1F972}, prExtendedPictographic}, // E13.0  [1] (🥲)       smiling face with tear
-	{runeRange{0x1F973, 0x1F976}, prExtendedPictographic}, // E11.0  [4] (🥳..🥶)    partying face..cold face
-	{runeRange{0x1F977, 0x1F978}, prExtendedPictographic}, // E13.0  [2] (🥷..🥸)    ninja..disguised face
+	{runeRange{0x0CC6, 0x0CC6}, prExtend},                 // Mn       KANNADA VOWEL SIGN E
+	{runeRange{0x26BD, 0x26BE}, prExtendedPictographic},   // E0.6   [2] (⚽..⚾)    soccer ball..baseball
+	{runeRange{0xB31C, 0xB31C}, prLV},                     // Lo       HANGUL SYLLABLE DYA
+	{runeRange{0xC11C, 0xC11C}, prLV},                     // Lo       HANGUL SYLLABLE SEO
+	{runeRange{0xCF1C, 0xCF1C}, prLV},                     // Lo       HANGUL SYLLABLE KYEO
+	{runeRange{0x115BE, 0x115BE}, prSpacingMark},          // Mc       SIDDHAM SIGN VISARGA
+	{runeRange{0x1F52E, 0x1F53D}, prExtendedPictographic}, // E0.6  [16] (🔮..🔽)    crystal ball..downwards button
 	{runeRange{0x1F979, 0x1F979}, prExtendedPictographic}, // E14.0  [1] (🥹)       face holding back tears
-	{runeRange{0x1F97A, 0x1F97A}, prExtendedPictographic}, // E11.0  [1] (🥺)       pleading face
-	{runeRange{0x1F97B, 0x1F97B}, prExtendedPictographic}, // E12.0  [1] (🥻)       sari
-	{runeRange{0x1F97C, 0x1F97F}, prExtendedPictographic}, // E11.0  [4] (🥼..🥿)    lab coat..flat shoe
-	{runeRange{0x1F980, 0x1F984}, prExtendedPictographic}, // E1.0   [5] (🦀..🦄)    crab..unicorn
-	{runeRange{0x1F985, 0x1F991}, prExtendedPictographic}, // E3.0  [13] (🦅..🦑)    eagle..squid
-	{runeRange{0x1F992, 0x1F997}, prExtendedPictographic}, // E5.0   [6] (🦒..🦗)    giraffe..cricket
-	{runeRange{0x1F998, 0x1F9A2}, prExtendedPictographic}, // E11.0 [11] (🦘..🦢)    kangaroo..swan
-	{runeRange{0x1F9A3, 0x1F9A4}, prExtendedPictographic}, // E13.0  [2] (🦣..🦤)    mammoth..dodo
-	{runeRange{0x1F9A5, 0x1F9AA}, prExtendedPictographic}, // E12.0  [6] (🦥..🦪)    sloth..oyster
-	{runeRange{0x1F9AB, 0x1F9AD}, prExtendedPictographic}, // E13.0  [3] (🦫..🦭)    beaver..seal
-	{runeRange{0x1F9AE, 0x1F9AF}, prExtendedPictographic}, // E12.0  [2] (🦮..🦯)    guide dog..white cane
-	{runeRange{0x1F9B0, 0x1F9B9}, prExtendedPictographic}, // E11.0 [10] (🦰..🦹)    red hair..supervillain
-	{runeRange{0x1F9BA, 0x1F9BF}, prExtendedPictographic}, // E12.0  [6] (🦺..🦿)    safety vest..mechanical leg
-	{runeRange{0x1F9C0, 0x1F9C0}, prExtendedPictographic}, // E1.0   [1] (🧀)       cheese wedge
-	{runeRange{0x1F9C1, 0x1F9C2}, prExtendedPictographic}, // E11.0  [2] (🧁..🧂)    cupcake..salt
-	{runeRange{0x1F9C3, 0x1F9CA}, prExtendedPictographic}, // E12.0  [8] (🧃..🧊)    beverage box..ice
-	{runeRange{0x1F9CB, 0x1F9CB}, prExtendedPictographic}, // E13.0  [1] (🧋)       bubble tea
-	{runeRange{0x1F9CC, 0x1F9CC}, prExtendedPictographic}, // E14.0  [1] (🧌)       troll
-	{runeRange{0x1F9CD, 0x1F9CF}, prExtendedPictographic}, // E12.0  [3] (🧍..🧏)    person standing..deaf person
-	{runeRange{0x1F9D0, 0x1F9E6}, prExtendedPictographic}, // E5.0  [23] (🧐..🧦)    face with monocle..socks
-	{runeRange{0x1F9E7, 0x1F9FF}, prExtendedPictographic}, // E11.0 [25] (🧧..🧿)    red envelope..nazar amulet
-	{runeRange{0x1FA00, 0x1FA6F}, prExtendedPictographic}, // E0.0 [112] (🨀..🩯)    NEUTRAL CHESS KING..<reserved-1FA6F>
-	{runeRange{0x1FA70, 0x1FA73}, prExtendedPictographic}, // E12.0  [4] (🩰..🩳)    ballet shoes..shorts
-	{runeRange{0x1FA74, 0x1FA74}, prExtendedPictographic}, // E13.0  [1] (🩴)       thong sandal
-	{runeRange{0x1FA75, 0x1FA77}, prExtendedPictographic}, // E15.0  [3] (🩵..🩷)    light blue heart..pink heart
-	{runeRange{0x1FA78, 0x1FA7A}, prExtendedPictographic}, // E12.0  [3] (🩸..🩺)    drop of blood..stethoscope
-	{runeRange{0x1FA7B, 0x1FA7C}, prExtendedPictographic}, // E14.0  [2] (🩻..🩼)    x-ray..crutch
-	{runeRange{0x1FA7D, 0x1FA7F}, prExtendedPictographic}, // E0.0   [3] (🩽..🩿)    <reserved-1FA7D>..<reserved-1FA7F>
-	{runeRange{0x1FA80, 0x1FA82}, prExtendedPictographic}, // E12.0  [3] (🪀..🪂)    yo-yo..parachute
-	{runeRange{0x1FA83, 0x1FA86}, prExtendedPictographic}, // E13.0  [4] (🪃..🪆)    boomerang..nesting dolls
-	{runeRange{0x1FA87, 0x1FA88}, prExtendedPictographic}, // E15.0  [2] (🪇..🪈)    maracas..flute
+	{runeRange{0x09D7, 0x09D7}, prExtend},                 // Mc       BENGALI AU LENGTH MARK
+	{runeRange{0x1100, 0x115F}, prL},                      // Lo  [96] HANGUL CHOSEONG KIYEOK..HANGUL CHOSEONG FILLER
+	{runeRange{0x2607, 0x260D}, prExtendedPictographic},   // E0.0   [7] (☇..☍)    LIGHTNING..OPPOSITION
+	{runeRange{0x302E, 0x302F}, prExtend},                 // Mc   [2] HANGUL SINGLE DOT TONE MARK..HANGUL DOUBLE DOT TONE MARK
+	{runeRange{0xAF9C, 0xAF9C}, prLV},                     // Lo       HANGUL SYLLABLE GGYO
+	{runeRange{0xB69C, 0xB69C}, prLV},                     // Lo       HANGUL SYLLABLE DDU
+	{runeRange{0xBD9C, 0xBD9C}, prLV},                     // Lo       HANGUL SYLLABLE BWEO
+	{runeRange{0xC49C, 0xC49C}, prLV},                     // Lo       HANGUL SYLLABLE SSWE
+	{runeRange{0xCB9C, 0xCB9C}, prLV},                     // Lo       HANGUL SYLLABLE JJWI
+	{runeRange{0xD29C, 0xD29C}, prLV},                     // Lo       HANGUL SYLLABLE TYU
+	{runeRange{0x110C2, 0x110C2}, prExtend},               // Mn       KAITHI VOWEL SIGN VOCALIC R
+	{runeRange{0x11CB4, 0x11CB4}, prSpacingMark},          // Mc       MARCHEN VOWEL SIGN O
+	{runeRange{0x1F3C5, 0x1F3C5}, prExtendedPictographic}, // E1.0   [1] (🏅)       sports medal
+	{runeRange{0x1F61C, 0x1F61E}, prExtendedPictographic}, // E0.6   [3] (😜..😞)    winking face with tongue..disappointed face
+	{runeRange{0x1F7E0, 0x1F7EB}, prExtendedPictographic}, // E12.0 [12] (🟠..🟫)    orange circle..brown square
 	{runeRange{0x1FA89, 0x1FA8F}, prExtendedPictographic}, // E0.0   [7] (🪉..🪏)    <reserved-1FA89>..<reserved-1FA8F>
-	{runeRange{0x1FA90, 0x1FA95}, prExtendedPictographic}, // E12.0  [6] (🪐..🪕)    ringed planet..banjo
-	{runeRange{0x1FA96, 0x1FAA8}, prExtendedPictographic}, // E13.0 [19] (🪖..🪨)    military helmet..rock
-	{runeRange{0x1FAA9, 0x1FAAC}, prExtendedPictographic}, // E14.0  [4] (🪩..🪬)    mirror ball..hamsa
-	{runeRange{0x1FAAD, 0x1FAAF}, prExtendedPictographic}, // E15.0  [3] (🪭..🪯)    folding hand fan..khanda
-	{runeRange{0x1FAB0, 0x1FAB6}, prExtendedPictographic}, // E13.0  [7] (🪰..🪶)    fly..feather
-	{runeRange{0x1FAB7, 0x1FABA}, prExtendedPictographic}, // E14.0  [4] (🪷..🪺)    lotus..nest with eggs
-	{runeRange{0x1FABB, 0x1FABD}, prExtendedPictographic}, // E15.0  [3] (🪻..🪽)    hyacinth..wing
-	{runeRange{0x1FABE, 0x1FABE}, prExtendedPictographic}, // E0.0   [1] (🪾)       <reserved-1FABE>
-	{runeRange{0x1FABF, 0x1FABF}, prExtendedPictographic}, // E15.0  [1] (🪿)       goose
-	{runeRange{0x1FAC0, 0x1FAC2}, prExtendedPictographic}, // E13.0  [3] (🫀..🫂)    anatomical heart..people hugging
-	{runeRange{0x1FAC3, 0x1FAC5}, prExtendedPictographic}, // E14.0  [3] (🫃..🫅)    pregnant man..person with crown
-	{runeRange{0x1FAC6, 0x1FACD}, prExtendedPictographic}, // E0.0   [8] (🫆..🫍)    <reserved-1FAC6>..<reserved-1FACD>
-	{runeRange{0x1FACE, 0x1FACF}, prExtendedPictographic}, // E15.0  [2] (🫎..🫏)    moose..donkey
-	{runeRange{0x1FAD0, 0x1FAD6}, prExtendedPictographic}, // E13.0  [7] (🫐..🫖)    blueberries..teapot
-	{runeRange{0x1FAD7, 0x1FAD9}, prExtendedPictographic}, // E14.0  [3] (🫗..🫙)    pouring liquid..jar
+	{runeRange{0x07EB, 0x07F3}, prExtend},                 // Mn   [9] NKO COMBINING SHORT HIGH TONE..NKO COMBINING DOUBLE DOT ABOVE
+	{runeRange{0x0B4B, 0x0B4C}, prSpacingMark},            // Mc   [2] ORIYA VOWEL SIGN O..ORIYA VOWEL SIGN AU
+	{runeRange{0x0E47, 0x0E4E}, prExtend},                 // Mn   [8] THAI CHARACTER MAITAIKHU..THAI CHARACTER YAMAKKAN
+	{runeRange{0x1A19, 0x1A1A}, prSpacingMark},            // Mc   [2] BUGINESE VOWEL SIGN E..BUGINESE VOWEL SIGN O
+	{runeRange{0x2060, 0x2064}, prControl},                // Cf   [5] WORD JOINER..INVISIBLE PLUS
+	{runeRange{0x2660, 0x2660}, prExtendedPictographic},   // E0.6   [1] (♠️)       spade suit
+	{runeRange{0x270E, 0x270E}, prExtendedPictographic},   // E0.0   [1] (✎)       LOWER RIGHT PENCIL
+	{runeRange{0xA9BA, 0xA9BB}, prSpacingMark},            // Mc   [2] JAVANESE VOWEL SIGN TALING..JAVANESE VOWEL SIGN DIRGA MURE
+	{runeRange{0xADDC, 0xADDC}, prLV},                     // Lo       HANGUL SYLLABLE GYU
+	{runeRange{0xB15C, 0xB15C}, prLV},                     // Lo       HANGUL SYLLABLE NYE
+	{runeRange{0xB4DC, 0xB4DC}, prLV},                     // Lo       HANGUL SYLLABLE DEU
+	{runeRange{0xB85C, 0xB85C}, prLV},                     // Lo       HANGUL SYLLABLE RO
+	{runeRange{0xBBDC, 0xBBDC}, prLV},                     // Lo       HANGUL SYLLABLE MYI
+	{runeRange{0xBF5C, 0xBF5C}, prLV},                     // Lo       HANGUL SYLLABLE BBWA
+	{runeRange{0xC2DC, 0xC2DC}, prLV},                     // Lo       HANGUL SYLLABLE SI
+	{runeRange{0xC65C, 0xC65C}, prLV},                     // Lo       HANGUL SYLLABLE WAE
+	{runeRange{0xC9DC, 0xC9DC}, prLV},                     // Lo       HANGUL SYLLABLE JJA
+	{runeRange{0xCD5C, 0xCD5C}, prLV},                     // Lo       HANGUL SYLLABLE COE
+	{runeRange{0xD0DC, 0xD0DC}, prLV},                     // Lo       HANGUL SYLLABLE TAE
+	{runeRange{0xD45C, 0xD45C}, prLV},                     // Lo       HANGUL SYLLABLE PYO
+	{runeRange{0xFE20, 0xFE2F}, prExtend},                 // Mn  [16] COMBINING LIGATURE LEFT HALF..COMBINING CYRILLIC TITLO RIGHT HALF
+	{runeRange{0x1133F, 0x1133F}, prSpacingMark},          // Mc       GRANTHA VOWEL SIGN I
+	{runeRange{0x11941, 0x11941}, prPrepend},              // Lo       DIVES AKURU INITIAL RA
+	{runeRange{0x16F8F, 0x16F92}, prExtend},               // Mn   [4] MIAO TONE RIGHT..MIAO TONE BELOW
+	{runeRange{0x1F313, 0x1F315}, prExtendedPictographic}, // E0.6   [3] (🌓..🌕)    first quarter moon..full moon
+	{runeRange{0x1F42B, 0x1F43E}, prExtendedPictographic}, // E0.6  [20] (🐫..🐾)    two-hump camel..paw prints
+	{runeRange{0x1F5D1, 0x1F5D3}, prExtendedPictographic}, // E0.7   [3] (🗑️..🗓️)    wastebasket..spiral calendar
+	{runeRange{0x1F696, 0x1F696}, prExtendedPictographic}, // E1.0   [1] (🚖)       oncoming taxi
+	{runeRange{0x1F6E6, 0x1F6E8}, prExtendedPictographic}, // E0.0   [3] (🛦..🛨)    UP-POINTING MILITARY AIRPLANE..UP-POINTING SMALL AIRPLANE
+	{runeRange{0x1F930, 0x1F930}, prExtendedPictographic}, // E3.0   [1] (🤰)       pregnant woman
+	{runeRange{0x1F9C3, 0x1F9CA}, prExtendedPictographic}, // E12.0  [8] (🧃..🧊)    beverage box..ice
 	{runeRange{0x1FADA, 0x1FADB}, prExtendedPictographic}, // E15.0  [2] (🫚..🫛)    ginger root..pea pod
-	{runeRange{0x1FADC, 0x1FADF}, prExtendedPictographic}, // E0.0   [4] (🫜..🫟)    <reserved-1FADC>..<reserved-1FADF>
-	{runeRange{0x1FAE0, 0x1FAE7}, prExtendedPictographic}, // E14.0  [8] (🫠..🫧)    melting face..bubbles
-	{runeRange{0x1FAE8, 0x1FAE8}, prExtendedPictographic}, // E15.0  [1] (🫨)       shaking face
-	{runeRange{0x1FAE9, 0x1FAEF}, prExtendedPictographic}, // E0.0   [7] (🫩..🫯)    <reserved-1FAE9>..<reserved-1FAEF>
-	{runeRange{0x1FAF0, 0x1FAF6}, prExtendedPictographic}, // E14.0  [7] (🫰..🫶)    hand with index finger and thumb crossed..heart hands
-	{runeRange{0x1FAF7, 0x1FAF8}, prExtendedPictographic}, // E15.0  [2] (🫷..🫸)    leftwards pushing hand..rightwards pushing hand
-	{runeRange{0x1FAF9, 0x1FAFF}, prExtendedPictographic}, // E0.0   [7] (🫹..🫿)    <reserved-1FAF9>..<reserved-1FAFF>
+	{runeRange{0x05C4, 0x05C5}, prExtend},                 // Mn   [2] HEBREW MARK UPPER DOT..HEBREW MARK LOWER DOT
+	{runeRange{0x093E, 0x0940}, prSpacingMark},            // Mc   [3] DEVANAGARI VOWEL SIGN AA..DEVANAGARI VOWEL SIGN II
+	{runeRange{0x0ABE, 0x0AC0}, prSpacingMark},            // Mc   [3] GUJARATI VOWEL SIGN AA..GUJARATI VOWEL SIGN II
+	{runeRange{0x0C04, 0x0C04}, prExtend},                 // Mn       TELUGU SIGN COMBINING ANUSVARA ABOVE
+	{runeRange{0x0D4E, 0x0D4E}, prPrepend},                // Lo       MALAYALAM LETTER DOT REPH
+	{runeRange{0x0FC6, 0x0FC6}, prExtend},                 // Mn       TIBETAN SYMBOL PADMA GDAN
+	{runeRange{0x17C9, 0x17D3}, prExtend},                 // Mn  [11] KHMER SIGN MUUSIKATOAN..KHMER SIGN BATHAMASAT
+	{runeRange{0x1B04, 0x1B04}, prSpacingMark},            // Mc       BALINESE SIGN BISAH
+	{runeRange{0x1CE1, 0x1CE1}, prSpacingMark},            // Mc       VEDIC TONE ATHARVAVEDIC INDEPENDENT SVARITA
+	{runeRange{0x23E9, 0x23EC}, prExtendedPictographic},   // E0.6   [4] (⏩..⏬)    fast-forward button..fast down button
+	{runeRange{0x2627, 0x2629}, prExtendedPictographic},   // E0.0   [3] (☧..☩)    CHI RHO..CROSS OF JERUSALEM
+	{runeRange{0x2694, 0x2694}, prExtendedPictographic},   // E1.0   [1] (⚔️)       crossed swords
+	{runeRange{0x26EB, 0x26EF}, prExtendedPictographic},   // E0.0   [5] (⛫..⛯)    CASTLE..MAP SYMBOL FOR LIGHTHOUSE
+	{runeRange{0x2763, 0x2763}, prExtendedPictographic},   // E1.0   [1] (❣️)       heart exclamation
+	{runeRange{0xA827, 0xA827}, prSpacingMark},            // Mc       SYLOTI NAGRI VOWEL SIGN OO
+	{runeRange{0xAABE, 0xAABF}, prExtend},                 // Mn   [2] TAI VIET VOWEL AM..TAI VIET TONE MAI EK
+	{runeRange{0xACFC, 0xACFC}, prLV},                     // Lo       HANGUL SYLLABLE GWA
+	{runeRange{0xAEBC, 0xAEBC}, prLV},                     // Lo       HANGUL SYLLABLE GGEO
+	{runeRange{0xB07C, 0xB07C}, prLV},                     // Lo       HANGUL SYLLABLE GGI
+	{runeRange{0xB23C, 0xB23C}, prLV},                     // Lo       HANGUL SYLLABLE NWE
+	{runeRange{0xB3FC, 0xB3FC}, prLV},                     // Lo       HANGUL SYLLABLE DWAE
+	{runeRange{0xB5BC, 0xB5BC}, prLV},                     // Lo       HANGUL SYLLABLE DDE
+	{runeRange{0xB77C, 0xB77C}, prLV},                     // Lo       HANGUL SYLLABLE RA
+	{runeRange{0xB93C, 0xB93C}, prLV},                     // Lo       HANGUL SYLLABLE RWI
+	{runeRange{0xBAFC, 0xBAFC}, prLV},                     // Lo       HANGUL SYLLABLE MOE
+	{runeRange{0xBCBC, 0xBCBC}, prLV},                     // Lo       HANGUL SYLLABLE BYEO
+	{runeRange{0xBE7C, 0xBE7C}, prLV},                     // Lo       HANGUL SYLLABLE BBAE
+	{runeRange{0xC03C, 0xC03C}, prLV},                     // Lo       HANGUL SYLLABLE BBYU
+	{runeRange{0xC1FC, 0xC1FC}, prLV},                     // Lo       HANGUL SYLLABLE SYO
+	{runeRange{0xC3BC, 0xC3BC}, prLV},                     // Lo       HANGUL SYLLABLE SSYE
+	{runeRange{0xC57C, 0xC57C}, prLV},                     // Lo       HANGUL SYLLABLE YA
+	{runeRange{0xC73C, 0xC73C}, prLV},                     // Lo       HANGUL SYLLABLE EU
+	{runeRange{0xC8FC, 0xC8FC}, prLV},                     // Lo       HANGUL SYLLABLE JU
+	{runeRange{0xCABC, 0xCABC}, prLV},                     // Lo       HANGUL SYLLABLE JJO
+	{runeRange{0xCC7C, 0xCC7C}, prLV},                     // Lo       HANGUL SYLLABLE CYAE
+	{runeRange{0xCE3C, 0xCE3C}, prLV},                     // Lo       HANGUL SYLLABLE CYI
+	{runeRange{0xCFFC, 0xCFFC}, prLV},                     // Lo       HANGUL SYLLABLE KWEO
+	{runeRange{0xD1BC, 0xD1BC}, prLV},                     // Lo       HANGUL SYLLABLE TWA
+	{runeRange{0xD37C, 0xD37C}, prLV},                     // Lo       HANGUL SYLLABLE PEO
+	{runeRange{0xD53C, 0xD53C}, prLV},                     // Lo       HANGUL SYLLABLE PI
+	{runeRange{0xD6FC, 0xD6FC}, prLV},                     // Lo       HANGUL SYLLABLE HWE
+	{runeRange{0x10EFD, 0x10EFF}, prExtend},               // Mn   [3] ARABIC SMALL LOW WORD SAKTA..ARABIC SMALL LOW WORD MADDA
+	{runeRange{0x111CF, 0x111CF}, prExtend},               // Mn       SHARADA SIGN INVERTED CANDRABINDU
+	{runeRange{0x114B0, 0x114B0}, prExtend},               // Mc       TIRHUTA VOWEL SIGN AA
+	{runeRange{0x1171D, 0x1171F}, prExtend},               // Mn   [3] AHOM CONSONANT SIGN MEDIAL LA..AHOM CONSONANT SIGN MEDIAL LIGATING RA
+	{runeRange{0x11A57, 0x11A58}, prSpacingMark},          // Mc   [2] SOYOMBO VOWEL SIGN AI..SOYOMBO VOWEL SIGN AU
+	{runeRange{0x11F00, 0x11F01}, prExtend},               // Mn   [2] KAWI SIGN CANDRABINDU..KAWI SIGN ANUSVARA
+	{runeRange{0x1D242, 0x1D244}, prExtend},               // Mn   [3] COMBINING GREEK MUSICAL TRISEME..COMBINING GREEK MUSICAL PENTASEME
+	{runeRange{0x1F1E6, 0x1F1FF}, prRegionalIndicator},    // So  [26] REGIONAL INDICATOR SYMBOL LETTER A..REGIONAL INDICATOR SYMBOL LETTER Z
+	{runeRange{0x1F337, 0x1F34A}, prExtendedPictographic}, // E0.6  [20] (🌷..🍊)    tulip..tangerine
+	{runeRange{0x1F3F6, 0x1F3F6}, prExtendedPictographic}, // E0.0   [1] (🏶)       BLACK ROSETTE
+	{runeRange{0x1F4F0, 0x1F4F4}, prExtendedPictographic}, // E0.6   [5] (📰..📴)    newspaper..mobile phone off
+	{runeRange{0x1F58E, 0x1F58F}, prExtendedPictographic}, // E0.0   [2] (🖎..🖏)    LEFT WRITING HAND..TURNED OK HAND SIGN
+	{runeRange{0x1F600, 0x1F600}, prExtendedPictographic}, // E1.0   [1] (😀)       grinning face
+	{runeRange{0x1F681, 0x1F682}, prExtendedPictographic}, // E1.0   [2] (🚁..🚂)    helicopter..locomotive
+	{runeRange{0x1F6A6, 0x1F6A6}, prExtendedPictographic}, // E1.0   [1] (🚦)       vertical traffic light
+	{runeRange{0x1F6D1, 0x1F6D2}, prExtendedPictographic}, // E3.0   [2] (🛑..🛒)    stop sign..shopping cart
+	{runeRange{0x1F6F4, 0x1F6F6}, prExtendedPictographic}, // E3.0   [3] (🛴..🛶)    kick scooter..canoe
+	{runeRange{0x1F8AE, 0x1F8FF}, prExtendedPictographic}, // E0.0  [82] (🢮..🣿)    <reserved-1F8AE>..<reserved-1F8FF>
+	{runeRange{0x1F94D, 0x1F94F}, prExtendedPictographic}, // E11.0  [3] (🥍..🥏)    lacrosse..flying disc
+	{runeRange{0x1F9A3, 0x1F9A4}, prExtendedPictographic}, // E13.0  [2] (🦣..🦤)    mammoth..dodo
+	{runeRange{0x1FA74, 0x1FA74}, prExtendedPictographic}, // E13.0  [1] (🩴)       thong sandal
+	{runeRange{0x1FABE, 0x1FABE}, prExtendedPictographic}, // E0.0   [1] (🪾)       <reserved-1FABE>
 	{runeRange{0x1FC00, 0x1FFFD}, prExtendedPictographic}, // E0.0[1022] (🰀..🿽)    <reserved-1FC00>..<reserved-1FFFD>
-	{runeRange{0xE0000, 0xE0000}, prControl},              // Cn       <reserved-E0000>
-	{runeRange{0xE0001, 0xE0001}, prControl},              // Cf       LANGUAGE TAG
-	{runeRange{0xE0002, 0xE001F}, prControl},              // Cn  [30] <reserved-E0002>..<reserved-E001F>
+	{runeRange{0x00AD, 0x00AD}, prControl},                // Cf       SOFT HYPHEN
+	{runeRange{0x06DD, 0x06DD}, prPrepend},                // Cf       ARABIC END OF AYAH
+	{runeRange{0x0898, 0x089F}, prExtend},                 // Mn   [8] ARABIC SMALL HIGH WORD AL-JUZ..ARABIC HALF MADDA OVER MADDA
+	{runeRange{0x0982, 0x0983}, prSpacingMark},            // Mc   [2] BENGALI SIGN ANUSVARA..BENGALI SIGN VISARGA
+	{runeRange{0x0A47, 0x0A48}, prExtend},                 // Mn   [2] GURMUKHI VOWEL SIGN EE..GURMUKHI VOWEL SIGN AI
+	{runeRange{0x0B01, 0x0B01}, prExtend},                 // Mn       ORIYA SIGN CANDRABINDU
+	{runeRange{0x0BC0, 0x0BC0}, prExtend},                 // Mn       TAMIL VOWEL SIGN II
+	{runeRange{0x0C81, 0x0C81}, prExtend},                 // Mn       KANNADA SIGN CANDRABINDU
+	{runeRange{0x0D02, 0x0D03}, prSpacingMark},            // Mc   [2] MALAYALAM SIGN ANUSVARA..MALAYALAM SIGN VISARGA
+	{runeRange{0x0DD2, 0x0DD4}, prExtend},                 // Mn   [3] SINHALA VOWEL SIGN KETTI IS-PILLA..SINHALA VOWEL SIGN KETTI PAA-PILLA
+	{runeRange{0x0F39, 0x0F39}, prExtend},                 // Mn       TIBETAN MARK TSA -PHRU
+	{runeRange{0x1058, 0x1059}, prExtend},                 // Mn   [2] MYANMAR VOWEL SIGN VOCALIC L..MYANMAR VOWEL SIGN VOCALIC LL
+	{runeRange{0x1752, 0x1753}, prExtend},                 // Mn   [2] BUHID VOWEL SIGN I..BUHID VOWEL SIGN U
+	{runeRange{0x1923, 0x1926}, prSpacingMark},            // Mc   [4] LIMBU VOWEL SIGN EE..LIMBU VOWEL SIGN AU
+	{runeRange{0x1A65, 0x1A6C}, prExtend},                 // Mn   [8] TAI THAM VOWEL SIGN I..TAI THAM VOWEL SIGN OA BELOW
+	{runeRange{0x1B43, 0x1B44}, prSpacingMark},            // Mc   [2] BALINESE VOWEL SIGN PEPET TEDUNG..BALINESE ADEG ADEG
+	{runeRange{0x1BEF, 0x1BF1}, prExtend},                 // Mn   [3] BATAK VOWEL SIGN U FOR SIMALUNGUN SA..BATAK CONSONANT SIGN H
+	{runeRange{0x200C, 0x200C}, prExtend},                 // Cf       ZERO WIDTH NON-JOINER
+	{runeRange{0x2122, 0x2122}, prExtendedPictographic},   // E0.6   [1] (™️)       trade mark
+	{runeRange{0x25AA, 0x25AB}, prExtendedPictographic},   // E0.6   [2] (▪️..▫️)    black small square..white small square
+	{runeRange{0x2619, 0x261C}, prExtendedPictographic},   // E0.0   [4] (☙..☜)    REVERSED ROTATED FLORAL HEART BULLET..WHITE LEFT POINTING INDEX
+	{runeRange{0x263B, 0x263F}, prExtendedPictographic},   // E0.0   [5] (☻..☿)    BLACK SMILING FACE..MERCURY
+	{runeRange{0x267B, 0x267B}, prExtendedPictographic},   // E0.6   [1] (♻️)       recycling symbol
+	{runeRange{0x26A0, 0x26A1}, prExtendedPictographic},   // E0.6   [2] (⚠️..⚡)    warning..high voltage
+	{runeRange{0x26D0, 0x26D0}, prExtendedPictographic},   // E0.0   [1] (⛐)       CAR SLIDING
+	{runeRange{0x26FB, 0x26FC}, prExtendedPictographic},   // E0.0   [2] (⛻..⛼)    JAPANESE BANK SYMBOL..HEADSTONE GRAVEYARD SYMBOL
+	{runeRange{0x2728, 0x2728}, prExtendedPictographic},   // E0.6   [1] (✨)       sparkles
+	{runeRange{0x2B05, 0x2B07}, prExtendedPictographic},   // E0.6   [3] (⬅️..⬇️)    left arrow..down arrow
+	{runeRange{0xA674, 0xA67D}, prExtend},                 // Mn  [10] COMBINING CYRILLIC LETTER UKRAINIAN IE..COMBINING CYRILLIC PAYEROK
+	{runeRange{0xA947, 0xA951}, prExtend},                 // Mn  [11] REJANG VOWEL SIGN I..REJANG CONSONANT SIGN R
+	{runeRange{0xAA35, 0xAA36}, prExtend},                 // Mn   [2] CHAM CONSONANT SIGN LA..CHAM CONSONANT SIGN WA
+	{runeRange{0xABE5, 0xABE5}, prExtend},                 // Mn       MEETEI MAYEK VOWEL SIGN ANAP
+	{runeRange{0xAC8C, 0xAC8C}, prLV},                     // Lo       HANGUL SYLLABLE GE
+	{runeRange{0xAD6C, 0xAD6C}, prLV},                     // Lo       HANGUL SYLLABLE GU
+	{runeRange{0xAE4C, 0xAE4C}, prLV},                     // Lo       HANGUL SYLLABLE GGA
+	{runeRange{0xAF2C, 0xAF2C}, prLV},                     // Lo       HANGUL SYLLABLE GGO
+	{runeRange{0xB00C, 0xB00C}, prLV},                     // Lo       HANGUL SYLLABLE GGWI
+	{runeRange{0xB0EC, 0xB0EC}, prLV},                     // Lo       HANGUL SYLLABLE NYAE
+	{runeRange{0xB1CC, 0xB1CC}, prLV},                     // Lo       HANGUL SYLLABLE NOE
+	{runeRange{0xB2AC, 0xB2AC}, prLV},                     // Lo       HANGUL SYLLABLE NYI
+	{runeRange{0xB38C, 0xB38C}, prLV},                     // Lo       HANGUL SYLLABLE DYEO
+	{runeRange{0xB46C, 0xB46C}, prLV},                     // Lo       HANGUL SYLLABLE DWEO
+	{runeRange{0xB54C, 0xB54C}, prLV},                     // Lo       HANGUL SYLLABLE DDAE
+	{runeRange{0xB62C, 0xB62C}, prLV},                     // Lo       HANGUL SYLLABLE DDWA
+	{runeRange{0xB70C, 0xB70C}, prLV},                     // Lo       HANGUL SYLLABLE DDYU
+	{runeRange{0xB7EC, 0xB7EC}, prLV},                     // Lo       HANGUL SYLLABLE REO
+	{runeRange{0xB8CC, 0xB8CC}, prLV},                     // Lo       HANGUL SYLLABLE RYO
+	{runeRange{0xB9AC, 0xB9AC}, prLV},                     // Lo       HANGUL SYLLABLE RI
+	{runeRange{0xBA8C, 0xBA8C}, prLV},                     // Lo       HANGUL SYLLABLE MYE
+	{runeRange{0xBB6C, 0xBB6C}, prLV},                     // Lo       HANGUL SYLLABLE MWE
+	{runeRange{0xBC4C, 0xBC4C}, prLV},                     // Lo       HANGUL SYLLABLE BYA
+	{runeRange{0xBD2C, 0xBD2C}, prLV},                     // Lo       HANGUL SYLLABLE BWAE
+	{runeRange{0xBE0C, 0xBE0C}, prLV},                     // Lo       HANGUL SYLLABLE BEU
+	{runeRange{0xBEEC, 0xBEEC}, prLV},                     // Lo       HANGUL SYLLABLE BBE
+	{runeRange{0xBFCC, 0xBFCC}, prLV},                     // Lo       HANGUL SYLLABLE BBU
+	{runeRange{0xC0AC, 0xC0AC}, prLV},                     // Lo       HANGUL SYLLABLE SA
+	{runeRange{0xC18C, 0xC18C}, prLV},                     // Lo       HANGUL SYLLABLE SO
+	{runeRange{0xC26C, 0xC26C}, prLV},                     // Lo       HANGUL SYLLABLE SWI
+	{runeRange{0xC34C, 0xC34C}, prLV},                     // Lo       HANGUL SYLLABLE SSYAE
+	{runeRange{0xC42C, 0xC42C}, prLV},                     // Lo       HANGUL SYLLABLE SSOE
+	{runeRange{0xC50C, 0xC50C}, prLV},                     // Lo       HANGUL SYLLABLE SSYI
+	{runeRange{0xC5EC, 0xC5EC}, prLV},                     // Lo       HANGUL SYLLABLE YEO
+	{runeRange{0xC6CC, 0xC6CC}, prLV},                     // Lo       HANGUL SYLLABLE WEO
+	{runeRange{0xC7AC, 0xC7AC}, prLV},                     // Lo       HANGUL SYLLABLE JAE
+	{runeRange{0xC88C, 0xC88C}, prLV},                     // Lo       HANGUL SYLLABLE JWA
+	{runeRange{0xC96C, 0xC96C}, prLV},                     // Lo       HANGUL SYLLABLE JYU
+	{runeRange{0xCA4C, 0xCA4C}, prLV},                     // Lo       HANGUL SYLLABLE JJEO
+	{runeRange{0xCB2C, 0xCB2C}, prLV},                     // Lo       HANGUL SYLLABLE JJYO
+	{runeRange{0xCC0C, 0xCC0C}, prLV},                     // Lo       HANGUL SYLLABLE JJI
+	{runeRange{0xCCEC, 0xCCEC}, prLV},                     // Lo       HANGUL SYLLABLE CYE
+	{runeRange{0xCDCC, 0xCDCC}, prLV},                     // Lo       HANGUL SYLLABLE CWE
+	{runeRange{0xCEAC, 0xCEAC}, prLV},                     // Lo       HANGUL SYLLABLE KYA
+	{runeRange{0xCF8C, 0xCF8C}, prLV},                     // Lo       HANGUL SYLLABLE KWAE
+	{runeRange{0xD06C, 0xD06C}, prLV},                     // Lo       HANGUL SYLLABLE KEU
+	{runeRange{0xD14C, 0xD14C}, prLV},                     // Lo       HANGUL SYLLABLE TE
+	{runeRange{0xD22C, 0xD22C}, prLV},                     // Lo       HANGUL SYLLABLE TU
+	{runeRange{0xD30C, 0xD30C}, prLV},                     // Lo       HANGUL SYLLABLE PA
+	{runeRange{0xD3EC, 0xD3EC}, prLV},                     // Lo       HANGUL SYLLABLE PO
+	{runeRange{0xD4CC, 0xD4CC}, prLV},                     // Lo       HANGUL SYLLABLE PWI
+	{runeRange{0xD5AC, 0xD5AC}, prLV},                     // Lo       HANGUL SYLLABLE HYAE
+	{runeRange{0xD68C, 0xD68C}, prLV},                     // Lo       HANGUL SYLLABLE HOE
+	{runeRange{0xD76C, 0xD76C}, prLV},                     // Lo       HANGUL SYLLABLE HYI
+	{runeRange{0x10A01, 0x10A03}, prExtend},               // Mn   [3] KHAROSHTHI VOWEL SIGN I..KHAROSHTHI VOWEL SIGN VOCALIC R
+	{runeRange{0x11073, 0x11074}, prExtend},               // Mn   [2] BRAHMI VOWEL SIGN OLD TAMIL SHORT E..BRAHMI VOWEL SIGN OLD TAMIL SHORT O
+	{runeRange{0x11180, 0x11181}, prExtend},               // Mn   [2] SHARADA SIGN CANDRABINDU..SHARADA SIGN ANUSVARA
+	{runeRange{0x11241, 0x11241}, prExtend},               // Mn       KHOJKI VOWEL SIGN VOCALIC R
+	{runeRange{0x11370, 0x11374}, prExtend},               // Mn   [5] COMBINING GRANTHA LETTER A..COMBINING GRANTHA LETTER PA
+	{runeRange{0x114BF, 0x114C0}, prExtend},               // Mn   [2] TIRHUTA SIGN CANDRABINDU..TIRHUTA SIGN ANUSVARA
+	{runeRange{0x1163F, 0x11640}, prExtend},               // Mn   [2] MODI SIGN VIRAMA..MODI SIGN ARDHACANDRA
+	{runeRange{0x11930, 0x11930}, prExtend},               // Mc       DIVES AKURU VOWEL SIGN AA
+	{runeRange{0x119E4, 0x119E4}, prSpacingMark},          // Mc       NANDINAGARI VOWEL SIGN PRISHTHAMATRA E
+	{runeRange{0x11C38, 0x11C3D}, prExtend},               // Mn   [6] BHAIKSUKI VOWEL SIGN E..BHAIKSUKI SIGN ANUSVARA
+	{runeRange{0x11D8A, 0x11D8E}, prSpacingMark},          // Mc   [5] GUNJALA GONDI VOWEL SIGN AA..GUNJALA GONDI VOWEL SIGN UU
+	{runeRange{0x11F42, 0x11F42}, prExtend},               // Mn       KAWI CONJOINER
+	{runeRange{0x1D166, 0x1D166}, prSpacingMark},          // Mc       MUSICAL SYMBOL COMBINING SPRECHGESANG STEM
+	{runeRange{0x1E008, 0x1E018}, prExtend},               // Mn  [17] COMBINING GLAGOLITIC LETTER ZEMLJA..COMBINING GLAGOLITIC LETTER HERU
+	{runeRange{0x1F10D, 0x1F10F}, prExtendedPictographic}, // E0.0   [3] (🄍..🄏)    CIRCLED ZERO WITH SLASH..CIRCLED DOLLAR SIGN WITH OVERLAID BACKSLASH
+	{runeRange{0x1F250, 0x1F251}, prExtendedPictographic}, // E0.6   [2] (🉐..🉑)    Japanese “bargain” button..Japanese “acceptable” button
+	{runeRange{0x1F321, 0x1F321}, prExtendedPictographic}, // E0.7   [1] (🌡️)       thermometer
+	{runeRange{0x1F380, 0x1F393}, prExtendedPictographic}, // E0.6  [20] (🎀..🎓)    ribbon..graduation cap
+	{runeRange{0x1F3D4, 0x1F3DF}, prExtendedPictographic}, // E0.7  [12] (🏔️..🏟️)    snow-capped mountain..stadium
+	{runeRange{0x1F40F, 0x1F410}, prExtendedPictographic}, // E1.0   [2] (🐏..🐐)    ram..goat
+	{runeRange{0x1F46E, 0x1F4AC}, prExtendedPictographic}, // E0.6  [63] (👮..💬)    police officer..speech balloon
+	{runeRange{0x1F503, 0x1F503}, prExtendedPictographic}, // E0.6   [1] (🔃)       clockwise vertical arrows
+	{runeRange{0x1F56F, 0x1F570}, prExtendedPictographic}, // E0.7   [2] (🕯️..🕰️)    candle..mantelpiece clock
+	{runeRange{0x1F5A8, 0x1F5A8}, prExtendedPictographic}, // E0.7   [1] (🖨️)       printer
+	{runeRange{0x1F5E8, 0x1F5E8}, prExtendedPictographic}, // E2.0   [1] (🗨️)       left speech bubble
+	{runeRange{0x1F612, 0x1F614}, prExtendedPictographic}, // E0.6   [3] (😒..😔)    unamused face..pensive face
+	{runeRange{0x1F630, 0x1F633}, prExtendedPictographic}, // E0.6   [4] (😰..😳)    anxious face with sweat..flushed face
+	{runeRange{0x1F68D, 0x1F68D}, prExtendedPictographic}, // E0.7   [1] (🚍)       oncoming bus
+	{runeRange{0x1F69B, 0x1F6A1}, prExtendedPictographic}, // E1.0   [7] (🚛..🚡)    articulated lorry..aerial tramway
+	{runeRange{0x1F6B3, 0x1F6B5}, prExtendedPictographic}, // E1.0   [3] (🚳..🚵)    no bicycles..person mountain biking
+	{runeRange{0x1F6CB, 0x1F6CB}, prExtendedPictographic}, // E0.7   [1] (🛋️)       couch and lamp
+	{runeRange{0x1F6D8, 0x1F6DB}, prExtendedPictographic}, // E0.0   [4] (🛘..🛛)    <reserved-1F6D8>..<reserved-1F6DB>
+	{runeRange{0x1F6ED, 0x1F6EF}, prExtendedPictographic}, // E0.0   [3] (🛭..🛯)    <reserved-1F6ED>..<reserved-1F6EF>
+	{runeRange{0x1F6FB, 0x1F6FC}, prExtendedPictographic}, // E13.0  [2] (🛻..🛼)    pickup truck..roller skate
+	{runeRange{0x1F80C, 0x1F80F}, prExtendedPictographic}, // E0.0   [4] (🠌..🠏)    <reserved-1F80C>..<reserved-1F80F>
+	{runeRange{0x1F919, 0x1F91E}, prExtendedPictographic}, // E3.0   [6] (🤙..🤞)    call me hand..crossed fingers
+	{runeRange{0x1F93F, 0x1F93F}, prExtendedPictographic}, // E12.0  [1] (🤿)       diving mask
+	{runeRange{0x1F971, 0x1F971}, prExtendedPictographic}, // E12.0  [1] (🥱)       yawning face
+	{runeRange{0x1F980, 0x1F984}, prExtendedPictographic}, // E1.0   [5] (🦀..🦄)    crab..unicorn
+	{runeRange{0x1F9B0, 0x1F9B9}, prExtendedPictographic}, // E11.0 [10] (🦰..🦹)    red hair..supervillain
+	{runeRange{0x1F9D0, 0x1F9E6}, prExtendedPictographic}, // E5.0  [23] (🧐..🧦)    face with monocle..socks
+	{runeRange{0x1FA7D, 0x1FA7F}, prExtendedPictographic}, // E0.0   [3] (🩽..🩿)    <reserved-1FA7D>..<reserved-1FA7F>
+	{runeRange{0x1FAAD, 0x1FAAF}, prExtendedPictographic}, // E15.0  [3] (🪭..🪯)    folding hand fan..khanda
+	{runeRange{0x1FAC6, 0x1FACD}, prExtendedPictographic}, // E0.0   [8] (🫆..🫍)    <reserved-1FAC6>..<reserved-1FACD>
+	{runeRange{0x1FAE9, 0x1FAEF}, prExtendedPictographic}, // E0.0   [7] (🫩..🫯)    <reserved-1FAE9>..<reserved-1FAEF>
 	{runeRange{0xE0020, 0xE007F}, prExtend},               // Cf  [96] TAG SPACE..CANCEL TAG
-	{runeRange{0xE0080, 0xE00FF}, prControl},              // Cn [128] <reserved-E0080>..<reserved-E00FF>
+	{runeRange{0x000D, 0x000D}, prCR},                     // Cc       <control-000D>
+	{runeRange{0x0488, 0x0489}, prExtend},                 // Me   [2] COMBINING CYRILLIC HUNDRED THOUSANDS SIGN..COMBINING CYRILLIC MILLIONS SIGN
+	{runeRange{0x061C, 0x061C}, prControl},                // Cf       ARABIC LETTER MARK
+	{runeRange{0x070F, 0x070F}, prPrepend},                // Cf       SYRIAC ABBREVIATION MARK
+	{runeRange{0x0825, 0x0827}, prExtend},                 // Mn   [3] SAMARITAN VOWEL SIGN SHORT A..SAMARITAN VOWEL SIGN U
+	{runeRange{0x0903, 0x0903}, prSpacingMark},            // Mc       DEVANAGARI SIGN VISARGA
+	{runeRange{0x094E, 0x094F}, prSpacingMark},            // Mc   [2] DEVANAGARI VOWEL SIGN PRISHTHAMATRA E..DEVANAGARI VOWEL SIGN AW
+	{runeRange{0x09C1, 0x09C4}, prExtend},                 // Mn   [4] BENGALI VOWEL SIGN U..BENGALI VOWEL SIGN VOCALIC RR
+	{runeRange{0x0A03, 0x0A03}, prSpacingMark},            // Mc       GURMUKHI SIGN VISARGA
+	{runeRange{0x0A75, 0x0A75}, prExtend},                 // Mn       GURMUKHI SIGN YAKASH
+	{runeRange{0x0ACB, 0x0ACC}, prSpacingMark},            // Mc   [2] GUJARATI VOWEL SIGN O..GUJARATI VOWEL SIGN AU
+	{runeRange{0x0B3F, 0x0B3F}, prExtend},                 // Mn       ORIYA VOWEL SIGN I
+	{runeRange{0x0B62, 0x0B63}, prExtend},                 // Mn   [2] ORIYA VOWEL SIGN VOCALIC L..ORIYA VOWEL SIGN VOCALIC LL
+	{runeRange{0x0BCD, 0x0BCD}, prExtend},                 // Mn       TAMIL SIGN VIRAMA
+	{runeRange{0x0C46, 0x0C48}, prExtend},                 // Mn   [3] TELUGU VOWEL SIGN E..TELUGU VOWEL SIGN AI
+	{runeRange{0x0CBF, 0x0CBF}, prExtend},                 // Mn       KANNADA VOWEL SIGN I
+	{runeRange{0x0CD5, 0x0CD6}, prExtend},                 // Mc   [2] KANNADA LENGTH MARK..KANNADA AI LENGTH MARK
+	{runeRange{0x0D41, 0x0D44}, prExtend},                 // Mn   [4] MALAYALAM VOWEL SIGN U..MALAYALAM VOWEL SIGN VOCALIC RR
+	{runeRange{0x0D82, 0x0D83}, prSpacingMark},            // Mc   [2] SINHALA SIGN ANUSVARAYA..SINHALA SIGN VISARGAYA
+	{runeRange{0x0DF2, 0x0DF3}, prSpacingMark},            // Mc   [2] SINHALA VOWEL SIGN DIGA GAETTA-PILLA..SINHALA VOWEL SIGN DIGA GAYANUKITTA
+	{runeRange{0x0EC8, 0x0ECE}, prExtend},                 // Mn   [7] LAO TONE MAI EK..LAO YAMAKKAN
+	{runeRange{0x0F80, 0x0F84}, prExtend},                 // Mn   [5] TIBETAN VOWEL SIGN REVERSED I..TIBETAN MARK HALANTA
+	{runeRange{0x1039, 0x103A}, prExtend},                 // Mn   [2] MYANMAR SIGN VIRAMA..MYANMAR SIGN ASAT
+	{runeRange{0x1084, 0x1084}, prSpacingMark},            // Mc       MYANMAR VOWEL SIGN SHAN E
+	{runeRange{0x1712, 0x1714}, prExtend},                 // Mn   [3] TAGALOG VOWEL SIGN I..TAGALOG SIGN VIRAMA
+	{runeRange{0x17B7, 0x17BD}, prExtend},                 // Mn   [7] KHMER VOWEL SIGN I..KHMER VOWEL SIGN UA
+	{runeRange{0x180F, 0x180F}, prExtend},                 // Mn       MONGOLIAN FREE VARIATION SELECTOR FOUR
+	{runeRange{0x1932, 0x1932}, prExtend},                 // Mn       LIMBU SMALL LETTER ANUSVARA
+	{runeRange{0x1A57, 0x1A57}, prSpacingMark},            // Mc       TAI THAM CONSONANT SIGN LA TANG LAI
+	{runeRange{0x1AB0, 0x1ABD}, prExtend},                 // Mn  [14] COMBINING DOUBLED CIRCUMFLEX ACCENT..COMBINING PARENTHESES BELOW
+	{runeRange{0x1B3B, 0x1B3B}, prSpacingMark},            // Mc       BALINESE VOWEL SIGN RA REPA TEDUNG
+	{runeRange{0x1BA1, 0x1BA1}, prSpacingMark},            // Mc       SUNDANESE CONSONANT SIGN PAMINGKAL
+	{runeRange{0x1BE8, 0x1BE9}, prExtend},                 // Mn   [2] BATAK VOWEL SIGN PAKPAK E..BATAK VOWEL SIGN EE
+	{runeRange{0x1C34, 0x1C35}, prSpacingMark},            // Mc   [2] LEPCHA CONSONANT SIGN NYIN-DO..LEPCHA CONSONANT SIGN KANG
+	{runeRange{0x1CF7, 0x1CF7}, prSpacingMark},            // Mc       VEDIC SIGN ATIKRAMA
+	{runeRange{0x2029, 0x2029}, prControl},                // Zp       PARAGRAPH SEPARATOR
+	{runeRange{0x20DD, 0x20E0}, prExtend},                 // Me   [4] COMBINING ENCLOSING CIRCLE..COMBINING ENCLOSING CIRCLE BACKSLASH
+	{runeRange{0x231A, 0x231B}, prExtendedPictographic},   // E0.6   [2] (⌚..⌛)    watch..hourglass done
+	{runeRange{0x23F1, 0x23F2}, prExtendedPictographic},   // E1.0   [2] (⏱️..⏲️)    stopwatch..timer clock
+	{runeRange{0x2600, 0x2601}, prExtendedPictographic},   // E0.6   [2] (☀️..☁️)    sun..cloud
+	{runeRange{0x2612, 0x2612}, prExtendedPictographic},   // E0.0   [1] (☒)       BALLOT BOX WITH X
+	{runeRange{0x2621, 0x2621}, prExtendedPictographic},   // E0.0   [1] (☡)       CAUTION SIGN
+	{runeRange{0x262F, 0x262F}, prExtendedPictographic},   // E0.7   [1] (☯️)       yin yang
+	{runeRange{0x2643, 0x2647}, prExtendedPictographic},   // E0.0   [5] (♃..♇)    JUPITER..PLUTO
+	{runeRange{0x2665, 0x2666}, prExtendedPictographic},   // E0.6   [2] (♥️..♦️)    heart suit..diamond suit
+	{runeRange{0x2680, 0x2685}, prExtendedPictographic},   // E0.0   [6] (⚀..⚅)    DIE FACE-1..DIE FACE-6
+	{runeRange{0x2699, 0x2699}, prExtendedPictographic},   // E1.0   [1] (⚙️)       gear
+	{runeRange{0x26AA, 0x26AB}, prExtendedPictographic},   // E0.6   [2] (⚪..⚫)    white circle..black circle
+	{runeRange{0x26C8, 0x26C8}, prExtendedPictographic},   // E0.7   [1] (⛈️)       cloud with lightning and rain
+	{runeRange{0x26D4, 0x26D4}, prExtendedPictographic},   // E0.6   [1] (⛔)       no entry
+	{runeRange{0x26F5, 0x26F5}, prExtendedPictographic},   // E0.6   [1] (⛵)       sailboat
+	{runeRange{0x2703, 0x2704}, prExtendedPictographic},   // E0.0   [2] (✃..✄)    LOWER BLADE SCISSORS..WHITE SCISSORS
+	{runeRange{0x2714, 0x2714}, prExtendedPictographic},   // E0.6   [1] (✔️)       check mark
+	{runeRange{0x274C, 0x274C}, prExtendedPictographic},   // E0.6   [1] (❌)       cross mark
+	{runeRange{0x27A1, 0x27A1}, prExtendedPictographic},   // E0.6   [1] (➡️)       right arrow
+	{runeRange{0x2CEF, 0x2CF1}, prExtend},                 // Mn   [3] COPTIC COMBINING NI ABOVE..COPTIC COMBINING SPIRITUS LENIS
+	{runeRange{0x3297, 0x3297}, prExtendedPictographic},   // E0.6   [1] (㊗️)       Japanese “congratulations” button
+	{runeRange{0xA806, 0xA806}, prExtend},                 // Mn       SYLOTI NAGRI SIGN HASANTA
+	{runeRange{0xA8C4, 0xA8C5}, prExtend},                 // Mn   [2] SAURASHTRA SIGN VIRAMA..SAURASHTRA SIGN CANDRABINDU
+	{runeRange{0xA983, 0xA983}, prSpacingMark},            // Mc       JAVANESE SIGN WIGNYAN
+	{runeRange{0xAA29, 0xAA2E}, prExtend},                 // Mn   [6] CHAM VOWEL SIGN AA..CHAM VOWEL SIGN OE
+	{runeRange{0xAA7C, 0xAA7C}, prExtend},                 // Mn       MYANMAR SIGN TAI LAING TONE-2
+	{runeRange{0xAAEE, 0xAAEF}, prSpacingMark},            // Mc   [2] MEETEI MAYEK VOWEL SIGN AU..MEETEI MAYEK VOWEL SIGN AAU
+	{runeRange{0xABEC, 0xABEC}, prSpacingMark},            // Mc       MEETEI MAYEK LUM IYEK
+	{runeRange{0xAC54, 0xAC54}, prLV},                     // Lo       HANGUL SYLLABLE GYAE
+	{runeRange{0xACC4, 0xACC4}, prLV},                     // Lo       HANGUL SYLLABLE GYE
+	{runeRange{0xAD34, 0xAD34}, prLV},                     // Lo       HANGUL SYLLABLE GOE
+	{runeRange{0xADA4, 0xADA4}, prLV},                     // Lo       HANGUL SYLLABLE GWE
+	{runeRange{0xAE14, 0xAE14}, prLV},                     // Lo       HANGUL SYLLABLE GYI
+	{runeRange{0xAE84, 0xAE84}, prLV},                     // Lo       HANGUL SYLLABLE GGYA
+	{runeRange{0xAEF4, 0xAEF4}, prLV},                     // Lo       HANGUL SYLLABLE GGYEO
+	{runeRange{0xAF64, 0xAF64}, prLV},                     // Lo       HANGUL SYLLABLE GGWAE
+	{runeRange{0xAFD4, 0xAFD4}, prLV},                     // Lo       HANGUL SYLLABLE GGWEO
+	{runeRange{0xB044, 0xB044}, prLV},                     // Lo       HANGUL SYLLABLE GGEU
+	{runeRange{0xB0B4, 0xB0B4}, prLV},                     // Lo       HANGUL SYLLABLE NAE
+	{runeRange{0xB124, 0xB124}, prLV},                     // Lo       HANGUL SYLLABLE NE
+	{runeRange{0xB194, 0xB194}, prLV},                     // Lo       HANGUL SYLLABLE NWA
+	{runeRange{0xB204, 0xB204}, prLV},                     // Lo       HANGUL SYLLABLE NU
+	{runeRange{0xB274, 0xB274}, prLV},                     // Lo       HANGUL SYLLABLE NYU
+	{runeRange{0xB2E4, 0xB2E4}, prLV},                     // Lo       HANGUL SYLLABLE DA
+	{runeRange{0xB354, 0xB354}, prLV},                     // Lo       HANGUL SYLLABLE DEO
+	{runeRange{0xB3C4, 0xB3C4}, prLV},                     // Lo       HANGUL SYLLABLE DO
+	{runeRange{0xB434, 0xB434}, prLV},                     // Lo       HANGUL SYLLABLE DYO
+	{runeRange{0xB4A4, 0xB4A4}, prLV},                     // Lo       HANGUL SYLLABLE DWI
+	{runeRange{0xB514, 0xB514}, prLV},                     // Lo       HANGUL SYLLABLE DI
+	{runeRange{0xB584, 0xB584}, prLV},                     // Lo       HANGUL SYLLABLE DDYAE
+	{runeRange{0xB5F4, 0xB5F4}, prLV},                     // Lo       HANGUL SYLLABLE DDYE
+	{runeRange{0xB664, 0xB664}, prLV},                     // Lo       HANGUL SYLLABLE DDOE
+	{runeRange{0xB6D4, 0xB6D4}, prLV},                     // Lo       HANGUL SYLLABLE DDWE
+	{runeRange{0xB744, 0xB744}, prLV},                     // Lo       HANGUL SYLLABLE DDYI
+	{runeRange{0xB7B4, 0xB7B4}, prLV},                     // Lo       HANGUL SYLLABLE RYA
+	{runeRange{0xB824, 0xB824}, prLV},                     // Lo       HANGUL SYLLABLE RYEO
+	{runeRange{0xB894, 0xB894}, prLV},                     // Lo       HANGUL SYLLABLE RWAE
+	{runeRange{0xB904, 0xB904}, prLV},                     // Lo       HANGUL SYLLABLE RWEO
+	{runeRange{0xB974, 0xB974}, prLV},                     // Lo       HANGUL SYLLABLE REU
+	{runeRange{0xB9E4, 0xB9E4}, prLV},                     // Lo       HANGUL SYLLABLE MAE
+	{runeRange{0xBA54, 0xBA54}, prLV},                     // Lo       HANGUL SYLLABLE ME
+	{runeRange{0xBAC4, 0xBAC4}, prLV},                     // Lo       HANGUL SYLLABLE MWA
+	{runeRange{0xBB34, 0xBB34}, prLV},                     // Lo       HANGUL SYLLABLE MU
+	{runeRange{0xBBA4, 0xBBA4}, prLV},                     // Lo       HANGUL SYLLABLE MYU
+	{runeRange{0xBC14, 0xBC14}, prLV},                     // Lo       HANGUL SYLLABLE BA
+	{runeRange{0xBC84, 0xBC84}, prLV},                     // Lo       HANGUL SYLLABLE BEO
+	{runeRange{0xBCF4, 0xBCF4}, prLV},                     // Lo       HANGUL SYLLABLE BO
+	{runeRange{0xBD64, 0xBD64}, prLV},                     // Lo       HANGUL SYLLABLE BYO
+	{runeRange{0xBDD4, 0xBDD4}, prLV},                     // Lo       HANGUL SYLLABLE BWI
+	{runeRange{0xBE44, 0xBE44}, prLV},                     // Lo       HANGUL SYLLABLE BI
+	{runeRange{0xBEB4, 0xBEB4}, prLV},                     // Lo       HANGUL SYLLABLE BBYAE
+	{runeRange{0xBF24, 0xBF24}, prLV},                     // Lo       HANGUL SYLLABLE BBYE
+	{runeRange{0xBF94, 0xBF94}, prLV},                     // Lo       HANGUL SYLLABLE BBOE
+	{runeRange{0xC004, 0xC004}, prLV},                     // Lo       HANGUL SYLLABLE BBWE
+	{runeRange{0xC074, 0xC074}, prLV},                     // Lo       HANGUL SYLLABLE BBYI
+	{runeRange{0xC0E4, 0xC0E4}, prLV},                     // Lo       HANGUL SYLLABLE SYA
+	{runeRange{0xC154, 0xC154}, prLV},                     // Lo       HANGUL SYLLABLE SYEO
+	{runeRange{0xC1C4, 0xC1C4}, prLV},                     // Lo       HANGUL SYLLABLE SWAE
+	{runeRange{0xC234, 0xC234}, prLV},                     // Lo       HANGUL SYLLABLE SWEO
+	{runeRange{0xC2A4, 0xC2A4}, prLV},                     // Lo       HANGUL SYLLABLE SEU
+	{runeRange{0xC314, 0xC314}, prLV},                     // Lo       HANGUL SYLLABLE SSAE
+	{runeRange{0xC384, 0xC384}, prLV},                     // Lo       HANGUL SYLLABLE SSE
+	{runeRange{0xC3F4, 0xC3F4}, prLV},                     // Lo       HANGUL SYLLABLE SSWA
+	{runeRange{0xC464, 0xC464}, prLV},                     // Lo       HANGUL SYLLABLE SSU
+	{runeRange{0xC4D4, 0xC4D4}, prLV},                     // Lo       HANGUL SYLLABLE SSYU
+	{runeRange{0xC544, 0xC544}, prLV},                     // Lo       HANGUL SYLLABLE A
+	{runeRange{0xC5B4, 0xC5B4}, prLV},                     // Lo       HANGUL SYLLABLE EO
+	{runeRange{0xC624, 0xC624}, prLV},                     // Lo       HANGUL SYLLABLE O
+	{runeRange{0xC694, 0xC694}, prLV},                     // Lo       HANGUL SYLLABLE YO
+	{runeRange{0xC704, 0xC704}, prLV},                     // Lo       HANGUL SYLLABLE WI
+	{runeRange{0xC774, 0xC774}, prLV},                     // Lo       HANGUL SYLLABLE I
+	{runeRange{0xC7E4, 0xC7E4}, prLV},                     // Lo       HANGUL SYLLABLE JYAE
+	{runeRange{0xC854, 0xC854}, prLV},                     // Lo       HANGUL SYLLABLE JYE
+	{runeRange{0xC8C4, 0xC8C4}, prLV},                     // Lo       HANGUL SYLLABLE JOE
+	{runeRange{0xC934, 0xC934}, prLV},                     // Lo       HANGUL SYLLABLE JWE
+	{runeRange{0xC9A4, 0xC9A4}, prLV},                     // Lo       HANGUL SYLLABLE JYI
+	{runeRange{0xCA14, 0xCA14}, prLV},                     // Lo       HANGUL SYLLABLE JJYA
+	{runeRange{0xCA84, 0xCA84}, prLV},                     // Lo       HANGUL SYLLABLE JJYEO
+	{runeRange{0xCAF4, 0xCAF4}, prLV},                     // Lo       HANGUL SYLLABLE JJWAE
+	{runeRange{0xCB64, 0xCB64}, prLV},                     // Lo       HANGUL SYLLABLE JJWEO
+	{runeRange{0xCBD4, 0xCBD4}, prLV},                     // Lo       HANGUL SYLLABLE JJEU
+	{runeRange{0xCC44, 0xCC44}, prLV},                     // Lo       HANGUL SYLLABLE CAE
+	{runeRange{0xCCB4, 0xCCB4}, prLV},                     // Lo       HANGUL SYLLABLE CE
+	{runeRange{0xCD24, 0xCD24}, prLV},                     // Lo       HANGUL SYLLABLE CWA
+	{runeRange{0xCD94, 0xCD94}, prLV},                     // Lo       HANGUL SYLLABLE CU
+	{runeRange{0xCE04, 0xCE04}, prLV},                     // Lo       HANGUL SYLLABLE CYU
+	{runeRange{0xCE74, 0xCE74}, prLV},                     // Lo       HANGUL SYLLABLE KA
+	{runeRange{0xCEE4, 0xCEE4}, prLV},                     // Lo       HANGUL SYLLABLE KEO
+	{runeRange{0xCF54, 0xCF54}, prLV},                     // Lo       HANGUL SYLLABLE KO
+	{runeRange{0xCFC4, 0xCFC4}, prLV},                     // Lo       HANGUL SYLLABLE KYO
+	{runeRange{0xD034, 0xD034}, prLV},                     // Lo       HANGUL SYLLABLE KWI
+	{runeRange{0xD0A4, 0xD0A4}, prLV},                     // Lo       HANGUL SYLLABLE KI
+	{runeRange{0xD114, 0xD114}, prLV},                     // Lo       HANGUL SYLLABLE TYAE
+	{runeRange{0xD184, 0xD184}, prLV},                     // Lo       HANGUL SYLLABLE TYE
+	{runeRange{0xD1F4, 0xD1F4}, prLV},                     // Lo       HANGUL SYLLABLE TOE
+	{runeRange{0xD264, 0xD264}, prLV},                     // Lo       HANGUL SYLLABLE TWE
+	{runeRange{0xD2D4, 0xD2D4}, prLV},                     // Lo       HANGUL SYLLABLE TYI
+	{runeRange{0xD344, 0xD344}, prLV},                     // Lo       HANGUL SYLLABLE PYA
+	{runeRange{0xD3B4, 0xD3B4}, prLV},                     // Lo       HANGUL SYLLABLE PYEO
+	{runeRange{0xD424, 0xD424}, prLV},                     // Lo       HANGUL SYLLABLE PWAE
+	{runeRange{0xD494, 0xD494}, prLV},                     // Lo       HANGUL SYLLABLE PWEO
+	{runeRange{0xD504, 0xD504}, prLV},                     // Lo       HANGUL SYLLABLE PEU
+	{runeRange{0xD574, 0xD574}, prLV},                     // Lo       HANGUL SYLLABLE HAE
+	{runeRange{0xD5E4, 0xD5E4}, prLV},                     // Lo       HANGUL SYLLABLE HE
+	{runeRange{0xD654, 0xD654}, prLV},                     // Lo       HANGUL SYLLABLE HWA
+	{runeRange{0xD6C4, 0xD6C4}, prLV},                     // Lo       HANGUL SYLLABLE HU
+	{runeRange{0xD734, 0xD734}, prLV},                     // Lo       HANGUL SYLLABLE HYU
+	{runeRange{0xD7B0, 0xD7C6}, prV},                      // Lo  [23] HANGUL JUNGSEONG O-YEO..HANGUL JUNGSEONG ARAEA-E
+	{runeRange{0xFFF9, 0xFFFB}, prControl},                // Cf   [3] INTERLINEAR ANNOTATION ANCHOR..INTERLINEAR ANNOTATION TERMINATOR
+	{runeRange{0x10A3F, 0x10A3F}, prExtend},               // Mn       KHAROSHTHI VIRAMA
+	{runeRange{0x11001, 0x11001}, prExtend},               // Mn       BRAHMI SIGN ANUSVARA
+	{runeRange{0x110B3, 0x110B6}, prExtend},               // Mn   [4] KAITHI VOWEL SIGN U..KAITHI VOWEL SIGN AI
+	{runeRange{0x1112C, 0x1112C}, prSpacingMark},          // Mc       CHAKMA VOWEL SIGN E
+	{runeRange{0x111BF, 0x111C0}, prSpacingMark},          // Mc   [2] SHARADA VOWEL SIGN AU..SHARADA SIGN VIRAMA
+	{runeRange{0x11234, 0x11234}, prExtend},               // Mn       KHOJKI SIGN ANUSVARA
+	{runeRange{0x11300, 0x11301}, prExtend},               // Mn   [2] GRANTHA SIGN COMBINING ANUSVARA ABOVE..GRANTHA SIGN CANDRABINDU
+	{runeRange{0x1134B, 0x1134D}, prSpacingMark},          // Mc   [3] GRANTHA VOWEL SIGN OO..GRANTHA SIGN VIRAMA
+	{runeRange{0x11442, 0x11444}, prExtend},               // Mn   [3] NEWA SIGN VIRAMA..NEWA SIGN ANUSVARA
+	{runeRange{0x114BA, 0x114BA}, prExtend},               // Mn       TIRHUTA VOWEL SIGN SHORT E
+	{runeRange{0x115B0, 0x115B1}, prSpacingMark},          // Mc   [2] SIDDHAM VOWEL SIGN I..SIDDHAM VOWEL SIGN II
+	{runeRange{0x11633, 0x1163A}, prExtend},               // Mn   [8] MODI VOWEL SIGN U..MODI VOWEL SIGN AI
+	{runeRange{0x116AE, 0x116AF}, prSpacingMark},          // Mc   [2] TAKRI VOWEL SIGN I..TAKRI VOWEL SIGN II
+	{runeRange{0x1182C, 0x1182E}, prSpacingMark},          // Mc   [3] DOGRA VOWEL SIGN AA..DOGRA VOWEL SIGN II
+	{runeRange{0x1193D, 0x1193D}, prSpacingMark},          // Mc       DIVES AKURU SIGN HALANTA
+	{runeRange{0x119D4, 0x119D7}, prExtend},               // Mn   [4] NANDINAGARI VOWEL SIGN U..NANDINAGARI VOWEL SIGN VOCALIC RR
+	{runeRange{0x11A3A, 0x11A3A}, prPrepend},              // Lo       ZANABAZAR SQUARE CLUSTER-INITIAL LETTER RA
+	{runeRange{0x11A97, 0x11A97}, prSpacingMark},          // Mc       SOYOMBO SIGN VISARGA
+	{runeRange{0x11CA9, 0x11CA9}, prSpacingMark},          // Mc       MARCHEN SUBJOINED LETTER YA
+	{runeRange{0x11D3C, 0x11D3D}, prExtend},               // Mn   [2] MASARAM GONDI VOWEL SIGN AI..MASARAM GONDI VOWEL SIGN O
+	{runeRange{0x11D96, 0x11D96}, prSpacingMark},          // Mc       GUNJALA GONDI SIGN VISARGA
+	{runeRange{0x11F36, 0x11F3A}, prExtend},               // Mn   [5] KAWI VOWEL SIGN I..KAWI VOWEL SIGN VOCALIC R
+	{runeRange{0x16AF0, 0x16AF4}, prExtend},               // Mn   [5] BASSA VAH COMBINING HIGH TONE..BASSA VAH COMBINING HIGH-LOW TONE
+	{runeRange{0x1BCA0, 0x1BCA3}, prControl},              // Cf   [4] SHORTHAND FORMAT LETTER OVERLAP..SHORTHAND FORMAT UP STEP
+	{runeRange{0x1D173, 0x1D17A}, prControl},              // Cf   [8] MUSICAL SYMBOL BEGIN BEAM..MUSICAL SYMBOL END PHRASE
+	{runeRange{0x1DA84, 0x1DA84}, prExtend},               // Mn       SIGNWRITING LOCATION HEAD NECK
+	{runeRange{0x1E08F, 0x1E08F}, prExtend},               // Mn       COMBINING CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I
+	{runeRange{0x1F004, 0x1F004}, prExtendedPictographic}, // E0.6   [1] (🀄)       mahjong red dragon
+	{runeRange{0x1F17E, 0x1F17F}, prExtendedPictographic}, // E0.6   [2] (🅾️..🅿️)    O button (blood type)..P button
+	{runeRange{0x1F22F, 0x1F22F}, prExtendedPictographic}, // E0.6   [1] (🈯)       Japanese “reserved” button
+	{runeRange{0x1F30F, 0x1F30F}, prExtendedPictographic}, // E0.6   [1] (🌏)       globe showing Asia-Australia
+	{runeRange{0x1F31B, 0x1F31B}, prExtendedPictographic}, // E0.6   [1] (🌛)       first quarter moon face
+	{runeRange{0x1F330, 0x1F331}, prExtendedPictographic}, // E0.6   [2] (🌰..🌱)    chestnut..seedling
+	{runeRange{0x1F351, 0x1F37B}, prExtendedPictographic}, // E0.6  [43] (🍑..🍻)    peach..clinking beer mugs
+	{runeRange{0x1F399, 0x1F39B}, prExtendedPictographic}, // E0.7   [3] (🎙️..🎛️)    studio microphone..control knobs
+	{runeRange{0x1F3C9, 0x1F3C9}, prExtendedPictographic}, // E1.0   [1] (🏉)       rugby football
+	{runeRange{0x1F3F1, 0x1F3F2}, prExtendedPictographic}, // E0.0   [2] (🏱..🏲)    WHITE PENNANT..BLACK PENNANT
+	{runeRange{0x1F400, 0x1F407}, prExtendedPictographic}, // E1.0   [8] (🐀..🐇)    rat..rabbit
+	{runeRange{0x1F415, 0x1F415}, prExtendedPictographic}, // E0.7   [1] (🐕)       dog
+	{runeRange{0x1F442, 0x1F464}, prExtendedPictographic}, // E0.6  [35] (👂..👤)    ear..bust in silhouette
+	{runeRange{0x1F4B8, 0x1F4EB}, prExtendedPictographic}, // E0.6  [52] (💸..📫)    money with wings..closed mailbox with raised flag
+	{runeRange{0x1F4F9, 0x1F4FC}, prExtendedPictographic}, // E0.6   [4] (📹..📼)    video camera..videocassette
+	{runeRange{0x1F50A, 0x1F514}, prExtendedPictographic}, // E0.6  [11] (🔊..🔔)    speaker high volume..bell
+	{runeRange{0x1F54F, 0x1F54F}, prExtendedPictographic}, // E0.0   [1] (🕏)       BOWL OF HYGIEIA
+	{runeRange{0x1F57B, 0x1F586}, prExtendedPictographic}, // E0.0  [12] (🕻..🖆)    LEFT HAND TELEPHONE RECEIVER..PEN OVER STAMPED ENVELOPE
+	{runeRange{0x1F597, 0x1F5A3}, prExtendedPictographic}, // E0.0  [13] (🖗..🖣)    WHITE DOWN POINTING LEFT HAND INDEX..BLACK DOWN POINTING BACKHAND INDEX
+	{runeRange{0x1F5BC, 0x1F5BC}, prExtendedPictographic}, // E0.7   [1] (🖼️)       framed picture
+	{runeRange{0x1F5E1, 0x1F5E1}, prExtendedPictographic}, // E0.7   [1] (🗡️)       dagger
+	{runeRange{0x1F5F3, 0x1F5F3}, prExtendedPictographic}, // E0.7   [1] (🗳️)       ballot box with ballot
+	{runeRange{0x1F60E, 0x1F60E}, prExtendedPictographic}, // E1.0   [1] (😎)       smiling face with sunglasses
+	{runeRange{0x1F618, 0x1F618}, prExtendedPictographic}, // E0.6   [1] (😘)       face blowing a kiss
+	{runeRange{0x1F628, 0x1F62B}, prExtendedPictographic}, // E0.6   [4] (😨..😫)    fearful face..tired face
+	{runeRange{0x1F637, 0x1F640}, prExtendedPictographic}, // E0.6  [10] (😷..🙀)    face with medical mask..weary cat
+	{runeRange{0x1F688, 0x1F688}, prExtendedPictographic}, // E1.0   [1] (🚈)       light rail
+	{runeRange{0x1F691, 0x1F693}, prExtendedPictographic}, // E0.6   [3] (🚑..🚓)    ambulance..police car
+	{runeRange{0x1F698, 0x1F698}, prExtendedPictographic}, // E0.7   [1] (🚘)       oncoming automobile
+	{runeRange{0x1F6A3, 0x1F6A3}, prExtendedPictographic}, // E1.0   [1] (🚣)       person rowing boat
+	{runeRange{0x1F6AE, 0x1F6B1}, prExtendedPictographic}, // E1.0   [4] (🚮..🚱)    litter in bin sign..non-potable water
+	{runeRange{0x1F6B7, 0x1F6B8}, prExtendedPictographic}, // E1.0   [2] (🚷..🚸)    no pedestrians..children crossing
+	{runeRange{0x1F6C1, 0x1F6C5}, prExtendedPictographic}, // E1.0   [5] (🛁..🛅)    bathtub..left luggage
+	{runeRange{0x1F6CD, 0x1F6CF}, prExtendedPictographic}, // E0.7   [3] (🛍️..🛏️)    shopping bags..bed
+	{runeRange{0x1F6D5, 0x1F6D5}, prExtendedPictographic}, // E12.0  [1] (🛕)       hindu temple
+	{runeRange{0x1F6DD, 0x1F6DF}, prExtendedPictographic}, // E14.0  [3] (🛝..🛟)    playground slide..ring buoy
+	{runeRange{0x1F6EA, 0x1F6EA}, prExtendedPictographic}, // E0.0   [1] (🛪)       NORTHEAST-POINTING AIRPLANE
+	{runeRange{0x1F6F1, 0x1F6F2}, prExtendedPictographic}, // E0.0   [2] (🛱..🛲)    ONCOMING FIRE ENGINE..DIESEL LOCOMOTIVE
+	{runeRange{0x1F6F9, 0x1F6F9}, prExtendedPictographic}, // E11.0  [1] (🛹)       skateboard
+	{runeRange{0x1F774, 0x1F77F}, prExtendedPictographic}, // E0.0  [12] (🝴..🝿)    LOT OF FORTUNE..ORCUS
+	{runeRange{0x1F7F0, 0x1F7F0}, prExtendedPictographic}, // E14.0  [1] (🟰)       heavy equals sign
+	{runeRange{0x1F85A, 0x1F85F}, prExtendedPictographic}, // E0.0   [6] (🡚..🡟)    <reserved-1F85A>..<reserved-1F85F>
+	{runeRange{0x1F90D, 0x1F90F}, prExtendedPictographic}, // E12.0  [3] (🤍..🤏)    white heart..pinching hand
+	{runeRange{0x1F920, 0x1F927}, prExtendedPictographic}, // E3.0   [8] (🤠..🤧)    cowboy hat face..sneezing face
+	{runeRange{0x1F933, 0x1F93A}, prExtendedPictographic}, // E3.0   [8] (🤳..🤺)    selfie..person fencing
+	{runeRange{0x1F947, 0x1F94B}, prExtendedPictographic}, // E3.0   [5] (🥇..🥋)    1st place medal..martial arts uniform
+	{runeRange{0x1F95F, 0x1F96B}, prExtendedPictographic}, // E5.0  [13] (🥟..🥫)    dumpling..canned food
+	{runeRange{0x1F973, 0x1F976}, prExtendedPictographic}, // E11.0  [4] (🥳..🥶)    partying face..cold face
+	{runeRange{0x1F97B, 0x1F97B}, prExtendedPictographic}, // E12.0  [1] (🥻)       sari
+	{runeRange{0x1F992, 0x1F997}, prExtendedPictographic}, // E5.0   [6] (🦒..🦗)    giraffe..cricket
+	{runeRange{0x1F9AB, 0x1F9AD}, prExtendedPictographic}, // E13.0  [3] (🦫..🦭)    beaver..seal
+	{runeRange{0x1F9C0, 0x1F9C0}, prExtendedPictographic}, // E1.0   [1] (🧀)       cheese wedge
+	{runeRange{0x1F9CC, 0x1F9CC}, prExtendedPictographic}, // E14.0  [1] (🧌)       troll
+	{runeRange{0x1FA00, 0x1FA6F}, prExtendedPictographic}, // E0.0 [112] (🨀..🩯)    NEUTRAL CHESS KING..<reserved-1FA6F>
+	{runeRange{0x1FA78, 0x1FA7A}, prExtendedPictographic}, // E12.0  [3] (🩸..🩺)    drop of blood..stethoscope
+	{runeRange{0x1FA83, 0x1FA86}, prExtendedPictographic}, // E13.0  [4] (🪃..🪆)    boomerang..nesting dolls
+	{runeRange{0x1FA96, 0x1FAA8}, prExtendedPictographic}, // E13.0 [19] (🪖..🪨)    military helmet..rock
+	{runeRange{0x1FAB7, 0x1FABA}, prExtendedPictographic}, // E14.0  [4] (🪷..🪺)    lotus..nest with eggs
+	{runeRange{0x1FAC0, 0x1FAC2}, prExtendedPictographic}, // E13.0  [3] (🫀..🫂)    anatomical heart..people hugging
+	{runeRange{0x1FAD0, 0x1FAD6}, prExtendedPictographic}, // E13.0  [7] (🫐..🫖)    blueberries..teapot
+	{runeRange{0x1FAE0, 0x1FAE7}, prExtendedPictographic}, // E14.0  [8] (🫠..🫧)    melting face..bubbles
+	{runeRange{0x1FAF7, 0x1FAF8}, prExtendedPictographic}, // E15.0  [2] (🫷..🫸)    leftwards pushing hand..rightwards pushing hand
+	{runeRange{0xE0001, 0xE0001}, prControl},              // Cf       LANGUAGE TAG
 	{runeRange{0xE0100, 0xE01EF}, prExtend},               // Mn [240] VARIATION SELECTOR-17..VARIATION SELECTOR-256
+	{runeRange{0x000A, 0x000A}, prLF},                     // Cc       <control-000A>
+	{runeRange{0x007F, 0x009F}, prControl},                // Cc  [33] <control-007F>..<control-009F>
+	{runeRange{0x0300, 0x036F}, prExtend},                 // Mn [112] COMBINING GRAVE ACCENT..COMBINING LATIN SMALL LETTER X
+	{runeRange{0x05BF, 0x05BF}, prExtend},                 // Mn       HEBREW POINT RAFE
+	{runeRange{0x0600, 0x0605}, prPrepend},                // Cf   [6] ARABIC NUMBER SIGN..ARABIC NUMBER MARK ABOVE
+	{runeRange{0x0670, 0x0670}, prExtend},                 // Mn       ARABIC LETTER SUPERSCRIPT ALEF
+	{runeRange{0x06E7, 0x06E8}, prExtend},                 // Mn   [2] ARABIC SMALL HIGH YEH..ARABIC SMALL HIGH NOON
+	{runeRange{0x0730, 0x074A}, prExtend},                 // Mn  [27] SYRIAC PTHAHA ABOVE..SYRIAC BARREKH
+	{runeRange{0x0816, 0x0819}, prExtend},                 // Mn   [4] SAMARITAN MARK IN..SAMARITAN MARK DAGESH
+	{runeRange{0x0859, 0x085B}, prExtend},                 // Mn   [3] MANDAIC AFFRICATION MARK..MANDAIC GEMINATION MARK
+	{runeRange{0x08E2, 0x08E2}, prPrepend},                // Cf       ARABIC DISPUTED END OF AYAH
+	{runeRange{0x093B, 0x093B}, prSpacingMark},            // Mc       DEVANAGARI VOWEL SIGN OOE
+	{runeRange{0x0949, 0x094C}, prSpacingMark},            // Mc   [4] DEVANAGARI VOWEL SIGN CANDRA O..DEVANAGARI VOWEL SIGN AU
+	{runeRange{0x0962, 0x0963}, prExtend},                 // Mn   [2] DEVANAGARI VOWEL SIGN VOCALIC L..DEVANAGARI VOWEL SIGN VOCALIC LL
+	{runeRange{0x09BE, 0x09BE}, prExtend},                 // Mc       BENGALI VOWEL SIGN AA
+	{runeRange{0x09CB, 0x09CC}, prSpacingMark},            // Mc   [2] BENGALI VOWEL SIGN O..BENGALI VOWEL SIGN AU
+	{runeRange{0x09FE, 0x09FE}, prExtend},                 // Mn       BENGALI SANDHI MARK
+	{runeRange{0x0A3E, 0x0A40}, prSpacingMark},            // Mc   [3] GURMUKHI VOWEL SIGN AA..GURMUKHI VOWEL SIGN II
+	{runeRange{0x0A51, 0x0A51}, prExtend},                 // Mn       GURMUKHI SIGN UDAAT
+	{runeRange{0x0A83, 0x0A83}, prSpacingMark},            // Mc       GUJARATI SIGN VISARGA
+	{runeRange{0x0AC7, 0x0AC8}, prExtend},                 // Mn   [2] GUJARATI VOWEL SIGN E..GUJARATI VOWEL SIGN AI
+	{runeRange{0x0AE2, 0x0AE3}, prExtend},                 // Mn   [2] GUJARATI VOWEL SIGN VOCALIC L..GUJARATI VOWEL SIGN VOCALIC LL
+	{runeRange{0x0B3C, 0x0B3C}, prExtend},                 // Mn       ORIYA SIGN NUKTA
+	{runeRange{0x0B41, 0x0B44}, prExtend},                 // Mn   [4] ORIYA VOWEL SIGN U..ORIYA VOWEL SIGN VOCALIC RR
+	{runeRange{0x0B55, 0x0B56}, prExtend},                 // Mn   [2] ORIYA SIGN OVERLINE..ORIYA AI LENGTH MARK
+	{runeRange{0x0BBE, 0x0BBE}, prExtend},                 // Mc       TAMIL VOWEL SIGN AA
+	{runeRange{0x0BC6, 0x0BC8}, prSpacingMark},            // Mc   [3] TAMIL VOWEL SIGN E..TAMIL VOWEL SIGN AI
+	{runeRange{0x0C00, 0x0C00}, prExtend},                 // Mn       TELUGU SIGN COMBINING CANDRABINDU ABOVE
+	{runeRange{0x0C3E, 0x0C40}, prExtend},                 // Mn   [3] TELUGU VOWEL SIGN AA..TELUGU VOWEL SIGN II
+	{runeRange{0x0C55, 0x0C56}, prExtend},                 // Mn   [2] TELUGU LENGTH MARK..TELUGU AI LENGTH MARK
+	{runeRange{0x0CBC, 0x0CBC}, prExtend},                 // Mn       KANNADA SIGN NUKTA
+	{runeRange{0x0CC2, 0x0CC2}, prExtend},                 // Mc       KANNADA VOWEL SIGN UU
+	{runeRange{0x0CCA, 0x0CCB}, prSpacingMark},            // Mc   [2] KANNADA VOWEL SIGN O..KANNADA VOWEL SIGN OO
+	{runeRange{0x0CF3, 0x0CF3}, prSpacingMark},            // Mc       KANNADA SIGN COMBINING ANUSVARA ABOVE RIGHT
+	{runeRange{0x0D3E, 0x0D3E}, prExtend},                 // Mc       MALAYALAM VOWEL SIGN AA
+	{runeRange{0x0D4A, 0x0D4C}, prSpacingMark},            // Mc   [3] MALAYALAM VOWEL SIGN O..MALAYALAM VOWEL SIGN AU
+	{runeRange{0x0D62, 0x0D63}, prExtend},                 // Mn   [2] MALAYALAM VOWEL SIGN VOCALIC L..MALAYALAM VOWEL SIGN VOCALIC LL
+	{runeRange{0x0DCF, 0x0DCF}, prExtend},                 // Mc       SINHALA VOWEL SIGN AELA-PILLA
+	{runeRange{0x0DD8, 0x0DDE}, prSpacingMark},            // Mc   [7] SINHALA VOWEL SIGN GAETTA-PILLA..SINHALA VOWEL SIGN KOMBUVA HAA GAYANUKITTA
+	{runeRange{0x0E33, 0x0E33}, prSpacingMark},            // Lo       THAI CHARACTER SARA AM
+	{runeRange{0x0EB3, 0x0EB3}, prSpacingMark},            // Lo       LAO VOWEL SIGN AM
+	{runeRange{0x0F35, 0x0F35}, prExtend},                 // Mn       TIBETAN MARK NGAS BZUNG NYI ZLA
+	{runeRange{0x0F71, 0x0F7E}, prExtend},                 // Mn  [14] TIBETAN VOWEL SIGN AA..TIBETAN SIGN RJES SU NGA RO
+	{runeRange{0x0F8D, 0x0F97}, prExtend},                 // Mn  [11] TIBETAN SUBJOINED SIGN LCE TSA CAN..TIBETAN SUBJOINED LETTER JA
+	{runeRange{0x1031, 0x1031}, prSpacingMark},            // Mc       MYANMAR VOWEL SIGN E
+	{runeRange{0x103D, 0x103E}, prExtend},                 // Mn   [2] MYANMAR CONSONANT SIGN MEDIAL WA..MYANMAR CONSONANT SIGN MEDIAL HA
+	{runeRange{0x1071, 0x1074}, prExtend},                 // Mn   [4] MYANMAR VOWEL SIGN GEBA KAREN I..MYANMAR VOWEL SIGN KAYAH EE
+	{runeRange{0x108D, 0x108D}, prExtend},                 // Mn       MYANMAR SIGN SHAN COUNCIL EMPHATIC TONE
+	{runeRange{0x11A8, 0x11FF}, prT},                      // Lo  [88] HANGUL JONGSEONG KIYEOK..HANGUL JONGSEONG SSANGNIEUN
+	{runeRange{0x1732, 0x1733}, prExtend},                 // Mn   [2] HANUNOO VOWEL SIGN I..HANUNOO VOWEL SIGN U
+	{runeRange{0x17B4, 0x17B5}, prExtend},                 // Mn   [2] KHMER VOWEL INHERENT AQ..KHMER VOWEL INHERENT AA
+	{runeRange{0x17C6, 0x17C6}, prExtend},                 // Mn       KHMER SIGN NIKAHIT
+	{runeRange{0x180B, 0x180D}, prExtend},                 // Mn   [3] MONGOLIAN FREE VARIATION SELECTOR ONE..MONGOLIAN FREE VARIATION SELECTOR THREE
+	{runeRange{0x18A9, 0x18A9}, prExtend},                 // Mn       MONGOLIAN LETTER ALI GALI DAGALGA
+	{runeRange{0x1929, 0x192B}, prSpacingMark},            // Mc   [3] LIMBU SUBJOINED LETTER YA..LIMBU SUBJOINED LETTER WA
+	{runeRange{0x1939, 0x193B}, prExtend},                 // Mn   [3] LIMBU SIGN MUKPHRENG..LIMBU SIGN SA-I
+	{runeRange{0x1A55, 0x1A55}, prSpacingMark},            // Mc       TAI THAM CONSONANT SIGN MEDIAL RA
+	{runeRange{0x1A60, 0x1A60}, prExtend},                 // Mn       TAI THAM SIGN SAKOT
+	{runeRange{0x1A73, 0x1A7C}, prExtend},                 // Mn  [10] TAI THAM VOWEL SIGN OA ABOVE..TAI THAM SIGN KHUEN-LUE KARAN
+	{runeRange{0x1ABF, 0x1ACE}, prExtend},                 // Mn  [16] COMBINING LATIN SMALL LETTER W BELOW..COMBINING LATIN SMALL LETTER INSULAR T
+	{runeRange{0x1B35, 0x1B35}, prExtend},                 // Mc       BALINESE VOWEL SIGN TEDUNG
+	{runeRange{0x1B3D, 0x1B41}, prSpacingMark},            // Mc   [5] BALINESE VOWEL SIGN LA LENGA TEDUNG..BALINESE VOWEL SIGN TALING REPA TEDUNG
+	{runeRange{0x1B80, 0x1B81}, prExtend},                 // Mn   [2] SUNDANESE SIGN PANYECEK..SUNDANESE SIGN PANGLAYAR
+	{runeRange{0x1BA6, 0x1BA7}, prSpacingMark},            // Mc   [2] SUNDANESE VOWEL SIGN PANAELAENG..SUNDANESE VOWEL SIGN PANOLONG
+	{runeRange{0x1BE6, 0x1BE6}, prExtend},                 // Mn       BATAK SIGN TOMPI
+	{runeRange{0x1BED, 0x1BED}, prExtend},                 // Mn       BATAK VOWEL SIGN KARO O
+	{runeRange{0x1C24, 0x1C2B}, prSpacingMark},            // Mc   [8] LEPCHA SUBJOINED LETTER YA..LEPCHA VOWEL SIGN UU
+	{runeRange{0x1CD0, 0x1CD2}, prExtend},                 // Mn   [3] VEDIC TONE KARSHANA..VEDIC TONE PRENKHA
+	{runeRange{0x1CED, 0x1CED}, prExtend},                 // Mn       VEDIC SIGN TIRYAK
+	{runeRange{0x1DC0, 0x1DFF}, prExtend},                 // Mn  [64] COMBINING DOTTED GRAVE ACCENT..COMBINING RIGHT ARROWHEAD AND DOWN ARROWHEAD BELOW
+	{runeRange{0x200E, 0x200F}, prControl},                // Cf   [2] LEFT-TO-RIGHT MARK..RIGHT-TO-LEFT MARK
+	{runeRange{0x203C, 0x203C}, prExtendedPictographic},   // E0.6   [1] (‼️)       double exclamation mark
+	{runeRange{0x2066, 0x206F}, prControl},                // Cf  [10] LEFT-TO-RIGHT ISOLATE..NOMINAL DIGIT SHAPES
+	{runeRange{0x20E2, 0x20E4}, prExtend},                 // Me   [3] COMBINING ENCLOSING SCREEN..COMBINING ENCLOSING UPWARD POINTING TRIANGLE
+	{runeRange{0x2194, 0x2199}, prExtendedPictographic},   // E0.6   [6] (↔️..↙️)    left-right arrow..down-left arrow
+	{runeRange{0x2388, 0x2388}, prExtendedPictographic},   // E0.0   [1] (⎈)       HELM SYMBOL
+	{runeRange{0x23EF, 0x23EF}, prExtendedPictographic},   // E1.0   [1] (⏯️)       play or pause button
+	{runeRange{0x23F8, 0x23FA}, prExtendedPictographic},   // E0.7   [3] (⏸️..⏺️)    pause button..record button
+	{runeRange{0x25C0, 0x25C0}, prExtendedPictographic},   // E0.6   [1] (◀️)       reverse button
+	{runeRange{0x2604, 0x2604}, prExtendedPictographic},   // E1.0   [1] (☄️)       comet
+	{runeRange{0x260F, 0x2610}, prExtendedPictographic},   // E0.0   [2] (☏..☐)    WHITE TELEPHONE..BALLOT BOX
+	{runeRange{0x2616, 0x2617}, prExtendedPictographic},   // E0.0   [2] (☖..☗)    WHITE SHOGI PIECE..BLACK SHOGI PIECE
+	{runeRange{0x261E, 0x261F}, prExtendedPictographic},   // E0.0   [2] (☞..☟)    WHITE RIGHT POINTING INDEX..WHITE DOWN POINTING INDEX
+	{runeRange{0x2624, 0x2625}, prExtendedPictographic},   // E0.0   [2] (☤..☥)    CADUCEUS..ANKH
+	{runeRange{0x262B, 0x262D}, prExtendedPictographic},   // E0.0   [3] (☫..☭)    FARSI SYMBOL..HAMMER AND SICKLE
+	{runeRange{0x2638, 0x2639}, prExtendedPictographic},   // E0.7   [2] (☸️..☹️)    wheel of dharma..frowning face
+	{runeRange{0x2641, 0x2641}, prExtendedPictographic},   // E0.0   [1] (♁)       EARTH
+	{runeRange{0x2654, 0x265E}, prExtendedPictographic},   // E0.0  [11] (♔..♞)    WHITE CHESS KING..BLACK CHESS KNIGHT
+	{runeRange{0x2663, 0x2663}, prExtendedPictographic},   // E0.6   [1] (♣️)       club suit
+	{runeRange{0x2668, 0x2668}, prExtendedPictographic},   // E0.6   [1] (♨️)       hot springs
+	{runeRange{0x267E, 0x267E}, prExtendedPictographic},   // E11.0  [1] (♾️)       infinity
+	{runeRange{0x2692, 0x2692}, prExtendedPictographic},   // E1.0   [1] (⚒️)       hammer and pick
+	{runeRange{0x2696, 0x2697}, prExtendedPictographic},   // E1.0   [2] (⚖️..⚗️)    balance scale..alembic
+	{runeRange{0x269B, 0x269C}, prExtendedPictographic},   // E1.0   [2] (⚛️..⚜️)    atom symbol..fleur-de-lis
+	{runeRange{0x26A7, 0x26A7}, prExtendedPictographic},   // E13.0  [1] (⚧️)       transgender symbol
+	{runeRange{0x26B0, 0x26B1}, prExtendedPictographic},   // E1.0   [2] (⚰️..⚱️)    coffin..funeral urn
+	{runeRange{0x26C4, 0x26C5}, prExtendedPictographic},   // E0.6   [2] (⛄..⛅)    snowman without snow..sun behind cloud
+	{runeRange{0x26CE, 0x26CE}, prExtendedPictographic},   // E0.6   [1] (⛎)       Ophiuchus
+	{runeRange{0x26D2, 0x26D2}, prExtendedPictographic},   // E0.0   [1] (⛒)       CIRCLED CROSSING LANES
+	{runeRange{0x26E9, 0x26E9}, prExtendedPictographic},   // E0.7   [1] (⛩️)       shinto shrine
+	{runeRange{0x26F2, 0x26F3}, prExtendedPictographic},   // E0.6   [2] (⛲..⛳)    fountain..flag in hole
+	{runeRange{0x26F7, 0x26F9}, prExtendedPictographic},   // E0.7   [3] (⛷️..⛹️)    skier..person bouncing ball
+	{runeRange{0x26FE, 0x2701}, prExtendedPictographic},   // E0.0   [4] (⛾..✁)    CUP ON BLACK SQUARE..UPPER BLADE SCISSORS
+	{runeRange{0x2708, 0x270C}, prExtendedPictographic},   // E0.6   [5] (✈️..✌️)    airplane..victory hand
+	{runeRange{0x2710, 0x2711}, prExtendedPictographic},   // E0.0   [2] (✐..✑)    UPPER RIGHT PENCIL..WHITE NIB
+	{runeRange{0x271D, 0x271D}, prExtendedPictographic},   // E0.7   [1] (✝️)       latin cross
+	{runeRange{0x2744, 0x2744}, prExtendedPictographic},   // E0.6   [1] (❄️)       snowflake
+	{runeRange{0x2753, 0x2755}, prExtendedPictographic},   // E0.6   [3] (❓..❕)    red question mark..white exclamation mark
+	{runeRange{0x2765, 0x2767}, prExtendedPictographic},   // E0.0   [3] (❥..❧)    ROTATED HEAVY BLACK HEART BULLET..ROTATED FLORAL HEART BULLET
+	{runeRange{0x27BF, 0x27BF}, prExtendedPictographic},   // E1.0   [1] (➿)       double curly loop
+	{runeRange{0x2B50, 0x2B50}, prExtendedPictographic},   // E0.6   [1] (⭐)       star
+	{runeRange{0x2DE0, 0x2DFF}, prExtend},                 // Mn  [32] COMBINING CYRILLIC LETTER BE..COMBINING CYRILLIC LETTER IOTIFIED BIG YUS
+	{runeRange{0x303D, 0x303D}, prExtendedPictographic},   // E0.6   [1] (〽️)       part alternation mark
+	{runeRange{0xA66F, 0xA66F}, prExtend},                 // Mn       COMBINING CYRILLIC VZMET
+	{runeRange{0xA6F0, 0xA6F1}, prExtend},                 // Mn   [2] BAMUM COMBINING MARK KOQNDON..BAMUM COMBINING MARK TUKWENTIS
+	{runeRange{0xA823, 0xA824}, prSpacingMark},            // Mc   [2] SYLOTI NAGRI VOWEL SIGN A..SYLOTI NAGRI VOWEL SIGN I
+	{runeRange{0xA880, 0xA881}, prSpacingMark},            // Mc   [2] SAURASHTRA SIGN ANUSVARA..SAURASHTRA SIGN VISARGA
+	{runeRange{0xA8FF, 0xA8FF}, prExtend},                 // Mn       DEVANAGARI VOWEL SIGN AY
+	{runeRange{0xA960, 0xA97C}, prL},                      // Lo  [29] HANGUL CHOSEONG TIKEUT-MIEUM..HANGUL CHOSEONG SSANGYEORINHIEUH
+	{runeRange{0xA9B4, 0xA9B5}, prSpacingMark},            // Mc   [2] JAVANESE VOWEL SIGN TARUNG..JAVANESE VOWEL SIGN TOLONG
+	{runeRange{0xA9BE, 0xA9C0}, prSpacingMark},            // Mc   [3] JAVANESE CONSONANT SIGN PENGKAL..JAVANESE PANGKON
+	{runeRange{0xAA31, 0xAA32}, prExtend},                 // Mn   [2] CHAM VOWEL SIGN AU..CHAM VOWEL SIGN UE
+	{runeRange{0xAA4C, 0xAA4C}, prExtend},                 // Mn       CHAM CONSONANT SIGN FINAL M
+	{runeRange{0xAAB2, 0xAAB4}, prExtend},                 // Mn   [3] TAI VIET VOWEL I..TAI VIET VOWEL U
+	{runeRange{0xAAEB, 0xAAEB}, prSpacingMark},            // Mc       MEETEI MAYEK VOWEL SIGN II
+	{runeRange{0xAAF6, 0xAAF6}, prExtend},                 // Mn       MEETEI MAYEK VIRAMA
+	{runeRange{0xABE8, 0xABE8}, prExtend},                 // Mn       MEETEI MAYEK VOWEL SIGN UNAP
+	{runeRange{0xAC00, 0xAC00}, prLV},                     // Lo       HANGUL SYLLABLE GA
+	{runeRange{0xAC38, 0xAC38}, prLV},                     // Lo       HANGUL SYLLABLE GYA
+	{runeRange{0xAC70, 0xAC70}, prLV},                     // Lo       HANGUL SYLLABLE GEO
+	{runeRange{0xACA8, 0xACA8}, prLV},                     // Lo       HANGUL SYLLABLE GYEO
+	{runeRange{0xACE0, 0xACE0}, prLV},                     // Lo       HANGUL SYLLABLE GO
+	{runeRange{0xAD18, 0xAD18}, prLV},                     // Lo       HANGUL SYLLABLE GWAE
+	{runeRange{0xAD50, 0xAD50}, prLV},                     // Lo       HANGUL SYLLABLE GYO
+	{runeRange{0xAD88, 0xAD88}, prLV},                     // Lo       HANGUL SYLLABLE GWEO
+	{runeRange{0xADC0, 0xADC0}, prLV},                     // Lo       HANGUL SYLLABLE GWI
+	{runeRange{0xADF8, 0xADF8}, prLV},                     // Lo       HANGUL SYLLABLE GEU
+	{runeRange{0xAE30, 0xAE30}, prLV},                     // Lo       HANGUL SYLLABLE GI
+	{runeRange{0xAE68, 0xAE68}, prLV},                     // Lo       HANGUL SYLLABLE GGAE
+	{runeRange{0xAEA0, 0xAEA0}, prLV},                     // Lo       HANGUL SYLLABLE GGYAE
+	{runeRange{0xAED8, 0xAED8}, prLV},                     // Lo       HANGUL SYLLABLE GGE
+	{runeRange{0xAF10, 0xAF10}, prLV},                     // Lo       HANGUL SYLLABLE GGYE
+	{runeRange{0xAF48, 0xAF48}, prLV},                     // Lo       HANGUL SYLLABLE GGWA
+	{runeRange{0xAF80, 0xAF80}, prLV},                     // Lo       HANGUL SYLLABLE GGOE
+	{runeRange{0xAFB8, 0xAFB8}, prLV},                     // Lo       HANGUL SYLLABLE GGU
+	{runeRange{0xAFF0, 0xAFF0}, prLV},                     // Lo       HANGUL SYLLABLE GGWE
+	{runeRange{0xB028, 0xB028}, prLV},                     // Lo       HANGUL SYLLABLE GGYU
+	{runeRange{0xB060, 0xB060}, prLV},                     // Lo       HANGUL SYLLABLE GGYI
+	{runeRange{0xB098, 0xB098}, prLV},                     // Lo       HANGUL SYLLABLE NA
+	{runeRange{0xB0D0, 0xB0D0}, prLV},                     // Lo       HANGUL SYLLABLE NYA
+	{runeRange{0xB108, 0xB108}, prLV},                     // Lo       HANGUL SYLLABLE NEO
+	{runeRange{0xB140, 0xB140}, prLV},                     // Lo       HANGUL SYLLABLE NYEO
+	{runeRange{0xB178, 0xB178}, prLV},                     // Lo       HANGUL SYLLABLE NO
+	{runeRange{0xB1B0, 0xB1B0}, prLV},                     // Lo       HANGUL SYLLABLE NWAE
+	{runeRange{0xB1E8, 0xB1E8}, prLV},                     // Lo       HANGUL SYLLABLE NYO
+	{runeRange{0xB220, 0xB220}, prLV},                     // Lo       HANGUL SYLLABLE NWEO
+	{runeRange{0xB258, 0xB258}, prLV},                     // Lo       HANGUL SYLLABLE NWI
+	{runeRange{0xB290, 0xB290}, prLV},                     // Lo       HANGUL SYLLABLE NEU
+	{runeRange{0xB2C8, 0xB2C8}, prLV},                     // Lo       HANGUL SYLLABLE NI
+	{runeRange{0xB300, 0xB300}, prLV},                     // Lo       HANGUL SYLLABLE DAE
+	{runeRange{0xB338, 0xB338}, prLV},                     // Lo       HANGUL SYLLABLE DYAE
+	{runeRange{0xB370, 0xB370}, prLV},                     // Lo       HANGUL SYLLABLE DE
+	{runeRange{0xB3A8, 0xB3A8}, prLV},                     // Lo       HANGUL SYLLABLE DYE
+	{runeRange{0xB3E0, 0xB3E0}, prLV},                     // Lo       HANGUL SYLLABLE DWA
+	{runeRange{0xB418, 0xB418}, prLV},                     // Lo       HANGUL SYLLABLE DOE
+	{runeRange{0xB450, 0xB450}, prLV},                     // Lo       HANGUL SYLLABLE DU
+	{runeRange{0xB488, 0xB488}, prLV},                     // Lo       HANGUL SYLLABLE DWE
+	{runeRange{0xB4C0, 0xB4C0}, prLV},                     // Lo       HANGUL SYLLABLE DYU
+	{runeRange{0xB4F8, 0xB4F8}, prLV},                     // Lo       HANGUL SYLLABLE DYI
+	{runeRange{0xB530, 0xB530}, prLV},                     // Lo       HANGUL SYLLABLE DDA
+	{runeRange{0xB568, 0xB568}, prLV},                     // Lo       HANGUL SYLLABLE DDYA
+	{runeRange{0xB5A0, 0xB5A0}, prLV},                     // Lo       HANGUL SYLLABLE DDEO
+	{runeRange{0xB5D8, 0xB5D8}, prLV},                     // Lo       HANGUL SYLLABLE DDYEO
+	{runeRange{0xB610, 0xB610}, prLV},                     // Lo       HANGUL SYLLABLE DDO
+	{runeRange{0xB648, 0xB648}, prLV},                     // Lo       HANGUL SYLLABLE DDWAE
+	{runeRange{0xB680, 0xB680}, prLV},                     // Lo       HANGUL SYLLABLE DDYO
+	{runeRange{0xB6B8, 0xB6B8}, prLV},                     // Lo       HANGUL SYLLABLE DDWEO
+	{runeRange{0xB6F0, 0xB6F0}, prLV},                     // Lo       HANGUL SYLLABLE DDWI
+	{runeRange{0xB728, 0xB728}, prLV},                     // Lo       HANGUL SYLLABLE DDEU
+	{runeRange{0xB760, 0xB760}, prLV},                     // Lo       HANGUL SYLLABLE DDI
+	{runeRange{0xB798, 0xB798}, prLV},                     // Lo       HANGUL SYLLABLE RAE
+	{runeRange{0xB7D0, 0xB7D0}, prLV},                     // Lo       HANGUL SYLLABLE RYAE
+	{runeRange{0xB808, 0xB808}, prLV},                     // Lo       HANGUL SYLLABLE RE
+	{runeRange{0xB840, 0xB840}, prLV},                     // Lo       HANGUL SYLLABLE RYE
+	{runeRange{0xB878, 0xB878}, prLV},                     // Lo       HANGUL SYLLABLE RWA
+	{runeRange{0xB8B0, 0xB8B0}, prLV},                     // Lo       HANGUL SYLLABLE ROE
+	{runeRange{0xB8E8, 0xB8E8}, prLV},                     // Lo       HANGUL SYLLABLE RU
+	{runeRange{0xB920, 0xB920}, prLV},                     // Lo       HANGUL SYLLABLE RWE
+	{runeRange{0xB958, 0xB958}, prLV},                     // Lo       HANGUL SYLLABLE RYU
+	{runeRange{0xB990, 0xB990}, prLV},                     // Lo       HANGUL SYLLABLE RYI
+	{runeRange{0xB9C8, 0xB9C8}, prLV},                     // Lo       HANGUL SYLLABLE MA
+	{runeRange{0xBA00, 0xBA00}, prLV},                     // Lo       HANGUL SYLLABLE MYA
+	{runeRange{0xBA38, 0xBA38}, prLV},                     // Lo       HANGUL SYLLABLE MEO
+	{runeRange{0xBA70, 0xBA70}, prLV},                     // Lo       HANGUL SYLLABLE MYEO
+	{runeRange{0xBAA8, 0xBAA8}, prLV},                     // Lo       HANGUL SYLLABLE MO
+	{runeRange{0xBAE0, 0xBAE0}, prLV},                     // Lo       HANGUL SYLLABLE MWAE
+	{runeRange{0xBB18, 0xBB18}, prLV},                     // Lo       HANGUL SYLLABLE MYO
+	{runeRange{0xBB50, 0xBB50}, prLV},                     // Lo       HANGUL SYLLABLE MWEO
+	{runeRange{0xBB88, 0xBB88}, prLV},                     // Lo       HANGUL SYLLABLE MWI
+	{runeRange{0xBBC0, 0xBBC0}, prLV},                     // Lo       HANGUL SYLLABLE MEU
+	{runeRange{0xBBF8, 0xBBF8}, prLV},                     // Lo       HANGUL SYLLABLE MI
+	{runeRange{0xBC30, 0xBC30}, prLV},                     // Lo       HANGUL SYLLABLE BAE
+	{runeRange{0xBC68, 0xBC68}, prLV},                     // Lo       HANGUL SYLLABLE BYAE
+	{runeRange{0xBCA0, 0xBCA0}, prLV},                     // Lo       HANGUL SYLLABLE BE
+	{runeRange{0xBCD8, 0xBCD8}, prLV},                     // Lo       HANGUL SYLLABLE BYE
+	{runeRange{0xBD10, 0xBD10}, prLV},                     // Lo       HANGUL SYLLABLE BWA
+	{runeRange{0xBD48, 0xBD48}, prLV},                     // Lo       HANGUL SYLLABLE BOE
+	{runeRange{0xBD80, 0xBD80}, prLV},                     // Lo       HANGUL SYLLABLE BU
+	{runeRange{0xBDB8, 0xBDB8}, prLV},                     // Lo       HANGUL SYLLABLE BWE
+	{runeRange{0xBDF0, 0xBDF0}, prLV},                     // Lo       HANGUL SYLLABLE BYU
+	{runeRange{0xBE28, 0xBE28}, prLV},                     // Lo       HANGUL SYLLABLE BYI
+	{runeRange{0xBE60, 0xBE60}, prLV},                     // Lo       HANGUL SYLLABLE BBA
+	{runeRange{0xBE98, 0xBE98}, prLV},                     // Lo       HANGUL SYLLABLE BBYA
+	{runeRange{0xBED0, 0xBED0}, prLV},                     // Lo       HANGUL SYLLABLE BBEO
+	{runeRange{0xBF08, 0xBF08}, prLV},                     // Lo       HANGUL SYLLABLE BBYEO
+	{runeRange{0xBF40, 0xBF40}, prLV},                     // Lo       HANGUL SYLLABLE BBO
+	{runeRange{0xBF78, 0xBF78}, prLV},                     // Lo       HANGUL SYLLABLE BBWAE
+	{runeRange{0xBFB0, 0xBFB0}, prLV},                     // Lo       HANGUL SYLLABLE BBYO
+	{runeRange{0xBFE8, 0xBFE8}, prLV},                     // Lo       HANGUL SYLLABLE BBWEO
+	{runeRange{0xC020, 0xC020}, prLV},                     // Lo       HANGUL SYLLABLE BBWI
+	{runeRange{0xC058, 0xC058}, prLV},                     // Lo       HANGUL SYLLABLE BBEU
+	{runeRange{0xC090, 0xC090}, prLV},                     // Lo       HANGUL SYLLABLE BBI
+	{runeRange{0xC0C8, 0xC0C8}, prLV},                     // Lo       HANGUL SYLLABLE SAE
+	{runeRange{0xC100, 0xC100}, prLV},                     // Lo       HANGUL SYLLABLE SYAE
+	{runeRange{0xC138, 0xC138}, prLV},                     // Lo       HANGUL SYLLABLE SE
+	{runeRange{0xC170, 0xC170}, prLV},                     // Lo       HANGUL SYLLABLE SYE
+	{runeRange{0xC1A8, 0xC1A8}, prLV},                     // Lo       HANGUL SYLLABLE SWA
+	{runeRange{0xC1E0, 0xC1E0}, prLV},                     // Lo       HANGUL SYLLABLE SOE
+	{runeRange{0xC218, 0xC218}, prLV},                     // Lo       HANGUL SYLLABLE SU
+	{runeRange{0xC250, 0xC250}, prLV},                     // Lo       HANGUL SYLLABLE SWE
+	{runeRange{0xC288, 0xC288}, prLV},                     // Lo       HANGUL SYLLABLE SYU
+	{runeRange{0xC2C0, 0xC2C0}, prLV},                     // Lo       HANGUL SYLLABLE SYI
+	{runeRange{0xC2F8, 0xC2F8}, prLV},                     // Lo       HANGUL SYLLABLE SSA
+	{runeRange{0xC330, 0xC330}, prLV},                     // Lo       HANGUL SYLLABLE SSYA
+	{runeRange{0xC368, 0xC368}, prLV},                     // Lo       HANGUL SYLLABLE SSEO
+	{runeRange{0xC3A0, 0xC3A0}, prLV},                     // Lo       HANGUL SYLLABLE SSYEO
+	{runeRange{0xC3D8, 0xC3D8}, prLV},                     // Lo       HANGUL SYLLABLE SSO
+	{runeRange{0xC410, 0xC410}, prLV},                     // Lo       HANGUL SYLLABLE SSWAE
+	{runeRange{0xC448, 0xC448}, prLV},                     // Lo       HANGUL SYLLABLE SSYO
+	{runeRange{0xC480, 0xC480}, prLV},                     // Lo       HANGUL SYLLABLE SSWEO
+	{runeRange{0xC4B8, 0xC4B8}, prLV},                     // Lo       HANGUL SYLLABLE SSWI
+	{runeRange{0xC4F0, 0xC4F0}, prLV},                     // Lo       HANGUL SYLLABLE SSEU
+	{runeRange{0xC528, 0xC528}, prLV},                     // Lo       HANGUL SYLLABLE SSI
+	{runeRange{0xC560, 0xC560}, prLV},                     // Lo       HANGUL SYLLABLE AE
+	{runeRange{0xC598, 0xC598}, prLV},                     // Lo       HANGUL SYLLABLE YAE
+	{runeRange{0xC5D0, 0xC5D0}, prLV},                     // Lo       HANGUL SYLLABLE E
+	{runeRange{0xC608, 0xC608}, prLV},                     // Lo       HANGUL SYLLABLE YE
+	{runeRange{0xC640, 0xC640}, prLV},                     // Lo       HANGUL SYLLABLE WA
+	{runeRange{0xC678, 0xC678}, prLV},                     // Lo       HANGUL SYLLABLE OE
+	{runeRange{0xC6B0, 0xC6B0}, prLV},                     // Lo       HANGUL SYLLABLE U
+	{runeRange{0xC6E8, 0xC6E8}, prLV},                     // Lo       HANGUL SYLLABLE WE
+	{runeRange{0xC720, 0xC720}, prLV},                     // Lo       HANGUL SYLLABLE YU
+	{runeRange{0xC758, 0xC758}, prLV},                     // Lo       HANGUL SYLLABLE YI
+	{runeRange{0xC790, 0xC790}, prLV},                     // Lo       HANGUL SYLLABLE JA
+	{runeRange{0xC7C8, 0xC7C8}, prLV},                     // Lo       HANGUL SYLLABLE JYA
+	{runeRange{0xC800, 0xC800}, prLV},                     // Lo       HANGUL SYLLABLE JEO
+	{runeRange{0xC838, 0xC838}, prLV},                     // Lo       HANGUL SYLLABLE JYEO
+	{runeRange{0xC870, 0xC870}, prLV},                     // Lo       HANGUL SYLLABLE JO
+	{runeRange{0xC8A8, 0xC8A8}, prLV},                     // Lo       HANGUL SYLLABLE JWAE
+	{runeRange{0xC8E0, 0xC8E0}, prLV},                     // Lo       HANGUL SYLLABLE JYO
+	{runeRange{0xC918, 0xC918}, prLV},                     // Lo       HANGUL SYLLABLE JWEO
+	{runeRange{0xC950, 0xC950}, prLV},                     // Lo       HANGUL SYLLABLE JWI
+	{runeRange{0xC988, 0xC988}, prLV},                     // Lo       HANGUL SYLLABLE JEU
+	{runeRange{0xC9C0, 0xC9C0}, prLV},                     // Lo       HANGUL SYLLABLE JI
+	{runeRange{0xC9F8, 0xC9F8}, prLV},                     // Lo       HANGUL SYLLABLE JJAE
+	{runeRange{0xCA30, 0xCA30}, prLV},                     // Lo       HANGUL SYLLABLE JJYAE
+	{runeRange{0xCA68, 0xCA68}, prLV},                     // Lo       HANGUL SYLLABLE JJE
+	{runeRange{0xCAA0, 0xCAA0}, prLV},                     // Lo       HANGUL SYLLABLE JJYE
+	{runeRange{0xCAD8, 0xCAD8}, prLV},                     // Lo       HANGUL SYLLABLE JJWA
+	{runeRange{0xCB10, 0xCB10}, prLV},                     // Lo       HANGUL SYLLABLE JJOE
+	{runeRange{0xCB48, 0xCB48}, prLV},                     // Lo       HANGUL SYLLABLE JJU
+	{runeRange{0xCB80, 0xCB80}, prLV},                     // Lo       HANGUL SYLLABLE JJWE
+	{runeRange{0xCBB8, 0xCBB8}, prLV},                     // Lo       HANGUL SYLLABLE JJYU
+	{runeRange{0xCBF0, 0xCBF0}, prLV},                     // Lo       HANGUL SYLLABLE JJYI
+	{runeRange{0xCC28, 0xCC28}, prLV},                     // Lo       HANGUL SYLLABLE CA
+	{runeRange{0xCC60, 0xCC60}, prLV},                     // Lo       HANGUL SYLLABLE CYA
+	{runeRange{0xCC98, 0xCC98}, prLV},                     // Lo       HANGUL SYLLABLE CEO
+	{runeRange{0xCCD0, 0xCCD0}, prLV},                     // Lo       HANGUL SYLLABLE CYEO
+	{runeRange{0xCD08, 0xCD08}, prLV},                     // Lo       HANGUL SYLLABLE CO
+	{runeRange{0xCD40, 0xCD40}, prLV},                     // Lo       HANGUL SYLLABLE CWAE
+	{runeRange{0xCD78, 0xCD78}, prLV},                     // Lo       HANGUL SYLLABLE CYO
+	{runeRange{0xCDB0, 0xCDB0}, prLV},                     // Lo       HANGUL SYLLABLE CWEO
+	{runeRange{0xCDE8, 0xCDE8}, prLV},                     // Lo       HANGUL SYLLABLE CWI
+	{runeRange{0xCE20, 0xCE20}, prLV},                     // Lo       HANGUL SYLLABLE CEU
+	{runeRange{0xCE58, 0xCE58}, prLV},                     // Lo       HANGUL SYLLABLE CI
+	{runeRange{0xCE90, 0xCE90}, prLV},                     // Lo       HANGUL SYLLABLE KAE
+	{runeRange{0xCEC8, 0xCEC8}, prLV},                     // Lo       HANGUL SYLLABLE KYAE
+	{runeRange{0xCF00, 0xCF00}, prLV},                     // Lo       HANGUL SYLLABLE KE
+	{runeRange{0xCF38, 0xCF38}, prLV},                     // Lo       HANGUL SYLLABLE KYE
+	{runeRange{0xCF70, 0xCF70}, prLV},                     // Lo       HANGUL SYLLABLE KWA
+	{runeRange{0xCFA8, 0xCFA8}, prLV},                     // Lo       HANGUL SYLLABLE KOE
+	{runeRange{0xCFE0, 0xCFE0}, prLV},                     // Lo       HANGUL SYLLABLE KU
+	{runeRange{0xD018, 0xD018}, prLV},                     // Lo       HANGUL SYLLABLE KWE
+	{runeRange{0xD050, 0xD050}, prLV},                     // Lo       HANGUL SYLLABLE KYU
+	{runeRange{0xD088, 0xD088}, prLV},                     // Lo       HANGUL SYLLABLE KYI
+	{runeRange{0xD0C0, 0xD0C0}, prLV},                     // Lo       HANGUL SYLLABLE TA
+	{runeRange{0xD0F8, 0xD0F8}, prLV},                     // Lo       HANGUL SYLLABLE TYA
+	{runeRange{0xD130, 0xD130}, prLV},                     // Lo       HANGUL SYLLABLE TEO
+	{runeRange{0xD168, 0xD168}, prLV},                     // Lo       HANGUL SYLLABLE TYEO
+	{runeRange{0xD1A0, 0xD1A0}, prLV},                     // Lo       HANGUL SYLLABLE TO
+	{runeRange{0xD1D8, 0xD1D8}, prLV},                     // Lo       HANGUL SYLLABLE TWAE
+	{runeRange{0xD210, 0xD210}, prLV},                     // Lo       HANGUL SYLLABLE TYO
+	{runeRange{0xD248, 0xD248}, prLV},                     // Lo       HANGUL SYLLABLE TWEO
+	{runeRange{0xD280, 0xD280}, prLV},                     // Lo       HANGUL SYLLABLE TWI
+	{runeRange{0xD2B8, 0xD2B8}, prLV},                     // Lo       HANGUL SYLLABLE TEU
+	{runeRange{0xD2F0, 0xD2F0}, prLV},                     // Lo       HANGUL SYLLABLE TI
+	{runeRange{0xD328, 0xD328}, prLV},                     // Lo       HANGUL SYLLABLE PAE
+	{runeRange{0xD360, 0xD360}, prLV},                     // Lo       HANGUL SYLLABLE PYAE
+	{runeRange{0xD398, 0xD398}, prLV},                     // Lo       HANGUL SYLLABLE PE
+	{runeRange{0xD3D0, 0xD3D0}, prLV},                     // Lo       HANGUL SYLLABLE PYE
+	{runeRange{0xD408, 0xD408}, prLV},                     // Lo       HANGUL SYLLABLE PWA
+	{runeRange{0xD440, 0xD440}, prLV},                     // Lo       HANGUL SYLLABLE POE
+	{runeRange{0xD478, 0xD478}, prLV},                     // Lo       HANGUL SYLLABLE PU
+	{runeRange{0xD4B0, 0xD4B0}, prLV},                     // Lo       HANGUL SYLLABLE PWE
+	{runeRange{0xD4E8, 0xD4E8}, prLV},                     // Lo       HANGUL SYLLABLE PYU
+	{runeRange{0xD520, 0xD520}, prLV},                     // Lo       HANGUL SYLLABLE PYI
+	{runeRange{0xD558, 0xD558}, prLV},                     // Lo       HANGUL SYLLABLE HA
+	{runeRange{0xD590, 0xD590}, prLV},                     // Lo       HANGUL SYLLABLE HYA
+	{runeRange{0xD5C8, 0xD5C8}, prLV},                     // Lo       HANGUL SYLLABLE HEO
+	{runeRange{0xD600, 0xD600}, prLV},                     // Lo       HANGUL SYLLABLE HYEO
+	{runeRange{0xD638, 0xD638}, prLV},                     // Lo       HANGUL SYLLABLE HO
+	{runeRange{0xD670, 0xD670}, prLV},                     // Lo       HANGUL SYLLABLE HWAE
+	{runeRange{0xD6A8, 0xD6A8}, prLV},                     // Lo       HANGUL SYLLABLE HYO
+	{runeRange{0xD6E0, 0xD6E0}, prLV},                     // Lo       HANGUL SYLLABLE HWEO
+	{runeRange{0xD718, 0xD718}, prLV},                     // Lo       HANGUL SYLLABLE HWI
+	{runeRange{0xD750, 0xD750}, prLV},                     // Lo       HANGUL SYLLABLE HEU
+	{runeRange{0xD788, 0xD788}, prLV},                     // Lo       HANGUL SYLLABLE HI
+	{runeRange{0xFB1E, 0xFB1E}, prExtend},                 // Mn       HEBREW POINT JUDEO-SPANISH VARIKA
+	{runeRange{0xFF9E, 0xFF9F}, prExtend},                 // Lm   [2] HALFWIDTH KATAKANA VOICED SOUND MARK..HALFWIDTH KATAKANA SEMI-VOICED SOUND MARK
+	{runeRange{0x102E0, 0x102E0}, prExtend},               // Mn       COPTIC EPACT THOUSANDS MARK
+	{runeRange{0x10A0C, 0x10A0F}, prExtend},               // Mn   [4] KHAROSHTHI VOWEL LENGTH MARK..KHAROSHTHI SIGN VISARGA
+	{runeRange{0x10D24, 0x10D27}, prExtend},               // Mn   [4] HANIFI ROHINGYA SIGN HARBAHAY..HANIFI ROHINGYA SIGN TASSI
+	{runeRange{0x10F82, 0x10F85}, prExtend},               // Mn   [4] OLD UYGHUR COMBINING DOT ABOVE..OLD UYGHUR COMBINING TWO DOTS BELOW
+	{runeRange{0x11038, 0x11046}, prExtend},               // Mn  [15] BRAHMI VOWEL SIGN AA..BRAHMI VIRAMA
+	{runeRange{0x11082, 0x11082}, prSpacingMark},          // Mc       KAITHI SIGN VISARGA
+	{runeRange{0x110B9, 0x110BA}, prExtend},               // Mn   [2] KAITHI SIGN VIRAMA..KAITHI SIGN NUKTA
+	{runeRange{0x11100, 0x11102}, prExtend},               // Mn   [3] CHAKMA SIGN CANDRABINDU..CHAKMA SIGN VISARGA
+	{runeRange{0x11145, 0x11146}, prSpacingMark},          // Mc   [2] CHAKMA VOWEL SIGN AA..CHAKMA VOWEL SIGN EI
+	{runeRange{0x111B3, 0x111B5}, prSpacingMark},          // Mc   [3] SHARADA VOWEL SIGN AA..SHARADA VOWEL SIGN II
+	{runeRange{0x111C9, 0x111CC}, prExtend},               // Mn   [4] SHARADA SANDHI MARK..SHARADA EXTRA SHORT VOWEL MARK
+	{runeRange{0x1122F, 0x11231}, prExtend},               // Mn   [3] KHOJKI VOWEL SIGN U..KHOJKI VOWEL SIGN AI
+	{runeRange{0x11236, 0x11237}, prExtend},               // Mn   [2] KHOJKI SIGN NUKTA..KHOJKI SIGN SHADDA
+	{runeRange{0x112E0, 0x112E2}, prSpacingMark},          // Mc   [3] KHUDAWADI VOWEL SIGN AA..KHUDAWADI VOWEL SIGN II
+	{runeRange{0x1133B, 0x1133C}, prExtend},               // Mn   [2] COMBINING BINDU BELOW..GRANTHA SIGN NUKTA
+	{runeRange{0x11341, 0x11344}, prSpacingMark},          // Mc   [4] GRANTHA VOWEL SIGN U..GRANTHA VOWEL SIGN VOCALIC RR
+	{runeRange{0x11362, 0x11363}, prSpacingMark},          // Mc   [2] GRANTHA VOWEL SIGN VOCALIC L..GRANTHA VOWEL SIGN VOCALIC LL
+	{runeRange{0x11438, 0x1143F}, prExtend},               // Mn   [8] NEWA VOWEL SIGN U..NEWA VOWEL SIGN AI
+	{runeRange{0x11446, 0x11446}, prExtend},               // Mn       NEWA SIGN NUKTA
+	{runeRange{0x114B3, 0x114B8}, prExtend},               // Mn   [6] TIRHUTA VOWEL SIGN U..TIRHUTA VOWEL SIGN VOCALIC LL
+	{runeRange{0x114BD, 0x114BD}, prExtend},               // Mc       TIRHUTA VOWEL SIGN SHORT O
+	{runeRange{0x114C2, 0x114C3}, prExtend},               // Mn   [2] TIRHUTA SIGN VIRAMA..TIRHUTA SIGN NUKTA
+	{runeRange{0x115B8, 0x115BB}, prSpacingMark},          // Mc   [4] SIDDHAM VOWEL SIGN E..SIDDHAM VOWEL SIGN AU
+	{runeRange{0x115DC, 0x115DD}, prExtend},               // Mn   [2] SIDDHAM VOWEL SIGN ALTERNATE U..SIDDHAM VOWEL SIGN ALTERNATE UU
+	{runeRange{0x1163D, 0x1163D}, prExtend},               // Mn       MODI SIGN ANUSVARA
+	{runeRange{0x116AC, 0x116AC}, prSpacingMark},          // Mc       TAKRI SIGN VISARGA
+	{runeRange{0x116B6, 0x116B6}, prSpacingMark},          // Mc       TAKRI SIGN VIRAMA
+	{runeRange{0x11726, 0x11726}, prSpacingMark},          // Mc       AHOM VOWEL SIGN E
+	{runeRange{0x11838, 0x11838}, prSpacingMark},          // Mc       DOGRA SIGN VISARGA
+	{runeRange{0x11937, 0x11938}, prSpacingMark},          // Mc   [2] DIVES AKURU VOWEL SIGN AI..DIVES AKURU VOWEL SIGN O
+	{runeRange{0x1193F, 0x1193F}, prPrepend},              // Lo       DIVES AKURU PREFIXED NASAL SIGN
+	{runeRange{0x11943, 0x11943}, prExtend},               // Mn       DIVES AKURU SIGN NUKTA
+	{runeRange{0x119DC, 0x119DF}, prSpacingMark},          // Mc   [4] NANDINAGARI VOWEL SIGN O..NANDINAGARI SIGN VISARGA
+	{runeRange{0x11A33, 0x11A38}, prExtend},               // Mn   [6] ZANABAZAR SQUARE FINAL CONSONANT MARK..ZANABAZAR SQUARE SIGN ANUSVARA
+	{runeRange{0x11A47, 0x11A47}, prExtend},               // Mn       ZANABAZAR SQUARE SUBJOINER
+	{runeRange{0x11A84, 0x11A89}, prPrepend},              // Lo   [6] SOYOMBO SIGN JIHVAMULIYA..SOYOMBO CLUSTER-INITIAL LETTER SA
+	{runeRange{0x11C2F, 0x11C2F}, prSpacingMark},          // Mc       BHAIKSUKI VOWEL SIGN AA
+	{runeRange{0x11C3F, 0x11C3F}, prExtend},               // Mn       BHAIKSUKI SIGN VIRAMA
+	{runeRange{0x11CB1, 0x11CB1}, prSpacingMark},          // Mc       MARCHEN VOWEL SIGN I
+	{runeRange{0x11D31, 0x11D36}, prExtend},               // Mn   [6] MASARAM GONDI VOWEL SIGN AA..MASARAM GONDI VOWEL SIGN VOCALIC R
+	{runeRange{0x11D46, 0x11D46}, prPrepend},              // Lo       MASARAM GONDI REPHA
+	{runeRange{0x11D93, 0x11D94}, prSpacingMark},          // Mc   [2] GUNJALA GONDI VOWEL SIGN OO..GUNJALA GONDI VOWEL SIGN AU
+	{runeRange{0x11EF3, 0x11EF4}, prExtend},               // Mn   [2] MAKASAR VOWEL SIGN I..MAKASAR VOWEL SIGN U
+	{runeRange{0x11F03, 0x11F03}, prSpacingMark},          // Mc       KAWI SIGN VISARGA
+	{runeRange{0x11F40, 0x11F40}, prExtend},               // Mn       KAWI VOWEL SIGN EU
+	{runeRange{0x13440, 0x13440}, prExtend},               // Mn       EGYPTIAN HIEROGLYPH MIRROR HORIZONTALLY
+	{runeRange{0x16F4F, 0x16F4F}, prExtend},               // Mn       MIAO SIGN CONSONANT MODIFIER BAR
+	{runeRange{0x16FF0, 0x16FF1}, prSpacingMark},          // Mc   [2] VIETNAMESE ALTERNATE READING MARK CA..VIETNAMESE ALTERNATE READING MARK NHAY
+	{runeRange{0x1CF30, 0x1CF46}, prExtend},               // Mn  [23] ZNAMENNY COMBINING TONAL RANGE MARK MRACHNO..ZNAMENNY PRIZNAK MODIFIER ROG
+	{runeRange{0x1D16D, 0x1D16D}, prSpacingMark},          // Mc       MUSICAL SYMBOL COMBINING AUGMENTATION DOT
+	{runeRange{0x1D185, 0x1D18B}, prExtend},               // Mn   [7] MUSICAL SYMBOL COMBINING DOIT..MUSICAL SYMBOL COMBINING TRIPLE TONGUE
+	{runeRange{0x1DA3B, 0x1DA6C}, prExtend},               // Mn  [50] SIGNWRITING MOUTH CLOSED NEUTRAL..SIGNWRITING EXCITEMENT
+	{runeRange{0x1DAA1, 0x1DAAF}, prExtend},               // Mn  [15] SIGNWRITING ROTATION MODIFIER-2..SIGNWRITING ROTATION MODIFIER-16
+	{runeRange{0x1E023, 0x1E024}, prExtend},               // Mn   [2] COMBINING GLAGOLITIC LETTER YU..COMBINING GLAGOLITIC LETTER SMALL YUS
+	{runeRange{0x1E2AE, 0x1E2AE}, prExtend},               // Mn       TOTO SIGN RISING TONE
+	{runeRange{0x1E944, 0x1E94A}, prExtend},               // Mn   [7] ADLAM ALIF LENGTHENER..ADLAM NUKTA
+	{runeRange{0x1F0CF, 0x1F0CF}, prExtendedPictographic}, // E0.6   [1] (🃏)       joker
+	{runeRange{0x1F16C, 0x1F16F}, prExtendedPictographic}, // E0.0   [4] (🅬..🅯)    RAISED MR SIGN..CIRCLED HUMAN FIGURE
+	{runeRange{0x1F191, 0x1F19A}, prExtendedPictographic}, // E0.6  [10] (🆑..🆚)    CL button..VS button
+	{runeRange{0x1F203, 0x1F20F}, prExtendedPictographic}, // E0.0  [13] (🈃..🈏)    <reserved-1F203>..<reserved-1F20F>
+	{runeRange{0x1F23C, 0x1F23F}, prExtendedPictographic}, // E0.0   [4] (🈼..🈿)    <reserved-1F23C>..<reserved-1F23F>
+	{runeRange{0x1F300, 0x1F30C}, prExtendedPictographic}, // E0.6  [13] (🌀..🌌)    cyclone..milky way
+	{runeRange{0x1F311, 0x1F311}, prExtendedPictographic}, // E0.6   [1] (🌑)       new moon
+	{runeRange{0x1F319, 0x1F319}, prExtendedPictographic}, // E0.6   [1] (🌙)       crescent moon
+	{runeRange{0x1F31D, 0x1F31E}, prExtendedPictographic}, // E1.0   [2] (🌝..🌞)    full moon face..sun with face
+	{runeRange{0x1F324, 0x1F32C}, prExtendedPictographic}, // E0.7   [9] (🌤️..🌬️)    sun behind small cloud..wind face
+	{runeRange{0x1F334, 0x1F335}, prExtendedPictographic}, // E0.6   [2] (🌴..🌵)    palm tree..cactus
+	{runeRange{0x1F34C, 0x1F34F}, prExtendedPictographic}, // E0.6   [4] (🍌..🍏)    banana..green apple
+	{runeRange{0x1F37D, 0x1F37D}, prExtendedPictographic}, // E0.7   [1] (🍽️)       fork and knife with plate
+	{runeRange{0x1F396, 0x1F397}, prExtendedPictographic}, // E0.7   [2] (🎖️..🎗️)    military medal..reminder ribbon
+	{runeRange{0x1F39E, 0x1F39F}, prExtendedPictographic}, // E0.7   [2] (🎞️..🎟️)    film frames..admission tickets
+	{runeRange{0x1F3C7, 0x1F3C7}, prExtendedPictographic}, // E1.0   [1] (🏇)       horse racing
+	{runeRange{0x1F3CB, 0x1F3CE}, prExtendedPictographic}, // E0.7   [4] (🏋️..🏎️)    person lifting weights..racing car
+	{runeRange{0x1F3E4, 0x1F3E4}, prExtendedPictographic}, // E1.0   [1] (🏤)       post office
+	{runeRange{0x1F3F4, 0x1F3F4}, prExtendedPictographic}, // E1.0   [1] (🏴)       black flag
+	{runeRange{0x1F3F8, 0x1F3FA}, prExtendedPictographic}, // E1.0   [3] (🏸..🏺)    badminton..amphora
+	{runeRange{0x1F409, 0x1F40B}, prExtendedPictographic}, // E1.0   [3] (🐉..🐋)    dragon..whale
+	{runeRange{0x1F413, 0x1F413}, prExtendedPictographic}, // E1.0   [1] (🐓)       rooster
+	{runeRange{0x1F417, 0x1F429}, prExtendedPictographic}, // E0.6  [19] (🐗..🐩)    boar..poodle
+	{runeRange{0x1F440, 0x1F440}, prExtendedPictographic}, // E0.6   [1] (👀)       eyes
+	{runeRange{0x1F466, 0x1F46B}, prExtendedPictographic}, // E0.6   [6] (👦..👫)    boy..woman and man holding hands
+	{runeRange{0x1F4AE, 0x1F4B5}, prExtendedPictographic}, // E0.6   [8] (💮..💵)    white flower..dollar banknote
+	{runeRange{0x1F4EE, 0x1F4EE}, prExtendedPictographic}, // E0.6   [1] (📮)       postbox
+	{runeRange{0x1F4F6, 0x1F4F7}, prExtendedPictographic}, // E0.6   [2] (📶..📷)    antenna bars..camera
+	{runeRange{0x1F4FE, 0x1F4FE}, prExtendedPictographic}, // E0.0   [1] (📾)       PORTABLE STEREO
+	{runeRange{0x1F508, 0x1F508}, prExtendedPictographic}, // E0.7   [1] (🔈)       speaker low volume
+	{runeRange{0x1F516, 0x1F52B}, prExtendedPictographic}, // E0.6  [22] (🔖..🔫)    bookmark..water pistol
+	{runeRange{0x1F549, 0x1F54A}, prExtendedPictographic}, // E0.7   [2] (🕉️..🕊️)    om..dove
+	{runeRange{0x1F55C, 0x1F567}, prExtendedPictographic}, // E0.7  [12] (🕜..🕧)    one-thirty..twelve-thirty
+	{runeRange{0x1F573, 0x1F579}, prExtendedPictographic}, // E0.7   [7] (🕳️..🕹️)    hole..joystick
+	{runeRange{0x1F588, 0x1F589}, prExtendedPictographic}, // E0.0   [2] (🖈..🖉)    BLACK PUSHPIN..LOWER LEFT PENCIL
+	{runeRange{0x1F591, 0x1F594}, prExtendedPictographic}, // E0.0   [4] (🖑..🖔)    REVERSED RAISED HAND WITH FINGERS SPLAYED..REVERSED VICTORY HAND
+	{runeRange{0x1F5A5, 0x1F5A5}, prExtendedPictographic}, // E0.7   [1] (🖥️)       desktop computer
+	{runeRange{0x1F5B1, 0x1F5B2}, prExtendedPictographic}, // E0.7   [2] (🖱️..🖲️)    computer mouse..trackball
+	{runeRange{0x1F5C2, 0x1F5C4}, prExtendedPictographic}, // E0.7   [3] (🗂️..🗄️)    card index dividers..file cabinet
+	{runeRange{0x1F5DC, 0x1F5DE}, prExtendedPictographic}, // E0.7   [3] (🗜️..🗞️)    clamp..rolled-up newspaper
+	{runeRange{0x1F5E3, 0x1F5E3}, prExtendedPictographic}, // E0.7   [1] (🗣️)       speaking head
+	{runeRange{0x1F5EF, 0x1F5EF}, prExtendedPictographic}, // E0.7   [1] (🗯️)       right anger bubble
+	{runeRange{0x1F5FA, 0x1F5FA}, prExtendedPictographic}, // E0.7   [1] (🗺️)       world map
+	{runeRange{0x1F607, 0x1F608}, prExtendedPictographic}, // E1.0   [2] (😇..😈)    smiling face with halo..smiling face with horns
+	{runeRange{0x1F610, 0x1F610}, prExtendedPictographic}, // E0.7   [1] (😐)       neutral face
+	{runeRange{0x1F616, 0x1F616}, prExtendedPictographic}, // E0.6   [1] (😖)       confounded face
+	{runeRange{0x1F61A, 0x1F61A}, prExtendedPictographic}, // E0.6   [1] (😚)       kissing face with closed eyes
+	{runeRange{0x1F620, 0x1F625}, prExtendedPictographic}, // E0.6   [6] (😠..😥)    angry face..sad but relieved face
+	{runeRange{0x1F62D, 0x1F62D}, prExtendedPictographic}, // E0.6   [1] (😭)       loudly crying face
+	{runeRange{0x1F635, 0x1F635}, prExtendedPictographic}, // E0.6   [1] (😵)       face with crossed-out eyes
+	{runeRange{0x1F645, 0x1F64F}, prExtendedPictographic}, // E0.6  [11] (🙅..🙏)    person gesturing NO..folded hands
+	{runeRange{0x1F686, 0x1F686}, prExtendedPictographic}, // E1.0   [1] (🚆)       train
+	{runeRange{0x1F68A, 0x1F68B}, prExtendedPictographic}, // E1.0   [2] (🚊..🚋)    tram..tram car
+	{runeRange{0x1F68F, 0x1F68F}, prExtendedPictographic}, // E0.6   [1] (🚏)       bus stop
+	{runeRange{0x1F695, 0x1F695}, prExtendedPictographic}, // E0.6   [1] (🚕)       taxi
+	{runeRange{0x1F697, 0x1F697}, prExtendedPictographic}, // E0.6   [1] (🚗)       automobile
+	{runeRange{0x1F699, 0x1F69A}, prExtendedPictographic}, // E0.6   [2] (🚙..🚚)    sport utility vehicle..delivery truck
+	{runeRange{0x1F6A2, 0x1F6A2}, prExtendedPictographic}, // E0.6   [1] (🚢)       ship
+	{runeRange{0x1F6A4, 0x1F6A5}, prExtendedPictographic}, // E0.6   [2] (🚤..🚥)    speedboat..horizontal traffic light
+	{runeRange{0x1F6A7, 0x1F6AD}, prExtendedPictographic}, // E0.6   [7] (🚧..🚭)    construction..no smoking
+	{runeRange{0x1F6B2, 0x1F6B2}, prExtendedPictographic}, // E0.6   [1] (🚲)       bicycle
+	{runeRange{0x1F6B6, 0x1F6B6}, prExtendedPictographic}, // E0.6   [1] (🚶)       person walking
+	{runeRange{0x1F6B9, 0x1F6BE}, prExtendedPictographic}, // E0.6   [6] (🚹..🚾)    men’s room..water closet
+	{runeRange{0x1F6C0, 0x1F6C0}, prExtendedPictographic}, // E0.6   [1] (🛀)       person taking bath
+	{runeRange{0x1F6C6, 0x1F6CA}, prExtendedPictographic}, // E0.0   [5] (🛆..🛊)    TRIANGLE WITH ROUNDED CORNERS..GIRLS SYMBOL
+	{runeRange{0x1F6CC, 0x1F6CC}, prExtendedPictographic}, // E1.0   [1] (🛌)       person in bed
+	{runeRange{0x1F6D0, 0x1F6D0}, prExtendedPictographic}, // E1.0   [1] (🛐)       place of worship
+	{runeRange{0x1F6D3, 0x1F6D4}, prExtendedPictographic}, // E0.0   [2] (🛓..🛔)    STUPA..PAGODA
+	{runeRange{0x1F6D6, 0x1F6D7}, prExtendedPictographic}, // E13.0  [2] (🛖..🛗)    hut..elevator
+	{runeRange{0x1F6DC, 0x1F6DC}, prExtendedPictographic}, // E15.0  [1] (🛜)       wireless
+	{runeRange{0x1F6E0, 0x1F6E5}, prExtendedPictographic}, // E0.7   [6] (🛠️..🛥️)    hammer and wrench..motor boat
+	{runeRange{0x1F6E9, 0x1F6E9}, prExtendedPictographic}, // E0.7   [1] (🛩️)       small airplane
+	{runeRange{0x1F6EB, 0x1F6EC}, prExtendedPictographic}, // E1.0   [2] (🛫..🛬)    airplane departure..airplane arrival
+	{runeRange{0x1F6F0, 0x1F6F0}, prExtendedPictographic}, // E0.7   [1] (🛰️)       satellite
+	{runeRange{0x1F6F3, 0x1F6F3}, prExtendedPictographic}, // E0.7   [1] (🛳️)       passenger ship
+	{runeRange{0x1F6F7, 0x1F6F8}, prExtendedPictographic}, // E5.0   [2] (🛷..🛸)    sled..flying saucer
+	{runeRange{0x1F6FA, 0x1F6FA}, prExtendedPictographic}, // E12.0  [1] (🛺)       auto rickshaw
+	{runeRange{0x1F6FD, 0x1F6FF}, prExtendedPictographic}, // E0.0   [3] (🛽..🛿)    <reserved-1F6FD>..<reserved-1F6FF>
+	{runeRange{0x1F7D5, 0x1F7DF}, prExtendedPictographic}, // E0.0  [11] (🟕..🟟)    CIRCLED TRIANGLE..<reserved-1F7DF>
+	{runeRange{0x1F7EC, 0x1F7EF}, prExtendedPictographic}, // E0.0   [4] (🟬..🟯)    <reserved-1F7EC>..<reserved-1F7EF>
+	{runeRange{0x1F7F1, 0x1F7FF}, prExtendedPictographic}, // E0.0  [15] (🟱..🟿)    <reserved-1F7F1>..<reserved-1F7FF>
+	{runeRange{0x1F848, 0x1F84F}, prExtendedPictographic}, // E0.0   [8] (🡈..🡏)    <reserved-1F848>..<reserved-1F84F>
+	{runeRange{0x1F888, 0x1F88F}, prExtendedPictographic}, // E0.0   [8] (🢈..🢏)    <reserved-1F888>..<reserved-1F88F>
+	{runeRange{0x1F90C, 0x1F90C}, prExtendedPictographic}, // E13.0  [1] (🤌)       pinched fingers
+	{runeRange{0x1F910, 0x1F918}, prExtendedPictographic}, // E1.0   [9] (🤐..🤘)    zipper-mouth face..sign of the horns
+	{runeRange{0x1F91F, 0x1F91F}, prExtendedPictographic}, // E5.0   [1] (🤟)       love-you gesture
+	{runeRange{0x1F928, 0x1F92F}, prExtendedPictographic}, // E5.0   [8] (🤨..🤯)    face with raised eyebrow..exploding head
+	{runeRange{0x1F931, 0x1F932}, prExtendedPictographic}, // E5.0   [2] (🤱..🤲)    breast-feeding..palms up together
+	{runeRange{0x1F93C, 0x1F93E}, prExtendedPictographic}, // E3.0   [3] (🤼..🤾)    people wrestling..person playing handball
+	{runeRange{0x1F940, 0x1F945}, prExtendedPictographic}, // E3.0   [6] (🥀..🥅)    wilted flower..goal net
+	{runeRange{0x1F94C, 0x1F94C}, prExtendedPictographic}, // E5.0   [1] (🥌)       curling stone
+	{runeRange{0x1F950, 0x1F95E}, prExtendedPictographic}, // E3.0  [15] (🥐..🥞)    croissant..pancakes
+	{runeRange{0x1F96C, 0x1F970}, prExtendedPictographic}, // E11.0  [5] (🥬..🥰)    leafy green..smiling face with hearts
+	{runeRange{0x1F972, 0x1F972}, prExtendedPictographic}, // E13.0  [1] (🥲)       smiling face with tear
+	{runeRange{0x1F977, 0x1F978}, prExtendedPictographic}, // E13.0  [2] (🥷..🥸)    ninja..disguised face
+	{runeRange{0x1F97A, 0x1F97A}, prExtendedPictographic}, // E11.0  [1] (🥺)       pleading face
+	{runeRange{0x1F97C, 0x1F97F}, prExtendedPictographic}, // E11.0  [4] (🥼..🥿)    lab coat..flat shoe
+	{runeRange{0x1F985, 0x1F991}, prExtendedPictographic}, // E3.0  [13] (🦅..🦑)    eagle..squid
+	{runeRange{0x1F998, 0x1F9A2}, prExtendedPictographic}, // E11.0 [11] (🦘..🦢)    kangaroo..swan
+	{runeRange{0x1F9A5, 0x1F9AA}, prExtendedPictographic}, // E12.0  [6] (🦥..🦪)    sloth..oyster
+	{runeRange{0x1F9AE, 0x1F9AF}, prExtendedPictographic}, // E12.0  [2] (🦮..🦯)    guide dog..white cane
+	{runeRange{0x1F9BA, 0x1F9BF}, prExtendedPictographic}, // E12.0  [6] (🦺..🦿)    safety vest..mechanical leg
+	{runeRange{0x1F9C1, 0x1F9C2}, prExtendedPictographic}, // E11.0  [2] (🧁..🧂)    cupcake..salt
+	{runeRange{0x1F9CB, 0x1F9CB}, prExtendedPictographic}, // E13.0  [1] (🧋)       bubble tea
+	{runeRange{0x1F9CD, 0x1F9CF}, prExtendedPictographic}, // E12.0  [3] (🧍..🧏)    person standing..deaf person
+	{runeRange{0x1F9E7, 0x1F9FF}, prExtendedPictographic}, // E11.0 [25] (🧧..🧿)    red envelope..nazar amulet
+	{runeRange{0x1FA70, 0x1FA73}, prExtendedPictographic}, // E12.0  [4] (🩰..🩳)    ballet shoes..shorts
+	{runeRange{0x1FA75, 0x1FA77}, prExtendedPictographic}, // E15.0  [3] (🩵..🩷)    light blue heart..pink heart
+	{runeRange{0x1FA7B, 0x1FA7C}, prExtendedPictographic}, // E14.0  [2] (🩻..🩼)    x-ray..crutch
+	{runeRange{0x1FA80, 0x1FA82}, prExtendedPictographic}, // E12.0  [3] (🪀..🪂)    yo-yo..parachute
+	{runeRange{0x1FA87, 0x1FA88}, prExtendedPictographic}, // E15.0  [2] (🪇..🪈)    maracas..flute
+	{runeRange{0x1FA90, 0x1FA95}, prExtendedPictographic}, // E12.0  [6] (🪐..🪕)    ringed planet..banjo
+	{runeRange{0x1FAA9, 0x1FAAC}, prExtendedPictographic}, // E14.0  [4] (🪩..🪬)    mirror ball..hamsa
+	{runeRange{0x1FAB0, 0x1FAB6}, prExtendedPictographic}, // E13.0  [7] (🪰..🪶)    fly..feather
+	{runeRange{0x1FABB, 0x1FABD}, prExtendedPictographic}, // E15.0  [3] (🪻..🪽)    hyacinth..wing
+	{runeRange{0x1FABF, 0x1FABF}, prExtendedPictographic}, // E15.0  [1] (🪿)       goose
+	{runeRange{0x1FAC3, 0x1FAC5}, prExtendedPictographic}, // E14.0  [3] (🫃..🫅)    pregnant man..person with crown
+	{runeRange{0x1FACE, 0x1FACF}, prExtendedPictographic}, // E15.0  [2] (🫎..🫏)    moose..donkey
+	{runeRange{0x1FAD7, 0x1FAD9}, prExtendedPictographic}, // E14.0  [3] (🫗..🫙)    pouring liquid..jar
+	{runeRange{0x1FADC, 0x1FADF}, prExtendedPictographic}, // E0.0   [4] (🫜..🫟)    <reserved-1FADC>..<reserved-1FADF>
+	{runeRange{0x1FAE8, 0x1FAE8}, prExtendedPictographic}, // E15.0  [1] (🫨)       shaking face
+	{runeRange{0x1FAF0, 0x1FAF6}, prExtendedPictographic}, // E14.0  [7] (🫰..🫶)    hand with index finger and thumb crossed..heart hands
+	{runeRange{0x1FAF9, 0x1FAFF}, prExtendedPictographic}, // E0.0   [7] (🫹..🫿)    <reserved-1FAF9>..<reserved-1FAFF>
+	{runeRange{0xE0000, 0xE0000}, prControl},              // Cn       <reserved-E0000>
+	{runeRange{0xE0002, 0xE001F}, prControl},              // Cn  [30] <reserved-E0002>..<reserved-E001F>
+	{runeRange{0xE0080, 0xE00FF}, prControl},              // Cn [128] <reserved-E0080>..<reserved-E00FF>
 	{runeRange{0xE01F0, 0xE0FFF}, prControl},              // Cn [3600] <reserved-E01F0>..<reserved-E0FFF>
+	{runeRange{0x0000, 0x0009}, prControl},                // Cc  [10] <control-0000>..<control-0009>
+	{runeRange{0x000B, 0x000C}, prControl},                // Cc   [2] <control-000B>..<control-000C>
+	{runeRange{0x000E, 0x001F}, prControl},                // Cc  [18] <control-000E>..<control-001F>
+	{runeRange{0x00A9, 0x00A9}, prExtendedPictographic},   // E0.6   [1] (©️)       copyright
+	{runeRange{0x00AE, 0x00AE}, prExtendedPictographic},   // E0.6   [1] (®️)       registered
+	{runeRange{0x0483, 0x0487}, prExtend},                 // Mn   [5] COMBINING CYRILLIC TITLO..COMBINING CYRILLIC POKRYTIE
+	{runeRange{0x0591, 0x05BD}, prExtend},                 // Mn  [45] HEBREW ACCENT ETNAHTA..HEBREW POINT METEG
+	{runeRange{0x05C1, 0x05C2}, prExtend},                 // Mn   [2] HEBREW POINT SHIN DOT..HEBREW POINT SIN DOT
+	{runeRange{0x05C7, 0x05C7}, prExtend},                 // Mn       HEBREW POINT QAMATS QATAN
+	{runeRange{0x0610, 0x061A}, prExtend},                 // Mn  [11] ARABIC SIGN SALLALLAHOU ALAYHE WASSALLAM..ARABIC SMALL KASRA
+	{runeRange{0x064B, 0x065F}, prExtend},                 // Mn  [21] ARABIC FATHATAN..ARABIC WAVY HAMZA BELOW
+	{runeRange{0x06D6, 0x06DC}, prExtend},                 // Mn   [7] ARABIC SMALL HIGH LIGATURE SAD WITH LAM WITH ALEF MAKSURA..ARABIC SMALL HIGH SEEN
+	{runeRange{0x06DF, 0x06E4}, prExtend},                 // Mn   [6] ARABIC SMALL HIGH ROUNDED ZERO..ARABIC SMALL HIGH MADDA
+	{runeRange{0x06EA, 0x06ED}, prExtend},                 // Mn   [4] ARABIC EMPTY CENTRE LOW STOP..ARABIC SMALL LOW MEEM
+	{runeRange{0x0711, 0x0711}, prExtend},                 // Mn       SYRIAC LETTER SUPERSCRIPT ALAPH
+	{runeRange{0x07A6, 0x07B0}, prExtend},                 // Mn  [11] THAANA ABAFILI..THAANA SUKUN
+	{runeRange{0x07FD, 0x07FD}, prExtend},                 // Mn       NKO DANTAYALAN
+	{runeRange{0x081B, 0x0823}, prExtend},                 // Mn   [9] SAMARITAN MARK EPENTHETIC YUT..SAMARITAN VOWEL SIGN A
+	{runeRange{0x0829, 0x082D}, prExtend},                 // Mn   [5] SAMARITAN VOWEL SIGN LONG I..SAMARITAN MARK NEQUDAA
+	{runeRange{0x0890, 0x0891}, prPrepend},                // Cf   [2] ARABIC POUND MARK ABOVE..ARABIC PIASTRE MARK ABOVE
+	{runeRange{0x08CA, 0x08E1}, prExtend},                 // Mn  [24] ARABIC SMALL HIGH FARSI YEH..ARABIC SMALL HIGH SIGN SAFHA
+	{runeRange{0x08E3, 0x0902}, prExtend},                 // Mn  [32] ARABIC TURNED DAMMA BELOW..DEVANAGARI SIGN ANUSVARA
+	{runeRange{0x093A, 0x093A}, prExtend},                 // Mn       DEVANAGARI VOWEL SIGN OE
+	{runeRange{0x093C, 0x093C}, prExtend},                 // Mn       DEVANAGARI SIGN NUKTA
+	{runeRange{0x0941, 0x0948}, prExtend},                 // Mn   [8] DEVANAGARI VOWEL SIGN U..DEVANAGARI VOWEL SIGN AI
+	{runeRange{0x094D, 0x094D}, prExtend},                 // Mn       DEVANAGARI SIGN VIRAMA
+	{runeRange{0x0951, 0x0957}, prExtend},                 // Mn   [7] DEVANAGARI STRESS SIGN UDATTA..DEVANAGARI VOWEL SIGN UUE
+	{runeRange{0x0981, 0x0981}, prExtend},                 // Mn       BENGALI SIGN CANDRABINDU
+	{runeRange{0x09BC, 0x09BC}, prExtend},                 // Mn       BENGALI SIGN NUKTA
+	{runeRange{0x09BF, 0x09C0}, prSpacingMark},            // Mc   [2] BENGALI VOWEL SIGN I..BENGALI VOWEL SIGN II
+	{runeRange{0x09C7, 0x09C8}, prSpacingMark},            // Mc   [2] BENGALI VOWEL SIGN E..BENGALI VOWEL SIGN AI
+	{runeRange{0x09CD, 0x09CD}, prExtend},                 // Mn       BENGALI SIGN VIRAMA
+	{runeRange{0x09E2, 0x09E3}, prExtend},                 // Mn   [2] BENGALI VOWEL SIGN VOCALIC L..BENGALI VOWEL SIGN VOCALIC LL
+	{runeRange{0x0A01, 0x0A02}, prExtend},                 // Mn   [2] GURMUKHI SIGN ADAK BINDI..GURMUKHI SIGN BINDI
+	{runeRange{0x0A3C, 0x0A3C}, prExtend},                 // Mn       GURMUKHI SIGN NUKTA
+	{runeRange{0x0A41, 0x0A42}, prExtend},                 // Mn   [2] GURMUKHI VOWEL SIGN U..GURMUKHI VOWEL SIGN UU
+	{runeRange{0x0A4B, 0x0A4D}, prExtend},                 // Mn   [3] GURMUKHI VOWEL SIGN OO..GURMUKHI SIGN VIRAMA
+	{runeRange{0x0A70, 0x0A71}, prExtend},                 // Mn   [2] GURMUKHI TIPPI..GURMUKHI ADDAK
+	{runeRange{0x0A81, 0x0A82}, prExtend},                 // Mn   [2] GUJARATI SIGN CANDRABINDU..GUJARATI SIGN ANUSVARA
+	{runeRange{0x0ABC, 0x0ABC}, prExtend},                 // Mn       GUJARATI SIGN NUKTA
+	{runeRange{0x0AC1, 0x0AC5}, prExtend},                 // Mn   [5] GUJARATI VOWEL SIGN U..GUJARATI VOWEL SIGN CANDRA E
+	{runeRange{0x0AC9, 0x0AC9}, prSpacingMark},            // Mc       GUJARATI VOWEL SIGN CANDRA O
+	{runeRange{0x0ACD, 0x0ACD}, prExtend},                 // Mn       GUJARATI SIGN VIRAMA
+	{runeRange{0x0AFA, 0x0AFF}, prExtend},                 // Mn   [6] GUJARATI SIGN SUKUN..GUJARATI SIGN TWO-CIRCLE NUKTA ABOVE
+	{runeRange{0x0B02, 0x0B03}, prSpacingMark},            // Mc   [2] ORIYA SIGN ANUSVARA..ORIYA SIGN VISARGA
+	{runeRange{0x0B3E, 0x0B3E}, prExtend},                 // Mc       ORIYA VOWEL SIGN AA
+	{runeRange{0x0B40, 0x0B40}, prSpacingMark},            // Mc       ORIYA VOWEL SIGN II
+	{runeRange{0x0B47, 0x0B48}, prSpacingMark},            // Mc   [2] ORIYA VOWEL SIGN E..ORIYA VOWEL SIGN AI
+	{runeRange{0x0B4D, 0x0B4D}, prExtend},                 // Mn       ORIYA SIGN VIRAMA
+	{runeRange{0x0B57, 0x0B57}, prExtend},                 // Mc       ORIYA AU LENGTH MARK
+	{runeRange{0x0B82, 0x0B82}, prExtend},                 // Mn       TAMIL SIGN ANUSVARA
+	{runeRange{0x0BBF, 0x0BBF}, prSpacingMark},            // Mc       TAMIL VOWEL SIGN I
+	{runeRange{0x0BC1, 0x0BC2}, prSpacingMark},            // Mc   [2] TAMIL VOWEL SIGN U..TAMIL VOWEL SIGN UU
+	{runeRange{0x0BCA, 0x0BCC}, prSpacingMark},            // Mc   [3] TAMIL VOWEL SIGN O..TAMIL VOWEL SIGN AU
+	{runeRange{0x0BD7, 0x0BD7}, prExtend},                 // Mc       TAMIL AU LENGTH MARK
+	{runeRange{0x0C01, 0x0C03}, prSpacingMark},            // Mc   [3] TELUGU SIGN CANDRABINDU..TELUGU SIGN VISARGA
+	{runeRange{0x0C3C, 0x0C3C}, prExtend},                 // Mn       TELUGU SIGN NUKTA
+	{runeRange{0x0C41, 0x0C44}, prSpacingMark},            // Mc   [4] TELUGU VOWEL SIGN U..TELUGU VOWEL SIGN VOCALIC RR
+	{runeRange{0x0C4A, 0x0C4D}, prExtend},                 // Mn   [4] TELUGU VOWEL SIGN O..TELUGU SIGN VIRAMA
+	{runeRange{0x0C62, 0x0C63}, prExtend},                 // Mn   [2] TELUGU VOWEL SIGN VOCALIC L..TELUGU VOWEL SIGN VOCALIC LL
+	{runeRange{0x0C82, 0x0C83}, prSpacingMark},            // Mc   [2] KANNADA SIGN ANUSVARA..KANNADA SIGN VISARGA
+	{runeRange{0x0CBE, 0x0CBE}, prSpacingMark},            // Mc       KANNADA VOWEL SIGN AA
+	{runeRange{0x0CC0, 0x0CC1}, prSpacingMark},            // Mc   [2] KANNADA VOWEL SIGN II..KANNADA VOWEL SIGN U
+	{runeRange{0x0CC3, 0x0CC4}, prSpacingMark},            // Mc   [2] KANNADA VOWEL SIGN VOCALIC R..KANNADA VOWEL SIGN VOCALIC RR
+	{runeRange{0x0CC7, 0x0CC8}, prSpacingMark},            // Mc   [2] KANNADA VOWEL SIGN EE..KANNADA VOWEL SIGN AI
+	{runeRange{0x0CCC, 0x0CCD}, prExtend},                 // Mn   [2] KANNADA VOWEL SIGN AU..KANNADA SIGN VIRAMA
+	{runeRange{0x0CE2, 0x0CE3}, prExtend},                 // Mn   [2] KANNADA VOWEL SIGN VOCALIC L..KANNADA VOWEL SIGN VOCALIC LL
+	{runeRange{0x0D00, 0x0D01}, prExtend},                 // Mn   [2] MALAYALAM SIGN COMBINING ANUSVARA ABOVE..MALAYALAM SIGN CANDRABINDU
+	{runeRange{0x0D3B, 0x0D3C}, prExtend},                 // Mn   [2] MALAYALAM SIGN VERTICAL BAR VIRAMA..MALAYALAM SIGN CIRCULAR VIRAMA
+	{runeRange{0x0D3F, 0x0D40}, prSpacingMark},            // Mc   [2] MALAYALAM VOWEL SIGN I..MALAYALAM VOWEL SIGN II
+	{runeRange{0x0D46, 0x0D48}, prSpacingMark},            // Mc   [3] MALAYALAM VOWEL SIGN E..MALAYALAM VOWEL SIGN AI
+	{runeRange{0x0D4D, 0x0D4D}, prExtend},                 // Mn       MALAYALAM SIGN VIRAMA
+	{runeRange{0x0D57, 0x0D57}, prExtend},                 // Mc       MALAYALAM AU LENGTH MARK
+	{runeRange{0x0D81, 0x0D81}, prExtend},                 // Mn       SINHALA SIGN CANDRABINDU
+	{runeRange{0x0DCA, 0x0DCA}, prExtend},                 // Mn       SINHALA SIGN AL-LAKUNA
+	{runeRange{0x0DD0, 0x0DD1}, prSpacingMark},            // Mc   [2] SINHALA VOWEL SIGN KETTI AEDA-PILLA..SINHALA VOWEL SIGN DIGA AEDA-PILLA
+	{runeRange{0x0DD6, 0x0DD6}, prExtend},                 // Mn       SINHALA VOWEL SIGN DIGA PAA-PILLA
+	{runeRange{0x0DDF, 0x0DDF}, prExtend},                 // Mc       SINHALA VOWEL SIGN GAYANUKITTA
+	{runeRange{0x0E31, 0x0E31}, prExtend},                 // Mn       THAI CHARACTER MAI HAN-AKAT
+	{runeRange{0x0E34, 0x0E3A}, prExtend},                 // Mn   [7] THAI CHARACTER SARA I..THAI CHARACTER PHINTHU
+	{runeRange{0x0EB1, 0x0EB1}, prExtend},                 // Mn       LAO VOWEL SIGN MAI KAN
+	{runeRange{0x0EB4, 0x0EBC}, prExtend},                 // Mn   [9] LAO VOWEL SIGN I..LAO SEMIVOWEL SIGN LO
+	{runeRange{0x0F18, 0x0F19}, prExtend},                 // Mn   [2] TIBETAN ASTROLOGICAL SIGN -KHYUD PA..TIBETAN ASTROLOGICAL SIGN SDONG TSHUGS
+	{runeRange{0x0F37, 0x0F37}, prExtend},                 // Mn       TIBETAN MARK NGAS BZUNG SGOR RTAGS
+	{runeRange{0x0F3E, 0x0F3F}, prSpacingMark},            // Mc   [2] TIBETAN SIGN YAR TSHES..TIBETAN SIGN MAR TSHES
+	{runeRange{0x0F7F, 0x0F7F}, prSpacingMark},            // Mc       TIBETAN SIGN RNAM BCAD
+	{runeRange{0x0F86, 0x0F87}, prExtend},                 // Mn   [2] TIBETAN SIGN LCI RTAGS..TIBETAN SIGN YANG RTAGS
+	{runeRange{0x0F99, 0x0FBC}, prExtend},                 // Mn  [36] TIBETAN SUBJOINED LETTER NYA..TIBETAN SUBJOINED LETTER FIXED-FORM RA
+	{runeRange{0x102D, 0x1030}, prExtend},                 // Mn   [4] MYANMAR VOWEL SIGN I..MYANMAR VOWEL SIGN UU
+	{runeRange{0x1032, 0x1037}, prExtend},                 // Mn   [6] MYANMAR VOWEL SIGN AI..MYANMAR SIGN DOT BELOW
+	{runeRange{0x103B, 0x103C}, prSpacingMark},            // Mc   [2] MYANMAR CONSONANT SIGN MEDIAL YA..MYANMAR CONSONANT SIGN MEDIAL RA
+	{runeRange{0x1056, 0x1057}, prSpacingMark},            // Mc   [2] MYANMAR VOWEL SIGN VOCALIC R..MYANMAR VOWEL SIGN VOCALIC RR
+	{runeRange{0x105E, 0x1060}, prExtend},                 // Mn   [3] MYANMAR CONSONANT SIGN MON MEDIAL NA..MYANMAR CONSONANT SIGN MON MEDIAL LA
+	{runeRange{0x1082, 0x1082}, prExtend},                 // Mn       MYANMAR CONSONANT SIGN SHAN MEDIAL WA
+	{runeRange{0x1085, 0x1086}, prExtend},                 // Mn   [2] MYANMAR VOWEL SIGN SHAN E ABOVE..MYANMAR VOWEL SIGN SHAN FINAL Y
+	{runeRange{0x109D, 0x109D}, prExtend},                 // Mn       MYANMAR VOWEL SIGN AITON AI
+	{runeRange{0x1160, 0x11A7}, prV},                      // Lo  [72] HANGUL JUNGSEONG FILLER..HANGUL JUNGSEONG O-YAE
+	{runeRange{0x135D, 0x135F}, prExtend},                 // Mn   [3] ETHIOPIC COMBINING GEMINATION AND VOWEL LENGTH MARK..ETHIOPIC COMBINING GEMINATION MARK
+	{runeRange{0x1715, 0x1715}, prSpacingMark},            // Mc       TAGALOG SIGN PAMUDPOD
+	{runeRange{0x1734, 0x1734}, prSpacingMark},            // Mc       HANUNOO SIGN PAMUDPOD
+	{runeRange{0x1772, 0x1773}, prExtend},                 // Mn   [2] TAGBANWA VOWEL SIGN I..TAGBANWA VOWEL SIGN U
+	{runeRange{0x17B6, 0x17B6}, prSpacingMark},            // Mc       KHMER VOWEL SIGN AA
+	{runeRange{0x17BE, 0x17C5}, prSpacingMark},            // Mc   [8] KHMER VOWEL SIGN OE..KHMER VOWEL SIGN AU
+	{runeRange{0x17C7, 0x17C8}, prSpacingMark},            // Mc   [2] KHMER SIGN REAHMUK..KHMER SIGN YUUKALEAPINTU
+	{runeRange{0x17DD, 0x17DD}, prExtend},                 // Mn       KHMER SIGN ATTHACAN
+	{runeRange{0x180E, 0x180E}, prControl},                // Cf       MONGOLIAN VOWEL SEPARATOR
+	{runeRange{0x1885, 0x1886}, prExtend},                 // Mn   [2] MONGOLIAN LETTER ALI GALI BALUDA..MONGOLIAN LETTER ALI GALI THREE BALUDA
+	{runeRange{0x1920, 0x1922}, prExtend},                 // Mn   [3] LIMBU VOWEL SIGN A..LIMBU VOWEL SIGN U
+	{runeRange{0x1927, 0x1928}, prExtend},                 // Mn   [2] LIMBU VOWEL SIGN E..LIMBU VOWEL SIGN O
+	{runeRange{0x1930, 0x1931}, prSpacingMark},            // Mc   [2] LIMBU SMALL LETTER KA..LIMBU SMALL LETTER NGA
+	{runeRange{0x1933, 0x1938}, prSpacingMark},            // Mc   [6] LIMBU SMALL LETTER TA..LIMBU SMALL LETTER LA
+	{runeRange{0x1A17, 0x1A18}, prExtend},                 // Mn   [2] BUGINESE VOWEL SIGN I..BUGINESE VOWEL SIGN U
+	{runeRange{0x1A1B, 0x1A1B}, prExtend},                 // Mn       BUGINESE VOWEL SIGN AE
+	{runeRange{0x1A56, 0x1A56}, prExtend},                 // Mn       TAI THAM CONSONANT SIGN MEDIAL LA
+	{runeRange{0x1A58, 0x1A5E}, prExtend},                 // Mn   [7] TAI THAM SIGN MAI KANG LAI..TAI THAM CONSONANT SIGN SA
+	{runeRange{0x1A62, 0x1A62}, prExtend},                 // Mn       TAI THAM VOWEL SIGN MAI SAT
+	{runeRange{0x1A6D, 0x1A72}, prSpacingMark},            // Mc   [6] TAI THAM VOWEL SIGN OY..TAI THAM VOWEL SIGN THAM AI
+	{runeRange{0x1A7F, 0x1A7F}, prExtend},                 // Mn       TAI THAM COMBINING CRYPTOGRAMMIC DOT
+	{runeRange{0x1ABE, 0x1ABE}, prExtend},                 // Me       COMBINING PARENTHESES OVERLAY
+	{runeRange{0x1B00, 0x1B03}, prExtend},                 // Mn   [4] BALINESE SIGN ULU RICEM..BALINESE SIGN SURANG
+	{runeRange{0x1B34, 0x1B34}, prExtend},                 // Mn       BALINESE SIGN REREKAN
+	{runeRange{0x1B36, 0x1B3A}, prExtend},                 // Mn   [5] BALINESE VOWEL SIGN ULU..BALINESE VOWEL SIGN RA REPA
+	{runeRange{0x1B3C, 0x1B3C}, prExtend},                 // Mn       BALINESE VOWEL SIGN LA LENGA
+	{runeRange{0x1B42, 0x1B42}, prExtend},                 // Mn       BALINESE VOWEL SIGN PEPET
+	{runeRange{0x1B6B, 0x1B73}, prExtend},                 // Mn   [9] BALINESE MUSICAL SYMBOL COMBINING TEGEH..BALINESE MUSICAL SYMBOL COMBINING GONG
+	{runeRange{0x1B82, 0x1B82}, prSpacingMark},            // Mc       SUNDANESE SIGN PANGWISAD
+	{runeRange{0x1BA2, 0x1BA5}, prExtend},                 // Mn   [4] SUNDANESE CONSONANT SIGN PANYAKRA..SUNDANESE VOWEL SIGN PANYUKU
+	{runeRange{0x1BA8, 0x1BA9}, prExtend},                 // Mn   [2] SUNDANESE VOWEL SIGN PAMEPET..SUNDANESE VOWEL SIGN PANEULEUNG
+	{runeRange{0x1BAB, 0x1BAD}, prExtend},                 // Mn   [3] SUNDANESE SIGN VIRAMA..SUNDANESE CONSONANT SIGN PASANGAN WA
+	{runeRange{0x1BE7, 0x1BE7}, prSpacingMark},            // Mc       BATAK VOWEL SIGN E
+	{runeRange{0x1BEA, 0x1BEC}, prSpacingMark},            // Mc   [3] BATAK VOWEL SIGN I..BATAK VOWEL SIGN O
+	{runeRange{0x1BEE, 0x1BEE}, prSpacingMark},            // Mc       BATAK VOWEL SIGN U
+	{runeRange{0x1BF2, 0x1BF3}, prSpacingMark},            // Mc   [2] BATAK PANGOLAT..BATAK PANONGONAN
+	{runeRange{0x1C2C, 0x1C33}, prExtend},                 // Mn   [8] LEPCHA VOWEL SIGN E..LEPCHA CONSONANT SIGN T
+	{runeRange{0x1C36, 0x1C37}, prExtend},                 // Mn   [2] LEPCHA SIGN RAN..LEPCHA SIGN NUKTA
+	{runeRange{0x1CD4, 0x1CE0}, prExtend},                 // Mn  [13] VEDIC SIGN YAJURVEDIC MIDLINE SVARITA..VEDIC TONE RIGVEDIC KASHMIRI INDEPENDENT SVARITA
+	{runeRange{0x1CE2, 0x1CE8}, prExtend},                 // Mn   [7] VEDIC SIGN VISARGA SVARITA..VEDIC SIGN VISARGA ANUDATTA WITH TAIL
+	{runeRange{0x1CF4, 0x1CF4}, prExtend},                 // Mn       VEDIC TONE CANDRA ABOVE
+	{runeRange{0x1CF8, 0x1CF9}, prExtend},                 // Mn   [2] VEDIC TONE RING ABOVE..VEDIC TONE DOUBLE RING ABOVE
+	{runeRange{0x200B, 0x200B}, prControl},                // Cf       ZERO WIDTH SPACE
+	{runeRange{0x200D, 0x200D}, prZWJ},                    // Cf       ZERO WIDTH JOINER
+	{runeRange{0x2028, 0x2028}, prControl},                // Zl       LINE SEPARATOR
+	{runeRange{0x202A, 0x202E}, prControl},                // Cf   [5] LEFT-TO-RIGHT EMBEDDING..RIGHT-TO-LEFT OVERRIDE
+	{runeRange{0x2049, 0x2049}, prExtendedPictographic},   // E0.6   [1] (⁉️)       exclamation question mark
+	{runeRange{0x2065, 0x2065}, prControl},                // Cn       <reserved-2065>
+	{runeRange{0x20D0, 0x20DC}, prExtend},                 // Mn  [13] COMBINING LEFT HARPOON ABOVE..COMBINING FOUR DOTS ABOVE
+	{runeRange{0x20E1, 0x20E1}, prExtend},                 // Mn       COMBINING LEFT RIGHT ARROW ABOVE
+	{runeRange{0x20E5, 0x20F0}, prExtend},                 // Mn  [12] COMBINING REVERSE SOLIDUS OVERLAY..COMBINING ASTERISK ABOVE
+	{runeRange{0x2139, 0x2139}, prExtendedPictographic},   // E0.6   [1] (ℹ️)       information
+	{runeRange{0x21A9, 0x21AA}, prExtendedPictographic},   // E0.6   [2] (↩️..↪️)    right arrow curving left..left arrow curving right
+	{runeRange{0x2328, 0x2328}, prExtendedPictographic},   // E1.0   [1] (⌨️)       keyboard
+	{runeRange{0x23CF, 0x23CF}, prExtendedPictographic},   // E1.0   [1] (⏏️)       eject button
+	{runeRange{0x23ED, 0x23EE}, prExtendedPictographic},   // E0.7   [2] (⏭️..⏮️)    next track button..last track button
+	{runeRange{0x23F0, 0x23F0}, prExtendedPictographic},   // E0.6   [1] (⏰)       alarm clock
+	{runeRange{0x23F3, 0x23F3}, prExtendedPictographic},   // E0.6   [1] (⏳)       hourglass not done
+	{runeRange{0x24C2, 0x24C2}, prExtendedPictographic},   // E0.6   [1] (Ⓜ️)       circled M
+	{runeRange{0x25B6, 0x25B6}, prExtendedPictographic},   // E0.6   [1] (▶️)       play button
+	{runeRange{0x25FB, 0x25FE}, prExtendedPictographic},   // E0.6   [4] (◻️..◾)    white medium square..black medium-small square
+	{runeRange{0x2602, 0x2603}, prExtendedPictographic},   // E0.7   [2] (☂️..☃️)    umbrella..snowman
+	{runeRange{0x2605, 0x2605}, prExtendedPictographic},   // E0.0   [1] (★)       BLACK STAR
+	{runeRange{0x260E, 0x260E}, prExtendedPictographic},   // E0.6   [1] (☎️)       telephone
+	{runeRange{0x2611, 0x2611}, prExtendedPictographic},   // E0.6   [1] (☑️)       check box with check
+	{runeRange{0x2614, 0x2615}, prExtendedPictographic},   // E0.6   [2] (☔..☕)    umbrella with rain drops..hot beverage
+	{runeRange{0x2618, 0x2618}, prExtendedPictographic},   // E1.0   [1] (☘️)       shamrock
+	{runeRange{0x261D, 0x261D}, prExtendedPictographic},   // E0.6   [1] (☝️)       index pointing up
+	{runeRange{0x2620, 0x2620}, prExtendedPictographic},   // E1.0   [1] (☠️)       skull and crossbones
+	{runeRange{0x2622, 0x2623}, prExtendedPictographic},   // E1.0   [2] (☢️..☣️)    radioactive..biohazard
+	{runeRange{0x2626, 0x2626}, prExtendedPictographic},   // E1.0   [1] (☦️)       orthodox cross
+	{runeRange{0x262A, 0x262A}, prExtendedPictographic},   // E0.7   [1] (☪️)       star and crescent
+	{runeRange{0x262E, 0x262E}, prExtendedPictographic},   // E1.0   [1] (☮️)       peace symbol
+	{runeRange{0x2630, 0x2637}, prExtendedPictographic},   // E0.0   [8] (☰..☷)    TRIGRAM FOR HEAVEN..TRIGRAM FOR EARTH
+	{runeRange{0x263A, 0x263A}, prExtendedPictographic},   // E0.6   [1] (☺️)       smiling face
+	{runeRange{0x2640, 0x2640}, prExtendedPictographic},   // E4.0   [1] (♀️)       female sign
+	{runeRange{0x2642, 0x2642}, prExtendedPictographic},   // E4.0   [1] (♂️)       male sign
+	{runeRange{0x2648, 0x2653}, prExtendedPictographic},   // E0.6  [12] (♈..♓)    Aries..Pisces
+	{runeRange{0x265F, 0x265F}, prExtendedPictographic},   // E11.0  [1] (♟️)       chess pawn
+	{runeRange{0x2661, 0x2662}, prExtendedPictographic},   // E0.0   [2] (♡..♢)    WHITE HEART SUIT..WHITE DIAMOND SUIT
+	{runeRange{0x2664, 0x2664}, prExtendedPictographic},   // E0.0   [1] (♤)       WHITE SPADE SUIT
+	{runeRange{0x2667, 0x2667}, prExtendedPictographic},   // E0.0   [1] (♧)       WHITE CLUB SUIT
+	{runeRange{0x2669, 0x267A}, prExtendedPictographic},   // E0.0  [18] (♩..♺)    QUARTER NOTE..RECYCLING SYMBOL FOR GENERIC MATERIALS
+	{runeRange{0x267C, 0x267D}, prExtendedPictographic},   // E0.0   [2] (♼..♽)    RECYCLED PAPER SYMBOL..PARTIALLY-RECYCLED PAPER SYMBOL
+	{runeRange{0x267F, 0x267F}, prExtendedPictographic},   // E0.6   [1] (♿)       wheelchair symbol
+	{runeRange{0x2690, 0x2691}, prExtendedPictographic},   // E0.0   [2] (⚐..⚑)    WHITE FLAG..BLACK FLAG
+	{runeRange{0x2693, 0x2693}, prExtendedPictographic},   // E0.6   [1] (⚓)       anchor
+	{runeRange{0x2695, 0x2695}, prExtendedPictographic},   // E4.0   [1] (⚕️)       medical symbol
+	{runeRange{0x2698, 0x2698}, prExtendedPictographic},   // E0.0   [1] (⚘)       FLOWER
+	{runeRange{0x269A, 0x269A}, prExtendedPictographic},   // E0.0   [1] (⚚)       STAFF OF HERMES
+	{runeRange{0x269D, 0x269F}, prExtendedPictographic},   // E0.0   [3] (⚝..⚟)    OUTLINED WHITE STAR..THREE LINES CONVERGING LEFT
+	{runeRange{0x26A2, 0x26A6}, prExtendedPictographic},   // E0.0   [5] (⚢..⚦)    DOUBLED FEMALE SIGN..MALE WITH STROKE SIGN
+	{runeRange{0x26A8, 0x26A9}, prExtendedPictographic},   // E0.0   [2] (⚨..⚩)    VERTICAL MALE WITH STROKE SIGN..HORIZONTAL MALE WITH STROKE SIGN
+	{runeRange{0x26AC, 0x26AF}, prExtendedPictographic},   // E0.0   [4] (⚬..⚯)    MEDIUM SMALL WHITE CIRCLE..UNMARRIED PARTNERSHIP SYMBOL
+	{runeRange{0x26B2, 0x26BC}, prExtendedPictographic},   // E0.0  [11] (⚲..⚼)    NEUTER..SESQUIQUADRATE
+	{runeRange{0x26BF, 0x26C3}, prExtendedPictographic},   // E0.0   [5] (⚿..⛃)    SQUARED KEY..BLACK DRAUGHTS KING
+	{runeRange{0x26C6, 0x26C7}, prExtendedPictographic},   // E0.0   [2] (⛆..⛇)    RAIN..BLACK SNOWMAN
+	{runeRange{0x26C9, 0x26CD}, prExtendedPictographic},   // E0.0   [5] (⛉..⛍)    TURNED WHITE SHOGI PIECE..DISABLED CAR
+	{runeRange{0x26CF, 0x26CF}, prExtendedPictographic},   // E0.7   [1] (⛏️)       pick
+	{runeRange{0x26D1, 0x26D1}, prExtendedPictographic},   // E0.7   [1] (⛑️)       rescue worker’s helmet
+	{runeRange{0x26D3, 0x26D3}, prExtendedPictographic},   // E0.7   [1] (⛓️)       chains
+	{runeRange{0x26D5, 0x26E8}, prExtendedPictographic},   // E0.0  [20] (⛕..⛨)    ALTERNATE ONE-WAY LEFT WAY TRAFFIC..BLACK CROSS ON SHIELD
+	{runeRange{0x26EA, 0x26EA}, prExtendedPictographic},   // E0.6   [1] (⛪)       church
+	{runeRange{0x26F0, 0x26F1}, prExtendedPictographic},   // E0.7   [2] (⛰️..⛱️)    mountain..umbrella on ground
+	{runeRange{0x26F4, 0x26F4}, prExtendedPictographic},   // E0.7   [1] (⛴️)       ferry
+	{runeRange{0x26F6, 0x26F6}, prExtendedPictographic},   // E0.0   [1] (⛶)       SQUARE FOUR CORNERS
+	{runeRange{0x26FA, 0x26FA}, prExtendedPictographic},   // E0.6   [1] (⛺)       tent
+	{runeRange{0x26FD, 0x26FD}, prExtendedPictographic},   // E0.6   [1] (⛽)       fuel pump
+	{runeRange{0x2702, 0x2702}, prExtendedPictographic},   // E0.6   [1] (✂️)       scissors
+	{runeRange{0x2705, 0x2705}, prExtendedPictographic},   // E0.6   [1] (✅)       check mark button
+	{runeRange{0x270D, 0x270D}, prExtendedPictographic},   // E0.7   [1] (✍️)       writing hand
+	{runeRange{0x270F, 0x270F}, prExtendedPictographic},   // E0.6   [1] (✏️)       pencil
+	{runeRange{0x2712, 0x2712}, prExtendedPictographic},   // E0.6   [1] (✒️)       black nib
+	{runeRange{0x2716, 0x2716}, prExtendedPictographic},   // E0.6   [1] (✖️)       multiply
+	{runeRange{0x2721, 0x2721}, prExtendedPictographic},   // E0.7   [1] (✡️)       star of David
+	{runeRange{0x2733, 0x2734}, prExtendedPictographic},   // E0.6   [2] (✳️..✴️)    eight-spoked asterisk..eight-pointed star
+	{runeRange{0x2747, 0x2747}, prExtendedPictographic},   // E0.6   [1] (❇️)       sparkle
+	{runeRange{0x274E, 0x274E}, prExtendedPictographic},   // E0.6   [1] (❎)       cross mark button
+	{runeRange{0x2757, 0x2757}, prExtendedPictographic},   // E0.6   [1] (❗)       red exclamation mark
+	{runeRange{0x2764, 0x2764}, prExtendedPictographic},   // E0.6   [1] (❤️)       red heart
+	{runeRange{0x2795, 0x2797}, prExtendedPictographic},   // E0.6   [3] (➕..➗)    plus..divide
+	{runeRange{0x27B0, 0x27B0}, prExtendedPictographic},   // E0.6   [1] (➰)       curly loop
+	{runeRange{0x2934, 0x2935}, prExtendedPictographic},   // E0.6   [2] (⤴️..⤵️)    right arrow curving up..right arrow curving down
+	{runeRange{0x2B1B, 0x2B1C}, prExtendedPictographic},   // E0.6   [2] (⬛..⬜)    black large square..white large square
+	{runeRange{0x2B55, 0x2B55}, prExtendedPictographic},   // E0.6   [1] (⭕)       hollow red circle
+	{runeRange{0x2D7F, 0x2D7F}, prExtend},                 // Mn       TIFINAGH CONSONANT JOINER
+	{runeRange{0x302A, 0x302D}, prExtend},                 // Mn   [4] IDEOGRAPHIC LEVEL TONE MARK..IDEOGRAPHIC ENTERING TONE MARK
+	{runeRange{0x3030, 0x3030}, prExtendedPictographic},   // E0.6   [1] (〰️)       wavy dash
+	{runeRange{0x3099, 0x309A}, prExtend},                 // Mn   [2] COMBINING KATAKANA-HIRAGANA VOICED SOUND MARK..COMBINING KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK
+	{runeRange{0x3299, 0x3299}, prExtendedPictographic},   // E0.6   [1] (㊙️)       Japanese “secret” button
+	{runeRange{0xA670, 0xA672}, prExtend},                 // Me   [3] COMBINING CYRILLIC TEN MILLIONS SIGN..COMBINING CYRILLIC THOUSAND MILLIONS SIGN
+	{runeRange{0xA69E, 0xA69F}, prExtend},                 // Mn   [2] COMBINING CYRILLIC LETTER EF..COMBINING CYRILLIC LETTER IOTIFIED E
+	{runeRange{0xA802, 0xA802}, prExtend},                 // Mn       SYLOTI NAGRI SIGN DVISVARA
+	{runeRange{0xA80B, 0xA80B}, prExtend},                 // Mn       SYLOTI NAGRI SIGN ANUSVARA
+	{runeRange{0xA825, 0xA826}, prExtend},                 // Mn   [2] SYLOTI NAGRI VOWEL SIGN U..SYLOTI NAGRI VOWEL SIGN E
+	{runeRange{0xA82C, 0xA82C}, prExtend},                 // Mn       SYLOTI NAGRI SIGN ALTERNATE HASANTA
+	{runeRange{0xA8B4, 0xA8C3}, prSpacingMark},            // Mc  [16] SAURASHTRA CONSONANT SIGN HAARU..SAURASHTRA VOWEL SIGN AU
+	{runeRange{0xA8E0, 0xA8F1}, prExtend},                 // Mn  [18] COMBINING DEVANAGARI DIGIT ZERO..COMBINING DEVANAGARI SIGN AVAGRAHA
+	{runeRange{0xA926, 0xA92D}, prExtend},                 // Mn   [8] KAYAH LI VOWEL UE..KAYAH LI TONE CALYA PLOPHU
+	{runeRange{0xA952, 0xA953}, prSpacingMark},            // Mc   [2] REJANG CONSONANT SIGN H..REJANG VIRAMA
+	{runeRange{0xA980, 0xA982}, prExtend},                 // Mn   [3] JAVANESE SIGN PANYANGGA..JAVANESE SIGN LAYAR
+	{runeRange{0xA9B3, 0xA9B3}, prExtend},                 // Mn       JAVANESE SIGN CECAK TELU
+	{runeRange{0xA9B6, 0xA9B9}, prExtend},                 // Mn   [4] JAVANESE VOWEL SIGN WULU..JAVANESE VOWEL SIGN SUKU MENDUT
+	{runeRange{0xA9BC, 0xA9BD}, prExtend},                 // Mn   [2] JAVANESE VOWEL SIGN PEPET..JAVANESE CONSONANT SIGN KERET
+	{runeRange{0xA9E5, 0xA9E5}, prExtend},                 // Mn       MYANMAR SIGN SHAN SAW
+	{runeRange{0xAA2F, 0xAA30}, prSpacingMark},            // Mc   [2] CHAM VOWEL SIGN O..CHAM VOWEL SIGN AI
+	{runeRange{0xAA33, 0xAA34}, prSpacingMark},            // Mc   [2] CHAM CONSONANT SIGN YA..CHAM CONSONANT SIGN RA
+	{runeRange{0xAA43, 0xAA43}, prExtend},                 // Mn       CHAM CONSONANT SIGN FINAL NG
+	{runeRange{0xAA4D, 0xAA4D}, prSpacingMark},            // Mc       CHAM CONSONANT SIGN FINAL H
+	{runeRange{0xAAB0, 0xAAB0}, prExtend},                 // Mn       TAI VIET MAI KANG
+	{runeRange{0xAAB7, 0xAAB8}, prExtend},                 // Mn   [2] TAI VIET MAI KHIT..TAI VIET VOWEL IA
+	{runeRange{0xAAC1, 0xAAC1}, prExtend},                 // Mn       TAI VIET TONE MAI THO
+	{runeRange{0xAAEC, 0xAAED}, prExtend},                 // Mn   [2] MEETEI MAYEK VOWEL SIGN UU..MEETEI MAYEK VOWEL SIGN AAI
+	{runeRange{0xAAF5, 0xAAF5}, prSpacingMark},            // Mc       MEETEI MAYEK VOWEL SIGN VISARGA
+	{runeRange{0xABE3, 0xABE4}, prSpacingMark},            // Mc   [2] MEETEI MAYEK VOWEL SIGN ONAP..MEETEI MAYEK VOWEL SIGN INAP
+	{runeRange{0xABE6, 0xABE7}, prSpacingMark},            // Mc   [2] MEETEI MAYEK VOWEL SIGN YENAP..MEETEI MAYEK VOWEL SIGN SOUNAP
+	{runeRange{0xABE9, 0xABEA}, prSpacingMark},            // Mc   [2] MEETEI MAYEK VOWEL SIGN CHEINAP..MEETEI MAYEK VOWEL SIGN NUNG
+	{runeRange{0xABED, 0xABED}, prExtend},                 // Mn       MEETEI MAYEK APUN IYEK
+	{runeRange{0xAC01, 0xAC1B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GAG..HANGUL SYLLABLE GAH
+	{runeRange{0xAC1D, 0xAC37}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GAEG..HANGUL SYLLABLE GAEH
+	{runeRange{0xAC39, 0xAC53}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GYAG..HANGUL SYLLABLE GYAH
+	{runeRange{0xAC55, 0xAC6F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GYAEG..HANGUL SYLLABLE GYAEH
+	{runeRange{0xAC71, 0xAC8B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GEOG..HANGUL SYLLABLE GEOH
+	{runeRange{0xAC8D, 0xACA7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GEG..HANGUL SYLLABLE GEH
+	{runeRange{0xACA9, 0xACC3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GYEOG..HANGUL SYLLABLE GYEOH
+	{runeRange{0xACC5, 0xACDF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GYEG..HANGUL SYLLABLE GYEH
+	{runeRange{0xACE1, 0xACFB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GOG..HANGUL SYLLABLE GOH
+	{runeRange{0xACFD, 0xAD17}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GWAG..HANGUL SYLLABLE GWAH
+	{runeRange{0xAD19, 0xAD33}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GWAEG..HANGUL SYLLABLE GWAEH
+	{runeRange{0xAD35, 0xAD4F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GOEG..HANGUL SYLLABLE GOEH
+	{runeRange{0xAD51, 0xAD6B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GYOG..HANGUL SYLLABLE GYOH
+	{runeRange{0xAD6D, 0xAD87}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GUG..HANGUL SYLLABLE GUH
+	{runeRange{0xAD89, 0xADA3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GWEOG..HANGUL SYLLABLE GWEOH
+	{runeRange{0xADA5, 0xADBF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GWEG..HANGUL SYLLABLE GWEH
+	{runeRange{0xADC1, 0xADDB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GWIG..HANGUL SYLLABLE GWIH
+	{runeRange{0xADDD, 0xADF7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GYUG..HANGUL SYLLABLE GYUH
+	{runeRange{0xADF9, 0xAE13}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GEUG..HANGUL SYLLABLE GEUH
+	{runeRange{0xAE15, 0xAE2F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GYIG..HANGUL SYLLABLE GYIH
+	{runeRange{0xAE31, 0xAE4B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GIG..HANGUL SYLLABLE GIH
+	{runeRange{0xAE4D, 0xAE67}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGAG..HANGUL SYLLABLE GGAH
+	{runeRange{0xAE69, 0xAE83}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGAEG..HANGUL SYLLABLE GGAEH
+	{runeRange{0xAE85, 0xAE9F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGYAG..HANGUL SYLLABLE GGYAH
+	{runeRange{0xAEA1, 0xAEBB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGYAEG..HANGUL SYLLABLE GGYAEH
+	{runeRange{0xAEBD, 0xAED7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGEOG..HANGUL SYLLABLE GGEOH
+	{runeRange{0xAED9, 0xAEF3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGEG..HANGUL SYLLABLE GGEH
+	{runeRange{0xAEF5, 0xAF0F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGYEOG..HANGUL SYLLABLE GGYEOH
+	{runeRange{0xAF11, 0xAF2B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGYEG..HANGUL SYLLABLE GGYEH
+	{runeRange{0xAF2D, 0xAF47}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGOG..HANGUL SYLLABLE GGOH
+	{runeRange{0xAF49, 0xAF63}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGWAG..HANGUL SYLLABLE GGWAH
+	{runeRange{0xAF65, 0xAF7F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGWAEG..HANGUL SYLLABLE GGWAEH
+	{runeRange{0xAF81, 0xAF9B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGOEG..HANGUL SYLLABLE GGOEH
+	{runeRange{0xAF9D, 0xAFB7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGYOG..HANGUL SYLLABLE GGYOH
+	{runeRange{0xAFB9, 0xAFD3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGUG..HANGUL SYLLABLE GGUH
+	{runeRange{0xAFD5, 0xAFEF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGWEOG..HANGUL SYLLABLE GGWEOH
+	{runeRange{0xAFF1, 0xB00B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGWEG..HANGUL SYLLABLE GGWEH
+	{runeRange{0xB00D, 0xB027}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGWIG..HANGUL SYLLABLE GGWIH
+	{runeRange{0xB029, 0xB043}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGYUG..HANGUL SYLLABLE GGYUH
+	{runeRange{0xB045, 0xB05F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGEUG..HANGUL SYLLABLE GGEUH
+	{runeRange{0xB061, 0xB07B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGYIG..HANGUL SYLLABLE GGYIH
+	{runeRange{0xB07D, 0xB097}, prLVT},                    // Lo  [27] HANGUL SYLLABLE GGIG..HANGUL SYLLABLE GGIH
+	{runeRange{0xB099, 0xB0B3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NAG..HANGUL SYLLABLE NAH
+	{runeRange{0xB0B5, 0xB0CF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NAEG..HANGUL SYLLABLE NAEH
+	{runeRange{0xB0D1, 0xB0EB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NYAG..HANGUL SYLLABLE NYAH
+	{runeRange{0xB0ED, 0xB107}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NYAEG..HANGUL SYLLABLE NYAEH
+	{runeRange{0xB109, 0xB123}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NEOG..HANGUL SYLLABLE NEOH
+	{runeRange{0xB125, 0xB13F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NEG..HANGUL SYLLABLE NEH
+	{runeRange{0xB141, 0xB15B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NYEOG..HANGUL SYLLABLE NYEOH
+	{runeRange{0xB15D, 0xB177}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NYEG..HANGUL SYLLABLE NYEH
+	{runeRange{0xB179, 0xB193}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NOG..HANGUL SYLLABLE NOH
+	{runeRange{0xB195, 0xB1AF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NWAG..HANGUL SYLLABLE NWAH
+	{runeRange{0xB1B1, 0xB1CB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NWAEG..HANGUL SYLLABLE NWAEH
+	{runeRange{0xB1CD, 0xB1E7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NOEG..HANGUL SYLLABLE NOEH
+	{runeRange{0xB1E9, 0xB203}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NYOG..HANGUL SYLLABLE NYOH
+	{runeRange{0xB205, 0xB21F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NUG..HANGUL SYLLABLE NUH
+	{runeRange{0xB221, 0xB23B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NWEOG..HANGUL SYLLABLE NWEOH
+	{runeRange{0xB23D, 0xB257}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NWEG..HANGUL SYLLABLE NWEH
+	{runeRange{0xB259, 0xB273}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NWIG..HANGUL SYLLABLE NWIH
+	{runeRange{0xB275, 0xB28F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NYUG..HANGUL SYLLABLE NYUH
+	{runeRange{0xB291, 0xB2AB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NEUG..HANGUL SYLLABLE NEUH
+	{runeRange{0xB2AD, 0xB2C7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NYIG..HANGUL SYLLABLE NYIH
+	{runeRange{0xB2C9, 0xB2E3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE NIG..HANGUL SYLLABLE NIH
+	{runeRange{0xB2E5, 0xB2FF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DAG..HANGUL SYLLABLE DAH
+	{runeRange{0xB301, 0xB31B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DAEG..HANGUL SYLLABLE DAEH
+	{runeRange{0xB31D, 0xB337}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DYAG..HANGUL SYLLABLE DYAH
+	{runeRange{0xB339, 0xB353}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DYAEG..HANGUL SYLLABLE DYAEH
+	{runeRange{0xB355, 0xB36F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DEOG..HANGUL SYLLABLE DEOH
+	{runeRange{0xB371, 0xB38B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DEG..HANGUL SYLLABLE DEH
+	{runeRange{0xB38D, 0xB3A7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DYEOG..HANGUL SYLLABLE DYEOH
+	{runeRange{0xB3A9, 0xB3C3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DYEG..HANGUL SYLLABLE DYEH
+	{runeRange{0xB3C5, 0xB3DF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DOG..HANGUL SYLLABLE DOH
+	{runeRange{0xB3E1, 0xB3FB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DWAG..HANGUL SYLLABLE DWAH
+	{runeRange{0xB3FD, 0xB417}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DWAEG..HANGUL SYLLABLE DWAEH
+	{runeRange{0xB419, 0xB433}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DOEG..HANGUL SYLLABLE DOEH
+	{runeRange{0xB435, 0xB44F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DYOG..HANGUL SYLLABLE DYOH
+	{runeRange{0xB451, 0xB46B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DUG..HANGUL SYLLABLE DUH
+	{runeRange{0xB46D, 0xB487}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DWEOG..HANGUL SYLLABLE DWEOH
+	{runeRange{0xB489, 0xB4A3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DWEG..HANGUL SYLLABLE DWEH
+	{runeRange{0xB4A5, 0xB4BF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DWIG..HANGUL SYLLABLE DWIH
+	{runeRange{0xB4C1, 0xB4DB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DYUG..HANGUL SYLLABLE DYUH
+	{runeRange{0xB4DD, 0xB4F7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DEUG..HANGUL SYLLABLE DEUH
+	{runeRange{0xB4F9, 0xB513}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DYIG..HANGUL SYLLABLE DYIH
+	{runeRange{0xB515, 0xB52F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DIG..HANGUL SYLLABLE DIH
+	{runeRange{0xB531, 0xB54B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDAG..HANGUL SYLLABLE DDAH
+	{runeRange{0xB54D, 0xB567}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDAEG..HANGUL SYLLABLE DDAEH
+	{runeRange{0xB569, 0xB583}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDYAG..HANGUL SYLLABLE DDYAH
+	{runeRange{0xB585, 0xB59F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDYAEG..HANGUL SYLLABLE DDYAEH
+	{runeRange{0xB5A1, 0xB5BB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDEOG..HANGUL SYLLABLE DDEOH
+	{runeRange{0xB5BD, 0xB5D7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDEG..HANGUL SYLLABLE DDEH
+	{runeRange{0xB5D9, 0xB5F3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDYEOG..HANGUL SYLLABLE DDYEOH
+	{runeRange{0xB5F5, 0xB60F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDYEG..HANGUL SYLLABLE DDYEH
+	{runeRange{0xB611, 0xB62B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDOG..HANGUL SYLLABLE DDOH
+	{runeRange{0xB62D, 0xB647}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDWAG..HANGUL SYLLABLE DDWAH
+	{runeRange{0xB649, 0xB663}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDWAEG..HANGUL SYLLABLE DDWAEH
+	{runeRange{0xB665, 0xB67F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDOEG..HANGUL SYLLABLE DDOEH
+	{runeRange{0xB681, 0xB69B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDYOG..HANGUL SYLLABLE DDYOH
+	{runeRange{0xB69D, 0xB6B7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDUG..HANGUL SYLLABLE DDUH
+	{runeRange{0xB6B9, 0xB6D3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDWEOG..HANGUL SYLLABLE DDWEOH
+	{runeRange{0xB6D5, 0xB6EF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDWEG..HANGUL SYLLABLE DDWEH
+	{runeRange{0xB6F1, 0xB70B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDWIG..HANGUL SYLLABLE DDWIH
+	{runeRange{0xB70D, 0xB727}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDYUG..HANGUL SYLLABLE DDYUH
+	{runeRange{0xB729, 0xB743}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDEUG..HANGUL SYLLABLE DDEUH
+	{runeRange{0xB745, 0xB75F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDYIG..HANGUL SYLLABLE DDYIH
+	{runeRange{0xB761, 0xB77B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE DDIG..HANGUL SYLLABLE DDIH
+	{runeRange{0xB77D, 0xB797}, prLVT},                    // Lo  [27] HANGUL SYLLABLE RAG..HANGUL SYLLABLE RAH
+	{runeRange{0xB799, 0xB7B3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE RAEG..HANGUL SYLLABLE RAEH
+	{runeRange{0xB7B5, 0xB7CF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE RYAG..HANGUL SYLLABLE RYAH
+	{runeRange{0xB7D1, 0xB7EB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE RYAEG..HANGUL SYLLABLE RYAEH
+	{runeRange{0xB7ED, 0xB807}, prLVT},                    // Lo  [27] HANGUL SYLLABLE REOG..HANGUL SYLLABLE REOH
+	{runeRange{0xB809, 0xB823}, prLVT},                    // Lo  [27] HANGUL SYLLABLE REG..HANGUL SYLLABLE REH
+	{runeRange{0xB825, 0xB83F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE RYEOG..HANGUL SYLLABLE RYEOH
+	{runeRange{0xB841, 0xB85B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE RYEG..HANGUL SYLLABLE RYEH
+	{runeRange{0xB85D, 0xB877}, prLVT},                    // Lo  [27] HANGUL SYLLABLE ROG..HANGUL SYLLABLE ROH
+	{runeRange{0xB879, 0xB893}, prLVT},                    // Lo  [27] HANGUL SYLLABLE RWAG..HANGUL SYLLABLE RWAH
+	{runeRange{0xB895, 0xB8AF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE RWAEG..HANGUL SYLLABLE RWAEH
+	{runeRange{0xB8B1, 0xB8CB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE ROEG..HANGUL SYLLABLE ROEH
+	{runeRange{0xB8CD, 0xB8E7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE RYOG..HANGUL SYLLABLE RYOH
+	{runeRange{0xB8E9, 0xB903}, prLVT},                    // Lo  [27] HANGUL SYLLABLE RUG..HANGUL SYLLABLE RUH
+	{runeRange{0xB905, 0xB91F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE RWEOG..HANGUL SYLLABLE RWEOH
+	{runeRange{0xB921, 0xB93B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE RWEG..HANGUL SYLLABLE RWEH
+	{runeRange{0xB93D, 0xB957}, prLVT},                    // Lo  [27] HANGUL SYLLABLE RWIG..HANGUL SYLLABLE RWIH
+	{runeRange{0xB959, 0xB973}, prLVT},                    // Lo  [27] HANGUL SYLLABLE RYUG..HANGUL SYLLABLE RYUH
+	{runeRange{0xB975, 0xB98F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE REUG..HANGUL SYLLABLE REUH
+	{runeRange{0xB991, 0xB9AB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE RYIG..HANGUL SYLLABLE RYIH
+	{runeRange{0xB9AD, 0xB9C7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE RIG..HANGUL SYLLABLE RIH
+	{runeRange{0xB9C9, 0xB9E3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MAG..HANGUL SYLLABLE MAH
+	{runeRange{0xB9E5, 0xB9FF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MAEG..HANGUL SYLLABLE MAEH
+	{runeRange{0xBA01, 0xBA1B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MYAG..HANGUL SYLLABLE MYAH
+	{runeRange{0xBA1D, 0xBA37}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MYAEG..HANGUL SYLLABLE MYAEH
+	{runeRange{0xBA39, 0xBA53}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MEOG..HANGUL SYLLABLE MEOH
+	{runeRange{0xBA55, 0xBA6F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MEG..HANGUL SYLLABLE MEH
+	{runeRange{0xBA71, 0xBA8B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MYEOG..HANGUL SYLLABLE MYEOH
+	{runeRange{0xBA8D, 0xBAA7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MYEG..HANGUL SYLLABLE MYEH
+	{runeRange{0xBAA9, 0xBAC3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MOG..HANGUL SYLLABLE MOH
+	{runeRange{0xBAC5, 0xBADF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MWAG..HANGUL SYLLABLE MWAH
+	{runeRange{0xBAE1, 0xBAFB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MWAEG..HANGUL SYLLABLE MWAEH
+	{runeRange{0xBAFD, 0xBB17}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MOEG..HANGUL SYLLABLE MOEH
+	{runeRange{0xBB19, 0xBB33}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MYOG..HANGUL SYLLABLE MYOH
+	{runeRange{0xBB35, 0xBB4F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MUG..HANGUL SYLLABLE MUH
+	{runeRange{0xBB51, 0xBB6B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MWEOG..HANGUL SYLLABLE MWEOH
+	{runeRange{0xBB6D, 0xBB87}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MWEG..HANGUL SYLLABLE MWEH
+	{runeRange{0xBB89, 0xBBA3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MWIG..HANGUL SYLLABLE MWIH
+	{runeRange{0xBBA5, 0xBBBF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MYUG..HANGUL SYLLABLE MYUH
+	{runeRange{0xBBC1, 0xBBDB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MEUG..HANGUL SYLLABLE MEUH
+	{runeRange{0xBBDD, 0xBBF7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MYIG..HANGUL SYLLABLE MYIH
+	{runeRange{0xBBF9, 0xBC13}, prLVT},                    // Lo  [27] HANGUL SYLLABLE MIG..HANGUL SYLLABLE MIH
+	{runeRange{0xBC15, 0xBC2F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BAG..HANGUL SYLLABLE BAH
+	{runeRange{0xBC31, 0xBC4B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BAEG..HANGUL SYLLABLE BAEH
+	{runeRange{0xBC4D, 0xBC67}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BYAG..HANGUL SYLLABLE BYAH
+	{runeRange{0xBC69, 0xBC83}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BYAEG..HANGUL SYLLABLE BYAEH
+	{runeRange{0xBC85, 0xBC9F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BEOG..HANGUL SYLLABLE BEOH
+	{runeRange{0xBCA1, 0xBCBB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BEG..HANGUL SYLLABLE BEH
+	{runeRange{0xBCBD, 0xBCD7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BYEOG..HANGUL SYLLABLE BYEOH
+	{runeRange{0xBCD9, 0xBCF3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BYEG..HANGUL SYLLABLE BYEH
+	{runeRange{0xBCF5, 0xBD0F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BOG..HANGUL SYLLABLE BOH
+	{runeRange{0xBD11, 0xBD2B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BWAG..HANGUL SYLLABLE BWAH
+	{runeRange{0xBD2D, 0xBD47}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BWAEG..HANGUL SYLLABLE BWAEH
+	{runeRange{0xBD49, 0xBD63}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BOEG..HANGUL SYLLABLE BOEH
+	{runeRange{0xBD65, 0xBD7F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BYOG..HANGUL SYLLABLE BYOH
+	{runeRange{0xBD81, 0xBD9B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BUG..HANGUL SYLLABLE BUH
+	{runeRange{0xBD9D, 0xBDB7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BWEOG..HANGUL SYLLABLE BWEOH
+	{runeRange{0xBDB9, 0xBDD3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BWEG..HANGUL SYLLABLE BWEH
+	{runeRange{0xBDD5, 0xBDEF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BWIG..HANGUL SYLLABLE BWIH
+	{runeRange{0xBDF1, 0xBE0B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BYUG..HANGUL SYLLABLE BYUH
+	{runeRange{0xBE0D, 0xBE27}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BEUG..HANGUL SYLLABLE BEUH
+	{runeRange{0xBE29, 0xBE43}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BYIG..HANGUL SYLLABLE BYIH
+	{runeRange{0xBE45, 0xBE5F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BIG..HANGUL SYLLABLE BIH
+	{runeRange{0xBE61, 0xBE7B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBAG..HANGUL SYLLABLE BBAH
+	{runeRange{0xBE7D, 0xBE97}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBAEG..HANGUL SYLLABLE BBAEH
+	{runeRange{0xBE99, 0xBEB3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBYAG..HANGUL SYLLABLE BBYAH
+	{runeRange{0xBEB5, 0xBECF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBYAEG..HANGUL SYLLABLE BBYAEH
+	{runeRange{0xBED1, 0xBEEB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBEOG..HANGUL SYLLABLE BBEOH
+	{runeRange{0xBEED, 0xBF07}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBEG..HANGUL SYLLABLE BBEH
+	{runeRange{0xBF09, 0xBF23}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBYEOG..HANGUL SYLLABLE BBYEOH
+	{runeRange{0xBF25, 0xBF3F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBYEG..HANGUL SYLLABLE BBYEH
+	{runeRange{0xBF41, 0xBF5B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBOG..HANGUL SYLLABLE BBOH
+	{runeRange{0xBF5D, 0xBF77}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBWAG..HANGUL SYLLABLE BBWAH
+	{runeRange{0xBF79, 0xBF93}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBWAEG..HANGUL SYLLABLE BBWAEH
+	{runeRange{0xBF95, 0xBFAF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBOEG..HANGUL SYLLABLE BBOEH
+	{runeRange{0xBFB1, 0xBFCB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBYOG..HANGUL SYLLABLE BBYOH
+	{runeRange{0xBFCD, 0xBFE7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBUG..HANGUL SYLLABLE BBUH
+	{runeRange{0xBFE9, 0xC003}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBWEOG..HANGUL SYLLABLE BBWEOH
+	{runeRange{0xC005, 0xC01F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBWEG..HANGUL SYLLABLE BBWEH
+	{runeRange{0xC021, 0xC03B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBWIG..HANGUL SYLLABLE BBWIH
+	{runeRange{0xC03D, 0xC057}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBYUG..HANGUL SYLLABLE BBYUH
+	{runeRange{0xC059, 0xC073}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBEUG..HANGUL SYLLABLE BBEUH
+	{runeRange{0xC075, 0xC08F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBYIG..HANGUL SYLLABLE BBYIH
+	{runeRange{0xC091, 0xC0AB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE BBIG..HANGUL SYLLABLE BBIH
+	{runeRange{0xC0AD, 0xC0C7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SAG..HANGUL SYLLABLE SAH
+	{runeRange{0xC0C9, 0xC0E3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SAEG..HANGUL SYLLABLE SAEH
+	{runeRange{0xC0E5, 0xC0FF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SYAG..HANGUL SYLLABLE SYAH
+	{runeRange{0xC101, 0xC11B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SYAEG..HANGUL SYLLABLE SYAEH
+	{runeRange{0xC11D, 0xC137}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SEOG..HANGUL SYLLABLE SEOH
+	{runeRange{0xC139, 0xC153}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SEG..HANGUL SYLLABLE SEH
+	{runeRange{0xC155, 0xC16F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SYEOG..HANGUL SYLLABLE SYEOH
+	{runeRange{0xC171, 0xC18B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SYEG..HANGUL SYLLABLE SYEH
+	{runeRange{0xC18D, 0xC1A7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SOG..HANGUL SYLLABLE SOH
+	{runeRange{0xC1A9, 0xC1C3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SWAG..HANGUL SYLLABLE SWAH
+	{runeRange{0xC1C5, 0xC1DF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SWAEG..HANGUL SYLLABLE SWAEH
+	{runeRange{0xC1E1, 0xC1FB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SOEG..HANGUL SYLLABLE SOEH
+	{runeRange{0xC1FD, 0xC217}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SYOG..HANGUL SYLLABLE SYOH
+	{runeRange{0xC219, 0xC233}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SUG..HANGUL SYLLABLE SUH
+	{runeRange{0xC235, 0xC24F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SWEOG..HANGUL SYLLABLE SWEOH
+	{runeRange{0xC251, 0xC26B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SWEG..HANGUL SYLLABLE SWEH
+	{runeRange{0xC26D, 0xC287}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SWIG..HANGUL SYLLABLE SWIH
+	{runeRange{0xC289, 0xC2A3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SYUG..HANGUL SYLLABLE SYUH
+	{runeRange{0xC2A5, 0xC2BF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SEUG..HANGUL SYLLABLE SEUH
+	{runeRange{0xC2C1, 0xC2DB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SYIG..HANGUL SYLLABLE SYIH
+	{runeRange{0xC2DD, 0xC2F7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SIG..HANGUL SYLLABLE SIH
+	{runeRange{0xC2F9, 0xC313}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSAG..HANGUL SYLLABLE SSAH
+	{runeRange{0xC315, 0xC32F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSAEG..HANGUL SYLLABLE SSAEH
+	{runeRange{0xC331, 0xC34B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSYAG..HANGUL SYLLABLE SSYAH
+	{runeRange{0xC34D, 0xC367}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSYAEG..HANGUL SYLLABLE SSYAEH
+	{runeRange{0xC369, 0xC383}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSEOG..HANGUL SYLLABLE SSEOH
+	{runeRange{0xC385, 0xC39F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSEG..HANGUL SYLLABLE SSEH
+	{runeRange{0xC3A1, 0xC3BB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSYEOG..HANGUL SYLLABLE SSYEOH
+	{runeRange{0xC3BD, 0xC3D7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSYEG..HANGUL SYLLABLE SSYEH
+	{runeRange{0xC3D9, 0xC3F3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSOG..HANGUL SYLLABLE SSOH
+	{runeRange{0xC3F5, 0xC40F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSWAG..HANGUL SYLLABLE SSWAH
+	{runeRange{0xC411, 0xC42B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSWAEG..HANGUL SYLLABLE SSWAEH
+	{runeRange{0xC42D, 0xC447}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSOEG..HANGUL SYLLABLE SSOEH
+	{runeRange{0xC449, 0xC463}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSYOG..HANGUL SYLLABLE SSYOH
+	{runeRange{0xC465, 0xC47F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSUG..HANGUL SYLLABLE SSUH
+	{runeRange{0xC481, 0xC49B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSWEOG..HANGUL SYLLABLE SSWEOH
+	{runeRange{0xC49D, 0xC4B7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSWEG..HANGUL SYLLABLE SSWEH
+	{runeRange{0xC4B9, 0xC4D3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSWIG..HANGUL SYLLABLE SSWIH
+	{runeRange{0xC4D5, 0xC4EF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSYUG..HANGUL SYLLABLE SSYUH
+	{runeRange{0xC4F1, 0xC50B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSEUG..HANGUL SYLLABLE SSEUH
+	{runeRange{0xC50D, 0xC527}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSYIG..HANGUL SYLLABLE SSYIH
+	{runeRange{0xC529, 0xC543}, prLVT},                    // Lo  [27] HANGUL SYLLABLE SSIG..HANGUL SYLLABLE SSIH
+	{runeRange{0xC545, 0xC55F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE AG..HANGUL SYLLABLE AH
+	{runeRange{0xC561, 0xC57B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE AEG..HANGUL SYLLABLE AEH
+	{runeRange{0xC57D, 0xC597}, prLVT},                    // Lo  [27] HANGUL SYLLABLE YAG..HANGUL SYLLABLE YAH
+	{runeRange{0xC599, 0xC5B3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE YAEG..HANGUL SYLLABLE YAEH
+	{runeRange{0xC5B5, 0xC5CF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE EOG..HANGUL SYLLABLE EOH
+	{runeRange{0xC5D1, 0xC5EB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE EG..HANGUL SYLLABLE EH
+	{runeRange{0xC5ED, 0xC607}, prLVT},                    // Lo  [27] HANGUL SYLLABLE YEOG..HANGUL SYLLABLE YEOH
+	{runeRange{0xC609, 0xC623}, prLVT},                    // Lo  [27] HANGUL SYLLABLE YEG..HANGUL SYLLABLE YEH
+	{runeRange{0xC625, 0xC63F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE OG..HANGUL SYLLABLE OH
+	{runeRange{0xC641, 0xC65B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE WAG..HANGUL SYLLABLE WAH
+	{runeRange{0xC65D, 0xC677}, prLVT},                    // Lo  [27] HANGUL SYLLABLE WAEG..HANGUL SYLLABLE WAEH
+	{runeRange{0xC679, 0xC693}, prLVT},                    // Lo  [27] HANGUL SYLLABLE OEG..HANGUL SYLLABLE OEH
+	{runeRange{0xC695, 0xC6AF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE YOG..HANGUL SYLLABLE YOH
+	{runeRange{0xC6B1, 0xC6CB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE UG..HANGUL SYLLABLE UH
+	{runeRange{0xC6CD, 0xC6E7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE WEOG..HANGUL SYLLABLE WEOH
+	{runeRange{0xC6E9, 0xC703}, prLVT},                    // Lo  [27] HANGUL SYLLABLE WEG..HANGUL SYLLABLE WEH
+	{runeRange{0xC705, 0xC71F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE WIG..HANGUL SYLLABLE WIH
+	{runeRange{0xC721, 0xC73B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE YUG..HANGUL SYLLABLE YUH
+	{runeRange{0xC73D, 0xC757}, prLVT},                    // Lo  [27] HANGUL SYLLABLE EUG..HANGUL SYLLABLE EUH
+	{runeRange{0xC759, 0xC773}, prLVT},                    // Lo  [27] HANGUL SYLLABLE YIG..HANGUL SYLLABLE YIH
+	{runeRange{0xC775, 0xC78F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE IG..HANGUL SYLLABLE IH
+	{runeRange{0xC791, 0xC7AB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JAG..HANGUL SYLLABLE JAH
+	{runeRange{0xC7AD, 0xC7C7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JAEG..HANGUL SYLLABLE JAEH
+	{runeRange{0xC7C9, 0xC7E3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JYAG..HANGUL SYLLABLE JYAH
+	{runeRange{0xC7E5, 0xC7FF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JYAEG..HANGUL SYLLABLE JYAEH
+	{runeRange{0xC801, 0xC81B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JEOG..HANGUL SYLLABLE JEOH
+	{runeRange{0xC81D, 0xC837}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JEG..HANGUL SYLLABLE JEH
+	{runeRange{0xC839, 0xC853}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JYEOG..HANGUL SYLLABLE JYEOH
+	{runeRange{0xC855, 0xC86F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JYEG..HANGUL SYLLABLE JYEH
+	{runeRange{0xC871, 0xC88B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JOG..HANGUL SYLLABLE JOH
+	{runeRange{0xC88D, 0xC8A7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JWAG..HANGUL SYLLABLE JWAH
+	{runeRange{0xC8A9, 0xC8C3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JWAEG..HANGUL SYLLABLE JWAEH
+	{runeRange{0xC8C5, 0xC8DF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JOEG..HANGUL SYLLABLE JOEH
+	{runeRange{0xC8E1, 0xC8FB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JYOG..HANGUL SYLLABLE JYOH
+	{runeRange{0xC8FD, 0xC917}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JUG..HANGUL SYLLABLE JUH
+	{runeRange{0xC919, 0xC933}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JWEOG..HANGUL SYLLABLE JWEOH
+	{runeRange{0xC935, 0xC94F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JWEG..HANGUL SYLLABLE JWEH
+	{runeRange{0xC951, 0xC96B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JWIG..HANGUL SYLLABLE JWIH
+	{runeRange{0xC96D, 0xC987}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JYUG..HANGUL SYLLABLE JYUH
+	{runeRange{0xC989, 0xC9A3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JEUG..HANGUL SYLLABLE JEUH
+	{runeRange{0xC9A5, 0xC9BF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JYIG..HANGUL SYLLABLE JYIH
+	{runeRange{0xC9C1, 0xC9DB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JIG..HANGUL SYLLABLE JIH
+	{runeRange{0xC9DD, 0xC9F7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJAG..HANGUL SYLLABLE JJAH
+	{runeRange{0xC9F9, 0xCA13}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJAEG..HANGUL SYLLABLE JJAEH
+	{runeRange{0xCA15, 0xCA2F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJYAG..HANGUL SYLLABLE JJYAH
+	{runeRange{0xCA31, 0xCA4B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJYAEG..HANGUL SYLLABLE JJYAEH
+	{runeRange{0xCA4D, 0xCA67}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJEOG..HANGUL SYLLABLE JJEOH
+	{runeRange{0xCA69, 0xCA83}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJEG..HANGUL SYLLABLE JJEH
+	{runeRange{0xCA85, 0xCA9F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJYEOG..HANGUL SYLLABLE JJYEOH
+	{runeRange{0xCAA1, 0xCABB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJYEG..HANGUL SYLLABLE JJYEH
+	{runeRange{0xCABD, 0xCAD7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJOG..HANGUL SYLLABLE JJOH
+	{runeRange{0xCAD9, 0xCAF3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJWAG..HANGUL SYLLABLE JJWAH
+	{runeRange{0xCAF5, 0xCB0F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJWAEG..HANGUL SYLLABLE JJWAEH
+	{runeRange{0xCB11, 0xCB2B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJOEG..HANGUL SYLLABLE JJOEH
+	{runeRange{0xCB2D, 0xCB47}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJYOG..HANGUL SYLLABLE JJYOH
+	{runeRange{0xCB49, 0xCB63}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJUG..HANGUL SYLLABLE JJUH
+	{runeRange{0xCB65, 0xCB7F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJWEOG..HANGUL SYLLABLE JJWEOH
+	{runeRange{0xCB81, 0xCB9B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJWEG..HANGUL SYLLABLE JJWEH
+	{runeRange{0xCB9D, 0xCBB7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJWIG..HANGUL SYLLABLE JJWIH
+	{runeRange{0xCBB9, 0xCBD3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJYUG..HANGUL SYLLABLE JJYUH
+	{runeRange{0xCBD5, 0xCBEF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJEUG..HANGUL SYLLABLE JJEUH
+	{runeRange{0xCBF1, 0xCC0B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJYIG..HANGUL SYLLABLE JJYIH
+	{runeRange{0xCC0D, 0xCC27}, prLVT},                    // Lo  [27] HANGUL SYLLABLE JJIG..HANGUL SYLLABLE JJIH
+	{runeRange{0xCC29, 0xCC43}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CAG..HANGUL SYLLABLE CAH
+	{runeRange{0xCC45, 0xCC5F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CAEG..HANGUL SYLLABLE CAEH
+	{runeRange{0xCC61, 0xCC7B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CYAG..HANGUL SYLLABLE CYAH
+	{runeRange{0xCC7D, 0xCC97}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CYAEG..HANGUL SYLLABLE CYAEH
+	{runeRange{0xCC99, 0xCCB3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CEOG..HANGUL SYLLABLE CEOH
+	{runeRange{0xCCB5, 0xCCCF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CEG..HANGUL SYLLABLE CEH
+	{runeRange{0xCCD1, 0xCCEB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CYEOG..HANGUL SYLLABLE CYEOH
+	{runeRange{0xCCED, 0xCD07}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CYEG..HANGUL SYLLABLE CYEH
+	{runeRange{0xCD09, 0xCD23}, prLVT},                    // Lo  [27] HANGUL SYLLABLE COG..HANGUL SYLLABLE COH
+	{runeRange{0xCD25, 0xCD3F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CWAG..HANGUL SYLLABLE CWAH
+	{runeRange{0xCD41, 0xCD5B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CWAEG..HANGUL SYLLABLE CWAEH
+	{runeRange{0xCD5D, 0xCD77}, prLVT},                    // Lo  [27] HANGUL SYLLABLE COEG..HANGUL SYLLABLE COEH
+	{runeRange{0xCD79, 0xCD93}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CYOG..HANGUL SYLLABLE CYOH
+	{runeRange{0xCD95, 0xCDAF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CUG..HANGUL SYLLABLE CUH
+	{runeRange{0xCDB1, 0xCDCB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CWEOG..HANGUL SYLLABLE CWEOH
+	{runeRange{0xCDCD, 0xCDE7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CWEG..HANGUL SYLLABLE CWEH
+	{runeRange{0xCDE9, 0xCE03}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CWIG..HANGUL SYLLABLE CWIH
+	{runeRange{0xCE05, 0xCE1F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CYUG..HANGUL SYLLABLE CYUH
+	{runeRange{0xCE21, 0xCE3B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CEUG..HANGUL SYLLABLE CEUH
+	{runeRange{0xCE3D, 0xCE57}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CYIG..HANGUL SYLLABLE CYIH
+	{runeRange{0xCE59, 0xCE73}, prLVT},                    // Lo  [27] HANGUL SYLLABLE CIG..HANGUL SYLLABLE CIH
+	{runeRange{0xCE75, 0xCE8F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KAG..HANGUL SYLLABLE KAH
+	{runeRange{0xCE91, 0xCEAB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KAEG..HANGUL SYLLABLE KAEH
+	{runeRange{0xCEAD, 0xCEC7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KYAG..HANGUL SYLLABLE KYAH
+	{runeRange{0xCEC9, 0xCEE3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KYAEG..HANGUL SYLLABLE KYAEH
+	{runeRange{0xCEE5, 0xCEFF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KEOG..HANGUL SYLLABLE KEOH
+	{runeRange{0xCF01, 0xCF1B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KEG..HANGUL SYLLABLE KEH
+	{runeRange{0xCF1D, 0xCF37}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KYEOG..HANGUL SYLLABLE KYEOH
+	{runeRange{0xCF39, 0xCF53}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KYEG..HANGUL SYLLABLE KYEH
+	{runeRange{0xCF55, 0xCF6F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KOG..HANGUL SYLLABLE KOH
+	{runeRange{0xCF71, 0xCF8B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KWAG..HANGUL SYLLABLE KWAH
+	{runeRange{0xCF8D, 0xCFA7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KWAEG..HANGUL SYLLABLE KWAEH
+	{runeRange{0xCFA9, 0xCFC3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KOEG..HANGUL SYLLABLE KOEH
+	{runeRange{0xCFC5, 0xCFDF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KYOG..HANGUL SYLLABLE KYOH
+	{runeRange{0xCFE1, 0xCFFB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KUG..HANGUL SYLLABLE KUH
+	{runeRange{0xCFFD, 0xD017}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KWEOG..HANGUL SYLLABLE KWEOH
+	{runeRange{0xD019, 0xD033}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KWEG..HANGUL SYLLABLE KWEH
+	{runeRange{0xD035, 0xD04F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KWIG..HANGUL SYLLABLE KWIH
+	{runeRange{0xD051, 0xD06B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KYUG..HANGUL SYLLABLE KYUH
+	{runeRange{0xD06D, 0xD087}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KEUG..HANGUL SYLLABLE KEUH
+	{runeRange{0xD089, 0xD0A3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KYIG..HANGUL SYLLABLE KYIH
+	{runeRange{0xD0A5, 0xD0BF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE KIG..HANGUL SYLLABLE KIH
+	{runeRange{0xD0C1, 0xD0DB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TAG..HANGUL SYLLABLE TAH
+	{runeRange{0xD0DD, 0xD0F7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TAEG..HANGUL SYLLABLE TAEH
+	{runeRange{0xD0F9, 0xD113}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TYAG..HANGUL SYLLABLE TYAH
+	{runeRange{0xD115, 0xD12F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TYAEG..HANGUL SYLLABLE TYAEH
+	{runeRange{0xD131, 0xD14B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TEOG..HANGUL SYLLABLE TEOH
+	{runeRange{0xD14D, 0xD167}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TEG..HANGUL SYLLABLE TEH
+	{runeRange{0xD169, 0xD183}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TYEOG..HANGUL SYLLABLE TYEOH
+	{runeRange{0xD185, 0xD19F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TYEG..HANGUL SYLLABLE TYEH
+	{runeRange{0xD1A1, 0xD1BB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TOG..HANGUL SYLLABLE TOH
+	{runeRange{0xD1BD, 0xD1D7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TWAG..HANGUL SYLLABLE TWAH
+	{runeRange{0xD1D9, 0xD1F3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TWAEG..HANGUL SYLLABLE TWAEH
+	{runeRange{0xD1F5, 0xD20F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TOEG..HANGUL SYLLABLE TOEH
+	{runeRange{0xD211, 0xD22B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TYOG..HANGUL SYLLABLE TYOH
+	{runeRange{0xD22D, 0xD247}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TUG..HANGUL SYLLABLE TUH
+	{runeRange{0xD249, 0xD263}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TWEOG..HANGUL SYLLABLE TWEOH
+	{runeRange{0xD265, 0xD27F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TWEG..HANGUL SYLLABLE TWEH
+	{runeRange{0xD281, 0xD29B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TWIG..HANGUL SYLLABLE TWIH
+	{runeRange{0xD29D, 0xD2B7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TYUG..HANGUL SYLLABLE TYUH
+	{runeRange{0xD2B9, 0xD2D3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TEUG..HANGUL SYLLABLE TEUH
+	{runeRange{0xD2D5, 0xD2EF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TYIG..HANGUL SYLLABLE TYIH
+	{runeRange{0xD2F1, 0xD30B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE TIG..HANGUL SYLLABLE TIH
+	{runeRange{0xD30D, 0xD327}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PAG..HANGUL SYLLABLE PAH
+	{runeRange{0xD329, 0xD343}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PAEG..HANGUL SYLLABLE PAEH
+	{runeRange{0xD345, 0xD35F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PYAG..HANGUL SYLLABLE PYAH
+	{runeRange{0xD361, 0xD37B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PYAEG..HANGUL SYLLABLE PYAEH
+	{runeRange{0xD37D, 0xD397}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PEOG..HANGUL SYLLABLE PEOH
+	{runeRange{0xD399, 0xD3B3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PEG..HANGUL SYLLABLE PEH
+	{runeRange{0xD3B5, 0xD3CF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PYEOG..HANGUL SYLLABLE PYEOH
+	{runeRange{0xD3D1, 0xD3EB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PYEG..HANGUL SYLLABLE PYEH
+	{runeRange{0xD3ED, 0xD407}, prLVT},                    // Lo  [27] HANGUL SYLLABLE POG..HANGUL SYLLABLE POH
+	{runeRange{0xD409, 0xD423}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PWAG..HANGUL SYLLABLE PWAH
+	{runeRange{0xD425, 0xD43F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PWAEG..HANGUL SYLLABLE PWAEH
+	{runeRange{0xD441, 0xD45B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE POEG..HANGUL SYLLABLE POEH
+	{runeRange{0xD45D, 0xD477}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PYOG..HANGUL SYLLABLE PYOH
+	{runeRange{0xD479, 0xD493}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PUG..HANGUL SYLLABLE PUH
+	{runeRange{0xD495, 0xD4AF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PWEOG..HANGUL SYLLABLE PWEOH
+	{runeRange{0xD4B1, 0xD4CB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PWEG..HANGUL SYLLABLE PWEH
+	{runeRange{0xD4CD, 0xD4E7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PWIG..HANGUL SYLLABLE PWIH
+	{runeRange{0xD4E9, 0xD503}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PYUG..HANGUL SYLLABLE PYUH
+	{runeRange{0xD505, 0xD51F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PEUG..HANGUL SYLLABLE PEUH
+	{runeRange{0xD521, 0xD53B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PYIG..HANGUL SYLLABLE PYIH
+	{runeRange{0xD53D, 0xD557}, prLVT},                    // Lo  [27] HANGUL SYLLABLE PIG..HANGUL SYLLABLE PIH
+	{runeRange{0xD559, 0xD573}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HAG..HANGUL SYLLABLE HAH
+	{runeRange{0xD575, 0xD58F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HAEG..HANGUL SYLLABLE HAEH
+	{runeRange{0xD591, 0xD5AB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HYAG..HANGUL SYLLABLE HYAH
+	{runeRange{0xD5AD, 0xD5C7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HYAEG..HANGUL SYLLABLE HYAEH
+	{runeRange{0xD5C9, 0xD5E3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HEOG..HANGUL SYLLABLE HEOH
+	{runeRange{0xD5E5, 0xD5FF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HEG..HANGUL SYLLABLE HEH
+	{runeRange{0xD601, 0xD61B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HYEOG..HANGUL SYLLABLE HYEOH
+	{runeRange{0xD61D, 0xD637}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HYEG..HANGUL SYLLABLE HYEH
+	{runeRange{0xD639, 0xD653}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HOG..HANGUL SYLLABLE HOH
+	{runeRange{0xD655, 0xD66F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HWAG..HANGUL SYLLABLE HWAH
+	{runeRange{0xD671, 0xD68B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HWAEG..HANGUL SYLLABLE HWAEH
+	{runeRange{0xD68D, 0xD6A7}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HOEG..HANGUL SYLLABLE HOEH
+	{runeRange{0xD6A9, 0xD6C3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HYOG..HANGUL SYLLABLE HYOH
+	{runeRange{0xD6C5, 0xD6DF}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HUG..HANGUL SYLLABLE HUH
+	{runeRange{0xD6E1, 0xD6FB}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HWEOG..HANGUL SYLLABLE HWEOH
+	{runeRange{0xD6FD, 0xD717}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HWEG..HANGUL SYLLABLE HWEH
+	{runeRange{0xD719, 0xD733}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HWIG..HANGUL SYLLABLE HWIH
+	{runeRange{0xD735, 0xD74F}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HYUG..HANGUL SYLLABLE HYUH
+	{runeRange{0xD751, 0xD76B}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HEUG..HANGUL SYLLABLE HEUH
+	{runeRange{0xD76D, 0xD787}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HYIG..HANGUL SYLLABLE HYIH
+	{runeRange{0xD789, 0xD7A3}, prLVT},                    // Lo  [27] HANGUL SYLLABLE HIG..HANGUL SYLLABLE HIH
+	{runeRange{0xD7CB, 0xD7FB}, prT},                      // Lo  [49] HANGUL JONGSEONG NIEUN-RIEUL..HANGUL JONGSEONG PHIEUPH-THIEUTH
+	{runeRange{0xFE00, 0xFE0F}, prExtend},                 // Mn  [16] VARIATION SELECTOR-1..VARIATION SELECTOR-16
+	{runeRange{0xFEFF, 0xFEFF}, prControl},                // Cf       ZERO WIDTH NO-BREAK SPACE
+	{runeRange{0xFFF0, 0xFFF8}, prControl},                // Cn   [9] <reserved-FFF0>..<reserved-FFF8>
+	{runeRange{0x101FD, 0x101FD}, prExtend},               // Mn       PHAISTOS DISC SIGN COMBINING OBLIQUE STROKE
+	{runeRange{0x10376, 0x1037A}, prExtend},               // Mn   [5] COMBINING OLD PERMIC LETTER AN..COMBINING OLD PERMIC LETTER SII
+	{runeRange{0x10A05, 0x10A06}, prExtend},               // Mn   [2] KHAROSHTHI VOWEL SIGN E..KHAROSHTHI VOWEL SIGN O
+	{runeRange{0x10A38, 0x10A3A}, prExtend},               // Mn   [3] KHAROSHTHI SIGN BAR ABOVE..KHAROSHTHI SIGN DOT BELOW
+	{runeRange{0x10AE5, 0x10AE6}, prExtend},               // Mn   [2] MANICHAEAN ABBREVIATION MARK ABOVE..MANICHAEAN ABBREVIATION MARK BELOW
+	{runeRange{0x10EAB, 0x10EAC}, prExtend},               // Mn   [2] YEZIDI COMBINING HAMZA MARK..YEZIDI COMBINING MADDA MARK
+	{runeRange{0x10F46, 0x10F50}, prExtend},               // Mn  [11] SOGDIAN COMBINING DOT BELOW..SOGDIAN COMBINING STROKE BELOW
+	{runeRange{0x11000, 0x11000}, prSpacingMark},          // Mc       BRAHMI SIGN CANDRABINDU
+	{runeRange{0x11002, 0x11002}, prSpacingMark},          // Mc       BRAHMI SIGN VISARGA
+	{runeRange{0x11070, 0x11070}, prExtend},               // Mn       BRAHMI SIGN OLD TAMIL VIRAMA
+	{runeRange{0x1107F, 0x11081}, prExtend},               // Mn   [3] BRAHMI NUMBER JOINER..KAITHI SIGN ANUSVARA
+	{runeRange{0x110B0, 0x110B2}, prSpacingMark},          // Mc   [3] KAITHI VOWEL SIGN AA..KAITHI VOWEL SIGN II
+	{runeRange{0x110B7, 0x110B8}, prSpacingMark},          // Mc   [2] KAITHI VOWEL SIGN O..KAITHI VOWEL SIGN AU
+	{runeRange{0x110BD, 0x110BD}, prPrepend},              // Cf       KAITHI NUMBER SIGN
+	{runeRange{0x110CD, 0x110CD}, prPrepend},              // Cf       KAITHI NUMBER SIGN ABOVE
+	{runeRange{0x11127, 0x1112B}, prExtend},               // Mn   [5] CHAKMA VOWEL SIGN A..CHAKMA VOWEL SIGN UU
+	{runeRange{0x1112D, 0x11134}, prExtend},               // Mn   [8] CHAKMA VOWEL SIGN AI..CHAKMA MAAYYAA
+	{runeRange{0x11173, 0x11173}, prExtend},               // Mn       MAHAJANI SIGN NUKTA
+	{runeRange{0x11182, 0x11182}, prSpacingMark},          // Mc       SHARADA SIGN VISARGA
+	{runeRange{0x111B6, 0x111BE}, prExtend},               // Mn   [9] SHARADA VOWEL SIGN U..SHARADA VOWEL SIGN O
+	{runeRange{0x111C2, 0x111C3}, prPrepend},              // Lo   [2] SHARADA SIGN JIHVAMULIYA..SHARADA SIGN UPADHMANIYA
+	{runeRange{0x111CE, 0x111CE}, prSpacingMark},          // Mc       SHARADA VOWEL SIGN PRISHTHAMATRA E
+	{runeRange{0x1122C, 0x1122E}, prSpacingMark},          // Mc   [3] KHOJKI VOWEL SIGN AA..KHOJKI VOWEL SIGN II
+	{runeRange{0x11232, 0x11233}, prSpacingMark},          // Mc   [2] KHOJKI VOWEL SIGN O..KHOJKI VOWEL SIGN AU
+	{runeRange{0x11235, 0x11235}, prSpacingMark},          // Mc       KHOJKI SIGN VIRAMA
+	{runeRange{0x1123E, 0x1123E}, prExtend},               // Mn       KHOJKI SIGN SUKUN
+	{runeRange{0x112DF, 0x112DF}, prExtend},               // Mn       KHUDAWADI SIGN ANUSVARA
+	{runeRange{0x112E3, 0x112EA}, prExtend},               // Mn   [8] KHUDAWADI VOWEL SIGN U..KHUDAWADI SIGN VIRAMA
+	{runeRange{0x11302, 0x11303}, prSpacingMark},          // Mc   [2] GRANTHA SIGN ANUSVARA..GRANTHA SIGN VISARGA
+	{runeRange{0x1133E, 0x1133E}, prExtend},               // Mc       GRANTHA VOWEL SIGN AA
+	{runeRange{0x11340, 0x11340}, prExtend},               // Mn       GRANTHA VOWEL SIGN II
+	{runeRange{0x11347, 0x11348}, prSpacingMark},          // Mc   [2] GRANTHA VOWEL SIGN EE..GRANTHA VOWEL SIGN AI
+	{runeRange{0x11357, 0x11357}, prExtend},               // Mc       GRANTHA AU LENGTH MARK
+	{runeRange{0x11366, 0x1136C}, prExtend},               // Mn   [7] COMBINING GRANTHA DIGIT ZERO..COMBINING GRANTHA DIGIT SIX
+	{runeRange{0x11435, 0x11437}, prSpacingMark},          // Mc   [3] NEWA VOWEL SIGN AA..NEWA VOWEL SIGN II
+	{runeRange{0x11440, 0x11441}, prSpacingMark},          // Mc   [2] NEWA VOWEL SIGN O..NEWA VOWEL SIGN AU
+	{runeRange{0x11445, 0x11445}, prSpacingMark},          // Mc       NEWA SIGN VISARGA
+	{runeRange{0x1145E, 0x1145E}, prExtend},               // Mn       NEWA SANDHI MARK
+	{runeRange{0x114B1, 0x114B2}, prSpacingMark},          // Mc   [2] TIRHUTA VOWEL SIGN I..TIRHUTA VOWEL SIGN II
+	{runeRange{0x114B9, 0x114B9}, prSpacingMark},          // Mc       TIRHUTA VOWEL SIGN E
+	{runeRange{0x114BB, 0x114BC}, prSpacingMark},          // Mc   [2] TIRHUTA VOWEL SIGN AI..TIRHUTA VOWEL SIGN O
+	{runeRange{0x114BE, 0x114BE}, prSpacingMark},          // Mc       TIRHUTA VOWEL SIGN AU
+	{runeRange{0x114C1, 0x114C1}, prSpacingMark},          // Mc       TIRHUTA SIGN VISARGA
+	{runeRange{0x115AF, 0x115AF}, prExtend},               // Mc       SIDDHAM VOWEL SIGN AA
+	{runeRange{0x115B2, 0x115B5}, prExtend},               // Mn   [4] SIDDHAM VOWEL SIGN U..SIDDHAM VOWEL SIGN VOCALIC RR
+	{runeRange{0x115BC, 0x115BD}, prExtend},               // Mn   [2] SIDDHAM SIGN CANDRABINDU..SIDDHAM SIGN ANUSVARA
+	{runeRange{0x115BF, 0x115C0}, prExtend},               // Mn   [2] SIDDHAM SIGN VIRAMA..SIDDHAM SIGN NUKTA
+	{runeRange{0x11630, 0x11632}, prSpacingMark},          // Mc   [3] MODI VOWEL SIGN AA..MODI VOWEL SIGN II
+	{runeRange{0x1163B, 0x1163C}, prSpacingMark},          // Mc   [2] MODI VOWEL SIGN O..MODI VOWEL SIGN AU
+	{runeRange{0x1163E, 0x1163E}, prSpacingMark},          // Mc       MODI SIGN VISARGA
+	{runeRange{0x116AB, 0x116AB}, prExtend},               // Mn       TAKRI SIGN ANUSVARA
+	{runeRange{0x116AD, 0x116AD}, prExtend},               // Mn       TAKRI VOWEL SIGN AA
+	{runeRange{0x116B0, 0x116B5}, prExtend},               // Mn   [6] TAKRI VOWEL SIGN U..TAKRI VOWEL SIGN AU
+	{runeRange{0x116B7, 0x116B7}, prExtend},               // Mn       TAKRI SIGN NUKTA
+	{runeRange{0x11722, 0x11725}, prExtend},               // Mn   [4] AHOM VOWEL SIGN I..AHOM VOWEL SIGN UU
+	{runeRange{0x11727, 0x1172B}, prExtend},               // Mn   [5] AHOM VOWEL SIGN AW..AHOM SIGN KILLER
+	{runeRange{0x1182F, 0x11837}, prExtend},               // Mn   [9] DOGRA VOWEL SIGN U..DOGRA SIGN ANUSVARA
+	{runeRange{0x11839, 0x1183A}, prExtend},               // Mn   [2] DOGRA SIGN VIRAMA..DOGRA SIGN NUKTA
+	{runeRange{0x11931, 0x11935}, prSpacingMark},          // Mc   [5] DIVES AKURU VOWEL SIGN I..DIVES AKURU VOWEL SIGN E
+	{runeRange{0x1193B, 0x1193C}, prExtend},               // Mn   [2] DIVES AKURU SIGN ANUSVARA..DIVES AKURU SIGN CANDRABINDU
+	{runeRange{0x1193E, 0x1193E}, prExtend},               // Mn       DIVES AKURU VIRAMA
+	{runeRange{0x11940, 0x11940}, prSpacingMark},          // Mc       DIVES AKURU MEDIAL YA
+	{runeRange{0x11942, 0x11942}, prSpacingMark},          // Mc       DIVES AKURU MEDIAL RA
+	{runeRange{0x119D1, 0x119D3}, prSpacingMark},          // Mc   [3] NANDINAGARI VOWEL SIGN AA..NANDINAGARI VOWEL SIGN II
+	{runeRange{0x119DA, 0x119DB}, prExtend},               // Mn   [2] NANDINAGARI VOWEL SIGN E..NANDINAGARI VOWEL SIGN AI
+	{runeRange{0x119E0, 0x119E0}, prExtend},               // Mn       NANDINAGARI SIGN VIRAMA
+	{runeRange{0x11A01, 0x11A0A}, prExtend},               // Mn  [10] ZANABAZAR SQUARE VOWEL SIGN I..ZANABAZAR SQUARE VOWEL LENGTH MARK
+	{runeRange{0x11A39, 0x11A39}, prSpacingMark},          // Mc       ZANABAZAR SQUARE SIGN VISARGA
+	{runeRange{0x11A3B, 0x11A3E}, prExtend},               // Mn   [4] ZANABAZAR SQUARE CLUSTER-FINAL LETTER YA..ZANABAZAR SQUARE CLUSTER-FINAL LETTER VA
+	{runeRange{0x11A51, 0x11A56}, prExtend},               // Mn   [6] SOYOMBO VOWEL SIGN I..SOYOMBO VOWEL SIGN OE
+	{runeRange{0x11A59, 0x11A5B}, prExtend},               // Mn   [3] SOYOMBO VOWEL SIGN VOCALIC R..SOYOMBO VOWEL LENGTH MARK
+	{runeRange{0x11A8A, 0x11A96}, prExtend},               // Mn  [13] SOYOMBO FINAL CONSONANT SIGN G..SOYOMBO SIGN ANUSVARA
+	{runeRange{0x11A98, 0x11A99}, prExtend},               // Mn   [2] SOYOMBO GEMINATION MARK..SOYOMBO SUBJOINER
+	{runeRange{0x11C30, 0x11C36}, prExtend},               // Mn   [7] BHAIKSUKI VOWEL SIGN I..BHAIKSUKI VOWEL SIGN VOCALIC L
+	{runeRange{0x11C3E, 0x11C3E}, prSpacingMark},          // Mc       BHAIKSUKI SIGN VISARGA
+	{runeRange{0x11C92, 0x11CA7}, prExtend},               // Mn  [22] MARCHEN SUBJOINED LETTER KA..MARCHEN SUBJOINED LETTER ZA
+	{runeRange{0x11CAA, 0x11CB0}, prExtend},               // Mn   [7] MARCHEN SUBJOINED LETTER RA..MARCHEN VOWEL SIGN AA
+	{runeRange{0x11CB2, 0x11CB3}, prExtend},               // Mn   [2] MARCHEN VOWEL SIGN U..MARCHEN VOWEL SIGN E
+	{runeRange{0x11CB5, 0x11CB6}, prExtend},               // Mn   [2] MARCHEN SIGN ANUSVARA..MARCHEN SIGN CANDRABINDU
+	{runeRange{0x11D3A, 0x11D3A}, prExtend},               // Mn       MASARAM GONDI VOWEL SIGN E
+	{runeRange{0x11D3F, 0x11D45}, prExtend},               // Mn   [7] MASARAM GONDI VOWEL SIGN AU..MASARAM GONDI VIRAMA
+	{runeRange{0x11D47, 0x11D47}, prExtend},               // Mn       MASARAM GONDI RA-KARA
+	{runeRange{0x11D90, 0x11D91}, prExtend},               // Mn   [2] GUNJALA GONDI VOWEL SIGN EE..GUNJALA GONDI VOWEL SIGN AI
+	{runeRange{0x11D95, 0x11D95}, prExtend},               // Mn       GUNJALA GONDI SIGN ANUSVARA
+	{runeRange{0x11D97, 0x11D97}, prExtend},               // Mn       GUNJALA GONDI VIRAMA
+	{runeRange{0x11EF5, 0x11EF6}, prSpacingMark},          // Mc   [2] MAKASAR VOWEL SIGN E..MAKASAR VOWEL SIGN O
+	{runeRange{0x11F02, 0x11F02}, prPrepend},              // Lo       KAWI SIGN REPHA
+	{runeRange{0x11F34, 0x11F35}, prSpacingMark},          // Mc   [2] KAWI VOWEL SIGN AA..KAWI VOWEL SIGN ALTERNATE AA
+	{runeRange{0x11F3E, 0x11F3F}, prSpacingMark},          // Mc   [2] KAWI VOWEL SIGN E..KAWI VOWEL SIGN AI
+	{runeRange{0x11F41, 0x11F41}, prSpacingMark},          // Mc       KAWI SIGN KILLER
+	{runeRange{0x13430, 0x1343F}, prControl},              // Cf  [16] EGYPTIAN HIEROGLYPH VERTICAL JOINER..EGYPTIAN HIEROGLYPH END WALLED ENCLOSURE
+	{runeRange{0x13447, 0x13455}, prExtend},               // Mn  [15] EGYPTIAN HIEROGLYPH MODIFIER DAMAGED AT TOP START..EGYPTIAN HIEROGLYPH MODIFIER DAMAGED
+	{runeRange{0x16B30, 0x16B36}, prExtend},               // Mn   [7] PAHAWH HMONG MARK CIM TUB..PAHAWH HMONG MARK CIM TAUM
+	{runeRange{0x16F51, 0x16F87}, prSpacingMark},          // Mc  [55] MIAO SIGN ASPIRATION..MIAO VOWEL SIGN UI
+	{runeRange{0x16FE4, 0x16FE4}, prExtend},               // Mn       KHITAN SMALL SCRIPT FILLER
+	{runeRange{0x1BC9D, 0x1BC9E}, prExtend},               // Mn   [2] DUPLOYAN THICK LETTER SELECTOR..DUPLOYAN DOUBLE MARK
+	{runeRange{0x1CF00, 0x1CF2D}, prExtend},               // Mn  [46] ZNAMENNY COMBINING MARK GORAZDO NIZKO S KRYZHEM ON LEFT..ZNAMENNY COMBINING MARK KRYZH ON LEFT
+	{runeRange{0x1D165, 0x1D165}, prExtend},               // Mc       MUSICAL SYMBOL COMBINING STEM
+	{runeRange{0x1D167, 0x1D169}, prExtend},               // Mn   [3] MUSICAL SYMBOL COMBINING TREMOLO-1..MUSICAL SYMBOL COMBINING TREMOLO-3
+	{runeRange{0x1D16E, 0x1D172}, prExtend},               // Mc   [5] MUSICAL SYMBOL COMBINING FLAG-1..MUSICAL SYMBOL COMBINING FLAG-5
+	{runeRange{0x1D17B, 0x1D182}, prExtend},               // Mn   [8] MUSICAL SYMBOL COMBINING ACCENT..MUSICAL SYMBOL COMBINING LOURE
+	{runeRange{0x1D1AA, 0x1D1AD}, prExtend},               // Mn   [4] MUSICAL SYMBOL COMBINING DOWN BOW..MUSICAL SYMBOL COMBINING SNAP PIZZICATO
+	{runeRange{0x1DA00, 0x1DA36}, prExtend},               // Mn  [55] SIGNWRITING HEAD RIM..SIGNWRITING AIR SUCKING IN
+	{runeRange{0x1DA75, 0x1DA75}, prExtend},               // Mn       SIGNWRITING UPPER BODY TILTING FROM HIP JOINTS
+	{runeRange{0x1DA9B, 0x1DA9F}, prExtend},               // Mn   [5] SIGNWRITING FILL MODIFIER-2..SIGNWRITING FILL MODIFIER-6
+	{runeRange{0x1E000, 0x1E006}, prExtend},               // Mn   [7] COMBINING GLAGOLITIC LETTER AZU..COMBINING GLAGOLITIC LETTER ZHIVETE
+	{runeRange{0x1E01B, 0x1E021}, prExtend},               // Mn   [7] COMBINING GLAGOLITIC LETTER SHTA..COMBINING GLAGOLITIC LETTER YATI
+	{runeRange{0x1E026, 0x1E02A}, prExtend},               // Mn   [5] COMBINING GLAGOLITIC LETTER YO..COMBINING GLAGOLITIC LETTER FITA
+	{runeRange{0x1E130, 0x1E136}, prExtend},               // Mn   [7] NYIAKENG PUACHUE HMONG TONE-B..NYIAKENG PUACHUE HMONG TONE-D
+	{runeRange{0x1E2EC, 0x1E2EF}, prExtend},               // Mn   [4] WANCHO TONE TUP..WANCHO TONE KOINI
+	{runeRange{0x1E8D0, 0x1E8D6}, prExtend},               // Mn   [7] MENDE KIKAKUI COMBINING NUMBER TEENS..MENDE KIKAKUI COMBINING NUMBER MILLIONS
+	{runeRange{0x1F000, 0x1F003}, prExtendedPictographic}, // E0.0   [4] (🀀..🀃)    MAHJONG TILE EAST WIND..MAHJONG TILE NORTH WIND
+	{runeRange{0x1F005, 0x1F0CE}, prExtendedPictographic}, // E0.0 [202] (🀅..🃎)    MAHJONG TILE GREEN DRAGON..PLAYING CARD KING OF DIAMONDS
+	{runeRange{0x1F0D0, 0x1F0FF}, prExtendedPictographic}, // E0.0  [48] (🃐..🃿)    <reserved-1F0D0>..<reserved-1F0FF>
+	{runeRange{0x1F12F, 0x1F12F}, prExtendedPictographic}, // E0.0   [1] (🄯)       COPYLEFT SYMBOL
+	{runeRange{0x1F170, 0x1F171}, prExtendedPictographic}, // E0.6   [2] (🅰️..🅱️)    A button (blood type)..B button (blood type)
+	{runeRange{0x1F18E, 0x1F18E}, prExtendedPictographic}, // E0.6   [1] (🆎)       AB button (blood type)
+	{runeRange{0x1F1AD, 0x1F1E5}, prExtendedPictographic}, // E0.0  [57] (🆭..🇥)    MASK WORK SYMBOL..<reserved-1F1E5>
+	{runeRange{0x1F201, 0x1F202}, prExtendedPictographic}, // E0.6   [2] (🈁..🈂️)    Japanese “here” button..Japanese “service charge” button
+	{runeRange{0x1F21A, 0x1F21A}, prExtendedPictographic}, // E0.6   [1] (🈚)       Japanese “free of charge” button
+	{runeRange{0x1F232, 0x1F23A}, prExtendedPictographic}, // E0.6   [9] (🈲..🈺)    Japanese “prohibited” button..Japanese “open for business” button
+	{runeRange{0x1F249, 0x1F24F}, prExtendedPictographic}, // E0.0   [7] (🉉..🉏)    <reserved-1F249>..<reserved-1F24F>
+	{runeRange{0x1F252, 0x1F2FF}, prExtendedPictographic}, // E0.0 [174] (🉒..🋿)    <reserved-1F252>..<reserved-1F2FF>
+	{runeRange{0x1F30D, 0x1F30E}, prExtendedPictographic}, // E0.7   [2] (🌍..🌎)    globe showing Europe-Africa..globe showing Americas
+	{runeRange{0x1F310, 0x1F310}, prExtendedPictographic}, // E1.0   [1] (🌐)       globe with meridians
+	{runeRange{0x1F312, 0x1F312}, prExtendedPictographic}, // E1.0   [1] (🌒)       waxing crescent moon
+	{runeRange{0x1F316, 0x1F318}, prExtendedPictographic}, // E1.0   [3] (🌖..🌘)    waning gibbous moon..waning crescent moon
+	{runeRange{0x1F31A, 0x1F31A}, prExtendedPictographic}, // E1.0   [1] (🌚)       new moon face
+	{runeRange{0x1F31C, 0x1F31C}, prExtendedPictographic}, // E0.7   [1] (🌜)       last quarter moon face
+	{runeRange{0x1F31F, 0x1F320}, prExtendedPictographic}, // E0.6   [2] (🌟..🌠)    glowing star..shooting star
+	{runeRange{0x1F322, 0x1F323}, prExtendedPictographic}, // E0.0   [2] (🌢..🌣)    BLACK DROPLET..WHITE SUN
+	{runeRange{0x1F32D, 0x1F32F}, prExtendedPictographic}, // E1.0   [3] (🌭..🌯)    hot dog..burrito
+	{runeRange{0x1F332, 0x1F333}, prExtendedPictographic}, // E1.0   [2] (🌲..🌳)    evergreen tree..deciduous tree
+	{runeRange{0x1F336, 0x1F336}, prExtendedPictographic}, // E0.7   [1] (🌶️)       hot pepper
+	{runeRange{0x1F34B, 0x1F34B}, prExtendedPictographic}, // E1.0   [1] (🍋)       lemon
+	{runeRange{0x1F350, 0x1F350}, prExtendedPictographic}, // E1.0   [1] (🍐)       pear
+	{runeRange{0x1F37C, 0x1F37C}, prExtendedPictographic}, // E1.0   [1] (🍼)       baby bottle
+	{runeRange{0x1F37E, 0x1F37F}, prExtendedPictographic}, // E1.0   [2] (🍾..🍿)    bottle with popping cork..popcorn
+	{runeRange{0x1F394, 0x1F395}, prExtendedPictographic}, // E0.0   [2] (🎔..🎕)    HEART WITH TIP ON THE LEFT..BOUQUET OF FLOWERS
+	{runeRange{0x1F398, 0x1F398}, prExtendedPictographic}, // E0.0   [1] (🎘)       MUSICAL KEYBOARD WITH JACKS
+	{runeRange{0x1F39C, 0x1F39D}, prExtendedPictographic}, // E0.0   [2] (🎜..🎝)    BEAMED ASCENDING MUSICAL NOTES..BEAMED DESCENDING MUSICAL NOTES
+	{runeRange{0x1F3A0, 0x1F3C4}, prExtendedPictographic}, // E0.6  [37] (🎠..🏄)    carousel horse..person surfing
+	{runeRange{0x1F3C6, 0x1F3C6}, prExtendedPictographic}, // E0.6   [1] (🏆)       trophy
+	{runeRange{0x1F3C8, 0x1F3C8}, prExtendedPictographic}, // E0.6   [1] (🏈)       american football
+	{runeRange{0x1F3CA, 0x1F3CA}, prExtendedPictographic}, // E0.6   [1] (🏊)       person swimming
+	{runeRange{0x1F3CF, 0x1F3D3}, prExtendedPictographic}, // E1.0   [5] (🏏..🏓)    cricket game..ping pong
+	{runeRange{0x1F3E0, 0x1F3E3}, prExtendedPictographic}, // E0.6   [4] (🏠..🏣)    house..Japanese post office
+	{runeRange{0x1F3E5, 0x1F3F0}, prExtendedPictographic}, // E0.6  [12] (🏥..🏰)    hospital..castle
+	{runeRange{0x1F3F3, 0x1F3F3}, prExtendedPictographic}, // E0.7   [1] (🏳️)       white flag
+	{runeRange{0x1F3F5, 0x1F3F5}, prExtendedPictographic}, // E0.7   [1] (🏵️)       rosette
+	{runeRange{0x1F3F7, 0x1F3F7}, prExtendedPictographic}, // E0.7   [1] (🏷️)       label
+	{runeRange{0x1F3FB, 0x1F3FF}, prExtend},               // Sk   [5] EMOJI MODIFIER FITZPATRICK TYPE-1-2..EMOJI MODIFIER FITZPATRICK TYPE-6
+	{runeRange{0x1F408, 0x1F408}, prExtendedPictographic}, // E0.7   [1] (🐈)       cat
+	{runeRange{0x1F40C, 0x1F40E}, prExtendedPictographic}, // E0.6   [3] (🐌..🐎)    snail..horse
+	{runeRange{0x1F411, 0x1F412}, prExtendedPictographic}, // E0.6   [2] (🐑..🐒)    ewe..monkey
+	{runeRange{0x1F414, 0x1F414}, prExtendedPictographic}, // E0.6   [1] (🐔)       chicken
+	{runeRange{0x1F416, 0x1F416}, prExtendedPictographic}, // E1.0   [1] (🐖)       pig
+	{runeRange{0x1F42A, 0x1F42A}, prExtendedPictographic}, // E1.0   [1] (🐪)       camel
+	{runeRange{0x1F43F, 0x1F43F}, prExtendedPictographic}, // E0.7   [1] (🐿️)       chipmunk
+	{runeRange{0x1F441, 0x1F441}, prExtendedPictographic}, // E0.7   [1] (👁️)       eye
+	{runeRange{0x1F465, 0x1F465}, prExtendedPictographic}, // E1.0   [1] (👥)       busts in silhouette
+	{runeRange{0x1F46C, 0x1F46D}, prExtendedPictographic}, // E1.0   [2] (👬..👭)    men holding hands..women holding hands
+	{runeRange{0x1F4AD, 0x1F4AD}, prExtendedPictographic}, // E1.0   [1] (💭)       thought balloon
+	{runeRange{0x1F4B6, 0x1F4B7}, prExtendedPictographic}, // E1.0   [2] (💶..💷)    euro banknote..pound banknote
+	{runeRange{0x1F4EC, 0x1F4ED}, prExtendedPictographic}, // E0.7   [2] (📬..📭)    open mailbox with raised flag..open mailbox with lowered flag
+	{runeRange{0x1F4EF, 0x1F4EF}, prExtendedPictographic}, // E1.0   [1] (📯)       postal horn
+	{runeRange{0x1F4F5, 0x1F4F5}, prExtendedPictographic}, // E1.0   [1] (📵)       no mobile phones
+	{runeRange{0x1F4F8, 0x1F4F8}, prExtendedPictographic}, // E1.0   [1] (📸)       camera with flash
+	{runeRange{0x1F4FD, 0x1F4FD}, prExtendedPictographic}, // E0.7   [1] (📽️)       film projector
+	{runeRange{0x1F4FF, 0x1F502}, prExtendedPictographic}, // E1.0   [4] (📿..🔂)    prayer beads..repeat single button
+	{runeRange{0x1F504, 0x1F507}, prExtendedPictographic}, // E1.0   [4] (🔄..🔇)    counterclockwise arrows button..muted speaker
+	{runeRange{0x1F509, 0x1F509}, prExtendedPictographic}, // E1.0   [1] (🔉)       speaker medium volume
+	{runeRange{0x1F515, 0x1F515}, prExtendedPictographic}, // E1.0   [1] (🔕)       bell with slash
+	{runeRange{0x1F52C, 0x1F52D}, prExtendedPictographic}, // E1.0   [2] (🔬..🔭)    microscope..telescope
+	{runeRange{0x1F546, 0x1F548}, prExtendedPictographic}, // E0.0   [3] (🕆..🕈)    WHITE LATIN CROSS..CELTIC CROSS
+	{runeRange{0x1F54B, 0x1F54E}, prExtendedPictographic}, // E1.0   [4] (🕋..🕎)    kaaba..menorah
+	{runeRange{0x1F550, 0x1F55B}, prExtendedPictographic}, // E0.6  [12] (🕐..🕛)    one o’clock..twelve o’clock
+	{runeRange{0x1F568, 0x1F56E}, prExtendedPictographic}, // E0.0   [7] (🕨..🕮)    RIGHT SPEAKER..BOOK
+	{runeRange{0x1F571, 0x1F572}, prExtendedPictographic}, // E0.0   [2] (🕱..🕲)    BLACK SKULL AND CROSSBONES..NO PIRACY
+	{runeRange{0x1F57A, 0x1F57A}, prExtendedPictographic}, // E3.0   [1] (🕺)       man dancing
+	{runeRange{0x1F587, 0x1F587}, prExtendedPictographic}, // E0.7   [1] (🖇️)       linked paperclips
+	{runeRange{0x1F58A, 0x1F58D}, prExtendedPictographic}, // E0.7   [4] (🖊️..🖍️)    pen..crayon
+	{runeRange{0x1F590, 0x1F590}, prExtendedPictographic}, // E0.7   [1] (🖐️)       hand with fingers splayed
+	{runeRange{0x1F595, 0x1F596}, prExtendedPictographic}, // E1.0   [2] (🖕..🖖)    middle finger..vulcan salute
+	{runeRange{0x1F5A4, 0x1F5A4}, prExtendedPictographic}, // E3.0   [1] (🖤)       black heart
+	{runeRange{0x1F5A6, 0x1F5A7}, prExtendedPictographic}, // E0.0   [2] (🖦..🖧)    KEYBOARD AND MOUSE..THREE NETWORKED COMPUTERS
+	{runeRange{0x1F5A9, 0x1F5B0}, prExtendedPictographic}, // E0.0   [8] (🖩..🖰)    POCKET CALCULATOR..TWO BUTTON MOUSE
+	{runeRange{0x1F5B3, 0x1F5BB}, prExtendedPictographic}, // E0.0   [9] (🖳..🖻)    OLD PERSONAL COMPUTER..DOCUMENT WITH PICTURE
+	{runeRange{0x1F5BD, 0x1F5C1}, prExtendedPictographic}, // E0.0   [5] (🖽..🗁)    FRAME WITH TILES..OPEN FOLDER
+	{runeRange{0x1F5C5, 0x1F5D0}, prExtendedPictographic}, // E0.0  [12] (🗅..🗐)    EMPTY NOTE..PAGES
+	{runeRange{0x1F5D4, 0x1F5DB}, prExtendedPictographic}, // E0.0   [8] (🗔..🗛)    DESKTOP WINDOW..DECREASE FONT SIZE SYMBOL
+	{runeRange{0x1F5DF, 0x1F5E0}, prExtendedPictographic}, // E0.0   [2] (🗟..🗠)    PAGE WITH CIRCLED TEXT..STOCK CHART
+	{runeRange{0x1F5E2, 0x1F5E2}, prExtendedPictographic}, // E0.0   [1] (🗢)       LIPS
+	{runeRange{0x1F5E4, 0x1F5E7}, prExtendedPictographic}, // E0.0   [4] (🗤..🗧)    THREE RAYS ABOVE..THREE RAYS RIGHT
+	{runeRange{0x1F5E9, 0x1F5EE}, prExtendedPictographic}, // E0.0   [6] (🗩..🗮)    RIGHT SPEECH BUBBLE..LEFT ANGER BUBBLE
+	{runeRange{0x1F5F0, 0x1F5F2}, prExtendedPictographic}, // E0.0   [3] (🗰..🗲)    MOOD BUBBLE..LIGHTNING MOOD
+	{runeRange{0x1F5F4, 0x1F5F9}, prExtendedPictographic}, // E0.0   [6] (🗴..🗹)    BALLOT SCRIPT X..BALLOT BOX WITH BOLD CHECK
+	{runeRange{0x1F5FB, 0x1F5FF}, prExtendedPictographic}, // E0.6   [5] (🗻..🗿)    mount fuji..moai
+	{runeRange{0x1F601, 0x1F606}, prExtendedPictographic}, // E0.6   [6] (😁..😆)    beaming face with smiling eyes..grinning squinting face
+	{runeRange{0x1F609, 0x1F60D}, prExtendedPictographic}, // E0.6   [5] (😉..😍)    winking face..smiling face with heart-eyes
+	{runeRange{0x1F60F, 0x1F60F}, prExtendedPictographic}, // E0.6   [1] (😏)       smirking face
+	{runeRange{0x1F611, 0x1F611}, prExtendedPictographic}, // E1.0   [1] (😑)       expressionless face
+	{runeRange{0x1F615, 0x1F615}, prExtendedPictographic}, // E1.0   [1] (😕)       confused face
+	{runeRange{0x1F617, 0x1F617}, prExtendedPictographic}, // E1.0   [1] (😗)       kissing face
+	{runeRange{0x1F619, 0x1F619}, prExtendedPictographic}, // E1.0   [1] (😙)       kissing face with smiling eyes
+	{runeRange{0x1F61B, 0x1F61B}, prExtendedPictographic}, // E1.0   [1] (😛)       face with tongue
+	{runeRange{0x1F61F, 0x1F61F}, prExtendedPictographic}, // E1.0   [1] (😟)       worried face
+	{runeRange{0x1F626, 0x1F627}, prExtendedPictographic}, // E1.0   [2] (😦..😧)    frowning face with open mouth..anguished face
+	{runeRange{0x1F62C, 0x1F62C}, prExtendedPictographic}, // E1.0   [1] (😬)       grimacing face
+	{runeRange{0x1F62E, 0x1F62F}, prExtendedPictographic}, // E1.0   [2] (😮..😯)    face with open mouth..hushed face
+	{runeRange{0x1F634, 0x1F634}, prExtendedPictographic}, // E1.0   [1] (😴)       sleeping face
+	{runeRange{0x1F636, 0x1F636}, prExtendedPictographic}, // E1.0   [1] (😶)       face without mouth
+	{runeRange{0x1F641, 0x1F644}, prExtendedPictographic}, // E1.0   [4] (🙁..🙄)    slightly frowning face..face with rolling eyes
+	{runeRange{0x1F680, 0x1F680}, prExtendedPictographic}, // E0.6   [1] (🚀)       rocket
+	{runeRange{0x1F683, 0x1F685}, prExtendedPictographic}, // E0.6   [3] (🚃..🚅)    railway car..bullet train
+	{runeRange{0x1F687, 0x1F687}, prExtendedPictographic}, // E0.6   [1] (🚇)       metro
+	{runeRange{0x1F689, 0x1F689}, prExtendedPictographic}, // E0.6   [1] (🚉)       station
+	{runeRange{0x1F68C, 0x1F68C}, prExtendedPictographic}, // E0.6   [1] (🚌)       bus
+	{runeRange{0x1F68E, 0x1F68E}, prExtendedPictographic}, // E1.0   [1] (🚎)       trolleybus
+	{runeRange{0x1F690, 0x1F690}, prExtendedPictographic}, // E1.0   [1] (🚐)       minibus
+	{runeRange{0x1F694, 0x1F694}, prExtendedPictographic}, // E0.7   [1] (🚔)       oncoming police car
 }

--- a/lineproperties.go
+++ b/lineproperties.go
@@ -6,3545 +6,3545 @@ package uniseg
 // https://www.unicode.org/Public/15.0.0/ucd/LineBreak.txt
 // See https://www.unicode.org/license.html for the Unicode license agreement.
 var lineBreakCodePoints = dictionary[propertyGeneralCategory]{
-	{runeRange{0x0000, 0x0008}, propertyGeneralCategory{lbprCM, gcCc}},     //     [9] <control-0000>..<control-0008>
-	{runeRange{0x0009, 0x0009}, propertyGeneralCategory{lbprBA, gcCc}},     //         <control-0009>
-	{runeRange{0x000A, 0x000A}, propertyGeneralCategory{lbprLF, gcCc}},     //         <control-000A>
-	{runeRange{0x000B, 0x000C}, propertyGeneralCategory{lbprBK, gcCc}},     //     [2] <control-000B>..<control-000C>
-	{runeRange{0x000D, 0x000D}, propertyGeneralCategory{lbprCR, gcCc}},     //         <control-000D>
-	{runeRange{0x000E, 0x001F}, propertyGeneralCategory{lbprCM, gcCc}},     //    [18] <control-000E>..<control-001F>
-	{runeRange{0x0020, 0x0020}, propertyGeneralCategory{lbprSP, gcZs}},     //         SPACE
-	{runeRange{0x0021, 0x0021}, propertyGeneralCategory{lbprEX, gcPo}},     //         EXCLAMATION MARK
-	{runeRange{0x0022, 0x0022}, propertyGeneralCategory{lbprQU, gcPo}},     //         QUOTATION MARK
-	{runeRange{0x0023, 0x0023}, propertyGeneralCategory{lbprAL, gcPo}},     //         NUMBER SIGN
-	{runeRange{0x0024, 0x0024}, propertyGeneralCategory{lbprPR, gcSc}},     //         DOLLAR SIGN
-	{runeRange{0x0025, 0x0025}, propertyGeneralCategory{lbprPO, gcPo}},     //         PERCENT SIGN
-	{runeRange{0x0026, 0x0026}, propertyGeneralCategory{lbprAL, gcPo}},     //         AMPERSAND
-	{runeRange{0x0027, 0x0027}, propertyGeneralCategory{lbprQU, gcPo}},     //         APOSTROPHE
-	{runeRange{0x0028, 0x0028}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT PARENTHESIS
-	{runeRange{0x0029, 0x0029}, propertyGeneralCategory{lbprCP, gcPe}},     //         RIGHT PARENTHESIS
-	{runeRange{0x002A, 0x002A}, propertyGeneralCategory{lbprAL, gcPo}},     //         ASTERISK
-	{runeRange{0x002B, 0x002B}, propertyGeneralCategory{lbprPR, gcSm}},     //         PLUS SIGN
-	{runeRange{0x002C, 0x002C}, propertyGeneralCategory{lbprIS, gcPo}},     //         COMMA
-	{runeRange{0x002D, 0x002D}, propertyGeneralCategory{lbprHY, gcPd}},     //         HYPHEN-MINUS
-	{runeRange{0x002E, 0x002E}, propertyGeneralCategory{lbprIS, gcPo}},     //         FULL STOP
-	{runeRange{0x002F, 0x002F}, propertyGeneralCategory{lbprSY, gcPo}},     //         SOLIDUS
-	{runeRange{0x0030, 0x0039}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] DIGIT ZERO..DIGIT NINE
-	{runeRange{0x003A, 0x003B}, propertyGeneralCategory{lbprIS, gcPo}},     //     [2] COLON..SEMICOLON
-	{runeRange{0x003C, 0x003E}, propertyGeneralCategory{lbprAL, gcSm}},     //     [3] LESS-THAN SIGN..GREATER-THAN SIGN
-	{runeRange{0x003F, 0x003F}, propertyGeneralCategory{lbprEX, gcPo}},     //         QUESTION MARK
-	{runeRange{0x0040, 0x0040}, propertyGeneralCategory{lbprAL, gcPo}},     //         COMMERCIAL AT
-	{runeRange{0x0041, 0x005A}, propertyGeneralCategory{lbprAL, gcLu}},     //    [26] LATIN CAPITAL LETTER A..LATIN CAPITAL LETTER Z
-	{runeRange{0x005B, 0x005B}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT SQUARE BRACKET
-	{runeRange{0x005C, 0x005C}, propertyGeneralCategory{lbprPR, gcPo}},     //         REVERSE SOLIDUS
-	{runeRange{0x005D, 0x005D}, propertyGeneralCategory{lbprCP, gcPe}},     //         RIGHT SQUARE BRACKET
-	{runeRange{0x005E, 0x005E}, propertyGeneralCategory{lbprAL, gcSk}},     //         CIRCUMFLEX ACCENT
-	{runeRange{0x005F, 0x005F}, propertyGeneralCategory{lbprAL, gcPc}},     //         LOW LINE
-	{runeRange{0x0060, 0x0060}, propertyGeneralCategory{lbprAL, gcSk}},     //         GRAVE ACCENT
-	{runeRange{0x0061, 0x007A}, propertyGeneralCategory{lbprAL, gcLl}},     //    [26] LATIN SMALL LETTER A..LATIN SMALL LETTER Z
-	{runeRange{0x007B, 0x007B}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT CURLY BRACKET
-	{runeRange{0x007C, 0x007C}, propertyGeneralCategory{lbprBA, gcSm}},     //         VERTICAL LINE
-	{runeRange{0x007D, 0x007D}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT CURLY BRACKET
-	{runeRange{0x007E, 0x007E}, propertyGeneralCategory{lbprAL, gcSm}},     //         TILDE
-	{runeRange{0x007F, 0x007F}, propertyGeneralCategory{lbprCM, gcCc}},     //         <control-007F>
-	{runeRange{0x0080, 0x0084}, propertyGeneralCategory{lbprCM, gcCc}},     //     [5] <control-0080>..<control-0084>
-	{runeRange{0x0085, 0x0085}, propertyGeneralCategory{lbprNL, gcCc}},     //         <control-0085>
-	{runeRange{0x0086, 0x009F}, propertyGeneralCategory{lbprCM, gcCc}},     //    [26] <control-0086>..<control-009F>
-	{runeRange{0x00A0, 0x00A0}, propertyGeneralCategory{lbprGL, gcZs}},     //         NO-BREAK SPACE
-	{runeRange{0x00A1, 0x00A1}, propertyGeneralCategory{lbprOP, gcPo}},     //         INVERTED EXCLAMATION MARK
-	{runeRange{0x00A2, 0x00A2}, propertyGeneralCategory{lbprPO, gcSc}},     //         CENT SIGN
-	{runeRange{0x00A3, 0x00A5}, propertyGeneralCategory{lbprPR, gcSc}},     //     [3] POUND SIGN..YEN SIGN
-	{runeRange{0x00A6, 0x00A6}, propertyGeneralCategory{lbprAL, gcSo}},     //         BROKEN BAR
-	{runeRange{0x00A7, 0x00A7}, propertyGeneralCategory{lbprAI, gcPo}},     //         SECTION SIGN
-	{runeRange{0x00A8, 0x00A8}, propertyGeneralCategory{lbprAI, gcSk}},     //         DIAERESIS
-	{runeRange{0x00A9, 0x00A9}, propertyGeneralCategory{lbprAL, gcSo}},     //         COPYRIGHT SIGN
-	{runeRange{0x00AA, 0x00AA}, propertyGeneralCategory{lbprAI, gcLo}},     //         FEMININE ORDINAL INDICATOR
-	{runeRange{0x00AB, 0x00AB}, propertyGeneralCategory{lbprQU, gcPi}},     //         LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
-	{runeRange{0x00AC, 0x00AC}, propertyGeneralCategory{lbprAL, gcSm}},     //         NOT SIGN
-	{runeRange{0x00AD, 0x00AD}, propertyGeneralCategory{lbprBA, gcCf}},     //         SOFT HYPHEN
-	{runeRange{0x00AE, 0x00AE}, propertyGeneralCategory{lbprAL, gcSo}},     //         REGISTERED SIGN
-	{runeRange{0x00AF, 0x00AF}, propertyGeneralCategory{lbprAL, gcSk}},     //         MACRON
-	{runeRange{0x00B0, 0x00B0}, propertyGeneralCategory{lbprPO, gcSo}},     //         DEGREE SIGN
-	{runeRange{0x00B1, 0x00B1}, propertyGeneralCategory{lbprPR, gcSm}},     //         PLUS-MINUS SIGN
-	{runeRange{0x00B2, 0x00B3}, propertyGeneralCategory{lbprAI, gcNo}},     //     [2] SUPERSCRIPT TWO..SUPERSCRIPT THREE
-	{runeRange{0x00B4, 0x00B4}, propertyGeneralCategory{lbprBB, gcSk}},     //         ACUTE ACCENT
-	{runeRange{0x00B5, 0x00B5}, propertyGeneralCategory{lbprAL, gcLl}},     //         MICRO SIGN
-	{runeRange{0x00B6, 0x00B7}, propertyGeneralCategory{lbprAI, gcPo}},     //     [2] PILCROW SIGN..MIDDLE DOT
-	{runeRange{0x00B8, 0x00B8}, propertyGeneralCategory{lbprAI, gcSk}},     //         CEDILLA
-	{runeRange{0x00B9, 0x00B9}, propertyGeneralCategory{lbprAI, gcNo}},     //         SUPERSCRIPT ONE
-	{runeRange{0x00BA, 0x00BA}, propertyGeneralCategory{lbprAI, gcLo}},     //         MASCULINE ORDINAL INDICATOR
-	{runeRange{0x00BB, 0x00BB}, propertyGeneralCategory{lbprQU, gcPf}},     //         RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
-	{runeRange{0x00BC, 0x00BE}, propertyGeneralCategory{lbprAI, gcNo}},     //     [3] VULGAR FRACTION ONE QUARTER..VULGAR FRACTION THREE QUARTERS
-	{runeRange{0x00BF, 0x00BF}, propertyGeneralCategory{lbprOP, gcPo}},     //         INVERTED QUESTION MARK
-	{runeRange{0x00C0, 0x00D6}, propertyGeneralCategory{lbprAL, gcLu}},     //    [23] LATIN CAPITAL LETTER A WITH GRAVE..LATIN CAPITAL LETTER O WITH DIAERESIS
-	{runeRange{0x00D7, 0x00D7}, propertyGeneralCategory{lbprAI, gcSm}},     //         MULTIPLICATION SIGN
-	{runeRange{0x00D8, 0x00F6}, propertyGeneralCategory{lbprAL, gcLC}},     //    [31] LATIN CAPITAL LETTER O WITH STROKE..LATIN SMALL LETTER O WITH DIAERESIS
-	{runeRange{0x00F7, 0x00F7}, propertyGeneralCategory{lbprAI, gcSm}},     //         DIVISION SIGN
-	{runeRange{0x00F8, 0x00FF}, propertyGeneralCategory{lbprAL, gcLl}},     //     [8] LATIN SMALL LETTER O WITH STROKE..LATIN SMALL LETTER Y WITH DIAERESIS
-	{runeRange{0x0100, 0x017F}, propertyGeneralCategory{lbprAL, gcLC}},     //   [128] LATIN CAPITAL LETTER A WITH MACRON..LATIN SMALL LETTER LONG S
-	{runeRange{0x0180, 0x01BA}, propertyGeneralCategory{lbprAL, gcLC}},     //    [59] LATIN SMALL LETTER B WITH STROKE..LATIN SMALL LETTER EZH WITH TAIL
-	{runeRange{0x01BB, 0x01BB}, propertyGeneralCategory{lbprAL, gcLo}},     //         LATIN LETTER TWO WITH STROKE
-	{runeRange{0x01BC, 0x01BF}, propertyGeneralCategory{lbprAL, gcLC}},     //     [4] LATIN CAPITAL LETTER TONE FIVE..LATIN LETTER WYNN
-	{runeRange{0x01C0, 0x01C3}, propertyGeneralCategory{lbprAL, gcLo}},     //     [4] LATIN LETTER DENTAL CLICK..LATIN LETTER RETROFLEX CLICK
-	{runeRange{0x01C4, 0x024F}, propertyGeneralCategory{lbprAL, gcLC}},     //   [140] LATIN CAPITAL LETTER DZ WITH CARON..LATIN SMALL LETTER Y WITH STROKE
-	{runeRange{0x0250, 0x0293}, propertyGeneralCategory{lbprAL, gcLl}},     //    [68] LATIN SMALL LETTER TURNED A..LATIN SMALL LETTER EZH WITH CURL
-	{runeRange{0x0294, 0x0294}, propertyGeneralCategory{lbprAL, gcLo}},     //         LATIN LETTER GLOTTAL STOP
-	{runeRange{0x0295, 0x02AF}, propertyGeneralCategory{lbprAL, gcLl}},     //    [27] LATIN LETTER PHARYNGEAL VOICED FRICATIVE..LATIN SMALL LETTER TURNED H WITH FISHHOOK AND TAIL
-	{runeRange{0x02B0, 0x02C1}, propertyGeneralCategory{lbprAL, gcLm}},     //    [18] MODIFIER LETTER SMALL H..MODIFIER LETTER REVERSED GLOTTAL STOP
-	{runeRange{0x02C2, 0x02C5}, propertyGeneralCategory{lbprAL, gcSk}},     //     [4] MODIFIER LETTER LEFT ARROWHEAD..MODIFIER LETTER DOWN ARROWHEAD
-	{runeRange{0x02C6, 0x02C6}, propertyGeneralCategory{lbprAL, gcLm}},     //         MODIFIER LETTER CIRCUMFLEX ACCENT
-	{runeRange{0x02C7, 0x02C7}, propertyGeneralCategory{lbprAI, gcLm}},     //         CARON
-	{runeRange{0x02C8, 0x02C8}, propertyGeneralCategory{lbprBB, gcLm}},     //         MODIFIER LETTER VERTICAL LINE
-	{runeRange{0x02C9, 0x02CB}, propertyGeneralCategory{lbprAI, gcLm}},     //     [3] MODIFIER LETTER MACRON..MODIFIER LETTER GRAVE ACCENT
-	{runeRange{0x02CC, 0x02CC}, propertyGeneralCategory{lbprBB, gcLm}},     //         MODIFIER LETTER LOW VERTICAL LINE
-	{runeRange{0x02CD, 0x02CD}, propertyGeneralCategory{lbprAI, gcLm}},     //         MODIFIER LETTER LOW MACRON
-	{runeRange{0x02CE, 0x02CF}, propertyGeneralCategory{lbprAL, gcLm}},     //     [2] MODIFIER LETTER LOW GRAVE ACCENT..MODIFIER LETTER LOW ACUTE ACCENT
-	{runeRange{0x02D0, 0x02D0}, propertyGeneralCategory{lbprAI, gcLm}},     //         MODIFIER LETTER TRIANGULAR COLON
-	{runeRange{0x02D1, 0x02D1}, propertyGeneralCategory{lbprAL, gcLm}},     //         MODIFIER LETTER HALF TRIANGULAR COLON
-	{runeRange{0x02D2, 0x02D7}, propertyGeneralCategory{lbprAL, gcSk}},     //     [6] MODIFIER LETTER CENTRED RIGHT HALF RING..MODIFIER LETTER MINUS SIGN
-	{runeRange{0x02D8, 0x02DB}, propertyGeneralCategory{lbprAI, gcSk}},     //     [4] BREVE..OGONEK
-	{runeRange{0x02DC, 0x02DC}, propertyGeneralCategory{lbprAL, gcSk}},     //         SMALL TILDE
-	{runeRange{0x02DD, 0x02DD}, propertyGeneralCategory{lbprAI, gcSk}},     //         DOUBLE ACUTE ACCENT
-	{runeRange{0x02DE, 0x02DE}, propertyGeneralCategory{lbprAL, gcSk}},     //         MODIFIER LETTER RHOTIC HOOK
-	{runeRange{0x02DF, 0x02DF}, propertyGeneralCategory{lbprBB, gcSk}},     //         MODIFIER LETTER CROSS ACCENT
-	{runeRange{0x02E0, 0x02E4}, propertyGeneralCategory{lbprAL, gcLm}},     //     [5] MODIFIER LETTER SMALL GAMMA..MODIFIER LETTER SMALL REVERSED GLOTTAL STOP
-	{runeRange{0x02E5, 0x02EB}, propertyGeneralCategory{lbprAL, gcSk}},     //     [7] MODIFIER LETTER EXTRA-HIGH TONE BAR..MODIFIER LETTER YANG DEPARTING TONE MARK
-	{runeRange{0x02EC, 0x02EC}, propertyGeneralCategory{lbprAL, gcLm}},     //         MODIFIER LETTER VOICING
-	{runeRange{0x02ED, 0x02ED}, propertyGeneralCategory{lbprAL, gcSk}},     //         MODIFIER LETTER UNASPIRATED
-	{runeRange{0x02EE, 0x02EE}, propertyGeneralCategory{lbprAL, gcLm}},     //         MODIFIER LETTER DOUBLE APOSTROPHE
-	{runeRange{0x02EF, 0x02FF}, propertyGeneralCategory{lbprAL, gcSk}},     //    [17] MODIFIER LETTER LOW DOWN ARROWHEAD..MODIFIER LETTER LOW LEFT ARROW
-	{runeRange{0x0300, 0x034E}, propertyGeneralCategory{lbprCM, gcMn}},     //    [79] COMBINING GRAVE ACCENT..COMBINING UPWARDS ARROW BELOW
-	{runeRange{0x034F, 0x034F}, propertyGeneralCategory{lbprGL, gcMn}},     //         COMBINING GRAPHEME JOINER
-	{runeRange{0x0350, 0x035B}, propertyGeneralCategory{lbprCM, gcMn}},     //    [12] COMBINING RIGHT ARROWHEAD ABOVE..COMBINING ZIGZAG ABOVE
-	{runeRange{0x035C, 0x0362}, propertyGeneralCategory{lbprGL, gcMn}},     //     [7] COMBINING DOUBLE BREVE BELOW..COMBINING DOUBLE RIGHTWARDS ARROW BELOW
-	{runeRange{0x0363, 0x036F}, propertyGeneralCategory{lbprCM, gcMn}},     //    [13] COMBINING LATIN SMALL LETTER A..COMBINING LATIN SMALL LETTER X
-	{runeRange{0x0370, 0x0373}, propertyGeneralCategory{lbprAL, gcLC}},     //     [4] GREEK CAPITAL LETTER HETA..GREEK SMALL LETTER ARCHAIC SAMPI
-	{runeRange{0x0374, 0x0374}, propertyGeneralCategory{lbprAL, gcLm}},     //         GREEK NUMERAL SIGN
-	{runeRange{0x0375, 0x0375}, propertyGeneralCategory{lbprAL, gcSk}},     //         GREEK LOWER NUMERAL SIGN
-	{runeRange{0x0376, 0x0377}, propertyGeneralCategory{lbprAL, gcLC}},     //     [2] GREEK CAPITAL LETTER PAMPHYLIAN DIGAMMA..GREEK SMALL LETTER PAMPHYLIAN DIGAMMA
-	{runeRange{0x037A, 0x037A}, propertyGeneralCategory{lbprAL, gcLm}},     //         GREEK YPOGEGRAMMENI
-	{runeRange{0x037B, 0x037D}, propertyGeneralCategory{lbprAL, gcLl}},     //     [3] GREEK SMALL REVERSED LUNATE SIGMA SYMBOL..GREEK SMALL REVERSED DOTTED LUNATE SIGMA SYMBOL
-	{runeRange{0x037E, 0x037E}, propertyGeneralCategory{lbprIS, gcPo}},     //         GREEK QUESTION MARK
-	{runeRange{0x037F, 0x037F}, propertyGeneralCategory{lbprAL, gcLu}},     //         GREEK CAPITAL LETTER YOT
-	{runeRange{0x0384, 0x0385}, propertyGeneralCategory{lbprAL, gcSk}},     //     [2] GREEK TONOS..GREEK DIALYTIKA TONOS
-	{runeRange{0x0386, 0x0386}, propertyGeneralCategory{lbprAL, gcLu}},     //         GREEK CAPITAL LETTER ALPHA WITH TONOS
-	{runeRange{0x0387, 0x0387}, propertyGeneralCategory{lbprAL, gcPo}},     //         GREEK ANO TELEIA
-	{runeRange{0x0388, 0x038A}, propertyGeneralCategory{lbprAL, gcLu}},     //     [3] GREEK CAPITAL LETTER EPSILON WITH TONOS..GREEK CAPITAL LETTER IOTA WITH TONOS
-	{runeRange{0x038C, 0x038C}, propertyGeneralCategory{lbprAL, gcLu}},     //         GREEK CAPITAL LETTER OMICRON WITH TONOS
-	{runeRange{0x038E, 0x03A1}, propertyGeneralCategory{lbprAL, gcLC}},     //    [20] GREEK CAPITAL LETTER UPSILON WITH TONOS..GREEK CAPITAL LETTER RHO
-	{runeRange{0x03A3, 0x03F5}, propertyGeneralCategory{lbprAL, gcLC}},     //    [83] GREEK CAPITAL LETTER SIGMA..GREEK LUNATE EPSILON SYMBOL
-	{runeRange{0x03F6, 0x03F6}, propertyGeneralCategory{lbprAL, gcSm}},     //         GREEK REVERSED LUNATE EPSILON SYMBOL
-	{runeRange{0x03F7, 0x03FF}, propertyGeneralCategory{lbprAL, gcLC}},     //     [9] GREEK CAPITAL LETTER SHO..GREEK CAPITAL REVERSED DOTTED LUNATE SIGMA SYMBOL
-	{runeRange{0x0400, 0x0481}, propertyGeneralCategory{lbprAL, gcLC}},     //   [130] CYRILLIC CAPITAL LETTER IE WITH GRAVE..CYRILLIC SMALL LETTER KOPPA
-	{runeRange{0x0482, 0x0482}, propertyGeneralCategory{lbprAL, gcSo}},     //         CYRILLIC THOUSANDS SIGN
-	{runeRange{0x0483, 0x0487}, propertyGeneralCategory{lbprCM, gcMn}},     //     [5] COMBINING CYRILLIC TITLO..COMBINING CYRILLIC POKRYTIE
-	{runeRange{0x0488, 0x0489}, propertyGeneralCategory{lbprCM, gcMe}},     //     [2] COMBINING CYRILLIC HUNDRED THOUSANDS SIGN..COMBINING CYRILLIC MILLIONS SIGN
-	{runeRange{0x048A, 0x04FF}, propertyGeneralCategory{lbprAL, gcLC}},     //   [118] CYRILLIC CAPITAL LETTER SHORT I WITH TAIL..CYRILLIC SMALL LETTER HA WITH STROKE
-	{runeRange{0x0500, 0x052F}, propertyGeneralCategory{lbprAL, gcLC}},     //    [48] CYRILLIC CAPITAL LETTER KOMI DE..CYRILLIC SMALL LETTER EL WITH DESCENDER
-	{runeRange{0x0531, 0x0556}, propertyGeneralCategory{lbprAL, gcLu}},     //    [38] ARMENIAN CAPITAL LETTER AYB..ARMENIAN CAPITAL LETTER FEH
-	{runeRange{0x0559, 0x0559}, propertyGeneralCategory{lbprAL, gcLm}},     //         ARMENIAN MODIFIER LETTER LEFT HALF RING
-	{runeRange{0x055A, 0x055F}, propertyGeneralCategory{lbprAL, gcPo}},     //     [6] ARMENIAN APOSTROPHE..ARMENIAN ABBREVIATION MARK
-	{runeRange{0x0560, 0x0588}, propertyGeneralCategory{lbprAL, gcLl}},     //    [41] ARMENIAN SMALL LETTER TURNED AYB..ARMENIAN SMALL LETTER YI WITH STROKE
-	{runeRange{0x0589, 0x0589}, propertyGeneralCategory{lbprIS, gcPo}},     //         ARMENIAN FULL STOP
-	{runeRange{0x058A, 0x058A}, propertyGeneralCategory{lbprBA, gcPd}},     //         ARMENIAN HYPHEN
-	{runeRange{0x058D, 0x058E}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] RIGHT-FACING ARMENIAN ETERNITY SIGN..LEFT-FACING ARMENIAN ETERNITY SIGN
-	{runeRange{0x058F, 0x058F}, propertyGeneralCategory{lbprPR, gcSc}},     //         ARMENIAN DRAM SIGN
-	{runeRange{0x0591, 0x05BD}, propertyGeneralCategory{lbprCM, gcMn}},     //    [45] HEBREW ACCENT ETNAHTA..HEBREW POINT METEG
-	{runeRange{0x05BE, 0x05BE}, propertyGeneralCategory{lbprBA, gcPd}},     //         HEBREW PUNCTUATION MAQAF
-	{runeRange{0x05BF, 0x05BF}, propertyGeneralCategory{lbprCM, gcMn}},     //         HEBREW POINT RAFE
-	{runeRange{0x05C0, 0x05C0}, propertyGeneralCategory{lbprAL, gcPo}},     //         HEBREW PUNCTUATION PASEQ
-	{runeRange{0x05C1, 0x05C2}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] HEBREW POINT SHIN DOT..HEBREW POINT SIN DOT
-	{runeRange{0x05C3, 0x05C3}, propertyGeneralCategory{lbprAL, gcPo}},     //         HEBREW PUNCTUATION SOF PASUQ
-	{runeRange{0x05C4, 0x05C5}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] HEBREW MARK UPPER DOT..HEBREW MARK LOWER DOT
-	{runeRange{0x05C6, 0x05C6}, propertyGeneralCategory{lbprEX, gcPo}},     //         HEBREW PUNCTUATION NUN HAFUKHA
-	{runeRange{0x05C7, 0x05C7}, propertyGeneralCategory{lbprCM, gcMn}},     //         HEBREW POINT QAMATS QATAN
-	{runeRange{0x05D0, 0x05EA}, propertyGeneralCategory{lbprHL, gcLo}},     //    [27] HEBREW LETTER ALEF..HEBREW LETTER TAV
-	{runeRange{0x05EF, 0x05F2}, propertyGeneralCategory{lbprHL, gcLo}},     //     [4] HEBREW YOD TRIANGLE..HEBREW LIGATURE YIDDISH DOUBLE YOD
-	{runeRange{0x05F3, 0x05F4}, propertyGeneralCategory{lbprAL, gcPo}},     //     [2] HEBREW PUNCTUATION GERESH..HEBREW PUNCTUATION GERSHAYIM
-	{runeRange{0x0600, 0x0605}, propertyGeneralCategory{lbprAL, gcCf}},     //     [6] ARABIC NUMBER SIGN..ARABIC NUMBER MARK ABOVE
-	{runeRange{0x0606, 0x0608}, propertyGeneralCategory{lbprAL, gcSm}},     //     [3] ARABIC-INDIC CUBE ROOT..ARABIC RAY
-	{runeRange{0x0609, 0x060A}, propertyGeneralCategory{lbprPO, gcPo}},     //     [2] ARABIC-INDIC PER MILLE SIGN..ARABIC-INDIC PER TEN THOUSAND SIGN
-	{runeRange{0x060B, 0x060B}, propertyGeneralCategory{lbprPO, gcSc}},     //         AFGHANI SIGN
-	{runeRange{0x060C, 0x060D}, propertyGeneralCategory{lbprIS, gcPo}},     //     [2] ARABIC COMMA..ARABIC DATE SEPARATOR
-	{runeRange{0x060E, 0x060F}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] ARABIC POETIC VERSE SIGN..ARABIC SIGN MISRA
-	{runeRange{0x0610, 0x061A}, propertyGeneralCategory{lbprCM, gcMn}},     //    [11] ARABIC SIGN SALLALLAHOU ALAYHE WASSALLAM..ARABIC SMALL KASRA
-	{runeRange{0x061B, 0x061B}, propertyGeneralCategory{lbprEX, gcPo}},     //         ARABIC SEMICOLON
-	{runeRange{0x061C, 0x061C}, propertyGeneralCategory{lbprCM, gcCf}},     //         ARABIC LETTER MARK
-	{runeRange{0x061D, 0x061F}, propertyGeneralCategory{lbprEX, gcPo}},     //     [3] ARABIC END OF TEXT MARK..ARABIC QUESTION MARK
-	{runeRange{0x0620, 0x063F}, propertyGeneralCategory{lbprAL, gcLo}},     //    [32] ARABIC LETTER KASHMIRI YEH..ARABIC LETTER FARSI YEH WITH THREE DOTS ABOVE
-	{runeRange{0x0640, 0x0640}, propertyGeneralCategory{lbprAL, gcLm}},     //         ARABIC TATWEEL
-	{runeRange{0x0641, 0x064A}, propertyGeneralCategory{lbprAL, gcLo}},     //    [10] ARABIC LETTER FEH..ARABIC LETTER YEH
-	{runeRange{0x064B, 0x065F}, propertyGeneralCategory{lbprCM, gcMn}},     //    [21] ARABIC FATHATAN..ARABIC WAVY HAMZA BELOW
-	{runeRange{0x0660, 0x0669}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] ARABIC-INDIC DIGIT ZERO..ARABIC-INDIC DIGIT NINE
-	{runeRange{0x066A, 0x066A}, propertyGeneralCategory{lbprPO, gcPo}},     //         ARABIC PERCENT SIGN
-	{runeRange{0x066B, 0x066C}, propertyGeneralCategory{lbprNU, gcPo}},     //     [2] ARABIC DECIMAL SEPARATOR..ARABIC THOUSANDS SEPARATOR
-	{runeRange{0x066D, 0x066D}, propertyGeneralCategory{lbprAL, gcPo}},     //         ARABIC FIVE POINTED STAR
-	{runeRange{0x066E, 0x066F}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] ARABIC LETTER DOTLESS BEH..ARABIC LETTER DOTLESS QAF
-	{runeRange{0x0670, 0x0670}, propertyGeneralCategory{lbprCM, gcMn}},     //         ARABIC LETTER SUPERSCRIPT ALEF
-	{runeRange{0x0671, 0x06D3}, propertyGeneralCategory{lbprAL, gcLo}},     //    [99] ARABIC LETTER ALEF WASLA..ARABIC LETTER YEH BARREE WITH HAMZA ABOVE
-	{runeRange{0x06D4, 0x06D4}, propertyGeneralCategory{lbprEX, gcPo}},     //         ARABIC FULL STOP
-	{runeRange{0x06D5, 0x06D5}, propertyGeneralCategory{lbprAL, gcLo}},     //         ARABIC LETTER AE
-	{runeRange{0x06D6, 0x06DC}, propertyGeneralCategory{lbprCM, gcMn}},     //     [7] ARABIC SMALL HIGH LIGATURE SAD WITH LAM WITH ALEF MAKSURA..ARABIC SMALL HIGH SEEN
-	{runeRange{0x06DD, 0x06DD}, propertyGeneralCategory{lbprAL, gcCf}},     //         ARABIC END OF AYAH
-	{runeRange{0x06DE, 0x06DE}, propertyGeneralCategory{lbprAL, gcSo}},     //         ARABIC START OF RUB EL HIZB
-	{runeRange{0x06DF, 0x06E4}, propertyGeneralCategory{lbprCM, gcMn}},     //     [6] ARABIC SMALL HIGH ROUNDED ZERO..ARABIC SMALL HIGH MADDA
-	{runeRange{0x06E5, 0x06E6}, propertyGeneralCategory{lbprAL, gcLm}},     //     [2] ARABIC SMALL WAW..ARABIC SMALL YEH
-	{runeRange{0x06E7, 0x06E8}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] ARABIC SMALL HIGH YEH..ARABIC SMALL HIGH NOON
-	{runeRange{0x06E9, 0x06E9}, propertyGeneralCategory{lbprAL, gcSo}},     //         ARABIC PLACE OF SAJDAH
-	{runeRange{0x06EA, 0x06ED}, propertyGeneralCategory{lbprCM, gcMn}},     //     [4] ARABIC EMPTY CENTRE LOW STOP..ARABIC SMALL LOW MEEM
-	{runeRange{0x06EE, 0x06EF}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] ARABIC LETTER DAL WITH INVERTED V..ARABIC LETTER REH WITH INVERTED V
-	{runeRange{0x06F0, 0x06F9}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] EXTENDED ARABIC-INDIC DIGIT ZERO..EXTENDED ARABIC-INDIC DIGIT NINE
-	{runeRange{0x06FA, 0x06FC}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] ARABIC LETTER SHEEN WITH DOT BELOW..ARABIC LETTER GHAIN WITH DOT BELOW
-	{runeRange{0x06FD, 0x06FE}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] ARABIC SIGN SINDHI AMPERSAND..ARABIC SIGN SINDHI POSTPOSITION MEN
-	{runeRange{0x06FF, 0x06FF}, propertyGeneralCategory{lbprAL, gcLo}},     //         ARABIC LETTER HEH WITH INVERTED V
-	{runeRange{0x0700, 0x070D}, propertyGeneralCategory{lbprAL, gcPo}},     //    [14] SYRIAC END OF PARAGRAPH..SYRIAC HARKLEAN ASTERISCUS
-	{runeRange{0x070F, 0x070F}, propertyGeneralCategory{lbprAL, gcCf}},     //         SYRIAC ABBREVIATION MARK
-	{runeRange{0x0710, 0x0710}, propertyGeneralCategory{lbprAL, gcLo}},     //         SYRIAC LETTER ALAPH
-	{runeRange{0x0711, 0x0711}, propertyGeneralCategory{lbprCM, gcMn}},     //         SYRIAC LETTER SUPERSCRIPT ALAPH
-	{runeRange{0x0712, 0x072F}, propertyGeneralCategory{lbprAL, gcLo}},     //    [30] SYRIAC LETTER BETH..SYRIAC LETTER PERSIAN DHALATH
-	{runeRange{0x0730, 0x074A}, propertyGeneralCategory{lbprCM, gcMn}},     //    [27] SYRIAC PTHAHA ABOVE..SYRIAC BARREKH
-	{runeRange{0x074D, 0x074F}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] SYRIAC LETTER SOGDIAN ZHAIN..SYRIAC LETTER SOGDIAN FE
-	{runeRange{0x0750, 0x077F}, propertyGeneralCategory{lbprAL, gcLo}},     //    [48] ARABIC LETTER BEH WITH THREE DOTS HORIZONTALLY BELOW..ARABIC LETTER KAF WITH TWO DOTS ABOVE
-	{runeRange{0x0780, 0x07A5}, propertyGeneralCategory{lbprAL, gcLo}},     //    [38] THAANA LETTER HAA..THAANA LETTER WAAVU
-	{runeRange{0x07A6, 0x07B0}, propertyGeneralCategory{lbprCM, gcMn}},     //    [11] THAANA ABAFILI..THAANA SUKUN
-	{runeRange{0x07B1, 0x07B1}, propertyGeneralCategory{lbprAL, gcLo}},     //         THAANA LETTER NAA
-	{runeRange{0x07C0, 0x07C9}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] NKO DIGIT ZERO..NKO DIGIT NINE
-	{runeRange{0x07CA, 0x07EA}, propertyGeneralCategory{lbprAL, gcLo}},     //    [33] NKO LETTER A..NKO LETTER JONA RA
-	{runeRange{0x07EB, 0x07F3}, propertyGeneralCategory{lbprCM, gcMn}},     //     [9] NKO COMBINING SHORT HIGH TONE..NKO COMBINING DOUBLE DOT ABOVE
-	{runeRange{0x07F4, 0x07F5}, propertyGeneralCategory{lbprAL, gcLm}},     //     [2] NKO HIGH TONE APOSTROPHE..NKO LOW TONE APOSTROPHE
-	{runeRange{0x07F6, 0x07F6}, propertyGeneralCategory{lbprAL, gcSo}},     //         NKO SYMBOL OO DENNEN
-	{runeRange{0x07F7, 0x07F7}, propertyGeneralCategory{lbprAL, gcPo}},     //         NKO SYMBOL GBAKURUNEN
-	{runeRange{0x07F8, 0x07F8}, propertyGeneralCategory{lbprIS, gcPo}},     //         NKO COMMA
-	{runeRange{0x07F9, 0x07F9}, propertyGeneralCategory{lbprEX, gcPo}},     //         NKO EXCLAMATION MARK
-	{runeRange{0x07FA, 0x07FA}, propertyGeneralCategory{lbprAL, gcLm}},     //         NKO LAJANYALAN
-	{runeRange{0x07FD, 0x07FD}, propertyGeneralCategory{lbprCM, gcMn}},     //         NKO DANTAYALAN
-	{runeRange{0x07FE, 0x07FF}, propertyGeneralCategory{lbprPR, gcSc}},     //     [2] NKO DOROME SIGN..NKO TAMAN SIGN
-	{runeRange{0x0800, 0x0815}, propertyGeneralCategory{lbprAL, gcLo}},     //    [22] SAMARITAN LETTER ALAF..SAMARITAN LETTER TAAF
-	{runeRange{0x0816, 0x0819}, propertyGeneralCategory{lbprCM, gcMn}},     //     [4] SAMARITAN MARK IN..SAMARITAN MARK DAGESH
-	{runeRange{0x081A, 0x081A}, propertyGeneralCategory{lbprAL, gcLm}},     //         SAMARITAN MODIFIER LETTER EPENTHETIC YUT
-	{runeRange{0x081B, 0x0823}, propertyGeneralCategory{lbprCM, gcMn}},     //     [9] SAMARITAN MARK EPENTHETIC YUT..SAMARITAN VOWEL SIGN A
-	{runeRange{0x0824, 0x0824}, propertyGeneralCategory{lbprAL, gcLm}},     //         SAMARITAN MODIFIER LETTER SHORT A
-	{runeRange{0x0825, 0x0827}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] SAMARITAN VOWEL SIGN SHORT A..SAMARITAN VOWEL SIGN U
-	{runeRange{0x0828, 0x0828}, propertyGeneralCategory{lbprAL, gcLm}},     //         SAMARITAN MODIFIER LETTER I
-	{runeRange{0x0829, 0x082D}, propertyGeneralCategory{lbprCM, gcMn}},     //     [5] SAMARITAN VOWEL SIGN LONG I..SAMARITAN MARK NEQUDAA
-	{runeRange{0x0830, 0x083E}, propertyGeneralCategory{lbprAL, gcPo}},     //    [15] SAMARITAN PUNCTUATION NEQUDAA..SAMARITAN PUNCTUATION ANNAAU
-	{runeRange{0x0840, 0x0858}, propertyGeneralCategory{lbprAL, gcLo}},     //    [25] MANDAIC LETTER HALQA..MANDAIC LETTER AIN
-	{runeRange{0x0859, 0x085B}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] MANDAIC AFFRICATION MARK..MANDAIC GEMINATION MARK
-	{runeRange{0x085E, 0x085E}, propertyGeneralCategory{lbprAL, gcPo}},     //         MANDAIC PUNCTUATION
-	{runeRange{0x0860, 0x086A}, propertyGeneralCategory{lbprAL, gcLo}},     //    [11] SYRIAC LETTER MALAYALAM NGA..SYRIAC LETTER MALAYALAM SSA
-	{runeRange{0x0870, 0x0887}, propertyGeneralCategory{lbprAL, gcLo}},     //    [24] ARABIC LETTER ALEF WITH ATTACHED FATHA..ARABIC BASELINE ROUND DOT
-	{runeRange{0x0888, 0x0888}, propertyGeneralCategory{lbprAL, gcSk}},     //         ARABIC RAISED ROUND DOT
-	{runeRange{0x0889, 0x088E}, propertyGeneralCategory{lbprAL, gcLo}},     //     [6] ARABIC LETTER NOON WITH INVERTED SMALL V..ARABIC VERTICAL TAIL
-	{runeRange{0x0890, 0x0891}, propertyGeneralCategory{lbprAL, gcCf}},     //     [2] ARABIC POUND MARK ABOVE..ARABIC PIASTRE MARK ABOVE
-	{runeRange{0x0898, 0x089F}, propertyGeneralCategory{lbprCM, gcMn}},     //     [8] ARABIC SMALL HIGH WORD AL-JUZ..ARABIC HALF MADDA OVER MADDA
-	{runeRange{0x08A0, 0x08C8}, propertyGeneralCategory{lbprAL, gcLo}},     //    [41] ARABIC LETTER BEH WITH SMALL V BELOW..ARABIC LETTER GRAF
-	{runeRange{0x08C9, 0x08C9}, propertyGeneralCategory{lbprAL, gcLm}},     //         ARABIC SMALL FARSI YEH
-	{runeRange{0x08CA, 0x08E1}, propertyGeneralCategory{lbprCM, gcMn}},     //    [24] ARABIC SMALL HIGH FARSI YEH..ARABIC SMALL HIGH SIGN SAFHA
-	{runeRange{0x08E2, 0x08E2}, propertyGeneralCategory{lbprAL, gcCf}},     //         ARABIC DISPUTED END OF AYAH
-	{runeRange{0x08E3, 0x08FF}, propertyGeneralCategory{lbprCM, gcMn}},     //    [29] ARABIC TURNED DAMMA BELOW..ARABIC MARK SIDEWAYS NOON GHUNNA
-	{runeRange{0x0900, 0x0902}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] DEVANAGARI SIGN INVERTED CANDRABINDU..DEVANAGARI SIGN ANUSVARA
-	{runeRange{0x0903, 0x0903}, propertyGeneralCategory{lbprCM, gcMc}},     //         DEVANAGARI SIGN VISARGA
-	{runeRange{0x0904, 0x0939}, propertyGeneralCategory{lbprAL, gcLo}},     //    [54] DEVANAGARI LETTER SHORT A..DEVANAGARI LETTER HA
-	{runeRange{0x093A, 0x093A}, propertyGeneralCategory{lbprCM, gcMn}},     //         DEVANAGARI VOWEL SIGN OE
-	{runeRange{0x093B, 0x093B}, propertyGeneralCategory{lbprCM, gcMc}},     //         DEVANAGARI VOWEL SIGN OOE
-	{runeRange{0x093C, 0x093C}, propertyGeneralCategory{lbprCM, gcMn}},     //         DEVANAGARI SIGN NUKTA
-	{runeRange{0x093D, 0x093D}, propertyGeneralCategory{lbprAL, gcLo}},     //         DEVANAGARI SIGN AVAGRAHA
-	{runeRange{0x093E, 0x0940}, propertyGeneralCategory{lbprCM, gcMc}},     //     [3] DEVANAGARI VOWEL SIGN AA..DEVANAGARI VOWEL SIGN II
-	{runeRange{0x0941, 0x0948}, propertyGeneralCategory{lbprCM, gcMn}},     //     [8] DEVANAGARI VOWEL SIGN U..DEVANAGARI VOWEL SIGN AI
-	{runeRange{0x0949, 0x094C}, propertyGeneralCategory{lbprCM, gcMc}},     //     [4] DEVANAGARI VOWEL SIGN CANDRA O..DEVANAGARI VOWEL SIGN AU
-	{runeRange{0x094D, 0x094D}, propertyGeneralCategory{lbprCM, gcMn}},     //         DEVANAGARI SIGN VIRAMA
-	{runeRange{0x094E, 0x094F}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] DEVANAGARI VOWEL SIGN PRISHTHAMATRA E..DEVANAGARI VOWEL SIGN AW
-	{runeRange{0x0950, 0x0950}, propertyGeneralCategory{lbprAL, gcLo}},     //         DEVANAGARI OM
-	{runeRange{0x0951, 0x0957}, propertyGeneralCategory{lbprCM, gcMn}},     //     [7] DEVANAGARI STRESS SIGN UDATTA..DEVANAGARI VOWEL SIGN UUE
-	{runeRange{0x0958, 0x0961}, propertyGeneralCategory{lbprAL, gcLo}},     //    [10] DEVANAGARI LETTER QA..DEVANAGARI LETTER VOCALIC LL
-	{runeRange{0x0962, 0x0963}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] DEVANAGARI VOWEL SIGN VOCALIC L..DEVANAGARI VOWEL SIGN VOCALIC LL
-	{runeRange{0x0964, 0x0965}, propertyGeneralCategory{lbprBA, gcPo}},     //     [2] DEVANAGARI DANDA..DEVANAGARI DOUBLE DANDA
-	{runeRange{0x0966, 0x096F}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] DEVANAGARI DIGIT ZERO..DEVANAGARI DIGIT NINE
-	{runeRange{0x0970, 0x0970}, propertyGeneralCategory{lbprAL, gcPo}},     //         DEVANAGARI ABBREVIATION SIGN
-	{runeRange{0x0971, 0x0971}, propertyGeneralCategory{lbprAL, gcLm}},     //         DEVANAGARI SIGN HIGH SPACING DOT
-	{runeRange{0x0972, 0x097F}, propertyGeneralCategory{lbprAL, gcLo}},     //    [14] DEVANAGARI LETTER CANDRA A..DEVANAGARI LETTER BBA
-	{runeRange{0x0980, 0x0980}, propertyGeneralCategory{lbprAL, gcLo}},     //         BENGALI ANJI
-	{runeRange{0x0981, 0x0981}, propertyGeneralCategory{lbprCM, gcMn}},     //         BENGALI SIGN CANDRABINDU
-	{runeRange{0x0982, 0x0983}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] BENGALI SIGN ANUSVARA..BENGALI SIGN VISARGA
-	{runeRange{0x0985, 0x098C}, propertyGeneralCategory{lbprAL, gcLo}},     //     [8] BENGALI LETTER A..BENGALI LETTER VOCALIC L
-	{runeRange{0x098F, 0x0990}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] BENGALI LETTER E..BENGALI LETTER AI
-	{runeRange{0x0993, 0x09A8}, propertyGeneralCategory{lbprAL, gcLo}},     //    [22] BENGALI LETTER O..BENGALI LETTER NA
-	{runeRange{0x09AA, 0x09B0}, propertyGeneralCategory{lbprAL, gcLo}},     //     [7] BENGALI LETTER PA..BENGALI LETTER RA
-	{runeRange{0x09B2, 0x09B2}, propertyGeneralCategory{lbprAL, gcLo}},     //         BENGALI LETTER LA
-	{runeRange{0x09B6, 0x09B9}, propertyGeneralCategory{lbprAL, gcLo}},     //     [4] BENGALI LETTER SHA..BENGALI LETTER HA
-	{runeRange{0x09BC, 0x09BC}, propertyGeneralCategory{lbprCM, gcMn}},     //         BENGALI SIGN NUKTA
-	{runeRange{0x09BD, 0x09BD}, propertyGeneralCategory{lbprAL, gcLo}},     //         BENGALI SIGN AVAGRAHA
-	{runeRange{0x09BE, 0x09C0}, propertyGeneralCategory{lbprCM, gcMc}},     //     [3] BENGALI VOWEL SIGN AA..BENGALI VOWEL SIGN II
-	{runeRange{0x09C1, 0x09C4}, propertyGeneralCategory{lbprCM, gcMn}},     //     [4] BENGALI VOWEL SIGN U..BENGALI VOWEL SIGN VOCALIC RR
-	{runeRange{0x09C7, 0x09C8}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] BENGALI VOWEL SIGN E..BENGALI VOWEL SIGN AI
-	{runeRange{0x09CB, 0x09CC}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] BENGALI VOWEL SIGN O..BENGALI VOWEL SIGN AU
-	{runeRange{0x09CD, 0x09CD}, propertyGeneralCategory{lbprCM, gcMn}},     //         BENGALI SIGN VIRAMA
-	{runeRange{0x09CE, 0x09CE}, propertyGeneralCategory{lbprAL, gcLo}},     //         BENGALI LETTER KHANDA TA
-	{runeRange{0x09D7, 0x09D7}, propertyGeneralCategory{lbprCM, gcMc}},     //         BENGALI AU LENGTH MARK
-	{runeRange{0x09DC, 0x09DD}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] BENGALI LETTER RRA..BENGALI LETTER RHA
-	{runeRange{0x09DF, 0x09E1}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] BENGALI LETTER YYA..BENGALI LETTER VOCALIC LL
-	{runeRange{0x09E2, 0x09E3}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] BENGALI VOWEL SIGN VOCALIC L..BENGALI VOWEL SIGN VOCALIC LL
-	{runeRange{0x09E6, 0x09EF}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] BENGALI DIGIT ZERO..BENGALI DIGIT NINE
-	{runeRange{0x09F0, 0x09F1}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] BENGALI LETTER RA WITH MIDDLE DIAGONAL..BENGALI LETTER RA WITH LOWER DIAGONAL
-	{runeRange{0x09F2, 0x09F3}, propertyGeneralCategory{lbprPO, gcSc}},     //     [2] BENGALI RUPEE MARK..BENGALI RUPEE SIGN
-	{runeRange{0x09F4, 0x09F8}, propertyGeneralCategory{lbprAL, gcNo}},     //     [5] BENGALI CURRENCY NUMERATOR ONE..BENGALI CURRENCY NUMERATOR ONE LESS THAN THE DENOMINATOR
-	{runeRange{0x09F9, 0x09F9}, propertyGeneralCategory{lbprPO, gcNo}},     //         BENGALI CURRENCY DENOMINATOR SIXTEEN
-	{runeRange{0x09FA, 0x09FA}, propertyGeneralCategory{lbprAL, gcSo}},     //         BENGALI ISSHAR
-	{runeRange{0x09FB, 0x09FB}, propertyGeneralCategory{lbprPR, gcSc}},     //         BENGALI GANDA MARK
-	{runeRange{0x09FC, 0x09FC}, propertyGeneralCategory{lbprAL, gcLo}},     //         BENGALI LETTER VEDIC ANUSVARA
-	{runeRange{0x09FD, 0x09FD}, propertyGeneralCategory{lbprAL, gcPo}},     //         BENGALI ABBREVIATION SIGN
-	{runeRange{0x09FE, 0x09FE}, propertyGeneralCategory{lbprCM, gcMn}},     //         BENGALI SANDHI MARK
-	{runeRange{0x0A01, 0x0A02}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] GURMUKHI SIGN ADAK BINDI..GURMUKHI SIGN BINDI
-	{runeRange{0x0A03, 0x0A03}, propertyGeneralCategory{lbprCM, gcMc}},     //         GURMUKHI SIGN VISARGA
-	{runeRange{0x0A05, 0x0A0A}, propertyGeneralCategory{lbprAL, gcLo}},     //     [6] GURMUKHI LETTER A..GURMUKHI LETTER UU
-	{runeRange{0x0A0F, 0x0A10}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] GURMUKHI LETTER EE..GURMUKHI LETTER AI
-	{runeRange{0x0A13, 0x0A28}, propertyGeneralCategory{lbprAL, gcLo}},     //    [22] GURMUKHI LETTER OO..GURMUKHI LETTER NA
-	{runeRange{0x0A2A, 0x0A30}, propertyGeneralCategory{lbprAL, gcLo}},     //     [7] GURMUKHI LETTER PA..GURMUKHI LETTER RA
-	{runeRange{0x0A32, 0x0A33}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] GURMUKHI LETTER LA..GURMUKHI LETTER LLA
-	{runeRange{0x0A35, 0x0A36}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] GURMUKHI LETTER VA..GURMUKHI LETTER SHA
-	{runeRange{0x0A38, 0x0A39}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] GURMUKHI LETTER SA..GURMUKHI LETTER HA
-	{runeRange{0x0A3C, 0x0A3C}, propertyGeneralCategory{lbprCM, gcMn}},     //         GURMUKHI SIGN NUKTA
-	{runeRange{0x0A3E, 0x0A40}, propertyGeneralCategory{lbprCM, gcMc}},     //     [3] GURMUKHI VOWEL SIGN AA..GURMUKHI VOWEL SIGN II
-	{runeRange{0x0A41, 0x0A42}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] GURMUKHI VOWEL SIGN U..GURMUKHI VOWEL SIGN UU
-	{runeRange{0x0A47, 0x0A48}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] GURMUKHI VOWEL SIGN EE..GURMUKHI VOWEL SIGN AI
-	{runeRange{0x0A4B, 0x0A4D}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] GURMUKHI VOWEL SIGN OO..GURMUKHI SIGN VIRAMA
-	{runeRange{0x0A51, 0x0A51}, propertyGeneralCategory{lbprCM, gcMn}},     //         GURMUKHI SIGN UDAAT
-	{runeRange{0x0A59, 0x0A5C}, propertyGeneralCategory{lbprAL, gcLo}},     //     [4] GURMUKHI LETTER KHHA..GURMUKHI LETTER RRA
-	{runeRange{0x0A5E, 0x0A5E}, propertyGeneralCategory{lbprAL, gcLo}},     //         GURMUKHI LETTER FA
-	{runeRange{0x0A66, 0x0A6F}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] GURMUKHI DIGIT ZERO..GURMUKHI DIGIT NINE
-	{runeRange{0x0A70, 0x0A71}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] GURMUKHI TIPPI..GURMUKHI ADDAK
-	{runeRange{0x0A72, 0x0A74}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] GURMUKHI IRI..GURMUKHI EK ONKAR
-	{runeRange{0x0A75, 0x0A75}, propertyGeneralCategory{lbprCM, gcMn}},     //         GURMUKHI SIGN YAKASH
-	{runeRange{0x0A76, 0x0A76}, propertyGeneralCategory{lbprAL, gcPo}},     //         GURMUKHI ABBREVIATION SIGN
-	{runeRange{0x0A81, 0x0A82}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] GUJARATI SIGN CANDRABINDU..GUJARATI SIGN ANUSVARA
-	{runeRange{0x0A83, 0x0A83}, propertyGeneralCategory{lbprCM, gcMc}},     //         GUJARATI SIGN VISARGA
-	{runeRange{0x0A85, 0x0A8D}, propertyGeneralCategory{lbprAL, gcLo}},     //     [9] GUJARATI LETTER A..GUJARATI VOWEL CANDRA E
-	{runeRange{0x0A8F, 0x0A91}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] GUJARATI LETTER E..GUJARATI VOWEL CANDRA O
-	{runeRange{0x0A93, 0x0AA8}, propertyGeneralCategory{lbprAL, gcLo}},     //    [22] GUJARATI LETTER O..GUJARATI LETTER NA
-	{runeRange{0x0AAA, 0x0AB0}, propertyGeneralCategory{lbprAL, gcLo}},     //     [7] GUJARATI LETTER PA..GUJARATI LETTER RA
-	{runeRange{0x0AB2, 0x0AB3}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] GUJARATI LETTER LA..GUJARATI LETTER LLA
-	{runeRange{0x0AB5, 0x0AB9}, propertyGeneralCategory{lbprAL, gcLo}},     //     [5] GUJARATI LETTER VA..GUJARATI LETTER HA
-	{runeRange{0x0ABC, 0x0ABC}, propertyGeneralCategory{lbprCM, gcMn}},     //         GUJARATI SIGN NUKTA
-	{runeRange{0x0ABD, 0x0ABD}, propertyGeneralCategory{lbprAL, gcLo}},     //         GUJARATI SIGN AVAGRAHA
-	{runeRange{0x0ABE, 0x0AC0}, propertyGeneralCategory{lbprCM, gcMc}},     //     [3] GUJARATI VOWEL SIGN AA..GUJARATI VOWEL SIGN II
-	{runeRange{0x0AC1, 0x0AC5}, propertyGeneralCategory{lbprCM, gcMn}},     //     [5] GUJARATI VOWEL SIGN U..GUJARATI VOWEL SIGN CANDRA E
-	{runeRange{0x0AC7, 0x0AC8}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] GUJARATI VOWEL SIGN E..GUJARATI VOWEL SIGN AI
-	{runeRange{0x0AC9, 0x0AC9}, propertyGeneralCategory{lbprCM, gcMc}},     //         GUJARATI VOWEL SIGN CANDRA O
-	{runeRange{0x0ACB, 0x0ACC}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] GUJARATI VOWEL SIGN O..GUJARATI VOWEL SIGN AU
-	{runeRange{0x0ACD, 0x0ACD}, propertyGeneralCategory{lbprCM, gcMn}},     //         GUJARATI SIGN VIRAMA
-	{runeRange{0x0AD0, 0x0AD0}, propertyGeneralCategory{lbprAL, gcLo}},     //         GUJARATI OM
-	{runeRange{0x0AE0, 0x0AE1}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] GUJARATI LETTER VOCALIC RR..GUJARATI LETTER VOCALIC LL
-	{runeRange{0x0AE2, 0x0AE3}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] GUJARATI VOWEL SIGN VOCALIC L..GUJARATI VOWEL SIGN VOCALIC LL
-	{runeRange{0x0AE6, 0x0AEF}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] GUJARATI DIGIT ZERO..GUJARATI DIGIT NINE
-	{runeRange{0x0AF0, 0x0AF0}, propertyGeneralCategory{lbprAL, gcPo}},     //         GUJARATI ABBREVIATION SIGN
-	{runeRange{0x0AF1, 0x0AF1}, propertyGeneralCategory{lbprPR, gcSc}},     //         GUJARATI RUPEE SIGN
-	{runeRange{0x0AF9, 0x0AF9}, propertyGeneralCategory{lbprAL, gcLo}},     //         GUJARATI LETTER ZHA
-	{runeRange{0x0AFA, 0x0AFF}, propertyGeneralCategory{lbprCM, gcMn}},     //     [6] GUJARATI SIGN SUKUN..GUJARATI SIGN TWO-CIRCLE NUKTA ABOVE
-	{runeRange{0x0B01, 0x0B01}, propertyGeneralCategory{lbprCM, gcMn}},     //         ORIYA SIGN CANDRABINDU
-	{runeRange{0x0B02, 0x0B03}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] ORIYA SIGN ANUSVARA..ORIYA SIGN VISARGA
-	{runeRange{0x0B05, 0x0B0C}, propertyGeneralCategory{lbprAL, gcLo}},     //     [8] ORIYA LETTER A..ORIYA LETTER VOCALIC L
-	{runeRange{0x0B0F, 0x0B10}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] ORIYA LETTER E..ORIYA LETTER AI
-	{runeRange{0x0B13, 0x0B28}, propertyGeneralCategory{lbprAL, gcLo}},     //    [22] ORIYA LETTER O..ORIYA LETTER NA
-	{runeRange{0x0B2A, 0x0B30}, propertyGeneralCategory{lbprAL, gcLo}},     //     [7] ORIYA LETTER PA..ORIYA LETTER RA
-	{runeRange{0x0B32, 0x0B33}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] ORIYA LETTER LA..ORIYA LETTER LLA
-	{runeRange{0x0B35, 0x0B39}, propertyGeneralCategory{lbprAL, gcLo}},     //     [5] ORIYA LETTER VA..ORIYA LETTER HA
-	{runeRange{0x0B3C, 0x0B3C}, propertyGeneralCategory{lbprCM, gcMn}},     //         ORIYA SIGN NUKTA
-	{runeRange{0x0B3D, 0x0B3D}, propertyGeneralCategory{lbprAL, gcLo}},     //         ORIYA SIGN AVAGRAHA
-	{runeRange{0x0B3E, 0x0B3E}, propertyGeneralCategory{lbprCM, gcMc}},     //         ORIYA VOWEL SIGN AA
-	{runeRange{0x0B3F, 0x0B3F}, propertyGeneralCategory{lbprCM, gcMn}},     //         ORIYA VOWEL SIGN I
-	{runeRange{0x0B40, 0x0B40}, propertyGeneralCategory{lbprCM, gcMc}},     //         ORIYA VOWEL SIGN II
-	{runeRange{0x0B41, 0x0B44}, propertyGeneralCategory{lbprCM, gcMn}},     //     [4] ORIYA VOWEL SIGN U..ORIYA VOWEL SIGN VOCALIC RR
-	{runeRange{0x0B47, 0x0B48}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] ORIYA VOWEL SIGN E..ORIYA VOWEL SIGN AI
-	{runeRange{0x0B4B, 0x0B4C}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] ORIYA VOWEL SIGN O..ORIYA VOWEL SIGN AU
-	{runeRange{0x0B4D, 0x0B4D}, propertyGeneralCategory{lbprCM, gcMn}},     //         ORIYA SIGN VIRAMA
-	{runeRange{0x0B55, 0x0B56}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] ORIYA SIGN OVERLINE..ORIYA AI LENGTH MARK
-	{runeRange{0x0B57, 0x0B57}, propertyGeneralCategory{lbprCM, gcMc}},     //         ORIYA AU LENGTH MARK
-	{runeRange{0x0B5C, 0x0B5D}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] ORIYA LETTER RRA..ORIYA LETTER RHA
-	{runeRange{0x0B5F, 0x0B61}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] ORIYA LETTER YYA..ORIYA LETTER VOCALIC LL
-	{runeRange{0x0B62, 0x0B63}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] ORIYA VOWEL SIGN VOCALIC L..ORIYA VOWEL SIGN VOCALIC LL
-	{runeRange{0x0B66, 0x0B6F}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] ORIYA DIGIT ZERO..ORIYA DIGIT NINE
-	{runeRange{0x0B70, 0x0B70}, propertyGeneralCategory{lbprAL, gcSo}},     //         ORIYA ISSHAR
-	{runeRange{0x0B71, 0x0B71}, propertyGeneralCategory{lbprAL, gcLo}},     //         ORIYA LETTER WA
-	{runeRange{0x0B72, 0x0B77}, propertyGeneralCategory{lbprAL, gcNo}},     //     [6] ORIYA FRACTION ONE QUARTER..ORIYA FRACTION THREE SIXTEENTHS
-	{runeRange{0x0B82, 0x0B82}, propertyGeneralCategory{lbprCM, gcMn}},     //         TAMIL SIGN ANUSVARA
-	{runeRange{0x0B83, 0x0B83}, propertyGeneralCategory{lbprAL, gcLo}},     //         TAMIL SIGN VISARGA
-	{runeRange{0x0B85, 0x0B8A}, propertyGeneralCategory{lbprAL, gcLo}},     //     [6] TAMIL LETTER A..TAMIL LETTER UU
-	{runeRange{0x0B8E, 0x0B90}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] TAMIL LETTER E..TAMIL LETTER AI
-	{runeRange{0x0B92, 0x0B95}, propertyGeneralCategory{lbprAL, gcLo}},     //     [4] TAMIL LETTER O..TAMIL LETTER KA
-	{runeRange{0x0B99, 0x0B9A}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] TAMIL LETTER NGA..TAMIL LETTER CA
-	{runeRange{0x0B9C, 0x0B9C}, propertyGeneralCategory{lbprAL, gcLo}},     //         TAMIL LETTER JA
-	{runeRange{0x0B9E, 0x0B9F}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] TAMIL LETTER NYA..TAMIL LETTER TTA
-	{runeRange{0x0BA3, 0x0BA4}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] TAMIL LETTER NNA..TAMIL LETTER TA
-	{runeRange{0x0BA8, 0x0BAA}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] TAMIL LETTER NA..TAMIL LETTER PA
-	{runeRange{0x0BAE, 0x0BB9}, propertyGeneralCategory{lbprAL, gcLo}},     //    [12] TAMIL LETTER MA..TAMIL LETTER HA
-	{runeRange{0x0BBE, 0x0BBF}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] TAMIL VOWEL SIGN AA..TAMIL VOWEL SIGN I
-	{runeRange{0x0BC0, 0x0BC0}, propertyGeneralCategory{lbprCM, gcMn}},     //         TAMIL VOWEL SIGN II
-	{runeRange{0x0BC1, 0x0BC2}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] TAMIL VOWEL SIGN U..TAMIL VOWEL SIGN UU
-	{runeRange{0x0BC6, 0x0BC8}, propertyGeneralCategory{lbprCM, gcMc}},     //     [3] TAMIL VOWEL SIGN E..TAMIL VOWEL SIGN AI
-	{runeRange{0x0BCA, 0x0BCC}, propertyGeneralCategory{lbprCM, gcMc}},     //     [3] TAMIL VOWEL SIGN O..TAMIL VOWEL SIGN AU
-	{runeRange{0x0BCD, 0x0BCD}, propertyGeneralCategory{lbprCM, gcMn}},     //         TAMIL SIGN VIRAMA
-	{runeRange{0x0BD0, 0x0BD0}, propertyGeneralCategory{lbprAL, gcLo}},     //         TAMIL OM
-	{runeRange{0x0BD7, 0x0BD7}, propertyGeneralCategory{lbprCM, gcMc}},     //         TAMIL AU LENGTH MARK
-	{runeRange{0x0BE6, 0x0BEF}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] TAMIL DIGIT ZERO..TAMIL DIGIT NINE
-	{runeRange{0x0BF0, 0x0BF2}, propertyGeneralCategory{lbprAL, gcNo}},     //     [3] TAMIL NUMBER TEN..TAMIL NUMBER ONE THOUSAND
-	{runeRange{0x0BF3, 0x0BF8}, propertyGeneralCategory{lbprAL, gcSo}},     //     [6] TAMIL DAY SIGN..TAMIL AS ABOVE SIGN
-	{runeRange{0x0BF9, 0x0BF9}, propertyGeneralCategory{lbprPR, gcSc}},     //         TAMIL RUPEE SIGN
-	{runeRange{0x0BFA, 0x0BFA}, propertyGeneralCategory{lbprAL, gcSo}},     //         TAMIL NUMBER SIGN
-	{runeRange{0x0C00, 0x0C00}, propertyGeneralCategory{lbprCM, gcMn}},     //         TELUGU SIGN COMBINING CANDRABINDU ABOVE
-	{runeRange{0x0C01, 0x0C03}, propertyGeneralCategory{lbprCM, gcMc}},     //     [3] TELUGU SIGN CANDRABINDU..TELUGU SIGN VISARGA
-	{runeRange{0x0C04, 0x0C04}, propertyGeneralCategory{lbprCM, gcMn}},     //         TELUGU SIGN COMBINING ANUSVARA ABOVE
-	{runeRange{0x0C05, 0x0C0C}, propertyGeneralCategory{lbprAL, gcLo}},     //     [8] TELUGU LETTER A..TELUGU LETTER VOCALIC L
-	{runeRange{0x0C0E, 0x0C10}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] TELUGU LETTER E..TELUGU LETTER AI
-	{runeRange{0x0C12, 0x0C28}, propertyGeneralCategory{lbprAL, gcLo}},     //    [23] TELUGU LETTER O..TELUGU LETTER NA
-	{runeRange{0x0C2A, 0x0C39}, propertyGeneralCategory{lbprAL, gcLo}},     //    [16] TELUGU LETTER PA..TELUGU LETTER HA
-	{runeRange{0x0C3C, 0x0C3C}, propertyGeneralCategory{lbprCM, gcMn}},     //         TELUGU SIGN NUKTA
-	{runeRange{0x0C3D, 0x0C3D}, propertyGeneralCategory{lbprAL, gcLo}},     //         TELUGU SIGN AVAGRAHA
-	{runeRange{0x0C3E, 0x0C40}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] TELUGU VOWEL SIGN AA..TELUGU VOWEL SIGN II
-	{runeRange{0x0C41, 0x0C44}, propertyGeneralCategory{lbprCM, gcMc}},     //     [4] TELUGU VOWEL SIGN U..TELUGU VOWEL SIGN VOCALIC RR
-	{runeRange{0x0C46, 0x0C48}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] TELUGU VOWEL SIGN E..TELUGU VOWEL SIGN AI
-	{runeRange{0x0C4A, 0x0C4D}, propertyGeneralCategory{lbprCM, gcMn}},     //     [4] TELUGU VOWEL SIGN O..TELUGU SIGN VIRAMA
-	{runeRange{0x0C55, 0x0C56}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] TELUGU LENGTH MARK..TELUGU AI LENGTH MARK
-	{runeRange{0x0C58, 0x0C5A}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] TELUGU LETTER TSA..TELUGU LETTER RRRA
-	{runeRange{0x0C5D, 0x0C5D}, propertyGeneralCategory{lbprAL, gcLo}},     //         TELUGU LETTER NAKAARA POLLU
-	{runeRange{0x0C60, 0x0C61}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] TELUGU LETTER VOCALIC RR..TELUGU LETTER VOCALIC LL
-	{runeRange{0x0C62, 0x0C63}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] TELUGU VOWEL SIGN VOCALIC L..TELUGU VOWEL SIGN VOCALIC LL
-	{runeRange{0x0C66, 0x0C6F}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] TELUGU DIGIT ZERO..TELUGU DIGIT NINE
-	{runeRange{0x0C77, 0x0C77}, propertyGeneralCategory{lbprBB, gcPo}},     //         TELUGU SIGN SIDDHAM
-	{runeRange{0x0C78, 0x0C7E}, propertyGeneralCategory{lbprAL, gcNo}},     //     [7] TELUGU FRACTION DIGIT ZERO FOR ODD POWERS OF FOUR..TELUGU FRACTION DIGIT THREE FOR EVEN POWERS OF FOUR
-	{runeRange{0x0C7F, 0x0C7F}, propertyGeneralCategory{lbprAL, gcSo}},     //         TELUGU SIGN TUUMU
-	{runeRange{0x0C80, 0x0C80}, propertyGeneralCategory{lbprAL, gcLo}},     //         KANNADA SIGN SPACING CANDRABINDU
-	{runeRange{0x0C81, 0x0C81}, propertyGeneralCategory{lbprCM, gcMn}},     //         KANNADA SIGN CANDRABINDU
-	{runeRange{0x0C82, 0x0C83}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] KANNADA SIGN ANUSVARA..KANNADA SIGN VISARGA
-	{runeRange{0x0C84, 0x0C84}, propertyGeneralCategory{lbprBB, gcPo}},     //         KANNADA SIGN SIDDHAM
-	{runeRange{0x0C85, 0x0C8C}, propertyGeneralCategory{lbprAL, gcLo}},     //     [8] KANNADA LETTER A..KANNADA LETTER VOCALIC L
-	{runeRange{0x0C8E, 0x0C90}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] KANNADA LETTER E..KANNADA LETTER AI
-	{runeRange{0x0C92, 0x0CA8}, propertyGeneralCategory{lbprAL, gcLo}},     //    [23] KANNADA LETTER O..KANNADA LETTER NA
-	{runeRange{0x0CAA, 0x0CB3}, propertyGeneralCategory{lbprAL, gcLo}},     //    [10] KANNADA LETTER PA..KANNADA LETTER LLA
-	{runeRange{0x0CB5, 0x0CB9}, propertyGeneralCategory{lbprAL, gcLo}},     //     [5] KANNADA LETTER VA..KANNADA LETTER HA
-	{runeRange{0x0CBC, 0x0CBC}, propertyGeneralCategory{lbprCM, gcMn}},     //         KANNADA SIGN NUKTA
-	{runeRange{0x0CBD, 0x0CBD}, propertyGeneralCategory{lbprAL, gcLo}},     //         KANNADA SIGN AVAGRAHA
-	{runeRange{0x0CBE, 0x0CBE}, propertyGeneralCategory{lbprCM, gcMc}},     //         KANNADA VOWEL SIGN AA
-	{runeRange{0x0CBF, 0x0CBF}, propertyGeneralCategory{lbprCM, gcMn}},     //         KANNADA VOWEL SIGN I
-	{runeRange{0x0CC0, 0x0CC4}, propertyGeneralCategory{lbprCM, gcMc}},     //     [5] KANNADA VOWEL SIGN II..KANNADA VOWEL SIGN VOCALIC RR
-	{runeRange{0x0CC6, 0x0CC6}, propertyGeneralCategory{lbprCM, gcMn}},     //         KANNADA VOWEL SIGN E
-	{runeRange{0x0CC7, 0x0CC8}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] KANNADA VOWEL SIGN EE..KANNADA VOWEL SIGN AI
-	{runeRange{0x0CCA, 0x0CCB}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] KANNADA VOWEL SIGN O..KANNADA VOWEL SIGN OO
-	{runeRange{0x0CCC, 0x0CCD}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] KANNADA VOWEL SIGN AU..KANNADA SIGN VIRAMA
-	{runeRange{0x0CD5, 0x0CD6}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] KANNADA LENGTH MARK..KANNADA AI LENGTH MARK
-	{runeRange{0x0CDD, 0x0CDE}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] KANNADA LETTER NAKAARA POLLU..KANNADA LETTER FA
-	{runeRange{0x0CE0, 0x0CE1}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] KANNADA LETTER VOCALIC RR..KANNADA LETTER VOCALIC LL
-	{runeRange{0x0CE2, 0x0CE3}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] KANNADA VOWEL SIGN VOCALIC L..KANNADA VOWEL SIGN VOCALIC LL
-	{runeRange{0x0CE6, 0x0CEF}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] KANNADA DIGIT ZERO..KANNADA DIGIT NINE
-	{runeRange{0x0CF1, 0x0CF2}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] KANNADA SIGN JIHVAMULIYA..KANNADA SIGN UPADHMANIYA
-	{runeRange{0x0CF3, 0x0CF3}, propertyGeneralCategory{lbprCM, gcMc}},     //         KANNADA SIGN COMBINING ANUSVARA ABOVE RIGHT
-	{runeRange{0x0D00, 0x0D01}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] MALAYALAM SIGN COMBINING ANUSVARA ABOVE..MALAYALAM SIGN CANDRABINDU
-	{runeRange{0x0D02, 0x0D03}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] MALAYALAM SIGN ANUSVARA..MALAYALAM SIGN VISARGA
-	{runeRange{0x0D04, 0x0D0C}, propertyGeneralCategory{lbprAL, gcLo}},     //     [9] MALAYALAM LETTER VEDIC ANUSVARA..MALAYALAM LETTER VOCALIC L
-	{runeRange{0x0D0E, 0x0D10}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] MALAYALAM LETTER E..MALAYALAM LETTER AI
-	{runeRange{0x0D12, 0x0D3A}, propertyGeneralCategory{lbprAL, gcLo}},     //    [41] MALAYALAM LETTER O..MALAYALAM LETTER TTTA
-	{runeRange{0x0D3B, 0x0D3C}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] MALAYALAM SIGN VERTICAL BAR VIRAMA..MALAYALAM SIGN CIRCULAR VIRAMA
-	{runeRange{0x0D3D, 0x0D3D}, propertyGeneralCategory{lbprAL, gcLo}},     //         MALAYALAM SIGN AVAGRAHA
-	{runeRange{0x0D3E, 0x0D40}, propertyGeneralCategory{lbprCM, gcMc}},     //     [3] MALAYALAM VOWEL SIGN AA..MALAYALAM VOWEL SIGN II
-	{runeRange{0x0D41, 0x0D44}, propertyGeneralCategory{lbprCM, gcMn}},     //     [4] MALAYALAM VOWEL SIGN U..MALAYALAM VOWEL SIGN VOCALIC RR
-	{runeRange{0x0D46, 0x0D48}, propertyGeneralCategory{lbprCM, gcMc}},     //     [3] MALAYALAM VOWEL SIGN E..MALAYALAM VOWEL SIGN AI
-	{runeRange{0x0D4A, 0x0D4C}, propertyGeneralCategory{lbprCM, gcMc}},     //     [3] MALAYALAM VOWEL SIGN O..MALAYALAM VOWEL SIGN AU
-	{runeRange{0x0D4D, 0x0D4D}, propertyGeneralCategory{lbprCM, gcMn}},     //         MALAYALAM SIGN VIRAMA
-	{runeRange{0x0D4E, 0x0D4E}, propertyGeneralCategory{lbprAL, gcLo}},     //         MALAYALAM LETTER DOT REPH
-	{runeRange{0x0D4F, 0x0D4F}, propertyGeneralCategory{lbprAL, gcSo}},     //         MALAYALAM SIGN PARA
-	{runeRange{0x0D54, 0x0D56}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] MALAYALAM LETTER CHILLU M..MALAYALAM LETTER CHILLU LLL
-	{runeRange{0x0D57, 0x0D57}, propertyGeneralCategory{lbprCM, gcMc}},     //         MALAYALAM AU LENGTH MARK
-	{runeRange{0x0D58, 0x0D5E}, propertyGeneralCategory{lbprAL, gcNo}},     //     [7] MALAYALAM FRACTION ONE ONE-HUNDRED-AND-SIXTIETH..MALAYALAM FRACTION ONE FIFTH
-	{runeRange{0x0D5F, 0x0D61}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] MALAYALAM LETTER ARCHAIC II..MALAYALAM LETTER VOCALIC LL
-	{runeRange{0x0D62, 0x0D63}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] MALAYALAM VOWEL SIGN VOCALIC L..MALAYALAM VOWEL SIGN VOCALIC LL
-	{runeRange{0x0D66, 0x0D6F}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] MALAYALAM DIGIT ZERO..MALAYALAM DIGIT NINE
-	{runeRange{0x0D70, 0x0D78}, propertyGeneralCategory{lbprAL, gcNo}},     //     [9] MALAYALAM NUMBER TEN..MALAYALAM FRACTION THREE SIXTEENTHS
-	{runeRange{0x0D79, 0x0D79}, propertyGeneralCategory{lbprPO, gcSo}},     //         MALAYALAM DATE MARK
-	{runeRange{0x0D7A, 0x0D7F}, propertyGeneralCategory{lbprAL, gcLo}},     //     [6] MALAYALAM LETTER CHILLU NN..MALAYALAM LETTER CHILLU K
-	{runeRange{0x0D81, 0x0D81}, propertyGeneralCategory{lbprCM, gcMn}},     //         SINHALA SIGN CANDRABINDU
-	{runeRange{0x0D82, 0x0D83}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] SINHALA SIGN ANUSVARAYA..SINHALA SIGN VISARGAYA
-	{runeRange{0x0D85, 0x0D96}, propertyGeneralCategory{lbprAL, gcLo}},     //    [18] SINHALA LETTER AYANNA..SINHALA LETTER AUYANNA
-	{runeRange{0x0D9A, 0x0DB1}, propertyGeneralCategory{lbprAL, gcLo}},     //    [24] SINHALA LETTER ALPAPRAANA KAYANNA..SINHALA LETTER DANTAJA NAYANNA
-	{runeRange{0x0DB3, 0x0DBB}, propertyGeneralCategory{lbprAL, gcLo}},     //     [9] SINHALA LETTER SANYAKA DAYANNA..SINHALA LETTER RAYANNA
-	{runeRange{0x0DBD, 0x0DBD}, propertyGeneralCategory{lbprAL, gcLo}},     //         SINHALA LETTER DANTAJA LAYANNA
-	{runeRange{0x0DC0, 0x0DC6}, propertyGeneralCategory{lbprAL, gcLo}},     //     [7] SINHALA LETTER VAYANNA..SINHALA LETTER FAYANNA
-	{runeRange{0x0DCA, 0x0DCA}, propertyGeneralCategory{lbprCM, gcMn}},     //         SINHALA SIGN AL-LAKUNA
-	{runeRange{0x0DCF, 0x0DD1}, propertyGeneralCategory{lbprCM, gcMc}},     //     [3] SINHALA VOWEL SIGN AELA-PILLA..SINHALA VOWEL SIGN DIGA AEDA-PILLA
-	{runeRange{0x0DD2, 0x0DD4}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] SINHALA VOWEL SIGN KETTI IS-PILLA..SINHALA VOWEL SIGN KETTI PAA-PILLA
-	{runeRange{0x0DD6, 0x0DD6}, propertyGeneralCategory{lbprCM, gcMn}},     //         SINHALA VOWEL SIGN DIGA PAA-PILLA
-	{runeRange{0x0DD8, 0x0DDF}, propertyGeneralCategory{lbprCM, gcMc}},     //     [8] SINHALA VOWEL SIGN GAETTA-PILLA..SINHALA VOWEL SIGN GAYANUKITTA
-	{runeRange{0x0DE6, 0x0DEF}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] SINHALA LITH DIGIT ZERO..SINHALA LITH DIGIT NINE
-	{runeRange{0x0DF2, 0x0DF3}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] SINHALA VOWEL SIGN DIGA GAETTA-PILLA..SINHALA VOWEL SIGN DIGA GAYANUKITTA
-	{runeRange{0x0DF4, 0x0DF4}, propertyGeneralCategory{lbprAL, gcPo}},     //         SINHALA PUNCTUATION KUNDDALIYA
-	{runeRange{0x0E01, 0x0E30}, propertyGeneralCategory{lbprSA, gcLo}},     //    [48] THAI CHARACTER KO KAI..THAI CHARACTER SARA A
-	{runeRange{0x0E31, 0x0E31}, propertyGeneralCategory{lbprSA, gcMn}},     //         THAI CHARACTER MAI HAN-AKAT
-	{runeRange{0x0E32, 0x0E33}, propertyGeneralCategory{lbprSA, gcLo}},     //     [2] THAI CHARACTER SARA AA..THAI CHARACTER SARA AM
-	{runeRange{0x0E34, 0x0E3A}, propertyGeneralCategory{lbprSA, gcMn}},     //     [7] THAI CHARACTER SARA I..THAI CHARACTER PHINTHU
-	{runeRange{0x0E3F, 0x0E3F}, propertyGeneralCategory{lbprPR, gcSc}},     //         THAI CURRENCY SYMBOL BAHT
-	{runeRange{0x0E40, 0x0E45}, propertyGeneralCategory{lbprSA, gcLo}},     //     [6] THAI CHARACTER SARA E..THAI CHARACTER LAKKHANGYAO
-	{runeRange{0x0E46, 0x0E46}, propertyGeneralCategory{lbprSA, gcLm}},     //         THAI CHARACTER MAIYAMOK
-	{runeRange{0x0E47, 0x0E4E}, propertyGeneralCategory{lbprSA, gcMn}},     //     [8] THAI CHARACTER MAITAIKHU..THAI CHARACTER YAMAKKAN
-	{runeRange{0x0E4F, 0x0E4F}, propertyGeneralCategory{lbprAL, gcPo}},     //         THAI CHARACTER FONGMAN
-	{runeRange{0x0E50, 0x0E59}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] THAI DIGIT ZERO..THAI DIGIT NINE
-	{runeRange{0x0E5A, 0x0E5B}, propertyGeneralCategory{lbprBA, gcPo}},     //     [2] THAI CHARACTER ANGKHANKHU..THAI CHARACTER KHOMUT
-	{runeRange{0x0E81, 0x0E82}, propertyGeneralCategory{lbprSA, gcLo}},     //     [2] LAO LETTER KO..LAO LETTER KHO SUNG
-	{runeRange{0x0E84, 0x0E84}, propertyGeneralCategory{lbprSA, gcLo}},     //         LAO LETTER KHO TAM
-	{runeRange{0x0E86, 0x0E8A}, propertyGeneralCategory{lbprSA, gcLo}},     //     [5] LAO LETTER PALI GHA..LAO LETTER SO TAM
-	{runeRange{0x0E8C, 0x0EA3}, propertyGeneralCategory{lbprSA, gcLo}},     //    [24] LAO LETTER PALI JHA..LAO LETTER LO LING
-	{runeRange{0x0EA5, 0x0EA5}, propertyGeneralCategory{lbprSA, gcLo}},     //         LAO LETTER LO LOOT
-	{runeRange{0x0EA7, 0x0EB0}, propertyGeneralCategory{lbprSA, gcLo}},     //    [10] LAO LETTER WO..LAO VOWEL SIGN A
-	{runeRange{0x0EB1, 0x0EB1}, propertyGeneralCategory{lbprSA, gcMn}},     //         LAO VOWEL SIGN MAI KAN
-	{runeRange{0x0EB2, 0x0EB3}, propertyGeneralCategory{lbprSA, gcLo}},     //     [2] LAO VOWEL SIGN AA..LAO VOWEL SIGN AM
-	{runeRange{0x0EB4, 0x0EBC}, propertyGeneralCategory{lbprSA, gcMn}},     //     [9] LAO VOWEL SIGN I..LAO SEMIVOWEL SIGN LO
-	{runeRange{0x0EBD, 0x0EBD}, propertyGeneralCategory{lbprSA, gcLo}},     //         LAO SEMIVOWEL SIGN NYO
-	{runeRange{0x0EC0, 0x0EC4}, propertyGeneralCategory{lbprSA, gcLo}},     //     [5] LAO VOWEL SIGN E..LAO VOWEL SIGN AI
-	{runeRange{0x0EC6, 0x0EC6}, propertyGeneralCategory{lbprSA, gcLm}},     //         LAO KO LA
-	{runeRange{0x0EC8, 0x0ECE}, propertyGeneralCategory{lbprSA, gcMn}},     //     [7] LAO TONE MAI EK..LAO YAMAKKAN
-	{runeRange{0x0ED0, 0x0ED9}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] LAO DIGIT ZERO..LAO DIGIT NINE
-	{runeRange{0x0EDC, 0x0EDF}, propertyGeneralCategory{lbprSA, gcLo}},     //     [4] LAO HO NO..LAO LETTER KHMU NYO
-	{runeRange{0x0F00, 0x0F00}, propertyGeneralCategory{lbprAL, gcLo}},     //         TIBETAN SYLLABLE OM
-	{runeRange{0x0F01, 0x0F03}, propertyGeneralCategory{lbprBB, gcSo}},     //     [3] TIBETAN MARK GTER YIG MGO TRUNCATED A..TIBETAN MARK GTER YIG MGO -UM GTER TSHEG MA
-	{runeRange{0x0F04, 0x0F04}, propertyGeneralCategory{lbprBB, gcPo}},     //         TIBETAN MARK INITIAL YIG MGO MDUN MA
-	{runeRange{0x0F05, 0x0F05}, propertyGeneralCategory{lbprAL, gcPo}},     //         TIBETAN MARK CLOSING YIG MGO SGAB MA
-	{runeRange{0x0F06, 0x0F07}, propertyGeneralCategory{lbprBB, gcPo}},     //     [2] TIBETAN MARK CARET YIG MGO PHUR SHAD MA..TIBETAN MARK YIG MGO TSHEG SHAD MA
-	{runeRange{0x0F08, 0x0F08}, propertyGeneralCategory{lbprGL, gcPo}},     //         TIBETAN MARK SBRUL SHAD
-	{runeRange{0x0F09, 0x0F0A}, propertyGeneralCategory{lbprBB, gcPo}},     //     [2] TIBETAN MARK BSKUR YIG MGO..TIBETAN MARK BKA- SHOG YIG MGO
-	{runeRange{0x0F0B, 0x0F0B}, propertyGeneralCategory{lbprBA, gcPo}},     //         TIBETAN MARK INTERSYLLABIC TSHEG
-	{runeRange{0x0F0C, 0x0F0C}, propertyGeneralCategory{lbprGL, gcPo}},     //         TIBETAN MARK DELIMITER TSHEG BSTAR
-	{runeRange{0x0F0D, 0x0F11}, propertyGeneralCategory{lbprEX, gcPo}},     //     [5] TIBETAN MARK SHAD..TIBETAN MARK RIN CHEN SPUNGS SHAD
-	{runeRange{0x0F12, 0x0F12}, propertyGeneralCategory{lbprGL, gcPo}},     //         TIBETAN MARK RGYA GRAM SHAD
-	{runeRange{0x0F13, 0x0F13}, propertyGeneralCategory{lbprAL, gcSo}},     //         TIBETAN MARK CARET -DZUD RTAGS ME LONG CAN
-	{runeRange{0x0F14, 0x0F14}, propertyGeneralCategory{lbprEX, gcPo}},     //         TIBETAN MARK GTER TSHEG
-	{runeRange{0x0F15, 0x0F17}, propertyGeneralCategory{lbprAL, gcSo}},     //     [3] TIBETAN LOGOTYPE SIGN CHAD RTAGS..TIBETAN ASTROLOGICAL SIGN SGRA GCAN -CHAR RTAGS
-	{runeRange{0x0F18, 0x0F19}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] TIBETAN ASTROLOGICAL SIGN -KHYUD PA..TIBETAN ASTROLOGICAL SIGN SDONG TSHUGS
-	{runeRange{0x0F1A, 0x0F1F}, propertyGeneralCategory{lbprAL, gcSo}},     //     [6] TIBETAN SIGN RDEL DKAR GCIG..TIBETAN SIGN RDEL DKAR RDEL NAG
-	{runeRange{0x0F20, 0x0F29}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] TIBETAN DIGIT ZERO..TIBETAN DIGIT NINE
-	{runeRange{0x0F2A, 0x0F33}, propertyGeneralCategory{lbprAL, gcNo}},     //    [10] TIBETAN DIGIT HALF ONE..TIBETAN DIGIT HALF ZERO
-	{runeRange{0x0F34, 0x0F34}, propertyGeneralCategory{lbprBA, gcSo}},     //         TIBETAN MARK BSDUS RTAGS
-	{runeRange{0x0F35, 0x0F35}, propertyGeneralCategory{lbprCM, gcMn}},     //         TIBETAN MARK NGAS BZUNG NYI ZLA
-	{runeRange{0x0F36, 0x0F36}, propertyGeneralCategory{lbprAL, gcSo}},     //         TIBETAN MARK CARET -DZUD RTAGS BZHI MIG CAN
-	{runeRange{0x0F37, 0x0F37}, propertyGeneralCategory{lbprCM, gcMn}},     //         TIBETAN MARK NGAS BZUNG SGOR RTAGS
-	{runeRange{0x0F38, 0x0F38}, propertyGeneralCategory{lbprAL, gcSo}},     //         TIBETAN MARK CHE MGO
-	{runeRange{0x0F39, 0x0F39}, propertyGeneralCategory{lbprCM, gcMn}},     //         TIBETAN MARK TSA -PHRU
-	{runeRange{0x0F3A, 0x0F3A}, propertyGeneralCategory{lbprOP, gcPs}},     //         TIBETAN MARK GUG RTAGS GYON
-	{runeRange{0x0F3B, 0x0F3B}, propertyGeneralCategory{lbprCL, gcPe}},     //         TIBETAN MARK GUG RTAGS GYAS
-	{runeRange{0x0F3C, 0x0F3C}, propertyGeneralCategory{lbprOP, gcPs}},     //         TIBETAN MARK ANG KHANG GYON
-	{runeRange{0x0F3D, 0x0F3D}, propertyGeneralCategory{lbprCL, gcPe}},     //         TIBETAN MARK ANG KHANG GYAS
-	{runeRange{0x0F3E, 0x0F3F}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] TIBETAN SIGN YAR TSHES..TIBETAN SIGN MAR TSHES
-	{runeRange{0x0F40, 0x0F47}, propertyGeneralCategory{lbprAL, gcLo}},     //     [8] TIBETAN LETTER KA..TIBETAN LETTER JA
-	{runeRange{0x0F49, 0x0F6C}, propertyGeneralCategory{lbprAL, gcLo}},     //    [36] TIBETAN LETTER NYA..TIBETAN LETTER RRA
-	{runeRange{0x0F71, 0x0F7E}, propertyGeneralCategory{lbprCM, gcMn}},     //    [14] TIBETAN VOWEL SIGN AA..TIBETAN SIGN RJES SU NGA RO
-	{runeRange{0x0F7F, 0x0F7F}, propertyGeneralCategory{lbprBA, gcMc}},     //         TIBETAN SIGN RNAM BCAD
-	{runeRange{0x0F80, 0x0F84}, propertyGeneralCategory{lbprCM, gcMn}},     //     [5] TIBETAN VOWEL SIGN REVERSED I..TIBETAN MARK HALANTA
-	{runeRange{0x0F85, 0x0F85}, propertyGeneralCategory{lbprBA, gcPo}},     //         TIBETAN MARK PALUTA
-	{runeRange{0x0F86, 0x0F87}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] TIBETAN SIGN LCI RTAGS..TIBETAN SIGN YANG RTAGS
-	{runeRange{0x0F88, 0x0F8C}, propertyGeneralCategory{lbprAL, gcLo}},     //     [5] TIBETAN SIGN LCE TSA CAN..TIBETAN SIGN INVERTED MCHU CAN
-	{runeRange{0x0F8D, 0x0F97}, propertyGeneralCategory{lbprCM, gcMn}},     //    [11] TIBETAN SUBJOINED SIGN LCE TSA CAN..TIBETAN SUBJOINED LETTER JA
-	{runeRange{0x0F99, 0x0FBC}, propertyGeneralCategory{lbprCM, gcMn}},     //    [36] TIBETAN SUBJOINED LETTER NYA..TIBETAN SUBJOINED LETTER FIXED-FORM RA
-	{runeRange{0x0FBE, 0x0FBF}, propertyGeneralCategory{lbprBA, gcSo}},     //     [2] TIBETAN KU RU KHA..TIBETAN KU RU KHA BZHI MIG CAN
-	{runeRange{0x0FC0, 0x0FC5}, propertyGeneralCategory{lbprAL, gcSo}},     //     [6] TIBETAN CANTILLATION SIGN HEAVY BEAT..TIBETAN SYMBOL RDO RJE
-	{runeRange{0x0FC6, 0x0FC6}, propertyGeneralCategory{lbprCM, gcMn}},     //         TIBETAN SYMBOL PADMA GDAN
-	{runeRange{0x0FC7, 0x0FCC}, propertyGeneralCategory{lbprAL, gcSo}},     //     [6] TIBETAN SYMBOL RDO RJE RGYA GRAM..TIBETAN SYMBOL NOR BU BZHI -KHYIL
-	{runeRange{0x0FCE, 0x0FCF}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] TIBETAN SIGN RDEL NAG RDEL DKAR..TIBETAN SIGN RDEL NAG GSUM
-	{runeRange{0x0FD0, 0x0FD1}, propertyGeneralCategory{lbprBB, gcPo}},     //     [2] TIBETAN MARK BSKA- SHOG GI MGO RGYAN..TIBETAN MARK MNYAM YIG GI MGO RGYAN
-	{runeRange{0x0FD2, 0x0FD2}, propertyGeneralCategory{lbprBA, gcPo}},     //         TIBETAN MARK NYIS TSHEG
-	{runeRange{0x0FD3, 0x0FD3}, propertyGeneralCategory{lbprBB, gcPo}},     //         TIBETAN MARK INITIAL BRDA RNYING YIG MGO MDUN MA
-	{runeRange{0x0FD4, 0x0FD4}, propertyGeneralCategory{lbprAL, gcPo}},     //         TIBETAN MARK CLOSING BRDA RNYING YIG MGO SGAB MA
-	{runeRange{0x0FD5, 0x0FD8}, propertyGeneralCategory{lbprAL, gcSo}},     //     [4] RIGHT-FACING SVASTI SIGN..LEFT-FACING SVASTI SIGN WITH DOTS
-	{runeRange{0x0FD9, 0x0FDA}, propertyGeneralCategory{lbprGL, gcPo}},     //     [2] TIBETAN MARK LEADING MCHAN RTAGS..TIBETAN MARK TRAILING MCHAN RTAGS
-	{runeRange{0x1000, 0x102A}, propertyGeneralCategory{lbprSA, gcLo}},     //    [43] MYANMAR LETTER KA..MYANMAR LETTER AU
-	{runeRange{0x102B, 0x102C}, propertyGeneralCategory{lbprSA, gcMc}},     //     [2] MYANMAR VOWEL SIGN TALL AA..MYANMAR VOWEL SIGN AA
-	{runeRange{0x102D, 0x1030}, propertyGeneralCategory{lbprSA, gcMn}},     //     [4] MYANMAR VOWEL SIGN I..MYANMAR VOWEL SIGN UU
-	{runeRange{0x1031, 0x1031}, propertyGeneralCategory{lbprSA, gcMc}},     //         MYANMAR VOWEL SIGN E
-	{runeRange{0x1032, 0x1037}, propertyGeneralCategory{lbprSA, gcMn}},     //     [6] MYANMAR VOWEL SIGN AI..MYANMAR SIGN DOT BELOW
-	{runeRange{0x1038, 0x1038}, propertyGeneralCategory{lbprSA, gcMc}},     //         MYANMAR SIGN VISARGA
-	{runeRange{0x1039, 0x103A}, propertyGeneralCategory{lbprSA, gcMn}},     //     [2] MYANMAR SIGN VIRAMA..MYANMAR SIGN ASAT
-	{runeRange{0x103B, 0x103C}, propertyGeneralCategory{lbprSA, gcMc}},     //     [2] MYANMAR CONSONANT SIGN MEDIAL YA..MYANMAR CONSONANT SIGN MEDIAL RA
-	{runeRange{0x103D, 0x103E}, propertyGeneralCategory{lbprSA, gcMn}},     //     [2] MYANMAR CONSONANT SIGN MEDIAL WA..MYANMAR CONSONANT SIGN MEDIAL HA
-	{runeRange{0x103F, 0x103F}, propertyGeneralCategory{lbprSA, gcLo}},     //         MYANMAR LETTER GREAT SA
-	{runeRange{0x1040, 0x1049}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] MYANMAR DIGIT ZERO..MYANMAR DIGIT NINE
-	{runeRange{0x104A, 0x104B}, propertyGeneralCategory{lbprBA, gcPo}},     //     [2] MYANMAR SIGN LITTLE SECTION..MYANMAR SIGN SECTION
-	{runeRange{0x104C, 0x104F}, propertyGeneralCategory{lbprAL, gcPo}},     //     [4] MYANMAR SYMBOL LOCATIVE..MYANMAR SYMBOL GENITIVE
-	{runeRange{0x1050, 0x1055}, propertyGeneralCategory{lbprSA, gcLo}},     //     [6] MYANMAR LETTER SHA..MYANMAR LETTER VOCALIC LL
-	{runeRange{0x1056, 0x1057}, propertyGeneralCategory{lbprSA, gcMc}},     //     [2] MYANMAR VOWEL SIGN VOCALIC R..MYANMAR VOWEL SIGN VOCALIC RR
-	{runeRange{0x1058, 0x1059}, propertyGeneralCategory{lbprSA, gcMn}},     //     [2] MYANMAR VOWEL SIGN VOCALIC L..MYANMAR VOWEL SIGN VOCALIC LL
-	{runeRange{0x105A, 0x105D}, propertyGeneralCategory{lbprSA, gcLo}},     //     [4] MYANMAR LETTER MON NGA..MYANMAR LETTER MON BBE
-	{runeRange{0x105E, 0x1060}, propertyGeneralCategory{lbprSA, gcMn}},     //     [3] MYANMAR CONSONANT SIGN MON MEDIAL NA..MYANMAR CONSONANT SIGN MON MEDIAL LA
-	{runeRange{0x1061, 0x1061}, propertyGeneralCategory{lbprSA, gcLo}},     //         MYANMAR LETTER SGAW KAREN SHA
-	{runeRange{0x1062, 0x1064}, propertyGeneralCategory{lbprSA, gcMc}},     //     [3] MYANMAR VOWEL SIGN SGAW KAREN EU..MYANMAR TONE MARK SGAW KAREN KE PHO
-	{runeRange{0x1065, 0x1066}, propertyGeneralCategory{lbprSA, gcLo}},     //     [2] MYANMAR LETTER WESTERN PWO KAREN THA..MYANMAR LETTER WESTERN PWO KAREN PWA
-	{runeRange{0x1067, 0x106D}, propertyGeneralCategory{lbprSA, gcMc}},     //     [7] MYANMAR VOWEL SIGN WESTERN PWO KAREN EU..MYANMAR SIGN WESTERN PWO KAREN TONE-5
-	{runeRange{0x106E, 0x1070}, propertyGeneralCategory{lbprSA, gcLo}},     //     [3] MYANMAR LETTER EASTERN PWO KAREN NNA..MYANMAR LETTER EASTERN PWO KAREN GHWA
-	{runeRange{0x1071, 0x1074}, propertyGeneralCategory{lbprSA, gcMn}},     //     [4] MYANMAR VOWEL SIGN GEBA KAREN I..MYANMAR VOWEL SIGN KAYAH EE
-	{runeRange{0x1075, 0x1081}, propertyGeneralCategory{lbprSA, gcLo}},     //    [13] MYANMAR LETTER SHAN KA..MYANMAR LETTER SHAN HA
-	{runeRange{0x1082, 0x1082}, propertyGeneralCategory{lbprSA, gcMn}},     //         MYANMAR CONSONANT SIGN SHAN MEDIAL WA
-	{runeRange{0x1083, 0x1084}, propertyGeneralCategory{lbprSA, gcMc}},     //     [2] MYANMAR VOWEL SIGN SHAN AA..MYANMAR VOWEL SIGN SHAN E
-	{runeRange{0x1085, 0x1086}, propertyGeneralCategory{lbprSA, gcMn}},     //     [2] MYANMAR VOWEL SIGN SHAN E ABOVE..MYANMAR VOWEL SIGN SHAN FINAL Y
-	{runeRange{0x1087, 0x108C}, propertyGeneralCategory{lbprSA, gcMc}},     //     [6] MYANMAR SIGN SHAN TONE-2..MYANMAR SIGN SHAN COUNCIL TONE-3
-	{runeRange{0x108D, 0x108D}, propertyGeneralCategory{lbprSA, gcMn}},     //         MYANMAR SIGN SHAN COUNCIL EMPHATIC TONE
-	{runeRange{0x108E, 0x108E}, propertyGeneralCategory{lbprSA, gcLo}},     //         MYANMAR LETTER RUMAI PALAUNG FA
-	{runeRange{0x108F, 0x108F}, propertyGeneralCategory{lbprSA, gcMc}},     //         MYANMAR SIGN RUMAI PALAUNG TONE-5
-	{runeRange{0x1090, 0x1099}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] MYANMAR SHAN DIGIT ZERO..MYANMAR SHAN DIGIT NINE
-	{runeRange{0x109A, 0x109C}, propertyGeneralCategory{lbprSA, gcMc}},     //     [3] MYANMAR SIGN KHAMTI TONE-1..MYANMAR VOWEL SIGN AITON A
-	{runeRange{0x109D, 0x109D}, propertyGeneralCategory{lbprSA, gcMn}},     //         MYANMAR VOWEL SIGN AITON AI
-	{runeRange{0x109E, 0x109F}, propertyGeneralCategory{lbprSA, gcSo}},     //     [2] MYANMAR SYMBOL SHAN ONE..MYANMAR SYMBOL SHAN EXCLAMATION
-	{runeRange{0x10A0, 0x10C5}, propertyGeneralCategory{lbprAL, gcLu}},     //    [38] GEORGIAN CAPITAL LETTER AN..GEORGIAN CAPITAL LETTER HOE
-	{runeRange{0x10C7, 0x10C7}, propertyGeneralCategory{lbprAL, gcLu}},     //         GEORGIAN CAPITAL LETTER YN
-	{runeRange{0x10CD, 0x10CD}, propertyGeneralCategory{lbprAL, gcLu}},     //         GEORGIAN CAPITAL LETTER AEN
-	{runeRange{0x10D0, 0x10FA}, propertyGeneralCategory{lbprAL, gcLl}},     //    [43] GEORGIAN LETTER AN..GEORGIAN LETTER AIN
-	{runeRange{0x10FB, 0x10FB}, propertyGeneralCategory{lbprAL, gcPo}},     //         GEORGIAN PARAGRAPH SEPARATOR
-	{runeRange{0x10FC, 0x10FC}, propertyGeneralCategory{lbprAL, gcLm}},     //         MODIFIER LETTER GEORGIAN NAR
-	{runeRange{0x10FD, 0x10FF}, propertyGeneralCategory{lbprAL, gcLl}},     //     [3] GEORGIAN LETTER AEN..GEORGIAN LETTER LABIAL SIGN
-	{runeRange{0x1100, 0x115F}, propertyGeneralCategory{lbprJL, gcLo}},     //    [96] HANGUL CHOSEONG KIYEOK..HANGUL CHOSEONG FILLER
-	{runeRange{0x1160, 0x11A7}, propertyGeneralCategory{lbprJV, gcLo}},     //    [72] HANGUL JUNGSEONG FILLER..HANGUL JUNGSEONG O-YAE
-	{runeRange{0x11A8, 0x11FF}, propertyGeneralCategory{lbprJT, gcLo}},     //    [88] HANGUL JONGSEONG KIYEOK..HANGUL JONGSEONG SSANGNIEUN
-	{runeRange{0x1200, 0x1248}, propertyGeneralCategory{lbprAL, gcLo}},     //    [73] ETHIOPIC SYLLABLE HA..ETHIOPIC SYLLABLE QWA
-	{runeRange{0x124A, 0x124D}, propertyGeneralCategory{lbprAL, gcLo}},     //     [4] ETHIOPIC SYLLABLE QWI..ETHIOPIC SYLLABLE QWE
-	{runeRange{0x1250, 0x1256}, propertyGeneralCategory{lbprAL, gcLo}},     //     [7] ETHIOPIC SYLLABLE QHA..ETHIOPIC SYLLABLE QHO
-	{runeRange{0x1258, 0x1258}, propertyGeneralCategory{lbprAL, gcLo}},     //         ETHIOPIC SYLLABLE QHWA
-	{runeRange{0x125A, 0x125D}, propertyGeneralCategory{lbprAL, gcLo}},     //     [4] ETHIOPIC SYLLABLE QHWI..ETHIOPIC SYLLABLE QHWE
-	{runeRange{0x1260, 0x1288}, propertyGeneralCategory{lbprAL, gcLo}},     //    [41] ETHIOPIC SYLLABLE BA..ETHIOPIC SYLLABLE XWA
-	{runeRange{0x128A, 0x128D}, propertyGeneralCategory{lbprAL, gcLo}},     //     [4] ETHIOPIC SYLLABLE XWI..ETHIOPIC SYLLABLE XWE
-	{runeRange{0x1290, 0x12B0}, propertyGeneralCategory{lbprAL, gcLo}},     //    [33] ETHIOPIC SYLLABLE NA..ETHIOPIC SYLLABLE KWA
-	{runeRange{0x12B2, 0x12B5}, propertyGeneralCategory{lbprAL, gcLo}},     //     [4] ETHIOPIC SYLLABLE KWI..ETHIOPIC SYLLABLE KWE
-	{runeRange{0x12B8, 0x12BE}, propertyGeneralCategory{lbprAL, gcLo}},     //     [7] ETHIOPIC SYLLABLE KXA..ETHIOPIC SYLLABLE KXO
-	{runeRange{0x12C0, 0x12C0}, propertyGeneralCategory{lbprAL, gcLo}},     //         ETHIOPIC SYLLABLE KXWA
-	{runeRange{0x12C2, 0x12C5}, propertyGeneralCategory{lbprAL, gcLo}},     //     [4] ETHIOPIC SYLLABLE KXWI..ETHIOPIC SYLLABLE KXWE
-	{runeRange{0x12C8, 0x12D6}, propertyGeneralCategory{lbprAL, gcLo}},     //    [15] ETHIOPIC SYLLABLE WA..ETHIOPIC SYLLABLE PHARYNGEAL O
-	{runeRange{0x12D8, 0x1310}, propertyGeneralCategory{lbprAL, gcLo}},     //    [57] ETHIOPIC SYLLABLE ZA..ETHIOPIC SYLLABLE GWA
-	{runeRange{0x1312, 0x1315}, propertyGeneralCategory{lbprAL, gcLo}},     //     [4] ETHIOPIC SYLLABLE GWI..ETHIOPIC SYLLABLE GWE
-	{runeRange{0x1318, 0x135A}, propertyGeneralCategory{lbprAL, gcLo}},     //    [67] ETHIOPIC SYLLABLE GGA..ETHIOPIC SYLLABLE FYA
-	{runeRange{0x135D, 0x135F}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] ETHIOPIC COMBINING GEMINATION AND VOWEL LENGTH MARK..ETHIOPIC COMBINING GEMINATION MARK
-	{runeRange{0x1360, 0x1360}, propertyGeneralCategory{lbprAL, gcPo}},     //         ETHIOPIC SECTION MARK
-	{runeRange{0x1361, 0x1361}, propertyGeneralCategory{lbprBA, gcPo}},     //         ETHIOPIC WORDSPACE
-	{runeRange{0x1362, 0x1368}, propertyGeneralCategory{lbprAL, gcPo}},     //     [7] ETHIOPIC FULL STOP..ETHIOPIC PARAGRAPH SEPARATOR
-	{runeRange{0x1369, 0x137C}, propertyGeneralCategory{lbprAL, gcNo}},     //    [20] ETHIOPIC DIGIT ONE..ETHIOPIC NUMBER TEN THOUSAND
-	{runeRange{0x1380, 0x138F}, propertyGeneralCategory{lbprAL, gcLo}},     //    [16] ETHIOPIC SYLLABLE SEBATBEIT MWA..ETHIOPIC SYLLABLE PWE
-	{runeRange{0x1390, 0x1399}, propertyGeneralCategory{lbprAL, gcSo}},     //    [10] ETHIOPIC TONAL MARK YIZET..ETHIOPIC TONAL MARK KURT
-	{runeRange{0x13A0, 0x13F5}, propertyGeneralCategory{lbprAL, gcLu}},     //    [86] CHEROKEE LETTER A..CHEROKEE LETTER MV
-	{runeRange{0x13F8, 0x13FD}, propertyGeneralCategory{lbprAL, gcLl}},     //     [6] CHEROKEE SMALL LETTER YE..CHEROKEE SMALL LETTER MV
-	{runeRange{0x1400, 0x1400}, propertyGeneralCategory{lbprBA, gcPd}},     //         CANADIAN SYLLABICS HYPHEN
-	{runeRange{0x1401, 0x166C}, propertyGeneralCategory{lbprAL, gcLo}},     //   [620] CANADIAN SYLLABICS E..CANADIAN SYLLABICS CARRIER TTSA
-	{runeRange{0x166D, 0x166D}, propertyGeneralCategory{lbprAL, gcSo}},     //         CANADIAN SYLLABICS CHI SIGN
-	{runeRange{0x166E, 0x166E}, propertyGeneralCategory{lbprAL, gcPo}},     //         CANADIAN SYLLABICS FULL STOP
-	{runeRange{0x166F, 0x167F}, propertyGeneralCategory{lbprAL, gcLo}},     //    [17] CANADIAN SYLLABICS QAI..CANADIAN SYLLABICS BLACKFOOT W
-	{runeRange{0x1680, 0x1680}, propertyGeneralCategory{lbprBA, gcZs}},     //         OGHAM SPACE MARK
-	{runeRange{0x1681, 0x169A}, propertyGeneralCategory{lbprAL, gcLo}},     //    [26] OGHAM LETTER BEITH..OGHAM LETTER PEITH
-	{runeRange{0x169B, 0x169B}, propertyGeneralCategory{lbprOP, gcPs}},     //         OGHAM FEATHER MARK
-	{runeRange{0x169C, 0x169C}, propertyGeneralCategory{lbprCL, gcPe}},     //         OGHAM REVERSED FEATHER MARK
-	{runeRange{0x16A0, 0x16EA}, propertyGeneralCategory{lbprAL, gcLo}},     //    [75] RUNIC LETTER FEHU FEOH FE F..RUNIC LETTER X
-	{runeRange{0x16EB, 0x16ED}, propertyGeneralCategory{lbprBA, gcPo}},     //     [3] RUNIC SINGLE PUNCTUATION..RUNIC CROSS PUNCTUATION
-	{runeRange{0x16EE, 0x16F0}, propertyGeneralCategory{lbprAL, gcNl}},     //     [3] RUNIC ARLAUG SYMBOL..RUNIC BELGTHOR SYMBOL
-	{runeRange{0x16F1, 0x16F8}, propertyGeneralCategory{lbprAL, gcLo}},     //     [8] RUNIC LETTER K..RUNIC LETTER FRANKS CASKET AESC
-	{runeRange{0x1700, 0x1711}, propertyGeneralCategory{lbprAL, gcLo}},     //    [18] TAGALOG LETTER A..TAGALOG LETTER HA
-	{runeRange{0x1712, 0x1714}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] TAGALOG VOWEL SIGN I..TAGALOG SIGN VIRAMA
-	{runeRange{0x1715, 0x1715}, propertyGeneralCategory{lbprCM, gcMc}},     //         TAGALOG SIGN PAMUDPOD
-	{runeRange{0x171F, 0x171F}, propertyGeneralCategory{lbprAL, gcLo}},     //         TAGALOG LETTER ARCHAIC RA
-	{runeRange{0x1720, 0x1731}, propertyGeneralCategory{lbprAL, gcLo}},     //    [18] HANUNOO LETTER A..HANUNOO LETTER HA
-	{runeRange{0x1732, 0x1733}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] HANUNOO VOWEL SIGN I..HANUNOO VOWEL SIGN U
-	{runeRange{0x1734, 0x1734}, propertyGeneralCategory{lbprCM, gcMc}},     //         HANUNOO SIGN PAMUDPOD
-	{runeRange{0x1735, 0x1736}, propertyGeneralCategory{lbprBA, gcPo}},     //     [2] PHILIPPINE SINGLE PUNCTUATION..PHILIPPINE DOUBLE PUNCTUATION
-	{runeRange{0x1740, 0x1751}, propertyGeneralCategory{lbprAL, gcLo}},     //    [18] BUHID LETTER A..BUHID LETTER HA
-	{runeRange{0x1752, 0x1753}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] BUHID VOWEL SIGN I..BUHID VOWEL SIGN U
-	{runeRange{0x1760, 0x176C}, propertyGeneralCategory{lbprAL, gcLo}},     //    [13] TAGBANWA LETTER A..TAGBANWA LETTER YA
-	{runeRange{0x176E, 0x1770}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] TAGBANWA LETTER LA..TAGBANWA LETTER SA
-	{runeRange{0x1772, 0x1773}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] TAGBANWA VOWEL SIGN I..TAGBANWA VOWEL SIGN U
-	{runeRange{0x1780, 0x17B3}, propertyGeneralCategory{lbprSA, gcLo}},     //    [52] KHMER LETTER KA..KHMER INDEPENDENT VOWEL QAU
-	{runeRange{0x17B4, 0x17B5}, propertyGeneralCategory{lbprSA, gcMn}},     //     [2] KHMER VOWEL INHERENT AQ..KHMER VOWEL INHERENT AA
-	{runeRange{0x17B6, 0x17B6}, propertyGeneralCategory{lbprSA, gcMc}},     //         KHMER VOWEL SIGN AA
-	{runeRange{0x17B7, 0x17BD}, propertyGeneralCategory{lbprSA, gcMn}},     //     [7] KHMER VOWEL SIGN I..KHMER VOWEL SIGN UA
-	{runeRange{0x17BE, 0x17C5}, propertyGeneralCategory{lbprSA, gcMc}},     //     [8] KHMER VOWEL SIGN OE..KHMER VOWEL SIGN AU
-	{runeRange{0x17C6, 0x17C6}, propertyGeneralCategory{lbprSA, gcMn}},     //         KHMER SIGN NIKAHIT
-	{runeRange{0x17C7, 0x17C8}, propertyGeneralCategory{lbprSA, gcMc}},     //     [2] KHMER SIGN REAHMUK..KHMER SIGN YUUKALEAPINTU
-	{runeRange{0x17C9, 0x17D3}, propertyGeneralCategory{lbprSA, gcMn}},     //    [11] KHMER SIGN MUUSIKATOAN..KHMER SIGN BATHAMASAT
-	{runeRange{0x17D4, 0x17D5}, propertyGeneralCategory{lbprBA, gcPo}},     //     [2] KHMER SIGN KHAN..KHMER SIGN BARIYOOSAN
-	{runeRange{0x17D6, 0x17D6}, propertyGeneralCategory{lbprNS, gcPo}},     //         KHMER SIGN CAMNUC PII KUUH
-	{runeRange{0x17D7, 0x17D7}, propertyGeneralCategory{lbprSA, gcLm}},     //         KHMER SIGN LEK TOO
-	{runeRange{0x17D8, 0x17D8}, propertyGeneralCategory{lbprBA, gcPo}},     //         KHMER SIGN BEYYAL
-	{runeRange{0x17D9, 0x17D9}, propertyGeneralCategory{lbprAL, gcPo}},     //         KHMER SIGN PHNAEK MUAN
-	{runeRange{0x17DA, 0x17DA}, propertyGeneralCategory{lbprBA, gcPo}},     //         KHMER SIGN KOOMUUT
-	{runeRange{0x17DB, 0x17DB}, propertyGeneralCategory{lbprPR, gcSc}},     //         KHMER CURRENCY SYMBOL RIEL
-	{runeRange{0x17DC, 0x17DC}, propertyGeneralCategory{lbprSA, gcLo}},     //         KHMER SIGN AVAKRAHASANYA
-	{runeRange{0x17DD, 0x17DD}, propertyGeneralCategory{lbprSA, gcMn}},     //         KHMER SIGN ATTHACAN
-	{runeRange{0x17E0, 0x17E9}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] KHMER DIGIT ZERO..KHMER DIGIT NINE
-	{runeRange{0x17F0, 0x17F9}, propertyGeneralCategory{lbprAL, gcNo}},     //    [10] KHMER SYMBOL LEK ATTAK SON..KHMER SYMBOL LEK ATTAK PRAM-BUON
-	{runeRange{0x1800, 0x1801}, propertyGeneralCategory{lbprAL, gcPo}},     //     [2] MONGOLIAN BIRGA..MONGOLIAN ELLIPSIS
-	{runeRange{0x1802, 0x1803}, propertyGeneralCategory{lbprEX, gcPo}},     //     [2] MONGOLIAN COMMA..MONGOLIAN FULL STOP
-	{runeRange{0x1804, 0x1805}, propertyGeneralCategory{lbprBA, gcPo}},     //     [2] MONGOLIAN COLON..MONGOLIAN FOUR DOTS
-	{runeRange{0x1806, 0x1806}, propertyGeneralCategory{lbprBB, gcPd}},     //         MONGOLIAN TODO SOFT HYPHEN
-	{runeRange{0x1807, 0x1807}, propertyGeneralCategory{lbprAL, gcPo}},     //         MONGOLIAN SIBE SYLLABLE BOUNDARY MARKER
-	{runeRange{0x1808, 0x1809}, propertyGeneralCategory{lbprEX, gcPo}},     //     [2] MONGOLIAN MANCHU COMMA..MONGOLIAN MANCHU FULL STOP
-	{runeRange{0x180A, 0x180A}, propertyGeneralCategory{lbprAL, gcPo}},     //         MONGOLIAN NIRUGU
-	{runeRange{0x180B, 0x180D}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] MONGOLIAN FREE VARIATION SELECTOR ONE..MONGOLIAN FREE VARIATION SELECTOR THREE
-	{runeRange{0x180E, 0x180E}, propertyGeneralCategory{lbprGL, gcCf}},     //         MONGOLIAN VOWEL SEPARATOR
-	{runeRange{0x180F, 0x180F}, propertyGeneralCategory{lbprCM, gcMn}},     //         MONGOLIAN FREE VARIATION SELECTOR FOUR
-	{runeRange{0x1810, 0x1819}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] MONGOLIAN DIGIT ZERO..MONGOLIAN DIGIT NINE
-	{runeRange{0x1820, 0x1842}, propertyGeneralCategory{lbprAL, gcLo}},     //    [35] MONGOLIAN LETTER A..MONGOLIAN LETTER CHI
-	{runeRange{0x1843, 0x1843}, propertyGeneralCategory{lbprAL, gcLm}},     //         MONGOLIAN LETTER TODO LONG VOWEL SIGN
-	{runeRange{0x1844, 0x1878}, propertyGeneralCategory{lbprAL, gcLo}},     //    [53] MONGOLIAN LETTER TODO E..MONGOLIAN LETTER CHA WITH TWO DOTS
-	{runeRange{0x1880, 0x1884}, propertyGeneralCategory{lbprAL, gcLo}},     //     [5] MONGOLIAN LETTER ALI GALI ANUSVARA ONE..MONGOLIAN LETTER ALI GALI INVERTED UBADAMA
-	{runeRange{0x1885, 0x1886}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] MONGOLIAN LETTER ALI GALI BALUDA..MONGOLIAN LETTER ALI GALI THREE BALUDA
-	{runeRange{0x1887, 0x18A8}, propertyGeneralCategory{lbprAL, gcLo}},     //    [34] MONGOLIAN LETTER ALI GALI A..MONGOLIAN LETTER MANCHU ALI GALI BHA
-	{runeRange{0x18A9, 0x18A9}, propertyGeneralCategory{lbprCM, gcMn}},     //         MONGOLIAN LETTER ALI GALI DAGALGA
-	{runeRange{0x18AA, 0x18AA}, propertyGeneralCategory{lbprAL, gcLo}},     //         MONGOLIAN LETTER MANCHU ALI GALI LHA
-	{runeRange{0x18B0, 0x18F5}, propertyGeneralCategory{lbprAL, gcLo}},     //    [70] CANADIAN SYLLABICS OY..CANADIAN SYLLABICS CARRIER DENTAL S
-	{runeRange{0x1900, 0x191E}, propertyGeneralCategory{lbprAL, gcLo}},     //    [31] LIMBU VOWEL-CARRIER LETTER..LIMBU LETTER TRA
-	{runeRange{0x1920, 0x1922}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] LIMBU VOWEL SIGN A..LIMBU VOWEL SIGN U
-	{runeRange{0x1923, 0x1926}, propertyGeneralCategory{lbprCM, gcMc}},     //     [4] LIMBU VOWEL SIGN EE..LIMBU VOWEL SIGN AU
-	{runeRange{0x1927, 0x1928}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] LIMBU VOWEL SIGN E..LIMBU VOWEL SIGN O
-	{runeRange{0x1929, 0x192B}, propertyGeneralCategory{lbprCM, gcMc}},     //     [3] LIMBU SUBJOINED LETTER YA..LIMBU SUBJOINED LETTER WA
-	{runeRange{0x1930, 0x1931}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] LIMBU SMALL LETTER KA..LIMBU SMALL LETTER NGA
-	{runeRange{0x1932, 0x1932}, propertyGeneralCategory{lbprCM, gcMn}},     //         LIMBU SMALL LETTER ANUSVARA
-	{runeRange{0x1933, 0x1938}, propertyGeneralCategory{lbprCM, gcMc}},     //     [6] LIMBU SMALL LETTER TA..LIMBU SMALL LETTER LA
-	{runeRange{0x1939, 0x193B}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] LIMBU SIGN MUKPHRENG..LIMBU SIGN SA-I
-	{runeRange{0x1940, 0x1940}, propertyGeneralCategory{lbprAL, gcSo}},     //         LIMBU SIGN LOO
-	{runeRange{0x1944, 0x1945}, propertyGeneralCategory{lbprEX, gcPo}},     //     [2] LIMBU EXCLAMATION MARK..LIMBU QUESTION MARK
-	{runeRange{0x1946, 0x194F}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] LIMBU DIGIT ZERO..LIMBU DIGIT NINE
-	{runeRange{0x1950, 0x196D}, propertyGeneralCategory{lbprSA, gcLo}},     //    [30] TAI LE LETTER KA..TAI LE LETTER AI
-	{runeRange{0x1970, 0x1974}, propertyGeneralCategory{lbprSA, gcLo}},     //     [5] TAI LE LETTER TONE-2..TAI LE LETTER TONE-6
-	{runeRange{0x1980, 0x19AB}, propertyGeneralCategory{lbprSA, gcLo}},     //    [44] NEW TAI LUE LETTER HIGH QA..NEW TAI LUE LETTER LOW SUA
-	{runeRange{0x19B0, 0x19C9}, propertyGeneralCategory{lbprSA, gcLo}},     //    [26] NEW TAI LUE VOWEL SIGN VOWEL SHORTENER..NEW TAI LUE TONE MARK-2
-	{runeRange{0x19D0, 0x19D9}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] NEW TAI LUE DIGIT ZERO..NEW TAI LUE DIGIT NINE
-	{runeRange{0x19DA, 0x19DA}, propertyGeneralCategory{lbprSA, gcNo}},     //         NEW TAI LUE THAM DIGIT ONE
-	{runeRange{0x19DE, 0x19DF}, propertyGeneralCategory{lbprSA, gcSo}},     //     [2] NEW TAI LUE SIGN LAE..NEW TAI LUE SIGN LAEV
-	{runeRange{0x19E0, 0x19FF}, propertyGeneralCategory{lbprAL, gcSo}},     //    [32] KHMER SYMBOL PATHAMASAT..KHMER SYMBOL DAP-PRAM ROC
-	{runeRange{0x1A00, 0x1A16}, propertyGeneralCategory{lbprAL, gcLo}},     //    [23] BUGINESE LETTER KA..BUGINESE LETTER HA
-	{runeRange{0x1A17, 0x1A18}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] BUGINESE VOWEL SIGN I..BUGINESE VOWEL SIGN U
-	{runeRange{0x1A19, 0x1A1A}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] BUGINESE VOWEL SIGN E..BUGINESE VOWEL SIGN O
-	{runeRange{0x1A1B, 0x1A1B}, propertyGeneralCategory{lbprCM, gcMn}},     //         BUGINESE VOWEL SIGN AE
-	{runeRange{0x1A1E, 0x1A1F}, propertyGeneralCategory{lbprAL, gcPo}},     //     [2] BUGINESE PALLAWA..BUGINESE END OF SECTION
-	{runeRange{0x1A20, 0x1A54}, propertyGeneralCategory{lbprSA, gcLo}},     //    [53] TAI THAM LETTER HIGH KA..TAI THAM LETTER GREAT SA
-	{runeRange{0x1A55, 0x1A55}, propertyGeneralCategory{lbprSA, gcMc}},     //         TAI THAM CONSONANT SIGN MEDIAL RA
-	{runeRange{0x1A56, 0x1A56}, propertyGeneralCategory{lbprSA, gcMn}},     //         TAI THAM CONSONANT SIGN MEDIAL LA
-	{runeRange{0x1A57, 0x1A57}, propertyGeneralCategory{lbprSA, gcMc}},     //         TAI THAM CONSONANT SIGN LA TANG LAI
-	{runeRange{0x1A58, 0x1A5E}, propertyGeneralCategory{lbprSA, gcMn}},     //     [7] TAI THAM SIGN MAI KANG LAI..TAI THAM CONSONANT SIGN SA
-	{runeRange{0x1A60, 0x1A60}, propertyGeneralCategory{lbprSA, gcMn}},     //         TAI THAM SIGN SAKOT
-	{runeRange{0x1A61, 0x1A61}, propertyGeneralCategory{lbprSA, gcMc}},     //         TAI THAM VOWEL SIGN A
-	{runeRange{0x1A62, 0x1A62}, propertyGeneralCategory{lbprSA, gcMn}},     //         TAI THAM VOWEL SIGN MAI SAT
-	{runeRange{0x1A63, 0x1A64}, propertyGeneralCategory{lbprSA, gcMc}},     //     [2] TAI THAM VOWEL SIGN AA..TAI THAM VOWEL SIGN TALL AA
-	{runeRange{0x1A65, 0x1A6C}, propertyGeneralCategory{lbprSA, gcMn}},     //     [8] TAI THAM VOWEL SIGN I..TAI THAM VOWEL SIGN OA BELOW
-	{runeRange{0x1A6D, 0x1A72}, propertyGeneralCategory{lbprSA, gcMc}},     //     [6] TAI THAM VOWEL SIGN OY..TAI THAM VOWEL SIGN THAM AI
-	{runeRange{0x1A73, 0x1A7C}, propertyGeneralCategory{lbprSA, gcMn}},     //    [10] TAI THAM VOWEL SIGN OA ABOVE..TAI THAM SIGN KHUEN-LUE KARAN
-	{runeRange{0x1A7F, 0x1A7F}, propertyGeneralCategory{lbprCM, gcMn}},     //         TAI THAM COMBINING CRYPTOGRAMMIC DOT
-	{runeRange{0x1A80, 0x1A89}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] TAI THAM HORA DIGIT ZERO..TAI THAM HORA DIGIT NINE
-	{runeRange{0x1A90, 0x1A99}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] TAI THAM THAM DIGIT ZERO..TAI THAM THAM DIGIT NINE
-	{runeRange{0x1AA0, 0x1AA6}, propertyGeneralCategory{lbprSA, gcPo}},     //     [7] TAI THAM SIGN WIANG..TAI THAM SIGN REVERSED ROTATED RANA
-	{runeRange{0x1AA7, 0x1AA7}, propertyGeneralCategory{lbprSA, gcLm}},     //         TAI THAM SIGN MAI YAMOK
-	{runeRange{0x1AA8, 0x1AAD}, propertyGeneralCategory{lbprSA, gcPo}},     //     [6] TAI THAM SIGN KAAN..TAI THAM SIGN CAANG
-	{runeRange{0x1AB0, 0x1ABD}, propertyGeneralCategory{lbprCM, gcMn}},     //    [14] COMBINING DOUBLED CIRCUMFLEX ACCENT..COMBINING PARENTHESES BELOW
-	{runeRange{0x1ABE, 0x1ABE}, propertyGeneralCategory{lbprCM, gcMe}},     //         COMBINING PARENTHESES OVERLAY
-	{runeRange{0x1ABF, 0x1ACE}, propertyGeneralCategory{lbprCM, gcMn}},     //    [16] COMBINING LATIN SMALL LETTER W BELOW..COMBINING LATIN SMALL LETTER INSULAR T
-	{runeRange{0x1B00, 0x1B03}, propertyGeneralCategory{lbprCM, gcMn}},     //     [4] BALINESE SIGN ULU RICEM..BALINESE SIGN SURANG
-	{runeRange{0x1B04, 0x1B04}, propertyGeneralCategory{lbprCM, gcMc}},     //         BALINESE SIGN BISAH
-	{runeRange{0x1B05, 0x1B33}, propertyGeneralCategory{lbprAL, gcLo}},     //    [47] BALINESE LETTER AKARA..BALINESE LETTER HA
-	{runeRange{0x1B34, 0x1B34}, propertyGeneralCategory{lbprCM, gcMn}},     //         BALINESE SIGN REREKAN
-	{runeRange{0x1B35, 0x1B35}, propertyGeneralCategory{lbprCM, gcMc}},     //         BALINESE VOWEL SIGN TEDUNG
-	{runeRange{0x1B36, 0x1B3A}, propertyGeneralCategory{lbprCM, gcMn}},     //     [5] BALINESE VOWEL SIGN ULU..BALINESE VOWEL SIGN RA REPA
-	{runeRange{0x1B3B, 0x1B3B}, propertyGeneralCategory{lbprCM, gcMc}},     //         BALINESE VOWEL SIGN RA REPA TEDUNG
-	{runeRange{0x1B3C, 0x1B3C}, propertyGeneralCategory{lbprCM, gcMn}},     //         BALINESE VOWEL SIGN LA LENGA
-	{runeRange{0x1B3D, 0x1B41}, propertyGeneralCategory{lbprCM, gcMc}},     //     [5] BALINESE VOWEL SIGN LA LENGA TEDUNG..BALINESE VOWEL SIGN TALING REPA TEDUNG
-	{runeRange{0x1B42, 0x1B42}, propertyGeneralCategory{lbprCM, gcMn}},     //         BALINESE VOWEL SIGN PEPET
-	{runeRange{0x1B43, 0x1B44}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] BALINESE VOWEL SIGN PEPET TEDUNG..BALINESE ADEG ADEG
-	{runeRange{0x1B45, 0x1B4C}, propertyGeneralCategory{lbprAL, gcLo}},     //     [8] BALINESE LETTER KAF SASAK..BALINESE LETTER ARCHAIC JNYA
-	{runeRange{0x1B50, 0x1B59}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] BALINESE DIGIT ZERO..BALINESE DIGIT NINE
-	{runeRange{0x1B5A, 0x1B5B}, propertyGeneralCategory{lbprBA, gcPo}},     //     [2] BALINESE PANTI..BALINESE PAMADA
-	{runeRange{0x1B5C, 0x1B5C}, propertyGeneralCategory{lbprAL, gcPo}},     //         BALINESE WINDU
-	{runeRange{0x1B5D, 0x1B60}, propertyGeneralCategory{lbprBA, gcPo}},     //     [4] BALINESE CARIK PAMUNGKAH..BALINESE PAMENENG
-	{runeRange{0x1B61, 0x1B6A}, propertyGeneralCategory{lbprAL, gcSo}},     //    [10] BALINESE MUSICAL SYMBOL DONG..BALINESE MUSICAL SYMBOL DANG GEDE
-	{runeRange{0x1B6B, 0x1B73}, propertyGeneralCategory{lbprCM, gcMn}},     //     [9] BALINESE MUSICAL SYMBOL COMBINING TEGEH..BALINESE MUSICAL SYMBOL COMBINING GONG
-	{runeRange{0x1B74, 0x1B7C}, propertyGeneralCategory{lbprAL, gcSo}},     //     [9] BALINESE MUSICAL SYMBOL RIGHT-HAND OPEN DUG..BALINESE MUSICAL SYMBOL LEFT-HAND OPEN PING
-	{runeRange{0x1B7D, 0x1B7E}, propertyGeneralCategory{lbprBA, gcPo}},     //     [2] BALINESE PANTI LANTANG..BALINESE PAMADA LANTANG
-	{runeRange{0x1B80, 0x1B81}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] SUNDANESE SIGN PANYECEK..SUNDANESE SIGN PANGLAYAR
-	{runeRange{0x1B82, 0x1B82}, propertyGeneralCategory{lbprCM, gcMc}},     //         SUNDANESE SIGN PANGWISAD
-	{runeRange{0x1B83, 0x1BA0}, propertyGeneralCategory{lbprAL, gcLo}},     //    [30] SUNDANESE LETTER A..SUNDANESE LETTER HA
-	{runeRange{0x1BA1, 0x1BA1}, propertyGeneralCategory{lbprCM, gcMc}},     //         SUNDANESE CONSONANT SIGN PAMINGKAL
-	{runeRange{0x1BA2, 0x1BA5}, propertyGeneralCategory{lbprCM, gcMn}},     //     [4] SUNDANESE CONSONANT SIGN PANYAKRA..SUNDANESE VOWEL SIGN PANYUKU
-	{runeRange{0x1BA6, 0x1BA7}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] SUNDANESE VOWEL SIGN PANAELAENG..SUNDANESE VOWEL SIGN PANOLONG
-	{runeRange{0x1BA8, 0x1BA9}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] SUNDANESE VOWEL SIGN PAMEPET..SUNDANESE VOWEL SIGN PANEULEUNG
-	{runeRange{0x1BAA, 0x1BAA}, propertyGeneralCategory{lbprCM, gcMc}},     //         SUNDANESE SIGN PAMAAEH
-	{runeRange{0x1BAB, 0x1BAD}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] SUNDANESE SIGN VIRAMA..SUNDANESE CONSONANT SIGN PASANGAN WA
-	{runeRange{0x1BAE, 0x1BAF}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] SUNDANESE LETTER KHA..SUNDANESE LETTER SYA
-	{runeRange{0x1BB0, 0x1BB9}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] SUNDANESE DIGIT ZERO..SUNDANESE DIGIT NINE
-	{runeRange{0x1BBA, 0x1BBF}, propertyGeneralCategory{lbprAL, gcLo}},     //     [6] SUNDANESE AVAGRAHA..SUNDANESE LETTER FINAL M
-	{runeRange{0x1BC0, 0x1BE5}, propertyGeneralCategory{lbprAL, gcLo}},     //    [38] BATAK LETTER A..BATAK LETTER U
-	{runeRange{0x1BE6, 0x1BE6}, propertyGeneralCategory{lbprCM, gcMn}},     //         BATAK SIGN TOMPI
-	{runeRange{0x1BE7, 0x1BE7}, propertyGeneralCategory{lbprCM, gcMc}},     //         BATAK VOWEL SIGN E
-	{runeRange{0x1BE8, 0x1BE9}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] BATAK VOWEL SIGN PAKPAK E..BATAK VOWEL SIGN EE
-	{runeRange{0x1BEA, 0x1BEC}, propertyGeneralCategory{lbprCM, gcMc}},     //     [3] BATAK VOWEL SIGN I..BATAK VOWEL SIGN O
-	{runeRange{0x1BED, 0x1BED}, propertyGeneralCategory{lbprCM, gcMn}},     //         BATAK VOWEL SIGN KARO O
-	{runeRange{0x1BEE, 0x1BEE}, propertyGeneralCategory{lbprCM, gcMc}},     //         BATAK VOWEL SIGN U
-	{runeRange{0x1BEF, 0x1BF1}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] BATAK VOWEL SIGN U FOR SIMALUNGUN SA..BATAK CONSONANT SIGN H
-	{runeRange{0x1BF2, 0x1BF3}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] BATAK PANGOLAT..BATAK PANONGONAN
-	{runeRange{0x1BFC, 0x1BFF}, propertyGeneralCategory{lbprAL, gcPo}},     //     [4] BATAK SYMBOL BINDU NA METEK..BATAK SYMBOL BINDU PANGOLAT
-	{runeRange{0x1C00, 0x1C23}, propertyGeneralCategory{lbprAL, gcLo}},     //    [36] LEPCHA LETTER KA..LEPCHA LETTER A
-	{runeRange{0x1C24, 0x1C2B}, propertyGeneralCategory{lbprCM, gcMc}},     //     [8] LEPCHA SUBJOINED LETTER YA..LEPCHA VOWEL SIGN UU
-	{runeRange{0x1C2C, 0x1C33}, propertyGeneralCategory{lbprCM, gcMn}},     //     [8] LEPCHA VOWEL SIGN E..LEPCHA CONSONANT SIGN T
-	{runeRange{0x1C34, 0x1C35}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] LEPCHA CONSONANT SIGN NYIN-DO..LEPCHA CONSONANT SIGN KANG
-	{runeRange{0x1C36, 0x1C37}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] LEPCHA SIGN RAN..LEPCHA SIGN NUKTA
-	{runeRange{0x1C3B, 0x1C3F}, propertyGeneralCategory{lbprBA, gcPo}},     //     [5] LEPCHA PUNCTUATION TA-ROL..LEPCHA PUNCTUATION TSHOOK
-	{runeRange{0x1C40, 0x1C49}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] LEPCHA DIGIT ZERO..LEPCHA DIGIT NINE
-	{runeRange{0x1C4D, 0x1C4F}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] LEPCHA LETTER TTA..LEPCHA LETTER DDA
-	{runeRange{0x1C50, 0x1C59}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] OL CHIKI DIGIT ZERO..OL CHIKI DIGIT NINE
-	{runeRange{0x1C5A, 0x1C77}, propertyGeneralCategory{lbprAL, gcLo}},     //    [30] OL CHIKI LETTER LA..OL CHIKI LETTER OH
-	{runeRange{0x1C78, 0x1C7D}, propertyGeneralCategory{lbprAL, gcLm}},     //     [6] OL CHIKI MU TTUDDAG..OL CHIKI AHAD
-	{runeRange{0x1C7E, 0x1C7F}, propertyGeneralCategory{lbprBA, gcPo}},     //     [2] OL CHIKI PUNCTUATION MUCAAD..OL CHIKI PUNCTUATION DOUBLE MUCAAD
-	{runeRange{0x1C80, 0x1C88}, propertyGeneralCategory{lbprAL, gcLl}},     //     [9] CYRILLIC SMALL LETTER ROUNDED VE..CYRILLIC SMALL LETTER UNBLENDED UK
-	{runeRange{0x1C90, 0x1CBA}, propertyGeneralCategory{lbprAL, gcLu}},     //    [43] GEORGIAN MTAVRULI CAPITAL LETTER AN..GEORGIAN MTAVRULI CAPITAL LETTER AIN
-	{runeRange{0x1CBD, 0x1CBF}, propertyGeneralCategory{lbprAL, gcLu}},     //     [3] GEORGIAN MTAVRULI CAPITAL LETTER AEN..GEORGIAN MTAVRULI CAPITAL LETTER LABIAL SIGN
-	{runeRange{0x1CC0, 0x1CC7}, propertyGeneralCategory{lbprAL, gcPo}},     //     [8] SUNDANESE PUNCTUATION BINDU SURYA..SUNDANESE PUNCTUATION BINDU BA SATANGA
-	{runeRange{0x1CD0, 0x1CD2}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] VEDIC TONE KARSHANA..VEDIC TONE PRENKHA
-	{runeRange{0x1CD3, 0x1CD3}, propertyGeneralCategory{lbprAL, gcPo}},     //         VEDIC SIGN NIHSHVASA
-	{runeRange{0x1CD4, 0x1CE0}, propertyGeneralCategory{lbprCM, gcMn}},     //    [13] VEDIC SIGN YAJURVEDIC MIDLINE SVARITA..VEDIC TONE RIGVEDIC KASHMIRI INDEPENDENT SVARITA
-	{runeRange{0x1CE1, 0x1CE1}, propertyGeneralCategory{lbprCM, gcMc}},     //         VEDIC TONE ATHARVAVEDIC INDEPENDENT SVARITA
-	{runeRange{0x1CE2, 0x1CE8}, propertyGeneralCategory{lbprCM, gcMn}},     //     [7] VEDIC SIGN VISARGA SVARITA..VEDIC SIGN VISARGA ANUDATTA WITH TAIL
-	{runeRange{0x1CE9, 0x1CEC}, propertyGeneralCategory{lbprAL, gcLo}},     //     [4] VEDIC SIGN ANUSVARA ANTARGOMUKHA..VEDIC SIGN ANUSVARA VAMAGOMUKHA WITH TAIL
-	{runeRange{0x1CED, 0x1CED}, propertyGeneralCategory{lbprCM, gcMn}},     //         VEDIC SIGN TIRYAK
-	{runeRange{0x1CEE, 0x1CF3}, propertyGeneralCategory{lbprAL, gcLo}},     //     [6] VEDIC SIGN HEXIFORM LONG ANUSVARA..VEDIC SIGN ROTATED ARDHAVISARGA
-	{runeRange{0x1CF4, 0x1CF4}, propertyGeneralCategory{lbprCM, gcMn}},     //         VEDIC TONE CANDRA ABOVE
-	{runeRange{0x1CF5, 0x1CF6}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] VEDIC SIGN JIHVAMULIYA..VEDIC SIGN UPADHMANIYA
-	{runeRange{0x1CF7, 0x1CF7}, propertyGeneralCategory{lbprCM, gcMc}},     //         VEDIC SIGN ATIKRAMA
-	{runeRange{0x1CF8, 0x1CF9}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] VEDIC TONE RING ABOVE..VEDIC TONE DOUBLE RING ABOVE
-	{runeRange{0x1CFA, 0x1CFA}, propertyGeneralCategory{lbprAL, gcLo}},     //         VEDIC SIGN DOUBLE ANUSVARA ANTARGOMUKHA
-	{runeRange{0x1D00, 0x1D2B}, propertyGeneralCategory{lbprAL, gcLl}},     //    [44] LATIN LETTER SMALL CAPITAL A..CYRILLIC LETTER SMALL CAPITAL EL
-	{runeRange{0x1D2C, 0x1D6A}, propertyGeneralCategory{lbprAL, gcLm}},     //    [63] MODIFIER LETTER CAPITAL A..GREEK SUBSCRIPT SMALL LETTER CHI
-	{runeRange{0x1D6B, 0x1D77}, propertyGeneralCategory{lbprAL, gcLl}},     //    [13] LATIN SMALL LETTER UE..LATIN SMALL LETTER TURNED G
-	{runeRange{0x1D78, 0x1D78}, propertyGeneralCategory{lbprAL, gcLm}},     //         MODIFIER LETTER CYRILLIC EN
-	{runeRange{0x1D79, 0x1D7F}, propertyGeneralCategory{lbprAL, gcLl}},     //     [7] LATIN SMALL LETTER INSULAR G..LATIN SMALL LETTER UPSILON WITH STROKE
-	{runeRange{0x1D80, 0x1D9A}, propertyGeneralCategory{lbprAL, gcLl}},     //    [27] LATIN SMALL LETTER B WITH PALATAL HOOK..LATIN SMALL LETTER EZH WITH RETROFLEX HOOK
-	{runeRange{0x1D9B, 0x1DBF}, propertyGeneralCategory{lbprAL, gcLm}},     //    [37] MODIFIER LETTER SMALL TURNED ALPHA..MODIFIER LETTER SMALL THETA
-	{runeRange{0x1DC0, 0x1DCC}, propertyGeneralCategory{lbprCM, gcMn}},     //    [13] COMBINING DOTTED GRAVE ACCENT..COMBINING MACRON-BREVE
-	{runeRange{0x1DCD, 0x1DCD}, propertyGeneralCategory{lbprGL, gcMn}},     //         COMBINING DOUBLE CIRCUMFLEX ABOVE
-	{runeRange{0x1DCE, 0x1DFB}, propertyGeneralCategory{lbprCM, gcMn}},     //    [46] COMBINING OGONEK ABOVE..COMBINING DELETION MARK
-	{runeRange{0x1DFC, 0x1DFC}, propertyGeneralCategory{lbprGL, gcMn}},     //         COMBINING DOUBLE INVERTED BREVE BELOW
-	{runeRange{0x1DFD, 0x1DFF}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] COMBINING ALMOST EQUAL TO BELOW..COMBINING RIGHT ARROWHEAD AND DOWN ARROWHEAD BELOW
-	{runeRange{0x1E00, 0x1EFF}, propertyGeneralCategory{lbprAL, gcLC}},     //   [256] LATIN CAPITAL LETTER A WITH RING BELOW..LATIN SMALL LETTER Y WITH LOOP
-	{runeRange{0x1F00, 0x1F15}, propertyGeneralCategory{lbprAL, gcLC}},     //    [22] GREEK SMALL LETTER ALPHA WITH PSILI..GREEK SMALL LETTER EPSILON WITH DASIA AND OXIA
-	{runeRange{0x1F18, 0x1F1D}, propertyGeneralCategory{lbprAL, gcLu}},     //     [6] GREEK CAPITAL LETTER EPSILON WITH PSILI..GREEK CAPITAL LETTER EPSILON WITH DASIA AND OXIA
-	{runeRange{0x1F20, 0x1F45}, propertyGeneralCategory{lbprAL, gcLC}},     //    [38] GREEK SMALL LETTER ETA WITH PSILI..GREEK SMALL LETTER OMICRON WITH DASIA AND OXIA
-	{runeRange{0x1F48, 0x1F4D}, propertyGeneralCategory{lbprAL, gcLu}},     //     [6] GREEK CAPITAL LETTER OMICRON WITH PSILI..GREEK CAPITAL LETTER OMICRON WITH DASIA AND OXIA
-	{runeRange{0x1F50, 0x1F57}, propertyGeneralCategory{lbprAL, gcLl}},     //     [8] GREEK SMALL LETTER UPSILON WITH PSILI..GREEK SMALL LETTER UPSILON WITH DASIA AND PERISPOMENI
-	{runeRange{0x1F59, 0x1F59}, propertyGeneralCategory{lbprAL, gcLu}},     //         GREEK CAPITAL LETTER UPSILON WITH DASIA
-	{runeRange{0x1F5B, 0x1F5B}, propertyGeneralCategory{lbprAL, gcLu}},     //         GREEK CAPITAL LETTER UPSILON WITH DASIA AND VARIA
-	{runeRange{0x1F5D, 0x1F5D}, propertyGeneralCategory{lbprAL, gcLu}},     //         GREEK CAPITAL LETTER UPSILON WITH DASIA AND OXIA
-	{runeRange{0x1F5F, 0x1F7D}, propertyGeneralCategory{lbprAL, gcLC}},     //    [31] GREEK CAPITAL LETTER UPSILON WITH DASIA AND PERISPOMENI..GREEK SMALL LETTER OMEGA WITH OXIA
-	{runeRange{0x1F80, 0x1FB4}, propertyGeneralCategory{lbprAL, gcLC}},     //    [53] GREEK SMALL LETTER ALPHA WITH PSILI AND YPOGEGRAMMENI..GREEK SMALL LETTER ALPHA WITH OXIA AND YPOGEGRAMMENI
-	{runeRange{0x1FB6, 0x1FBC}, propertyGeneralCategory{lbprAL, gcLC}},     //     [7] GREEK SMALL LETTER ALPHA WITH PERISPOMENI..GREEK CAPITAL LETTER ALPHA WITH PROSGEGRAMMENI
-	{runeRange{0x1FBD, 0x1FBD}, propertyGeneralCategory{lbprAL, gcSk}},     //         GREEK KORONIS
-	{runeRange{0x1FBE, 0x1FBE}, propertyGeneralCategory{lbprAL, gcLl}},     //         GREEK PROSGEGRAMMENI
-	{runeRange{0x1FBF, 0x1FC1}, propertyGeneralCategory{lbprAL, gcSk}},     //     [3] GREEK PSILI..GREEK DIALYTIKA AND PERISPOMENI
-	{runeRange{0x1FC2, 0x1FC4}, propertyGeneralCategory{lbprAL, gcLl}},     //     [3] GREEK SMALL LETTER ETA WITH VARIA AND YPOGEGRAMMENI..GREEK SMALL LETTER ETA WITH OXIA AND YPOGEGRAMMENI
-	{runeRange{0x1FC6, 0x1FCC}, propertyGeneralCategory{lbprAL, gcLC}},     //     [7] GREEK SMALL LETTER ETA WITH PERISPOMENI..GREEK CAPITAL LETTER ETA WITH PROSGEGRAMMENI
-	{runeRange{0x1FCD, 0x1FCF}, propertyGeneralCategory{lbprAL, gcSk}},     //     [3] GREEK PSILI AND VARIA..GREEK PSILI AND PERISPOMENI
-	{runeRange{0x1FD0, 0x1FD3}, propertyGeneralCategory{lbprAL, gcLl}},     //     [4] GREEK SMALL LETTER IOTA WITH VRACHY..GREEK SMALL LETTER IOTA WITH DIALYTIKA AND OXIA
-	{runeRange{0x1FD6, 0x1FDB}, propertyGeneralCategory{lbprAL, gcLC}},     //     [6] GREEK SMALL LETTER IOTA WITH PERISPOMENI..GREEK CAPITAL LETTER IOTA WITH OXIA
-	{runeRange{0x1FDD, 0x1FDF}, propertyGeneralCategory{lbprAL, gcSk}},     //     [3] GREEK DASIA AND VARIA..GREEK DASIA AND PERISPOMENI
-	{runeRange{0x1FE0, 0x1FEC}, propertyGeneralCategory{lbprAL, gcLC}},     //    [13] GREEK SMALL LETTER UPSILON WITH VRACHY..GREEK CAPITAL LETTER RHO WITH DASIA
-	{runeRange{0x1FED, 0x1FEF}, propertyGeneralCategory{lbprAL, gcSk}},     //     [3] GREEK DIALYTIKA AND VARIA..GREEK VARIA
-	{runeRange{0x1FF2, 0x1FF4}, propertyGeneralCategory{lbprAL, gcLl}},     //     [3] GREEK SMALL LETTER OMEGA WITH VARIA AND YPOGEGRAMMENI..GREEK SMALL LETTER OMEGA WITH OXIA AND YPOGEGRAMMENI
-	{runeRange{0x1FF6, 0x1FFC}, propertyGeneralCategory{lbprAL, gcLC}},     //     [7] GREEK SMALL LETTER OMEGA WITH PERISPOMENI..GREEK CAPITAL LETTER OMEGA WITH PROSGEGRAMMENI
-	{runeRange{0x1FFD, 0x1FFD}, propertyGeneralCategory{lbprBB, gcSk}},     //         GREEK OXIA
-	{runeRange{0x1FFE, 0x1FFE}, propertyGeneralCategory{lbprAL, gcSk}},     //         GREEK DASIA
-	{runeRange{0x2000, 0x2006}, propertyGeneralCategory{lbprBA, gcZs}},     //     [7] EN QUAD..SIX-PER-EM SPACE
-	{runeRange{0x2007, 0x2007}, propertyGeneralCategory{lbprGL, gcZs}},     //         FIGURE SPACE
-	{runeRange{0x2008, 0x200A}, propertyGeneralCategory{lbprBA, gcZs}},     //     [3] PUNCTUATION SPACE..HAIR SPACE
-	{runeRange{0x200B, 0x200B}, propertyGeneralCategory{lbprZW, gcCf}},     //         ZERO WIDTH SPACE
-	{runeRange{0x200C, 0x200C}, propertyGeneralCategory{lbprCM, gcCf}},     //         ZERO WIDTH NON-JOINER
-	{runeRange{0x200D, 0x200D}, propertyGeneralCategory{lbprZWJ, gcCf}},    //         ZERO WIDTH JOINER
-	{runeRange{0x200E, 0x200F}, propertyGeneralCategory{lbprCM, gcCf}},     //     [2] LEFT-TO-RIGHT MARK..RIGHT-TO-LEFT MARK
-	{runeRange{0x2010, 0x2010}, propertyGeneralCategory{lbprBA, gcPd}},     //         HYPHEN
-	{runeRange{0x2011, 0x2011}, propertyGeneralCategory{lbprGL, gcPd}},     //         NON-BREAKING HYPHEN
-	{runeRange{0x2012, 0x2013}, propertyGeneralCategory{lbprBA, gcPd}},     //     [2] FIGURE DASH..EN DASH
-	{runeRange{0x2014, 0x2014}, propertyGeneralCategory{lbprB2, gcPd}},     //         EM DASH
-	{runeRange{0x2015, 0x2015}, propertyGeneralCategory{lbprAI, gcPd}},     //         HORIZONTAL BAR
-	{runeRange{0x2016, 0x2016}, propertyGeneralCategory{lbprAI, gcPo}},     //         DOUBLE VERTICAL LINE
-	{runeRange{0x2017, 0x2017}, propertyGeneralCategory{lbprAL, gcPo}},     //         DOUBLE LOW LINE
-	{runeRange{0x2018, 0x2018}, propertyGeneralCategory{lbprQU, gcPi}},     //         LEFT SINGLE QUOTATION MARK
-	{runeRange{0x2019, 0x2019}, propertyGeneralCategory{lbprQU, gcPf}},     //         RIGHT SINGLE QUOTATION MARK
-	{runeRange{0x201A, 0x201A}, propertyGeneralCategory{lbprOP, gcPs}},     //         SINGLE LOW-9 QUOTATION MARK
-	{runeRange{0x201B, 0x201C}, propertyGeneralCategory{lbprQU, gcPi}},     //     [2] SINGLE HIGH-REVERSED-9 QUOTATION MARK..LEFT DOUBLE QUOTATION MARK
-	{runeRange{0x201D, 0x201D}, propertyGeneralCategory{lbprQU, gcPf}},     //         RIGHT DOUBLE QUOTATION MARK
-	{runeRange{0x201E, 0x201E}, propertyGeneralCategory{lbprOP, gcPs}},     //         DOUBLE LOW-9 QUOTATION MARK
-	{runeRange{0x201F, 0x201F}, propertyGeneralCategory{lbprQU, gcPi}},     //         DOUBLE HIGH-REVERSED-9 QUOTATION MARK
-	{runeRange{0x2020, 0x2021}, propertyGeneralCategory{lbprAI, gcPo}},     //     [2] DAGGER..DOUBLE DAGGER
-	{runeRange{0x2022, 0x2023}, propertyGeneralCategory{lbprAL, gcPo}},     //     [2] BULLET..TRIANGULAR BULLET
-	{runeRange{0x2024, 0x2026}, propertyGeneralCategory{lbprIN, gcPo}},     //     [3] ONE DOT LEADER..HORIZONTAL ELLIPSIS
-	{runeRange{0x2027, 0x2027}, propertyGeneralCategory{lbprBA, gcPo}},     //         HYPHENATION POINT
-	{runeRange{0x2028, 0x2028}, propertyGeneralCategory{lbprBK, gcZl}},     //         LINE SEPARATOR
-	{runeRange{0x2029, 0x2029}, propertyGeneralCategory{lbprBK, gcZp}},     //         PARAGRAPH SEPARATOR
-	{runeRange{0x202A, 0x202E}, propertyGeneralCategory{lbprCM, gcCf}},     //     [5] LEFT-TO-RIGHT EMBEDDING..RIGHT-TO-LEFT OVERRIDE
-	{runeRange{0x202F, 0x202F}, propertyGeneralCategory{lbprGL, gcZs}},     //         NARROW NO-BREAK SPACE
-	{runeRange{0x2030, 0x2037}, propertyGeneralCategory{lbprPO, gcPo}},     //     [8] PER MILLE SIGN..REVERSED TRIPLE PRIME
-	{runeRange{0x2038, 0x2038}, propertyGeneralCategory{lbprAL, gcPo}},     //         CARET
-	{runeRange{0x2039, 0x2039}, propertyGeneralCategory{lbprQU, gcPi}},     //         SINGLE LEFT-POINTING ANGLE QUOTATION MARK
-	{runeRange{0x203A, 0x203A}, propertyGeneralCategory{lbprQU, gcPf}},     //         SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
-	{runeRange{0x203B, 0x203B}, propertyGeneralCategory{lbprAI, gcPo}},     //         REFERENCE MARK
-	{runeRange{0x203C, 0x203D}, propertyGeneralCategory{lbprNS, gcPo}},     //     [2] DOUBLE EXCLAMATION MARK..INTERROBANG
-	{runeRange{0x203E, 0x203E}, propertyGeneralCategory{lbprAL, gcPo}},     //         OVERLINE
-	{runeRange{0x203F, 0x2040}, propertyGeneralCategory{lbprAL, gcPc}},     //     [2] UNDERTIE..CHARACTER TIE
-	{runeRange{0x2041, 0x2043}, propertyGeneralCategory{lbprAL, gcPo}},     //     [3] CARET INSERTION POINT..HYPHEN BULLET
-	{runeRange{0x2044, 0x2044}, propertyGeneralCategory{lbprIS, gcSm}},     //         FRACTION SLASH
-	{runeRange{0x2045, 0x2045}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT SQUARE BRACKET WITH QUILL
-	{runeRange{0x2046, 0x2046}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT SQUARE BRACKET WITH QUILL
-	{runeRange{0x2047, 0x2049}, propertyGeneralCategory{lbprNS, gcPo}},     //     [3] DOUBLE QUESTION MARK..EXCLAMATION QUESTION MARK
-	{runeRange{0x204A, 0x2051}, propertyGeneralCategory{lbprAL, gcPo}},     //     [8] TIRONIAN SIGN ET..TWO ASTERISKS ALIGNED VERTICALLY
-	{runeRange{0x2052, 0x2052}, propertyGeneralCategory{lbprAL, gcSm}},     //         COMMERCIAL MINUS SIGN
-	{runeRange{0x2053, 0x2053}, propertyGeneralCategory{lbprAL, gcPo}},     //         SWUNG DASH
-	{runeRange{0x2054, 0x2054}, propertyGeneralCategory{lbprAL, gcPc}},     //         INVERTED UNDERTIE
-	{runeRange{0x2055, 0x2055}, propertyGeneralCategory{lbprAL, gcPo}},     //         FLOWER PUNCTUATION MARK
-	{runeRange{0x2056, 0x2056}, propertyGeneralCategory{lbprBA, gcPo}},     //         THREE DOT PUNCTUATION
-	{runeRange{0x2057, 0x2057}, propertyGeneralCategory{lbprPO, gcPo}},     //         QUADRUPLE PRIME
-	{runeRange{0x2058, 0x205B}, propertyGeneralCategory{lbprBA, gcPo}},     //     [4] FOUR DOT PUNCTUATION..FOUR DOT MARK
-	{runeRange{0x205C, 0x205C}, propertyGeneralCategory{lbprAL, gcPo}},     //         DOTTED CROSS
-	{runeRange{0x205D, 0x205E}, propertyGeneralCategory{lbprBA, gcPo}},     //     [2] TRICOLON..VERTICAL FOUR DOTS
-	{runeRange{0x205F, 0x205F}, propertyGeneralCategory{lbprBA, gcZs}},     //         MEDIUM MATHEMATICAL SPACE
-	{runeRange{0x2060, 0x2060}, propertyGeneralCategory{lbprWJ, gcCf}},     //         WORD JOINER
-	{runeRange{0x2061, 0x2064}, propertyGeneralCategory{lbprAL, gcCf}},     //     [4] FUNCTION APPLICATION..INVISIBLE PLUS
-	{runeRange{0x2066, 0x206F}, propertyGeneralCategory{lbprCM, gcCf}},     //    [10] LEFT-TO-RIGHT ISOLATE..NOMINAL DIGIT SHAPES
-	{runeRange{0x2070, 0x2070}, propertyGeneralCategory{lbprAL, gcNo}},     //         SUPERSCRIPT ZERO
-	{runeRange{0x2071, 0x2071}, propertyGeneralCategory{lbprAL, gcLm}},     //         SUPERSCRIPT LATIN SMALL LETTER I
-	{runeRange{0x2074, 0x2074}, propertyGeneralCategory{lbprAI, gcNo}},     //         SUPERSCRIPT FOUR
-	{runeRange{0x2075, 0x2079}, propertyGeneralCategory{lbprAL, gcNo}},     //     [5] SUPERSCRIPT FIVE..SUPERSCRIPT NINE
-	{runeRange{0x207A, 0x207C}, propertyGeneralCategory{lbprAL, gcSm}},     //     [3] SUPERSCRIPT PLUS SIGN..SUPERSCRIPT EQUALS SIGN
-	{runeRange{0x207D, 0x207D}, propertyGeneralCategory{lbprOP, gcPs}},     //         SUPERSCRIPT LEFT PARENTHESIS
-	{runeRange{0x207E, 0x207E}, propertyGeneralCategory{lbprCL, gcPe}},     //         SUPERSCRIPT RIGHT PARENTHESIS
-	{runeRange{0x207F, 0x207F}, propertyGeneralCategory{lbprAI, gcLm}},     //         SUPERSCRIPT LATIN SMALL LETTER N
-	{runeRange{0x2080, 0x2080}, propertyGeneralCategory{lbprAL, gcNo}},     //         SUBSCRIPT ZERO
-	{runeRange{0x2081, 0x2084}, propertyGeneralCategory{lbprAI, gcNo}},     //     [4] SUBSCRIPT ONE..SUBSCRIPT FOUR
-	{runeRange{0x2085, 0x2089}, propertyGeneralCategory{lbprAL, gcNo}},     //     [5] SUBSCRIPT FIVE..SUBSCRIPT NINE
-	{runeRange{0x208A, 0x208C}, propertyGeneralCategory{lbprAL, gcSm}},     //     [3] SUBSCRIPT PLUS SIGN..SUBSCRIPT EQUALS SIGN
-	{runeRange{0x208D, 0x208D}, propertyGeneralCategory{lbprOP, gcPs}},     //         SUBSCRIPT LEFT PARENTHESIS
-	{runeRange{0x208E, 0x208E}, propertyGeneralCategory{lbprCL, gcPe}},     //         SUBSCRIPT RIGHT PARENTHESIS
-	{runeRange{0x2090, 0x209C}, propertyGeneralCategory{lbprAL, gcLm}},     //    [13] LATIN SUBSCRIPT SMALL LETTER A..LATIN SUBSCRIPT SMALL LETTER T
-	{runeRange{0x20A0, 0x20A6}, propertyGeneralCategory{lbprPR, gcSc}},     //     [7] EURO-CURRENCY SIGN..NAIRA SIGN
-	{runeRange{0x20A7, 0x20A7}, propertyGeneralCategory{lbprPO, gcSc}},     //         PESETA SIGN
-	{runeRange{0x20A8, 0x20B5}, propertyGeneralCategory{lbprPR, gcSc}},     //    [14] RUPEE SIGN..CEDI SIGN
-	{runeRange{0x20B6, 0x20B6}, propertyGeneralCategory{lbprPO, gcSc}},     //         LIVRE TOURNOIS SIGN
-	{runeRange{0x20B7, 0x20BA}, propertyGeneralCategory{lbprPR, gcSc}},     //     [4] SPESMILO SIGN..TURKISH LIRA SIGN
-	{runeRange{0x20BB, 0x20BB}, propertyGeneralCategory{lbprPO, gcSc}},     //         NORDIC MARK SIGN
-	{runeRange{0x20BC, 0x20BD}, propertyGeneralCategory{lbprPR, gcSc}},     //     [2] MANAT SIGN..RUBLE SIGN
-	{runeRange{0x20BE, 0x20BE}, propertyGeneralCategory{lbprPO, gcSc}},     //         LARI SIGN
-	{runeRange{0x20BF, 0x20BF}, propertyGeneralCategory{lbprPR, gcSc}},     //         BITCOIN SIGN
-	{runeRange{0x20C0, 0x20C0}, propertyGeneralCategory{lbprPO, gcSc}},     //         SOM SIGN
-	{runeRange{0x20C1, 0x20CF}, propertyGeneralCategory{lbprPR, gcCn}},     //    [15] <reserved-20C1>..<reserved-20CF>
-	{runeRange{0x20D0, 0x20DC}, propertyGeneralCategory{lbprCM, gcMn}},     //    [13] COMBINING LEFT HARPOON ABOVE..COMBINING FOUR DOTS ABOVE
-	{runeRange{0x20DD, 0x20E0}, propertyGeneralCategory{lbprCM, gcMe}},     //     [4] COMBINING ENCLOSING CIRCLE..COMBINING ENCLOSING CIRCLE BACKSLASH
-	{runeRange{0x20E1, 0x20E1}, propertyGeneralCategory{lbprCM, gcMn}},     //         COMBINING LEFT RIGHT ARROW ABOVE
-	{runeRange{0x20E2, 0x20E4}, propertyGeneralCategory{lbprCM, gcMe}},     //     [3] COMBINING ENCLOSING SCREEN..COMBINING ENCLOSING UPWARD POINTING TRIANGLE
-	{runeRange{0x20E5, 0x20F0}, propertyGeneralCategory{lbprCM, gcMn}},     //    [12] COMBINING REVERSE SOLIDUS OVERLAY..COMBINING ASTERISK ABOVE
-	{runeRange{0x2100, 0x2101}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] ACCOUNT OF..ADDRESSED TO THE SUBJECT
-	{runeRange{0x2102, 0x2102}, propertyGeneralCategory{lbprAL, gcLu}},     //         DOUBLE-STRUCK CAPITAL C
-	{runeRange{0x2103, 0x2103}, propertyGeneralCategory{lbprPO, gcSo}},     //         DEGREE CELSIUS
-	{runeRange{0x2104, 0x2104}, propertyGeneralCategory{lbprAL, gcSo}},     //         CENTRE LINE SYMBOL
-	{runeRange{0x2105, 0x2105}, propertyGeneralCategory{lbprAI, gcSo}},     //         CARE OF
-	{runeRange{0x2106, 0x2106}, propertyGeneralCategory{lbprAL, gcSo}},     //         CADA UNA
-	{runeRange{0x2107, 0x2107}, propertyGeneralCategory{lbprAL, gcLu}},     //         EULER CONSTANT
-	{runeRange{0x2108, 0x2108}, propertyGeneralCategory{lbprAL, gcSo}},     //         SCRUPLE
-	{runeRange{0x2109, 0x2109}, propertyGeneralCategory{lbprPO, gcSo}},     //         DEGREE FAHRENHEIT
-	{runeRange{0x210A, 0x2112}, propertyGeneralCategory{lbprAL, gcLC}},     //     [9] SCRIPT SMALL G..SCRIPT CAPITAL L
-	{runeRange{0x2113, 0x2113}, propertyGeneralCategory{lbprAI, gcLl}},     //         SCRIPT SMALL L
-	{runeRange{0x2114, 0x2114}, propertyGeneralCategory{lbprAL, gcSo}},     //         L B BAR SYMBOL
-	{runeRange{0x2115, 0x2115}, propertyGeneralCategory{lbprAL, gcLu}},     //         DOUBLE-STRUCK CAPITAL N
-	{runeRange{0x2116, 0x2116}, propertyGeneralCategory{lbprPR, gcSo}},     //         NUMERO SIGN
-	{runeRange{0x2117, 0x2117}, propertyGeneralCategory{lbprAL, gcSo}},     //         SOUND RECORDING COPYRIGHT
-	{runeRange{0x2118, 0x2118}, propertyGeneralCategory{lbprAL, gcSm}},     //         SCRIPT CAPITAL P
-	{runeRange{0x2119, 0x211D}, propertyGeneralCategory{lbprAL, gcLu}},     //     [5] DOUBLE-STRUCK CAPITAL P..DOUBLE-STRUCK CAPITAL R
-	{runeRange{0x211E, 0x2120}, propertyGeneralCategory{lbprAL, gcSo}},     //     [3] PRESCRIPTION TAKE..SERVICE MARK
-	{runeRange{0x2121, 0x2122}, propertyGeneralCategory{lbprAI, gcSo}},     //     [2] TELEPHONE SIGN..TRADE MARK SIGN
-	{runeRange{0x2123, 0x2123}, propertyGeneralCategory{lbprAL, gcSo}},     //         VERSICLE
-	{runeRange{0x2124, 0x2124}, propertyGeneralCategory{lbprAL, gcLu}},     //         DOUBLE-STRUCK CAPITAL Z
-	{runeRange{0x2125, 0x2125}, propertyGeneralCategory{lbprAL, gcSo}},     //         OUNCE SIGN
-	{runeRange{0x2126, 0x2126}, propertyGeneralCategory{lbprAL, gcLu}},     //         OHM SIGN
-	{runeRange{0x2127, 0x2127}, propertyGeneralCategory{lbprAL, gcSo}},     //         INVERTED OHM SIGN
-	{runeRange{0x2128, 0x2128}, propertyGeneralCategory{lbprAL, gcLu}},     //         BLACK-LETTER CAPITAL Z
-	{runeRange{0x2129, 0x2129}, propertyGeneralCategory{lbprAL, gcSo}},     //         TURNED GREEK SMALL LETTER IOTA
-	{runeRange{0x212A, 0x212A}, propertyGeneralCategory{lbprAL, gcLu}},     //         KELVIN SIGN
-	{runeRange{0x212B, 0x212B}, propertyGeneralCategory{lbprAI, gcLu}},     //         ANGSTROM SIGN
-	{runeRange{0x212C, 0x212D}, propertyGeneralCategory{lbprAL, gcLu}},     //     [2] SCRIPT CAPITAL B..BLACK-LETTER CAPITAL C
-	{runeRange{0x212E, 0x212E}, propertyGeneralCategory{lbprAL, gcSo}},     //         ESTIMATED SYMBOL
-	{runeRange{0x212F, 0x2134}, propertyGeneralCategory{lbprAL, gcLC}},     //     [6] SCRIPT SMALL E..SCRIPT SMALL O
-	{runeRange{0x2135, 0x2138}, propertyGeneralCategory{lbprAL, gcLo}},     //     [4] ALEF SYMBOL..DALET SYMBOL
-	{runeRange{0x2139, 0x2139}, propertyGeneralCategory{lbprAL, gcLl}},     //         INFORMATION SOURCE
-	{runeRange{0x213A, 0x213B}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] ROTATED CAPITAL Q..FACSIMILE SIGN
-	{runeRange{0x213C, 0x213F}, propertyGeneralCategory{lbprAL, gcLC}},     //     [4] DOUBLE-STRUCK SMALL PI..DOUBLE-STRUCK CAPITAL PI
-	{runeRange{0x2140, 0x2144}, propertyGeneralCategory{lbprAL, gcSm}},     //     [5] DOUBLE-STRUCK N-ARY SUMMATION..TURNED SANS-SERIF CAPITAL Y
-	{runeRange{0x2145, 0x2149}, propertyGeneralCategory{lbprAL, gcLC}},     //     [5] DOUBLE-STRUCK ITALIC CAPITAL D..DOUBLE-STRUCK ITALIC SMALL J
-	{runeRange{0x214A, 0x214A}, propertyGeneralCategory{lbprAL, gcSo}},     //         PROPERTY LINE
-	{runeRange{0x214B, 0x214B}, propertyGeneralCategory{lbprAL, gcSm}},     //         TURNED AMPERSAND
-	{runeRange{0x214C, 0x214D}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] PER SIGN..AKTIESELSKAB
-	{runeRange{0x214E, 0x214E}, propertyGeneralCategory{lbprAL, gcLl}},     //         TURNED SMALL F
-	{runeRange{0x214F, 0x214F}, propertyGeneralCategory{lbprAL, gcSo}},     //         SYMBOL FOR SAMARITAN SOURCE
-	{runeRange{0x2150, 0x2153}, propertyGeneralCategory{lbprAL, gcNo}},     //     [4] VULGAR FRACTION ONE SEVENTH..VULGAR FRACTION ONE THIRD
-	{runeRange{0x2154, 0x2155}, propertyGeneralCategory{lbprAI, gcNo}},     //     [2] VULGAR FRACTION TWO THIRDS..VULGAR FRACTION ONE FIFTH
-	{runeRange{0x2156, 0x215A}, propertyGeneralCategory{lbprAL, gcNo}},     //     [5] VULGAR FRACTION TWO FIFTHS..VULGAR FRACTION FIVE SIXTHS
-	{runeRange{0x215B, 0x215B}, propertyGeneralCategory{lbprAI, gcNo}},     //         VULGAR FRACTION ONE EIGHTH
-	{runeRange{0x215C, 0x215D}, propertyGeneralCategory{lbprAL, gcNo}},     //     [2] VULGAR FRACTION THREE EIGHTHS..VULGAR FRACTION FIVE EIGHTHS
-	{runeRange{0x215E, 0x215E}, propertyGeneralCategory{lbprAI, gcNo}},     //         VULGAR FRACTION SEVEN EIGHTHS
-	{runeRange{0x215F, 0x215F}, propertyGeneralCategory{lbprAL, gcNo}},     //         FRACTION NUMERATOR ONE
-	{runeRange{0x2160, 0x216B}, propertyGeneralCategory{lbprAI, gcNl}},     //    [12] ROMAN NUMERAL ONE..ROMAN NUMERAL TWELVE
-	{runeRange{0x216C, 0x216F}, propertyGeneralCategory{lbprAL, gcNl}},     //     [4] ROMAN NUMERAL FIFTY..ROMAN NUMERAL ONE THOUSAND
-	{runeRange{0x2170, 0x2179}, propertyGeneralCategory{lbprAI, gcNl}},     //    [10] SMALL ROMAN NUMERAL ONE..SMALL ROMAN NUMERAL TEN
-	{runeRange{0x217A, 0x2182}, propertyGeneralCategory{lbprAL, gcNl}},     //     [9] SMALL ROMAN NUMERAL ELEVEN..ROMAN NUMERAL TEN THOUSAND
-	{runeRange{0x2183, 0x2184}, propertyGeneralCategory{lbprAL, gcLC}},     //     [2] ROMAN NUMERAL REVERSED ONE HUNDRED..LATIN SMALL LETTER REVERSED C
-	{runeRange{0x2185, 0x2188}, propertyGeneralCategory{lbprAL, gcNl}},     //     [4] ROMAN NUMERAL SIX LATE FORM..ROMAN NUMERAL ONE HUNDRED THOUSAND
-	{runeRange{0x2189, 0x2189}, propertyGeneralCategory{lbprAI, gcNo}},     //         VULGAR FRACTION ZERO THIRDS
-	{runeRange{0x218A, 0x218B}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] TURNED DIGIT TWO..TURNED DIGIT THREE
-	{runeRange{0x2190, 0x2194}, propertyGeneralCategory{lbprAI, gcSm}},     //     [5] LEFTWARDS ARROW..LEFT RIGHT ARROW
-	{runeRange{0x2195, 0x2199}, propertyGeneralCategory{lbprAI, gcSo}},     //     [5] UP DOWN ARROW..SOUTH WEST ARROW
-	{runeRange{0x219A, 0x219B}, propertyGeneralCategory{lbprAL, gcSm}},     //     [2] LEFTWARDS ARROW WITH STROKE..RIGHTWARDS ARROW WITH STROKE
-	{runeRange{0x219C, 0x219F}, propertyGeneralCategory{lbprAL, gcSo}},     //     [4] LEFTWARDS WAVE ARROW..UPWARDS TWO HEADED ARROW
-	{runeRange{0x21A0, 0x21A0}, propertyGeneralCategory{lbprAL, gcSm}},     //         RIGHTWARDS TWO HEADED ARROW
-	{runeRange{0x21A1, 0x21A2}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] DOWNWARDS TWO HEADED ARROW..LEFTWARDS ARROW WITH TAIL
-	{runeRange{0x21A3, 0x21A3}, propertyGeneralCategory{lbprAL, gcSm}},     //         RIGHTWARDS ARROW WITH TAIL
-	{runeRange{0x21A4, 0x21A5}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] LEFTWARDS ARROW FROM BAR..UPWARDS ARROW FROM BAR
-	{runeRange{0x21A6, 0x21A6}, propertyGeneralCategory{lbprAL, gcSm}},     //         RIGHTWARDS ARROW FROM BAR
-	{runeRange{0x21A7, 0x21AD}, propertyGeneralCategory{lbprAL, gcSo}},     //     [7] DOWNWARDS ARROW FROM BAR..LEFT RIGHT WAVE ARROW
-	{runeRange{0x21AE, 0x21AE}, propertyGeneralCategory{lbprAL, gcSm}},     //         LEFT RIGHT ARROW WITH STROKE
-	{runeRange{0x21AF, 0x21CD}, propertyGeneralCategory{lbprAL, gcSo}},     //    [31] DOWNWARDS ZIGZAG ARROW..LEFTWARDS DOUBLE ARROW WITH STROKE
-	{runeRange{0x21CE, 0x21CF}, propertyGeneralCategory{lbprAL, gcSm}},     //     [2] LEFT RIGHT DOUBLE ARROW WITH STROKE..RIGHTWARDS DOUBLE ARROW WITH STROKE
-	{runeRange{0x21D0, 0x21D1}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] LEFTWARDS DOUBLE ARROW..UPWARDS DOUBLE ARROW
-	{runeRange{0x21D2, 0x21D2}, propertyGeneralCategory{lbprAI, gcSm}},     //         RIGHTWARDS DOUBLE ARROW
-	{runeRange{0x21D3, 0x21D3}, propertyGeneralCategory{lbprAL, gcSo}},     //         DOWNWARDS DOUBLE ARROW
-	{runeRange{0x21D4, 0x21D4}, propertyGeneralCategory{lbprAI, gcSm}},     //         LEFT RIGHT DOUBLE ARROW
-	{runeRange{0x21D5, 0x21F3}, propertyGeneralCategory{lbprAL, gcSo}},     //    [31] UP DOWN DOUBLE ARROW..UP DOWN WHITE ARROW
-	{runeRange{0x21F4, 0x21FF}, propertyGeneralCategory{lbprAL, gcSm}},     //    [12] RIGHT ARROW WITH SMALL CIRCLE..LEFT RIGHT OPEN-HEADED ARROW
-	{runeRange{0x2200, 0x2200}, propertyGeneralCategory{lbprAI, gcSm}},     //         FOR ALL
-	{runeRange{0x2201, 0x2201}, propertyGeneralCategory{lbprAL, gcSm}},     //         COMPLEMENT
-	{runeRange{0x2202, 0x2203}, propertyGeneralCategory{lbprAI, gcSm}},     //     [2] PARTIAL DIFFERENTIAL..THERE EXISTS
-	{runeRange{0x2204, 0x2206}, propertyGeneralCategory{lbprAL, gcSm}},     //     [3] THERE DOES NOT EXIST..INCREMENT
-	{runeRange{0x2207, 0x2208}, propertyGeneralCategory{lbprAI, gcSm}},     //     [2] NABLA..ELEMENT OF
-	{runeRange{0x2209, 0x220A}, propertyGeneralCategory{lbprAL, gcSm}},     //     [2] NOT AN ELEMENT OF..SMALL ELEMENT OF
-	{runeRange{0x220B, 0x220B}, propertyGeneralCategory{lbprAI, gcSm}},     //         CONTAINS AS MEMBER
-	{runeRange{0x220C, 0x220E}, propertyGeneralCategory{lbprAL, gcSm}},     //     [3] DOES NOT CONTAIN AS MEMBER..END OF PROOF
-	{runeRange{0x220F, 0x220F}, propertyGeneralCategory{lbprAI, gcSm}},     //         N-ARY PRODUCT
-	{runeRange{0x2210, 0x2210}, propertyGeneralCategory{lbprAL, gcSm}},     //         N-ARY COPRODUCT
-	{runeRange{0x2211, 0x2211}, propertyGeneralCategory{lbprAI, gcSm}},     //         N-ARY SUMMATION
-	{runeRange{0x2212, 0x2213}, propertyGeneralCategory{lbprPR, gcSm}},     //     [2] MINUS SIGN..MINUS-OR-PLUS SIGN
-	{runeRange{0x2214, 0x2214}, propertyGeneralCategory{lbprAL, gcSm}},     //         DOT PLUS
-	{runeRange{0x2215, 0x2215}, propertyGeneralCategory{lbprAI, gcSm}},     //         DIVISION SLASH
-	{runeRange{0x2216, 0x2219}, propertyGeneralCategory{lbprAL, gcSm}},     //     [4] SET MINUS..BULLET OPERATOR
-	{runeRange{0x221A, 0x221A}, propertyGeneralCategory{lbprAI, gcSm}},     //         SQUARE ROOT
-	{runeRange{0x221B, 0x221C}, propertyGeneralCategory{lbprAL, gcSm}},     //     [2] CUBE ROOT..FOURTH ROOT
-	{runeRange{0x221D, 0x2220}, propertyGeneralCategory{lbprAI, gcSm}},     //     [4] PROPORTIONAL TO..ANGLE
-	{runeRange{0x2221, 0x2222}, propertyGeneralCategory{lbprAL, gcSm}},     //     [2] MEASURED ANGLE..SPHERICAL ANGLE
-	{runeRange{0x2223, 0x2223}, propertyGeneralCategory{lbprAI, gcSm}},     //         DIVIDES
-	{runeRange{0x2224, 0x2224}, propertyGeneralCategory{lbprAL, gcSm}},     //         DOES NOT DIVIDE
-	{runeRange{0x2225, 0x2225}, propertyGeneralCategory{lbprAI, gcSm}},     //         PARALLEL TO
-	{runeRange{0x2226, 0x2226}, propertyGeneralCategory{lbprAL, gcSm}},     //         NOT PARALLEL TO
-	{runeRange{0x2227, 0x222C}, propertyGeneralCategory{lbprAI, gcSm}},     //     [6] LOGICAL AND..DOUBLE INTEGRAL
-	{runeRange{0x222D, 0x222D}, propertyGeneralCategory{lbprAL, gcSm}},     //         TRIPLE INTEGRAL
-	{runeRange{0x222E, 0x222E}, propertyGeneralCategory{lbprAI, gcSm}},     //         CONTOUR INTEGRAL
-	{runeRange{0x222F, 0x2233}, propertyGeneralCategory{lbprAL, gcSm}},     //     [5] SURFACE INTEGRAL..ANTICLOCKWISE CONTOUR INTEGRAL
-	{runeRange{0x2234, 0x2237}, propertyGeneralCategory{lbprAI, gcSm}},     //     [4] THEREFORE..PROPORTION
-	{runeRange{0x2238, 0x223B}, propertyGeneralCategory{lbprAL, gcSm}},     //     [4] DOT MINUS..HOMOTHETIC
-	{runeRange{0x223C, 0x223D}, propertyGeneralCategory{lbprAI, gcSm}},     //     [2] TILDE OPERATOR..REVERSED TILDE
-	{runeRange{0x223E, 0x2247}, propertyGeneralCategory{lbprAL, gcSm}},     //    [10] INVERTED LAZY S..NEITHER APPROXIMATELY NOR ACTUALLY EQUAL TO
-	{runeRange{0x2248, 0x2248}, propertyGeneralCategory{lbprAI, gcSm}},     //         ALMOST EQUAL TO
-	{runeRange{0x2249, 0x224B}, propertyGeneralCategory{lbprAL, gcSm}},     //     [3] NOT ALMOST EQUAL TO..TRIPLE TILDE
-	{runeRange{0x224C, 0x224C}, propertyGeneralCategory{lbprAI, gcSm}},     //         ALL EQUAL TO
-	{runeRange{0x224D, 0x2251}, propertyGeneralCategory{lbprAL, gcSm}},     //     [5] EQUIVALENT TO..GEOMETRICALLY EQUAL TO
-	{runeRange{0x2252, 0x2252}, propertyGeneralCategory{lbprAI, gcSm}},     //         APPROXIMATELY EQUAL TO OR THE IMAGE OF
-	{runeRange{0x2253, 0x225F}, propertyGeneralCategory{lbprAL, gcSm}},     //    [13] IMAGE OF OR APPROXIMATELY EQUAL TO..QUESTIONED EQUAL TO
-	{runeRange{0x2260, 0x2261}, propertyGeneralCategory{lbprAI, gcSm}},     //     [2] NOT EQUAL TO..IDENTICAL TO
-	{runeRange{0x2262, 0x2263}, propertyGeneralCategory{lbprAL, gcSm}},     //     [2] NOT IDENTICAL TO..STRICTLY EQUIVALENT TO
-	{runeRange{0x2264, 0x2267}, propertyGeneralCategory{lbprAI, gcSm}},     //     [4] LESS-THAN OR EQUAL TO..GREATER-THAN OVER EQUAL TO
-	{runeRange{0x2268, 0x2269}, propertyGeneralCategory{lbprAL, gcSm}},     //     [2] LESS-THAN BUT NOT EQUAL TO..GREATER-THAN BUT NOT EQUAL TO
-	{runeRange{0x226A, 0x226B}, propertyGeneralCategory{lbprAI, gcSm}},     //     [2] MUCH LESS-THAN..MUCH GREATER-THAN
-	{runeRange{0x226C, 0x226D}, propertyGeneralCategory{lbprAL, gcSm}},     //     [2] BETWEEN..NOT EQUIVALENT TO
-	{runeRange{0x226E, 0x226F}, propertyGeneralCategory{lbprAI, gcSm}},     //     [2] NOT LESS-THAN..NOT GREATER-THAN
-	{runeRange{0x2270, 0x2281}, propertyGeneralCategory{lbprAL, gcSm}},     //    [18] NEITHER LESS-THAN NOR EQUAL TO..DOES NOT SUCCEED
-	{runeRange{0x2282, 0x2283}, propertyGeneralCategory{lbprAI, gcSm}},     //     [2] SUBSET OF..SUPERSET OF
-	{runeRange{0x2284, 0x2285}, propertyGeneralCategory{lbprAL, gcSm}},     //     [2] NOT A SUBSET OF..NOT A SUPERSET OF
-	{runeRange{0x2286, 0x2287}, propertyGeneralCategory{lbprAI, gcSm}},     //     [2] SUBSET OF OR EQUAL TO..SUPERSET OF OR EQUAL TO
-	{runeRange{0x2288, 0x2294}, propertyGeneralCategory{lbprAL, gcSm}},     //    [13] NEITHER A SUBSET OF NOR EQUAL TO..SQUARE CUP
-	{runeRange{0x2295, 0x2295}, propertyGeneralCategory{lbprAI, gcSm}},     //         CIRCLED PLUS
-	{runeRange{0x2296, 0x2298}, propertyGeneralCategory{lbprAL, gcSm}},     //     [3] CIRCLED MINUS..CIRCLED DIVISION SLASH
-	{runeRange{0x2299, 0x2299}, propertyGeneralCategory{lbprAI, gcSm}},     //         CIRCLED DOT OPERATOR
-	{runeRange{0x229A, 0x22A4}, propertyGeneralCategory{lbprAL, gcSm}},     //    [11] CIRCLED RING OPERATOR..DOWN TACK
-	{runeRange{0x22A5, 0x22A5}, propertyGeneralCategory{lbprAI, gcSm}},     //         UP TACK
-	{runeRange{0x22A6, 0x22BE}, propertyGeneralCategory{lbprAL, gcSm}},     //    [25] ASSERTION..RIGHT ANGLE WITH ARC
-	{runeRange{0x22BF, 0x22BF}, propertyGeneralCategory{lbprAI, gcSm}},     //         RIGHT TRIANGLE
-	{runeRange{0x22C0, 0x22EE}, propertyGeneralCategory{lbprAL, gcSm}},     //    [47] N-ARY LOGICAL AND..VERTICAL ELLIPSIS
-	{runeRange{0x22EF, 0x22EF}, propertyGeneralCategory{lbprIN, gcSm}},     //         MIDLINE HORIZONTAL ELLIPSIS
-	{runeRange{0x22F0, 0x22FF}, propertyGeneralCategory{lbprAL, gcSm}},     //    [16] UP RIGHT DIAGONAL ELLIPSIS..Z NOTATION BAG MEMBERSHIP
-	{runeRange{0x2300, 0x2307}, propertyGeneralCategory{lbprAL, gcSo}},     //     [8] DIAMETER SIGN..WAVY LINE
-	{runeRange{0x2308, 0x2308}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT CEILING
-	{runeRange{0x2309, 0x2309}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT CEILING
-	{runeRange{0x230A, 0x230A}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT FLOOR
-	{runeRange{0x230B, 0x230B}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT FLOOR
-	{runeRange{0x230C, 0x2311}, propertyGeneralCategory{lbprAL, gcSo}},     //     [6] BOTTOM RIGHT CROP..SQUARE LOZENGE
-	{runeRange{0x2312, 0x2312}, propertyGeneralCategory{lbprAI, gcSo}},     //         ARC
-	{runeRange{0x2313, 0x2319}, propertyGeneralCategory{lbprAL, gcSo}},     //     [7] SEGMENT..TURNED NOT SIGN
-	{runeRange{0x231A, 0x231B}, propertyGeneralCategory{lbprID, gcSo}},     //     [2] WATCH..HOURGLASS
-	{runeRange{0x231C, 0x231F}, propertyGeneralCategory{lbprAL, gcSo}},     //     [4] TOP LEFT CORNER..BOTTOM RIGHT CORNER
-	{runeRange{0x2320, 0x2321}, propertyGeneralCategory{lbprAL, gcSm}},     //     [2] TOP HALF INTEGRAL..BOTTOM HALF INTEGRAL
-	{runeRange{0x2322, 0x2328}, propertyGeneralCategory{lbprAL, gcSo}},     //     [7] FROWN..KEYBOARD
-	{runeRange{0x2329, 0x2329}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT-POINTING ANGLE BRACKET
-	{runeRange{0x232A, 0x232A}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT-POINTING ANGLE BRACKET
-	{runeRange{0x232B, 0x237B}, propertyGeneralCategory{lbprAL, gcSo}},     //    [81] ERASE TO THE LEFT..NOT CHECK MARK
-	{runeRange{0x237C, 0x237C}, propertyGeneralCategory{lbprAL, gcSm}},     //         RIGHT ANGLE WITH DOWNWARDS ZIGZAG ARROW
-	{runeRange{0x237D, 0x239A}, propertyGeneralCategory{lbprAL, gcSo}},     //    [30] SHOULDERED OPEN BOX..CLEAR SCREEN SYMBOL
-	{runeRange{0x239B, 0x23B3}, propertyGeneralCategory{lbprAL, gcSm}},     //    [25] LEFT PARENTHESIS UPPER HOOK..SUMMATION BOTTOM
-	{runeRange{0x23B4, 0x23DB}, propertyGeneralCategory{lbprAL, gcSo}},     //    [40] TOP SQUARE BRACKET..FUSE
-	{runeRange{0x23DC, 0x23E1}, propertyGeneralCategory{lbprAL, gcSm}},     //     [6] TOP PARENTHESIS..BOTTOM TORTOISE SHELL BRACKET
-	{runeRange{0x23E2, 0x23EF}, propertyGeneralCategory{lbprAL, gcSo}},     //    [14] WHITE TRAPEZIUM..BLACK RIGHT-POINTING TRIANGLE WITH DOUBLE VERTICAL BAR
-	{runeRange{0x23F0, 0x23F3}, propertyGeneralCategory{lbprID, gcSo}},     //     [4] ALARM CLOCK..HOURGLASS WITH FLOWING SAND
-	{runeRange{0x23F4, 0x23FF}, propertyGeneralCategory{lbprAL, gcSo}},     //    [12] BLACK MEDIUM LEFT-POINTING TRIANGLE..OBSERVER EYE SYMBOL
-	{runeRange{0x2400, 0x2426}, propertyGeneralCategory{lbprAL, gcSo}},     //    [39] SYMBOL FOR NULL..SYMBOL FOR SUBSTITUTE FORM TWO
-	{runeRange{0x2440, 0x244A}, propertyGeneralCategory{lbprAL, gcSo}},     //    [11] OCR HOOK..OCR DOUBLE BACKSLASH
-	{runeRange{0x2460, 0x249B}, propertyGeneralCategory{lbprAI, gcNo}},     //    [60] CIRCLED DIGIT ONE..NUMBER TWENTY FULL STOP
-	{runeRange{0x249C, 0x24E9}, propertyGeneralCategory{lbprAI, gcSo}},     //    [78] PARENTHESIZED LATIN SMALL LETTER A..CIRCLED LATIN SMALL LETTER Z
-	{runeRange{0x24EA, 0x24FE}, propertyGeneralCategory{lbprAI, gcNo}},     //    [21] CIRCLED DIGIT ZERO..DOUBLE CIRCLED NUMBER TEN
-	{runeRange{0x24FF, 0x24FF}, propertyGeneralCategory{lbprAL, gcNo}},     //         NEGATIVE CIRCLED DIGIT ZERO
-	{runeRange{0x2500, 0x254B}, propertyGeneralCategory{lbprAI, gcSo}},     //    [76] BOX DRAWINGS LIGHT HORIZONTAL..BOX DRAWINGS HEAVY VERTICAL AND HORIZONTAL
-	{runeRange{0x254C, 0x254F}, propertyGeneralCategory{lbprAL, gcSo}},     //     [4] BOX DRAWINGS LIGHT DOUBLE DASH HORIZONTAL..BOX DRAWINGS HEAVY DOUBLE DASH VERTICAL
-	{runeRange{0x2550, 0x2574}, propertyGeneralCategory{lbprAI, gcSo}},     //    [37] BOX DRAWINGS DOUBLE HORIZONTAL..BOX DRAWINGS LIGHT LEFT
-	{runeRange{0x2575, 0x257F}, propertyGeneralCategory{lbprAL, gcSo}},     //    [11] BOX DRAWINGS LIGHT UP..BOX DRAWINGS HEAVY UP AND LIGHT DOWN
-	{runeRange{0x2580, 0x258F}, propertyGeneralCategory{lbprAI, gcSo}},     //    [16] UPPER HALF BLOCK..LEFT ONE EIGHTH BLOCK
-	{runeRange{0x2590, 0x2591}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] RIGHT HALF BLOCK..LIGHT SHADE
-	{runeRange{0x2592, 0x2595}, propertyGeneralCategory{lbprAI, gcSo}},     //     [4] MEDIUM SHADE..RIGHT ONE EIGHTH BLOCK
-	{runeRange{0x2596, 0x259F}, propertyGeneralCategory{lbprAL, gcSo}},     //    [10] QUADRANT LOWER LEFT..QUADRANT UPPER RIGHT AND LOWER LEFT AND LOWER RIGHT
-	{runeRange{0x25A0, 0x25A1}, propertyGeneralCategory{lbprAI, gcSo}},     //     [2] BLACK SQUARE..WHITE SQUARE
-	{runeRange{0x25A2, 0x25A2}, propertyGeneralCategory{lbprAL, gcSo}},     //         WHITE SQUARE WITH ROUNDED CORNERS
-	{runeRange{0x25A3, 0x25A9}, propertyGeneralCategory{lbprAI, gcSo}},     //     [7] WHITE SQUARE CONTAINING BLACK SMALL SQUARE..SQUARE WITH DIAGONAL CROSSHATCH FILL
-	{runeRange{0x25AA, 0x25B1}, propertyGeneralCategory{lbprAL, gcSo}},     //     [8] BLACK SMALL SQUARE..WHITE PARALLELOGRAM
-	{runeRange{0x25B2, 0x25B3}, propertyGeneralCategory{lbprAI, gcSo}},     //     [2] BLACK UP-POINTING TRIANGLE..WHITE UP-POINTING TRIANGLE
-	{runeRange{0x25B4, 0x25B5}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] BLACK UP-POINTING SMALL TRIANGLE..WHITE UP-POINTING SMALL TRIANGLE
-	{runeRange{0x25B6, 0x25B6}, propertyGeneralCategory{lbprAI, gcSo}},     //         BLACK RIGHT-POINTING TRIANGLE
-	{runeRange{0x25B7, 0x25B7}, propertyGeneralCategory{lbprAI, gcSm}},     //         WHITE RIGHT-POINTING TRIANGLE
-	{runeRange{0x25B8, 0x25BB}, propertyGeneralCategory{lbprAL, gcSo}},     //     [4] BLACK RIGHT-POINTING SMALL TRIANGLE..WHITE RIGHT-POINTING POINTER
-	{runeRange{0x25BC, 0x25BD}, propertyGeneralCategory{lbprAI, gcSo}},     //     [2] BLACK DOWN-POINTING TRIANGLE..WHITE DOWN-POINTING TRIANGLE
-	{runeRange{0x25BE, 0x25BF}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] BLACK DOWN-POINTING SMALL TRIANGLE..WHITE DOWN-POINTING SMALL TRIANGLE
-	{runeRange{0x25C0, 0x25C0}, propertyGeneralCategory{lbprAI, gcSo}},     //         BLACK LEFT-POINTING TRIANGLE
-	{runeRange{0x25C1, 0x25C1}, propertyGeneralCategory{lbprAI, gcSm}},     //         WHITE LEFT-POINTING TRIANGLE
-	{runeRange{0x25C2, 0x25C5}, propertyGeneralCategory{lbprAL, gcSo}},     //     [4] BLACK LEFT-POINTING SMALL TRIANGLE..WHITE LEFT-POINTING POINTER
-	{runeRange{0x25C6, 0x25C8}, propertyGeneralCategory{lbprAI, gcSo}},     //     [3] BLACK DIAMOND..WHITE DIAMOND CONTAINING BLACK SMALL DIAMOND
-	{runeRange{0x25C9, 0x25CA}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] FISHEYE..LOZENGE
-	{runeRange{0x25CB, 0x25CB}, propertyGeneralCategory{lbprAI, gcSo}},     //         WHITE CIRCLE
-	{runeRange{0x25CC, 0x25CD}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] DOTTED CIRCLE..CIRCLE WITH VERTICAL FILL
-	{runeRange{0x25CE, 0x25D1}, propertyGeneralCategory{lbprAI, gcSo}},     //     [4] BULLSEYE..CIRCLE WITH RIGHT HALF BLACK
-	{runeRange{0x25D2, 0x25E1}, propertyGeneralCategory{lbprAL, gcSo}},     //    [16] CIRCLE WITH LOWER HALF BLACK..LOWER HALF CIRCLE
-	{runeRange{0x25E2, 0x25E5}, propertyGeneralCategory{lbprAI, gcSo}},     //     [4] BLACK LOWER RIGHT TRIANGLE..BLACK UPPER RIGHT TRIANGLE
-	{runeRange{0x25E6, 0x25EE}, propertyGeneralCategory{lbprAL, gcSo}},     //     [9] WHITE BULLET..UP-POINTING TRIANGLE WITH RIGHT HALF BLACK
-	{runeRange{0x25EF, 0x25EF}, propertyGeneralCategory{lbprAI, gcSo}},     //         LARGE CIRCLE
-	{runeRange{0x25F0, 0x25F7}, propertyGeneralCategory{lbprAL, gcSo}},     //     [8] WHITE SQUARE WITH UPPER LEFT QUADRANT..WHITE CIRCLE WITH UPPER RIGHT QUADRANT
-	{runeRange{0x25F8, 0x25FF}, propertyGeneralCategory{lbprAL, gcSm}},     //     [8] UPPER LEFT TRIANGLE..LOWER RIGHT TRIANGLE
-	{runeRange{0x2600, 0x2603}, propertyGeneralCategory{lbprID, gcSo}},     //     [4] BLACK SUN WITH RAYS..SNOWMAN
-	{runeRange{0x2604, 0x2604}, propertyGeneralCategory{lbprAL, gcSo}},     //         COMET
-	{runeRange{0x2605, 0x2606}, propertyGeneralCategory{lbprAI, gcSo}},     //     [2] BLACK STAR..WHITE STAR
-	{runeRange{0x2607, 0x2608}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] LIGHTNING..THUNDERSTORM
-	{runeRange{0x2609, 0x2609}, propertyGeneralCategory{lbprAI, gcSo}},     //         SUN
-	{runeRange{0x260A, 0x260D}, propertyGeneralCategory{lbprAL, gcSo}},     //     [4] ASCENDING NODE..OPPOSITION
-	{runeRange{0x260E, 0x260F}, propertyGeneralCategory{lbprAI, gcSo}},     //     [2] BLACK TELEPHONE..WHITE TELEPHONE
-	{runeRange{0x2610, 0x2613}, propertyGeneralCategory{lbprAL, gcSo}},     //     [4] BALLOT BOX..SALTIRE
-	{runeRange{0x2614, 0x2615}, propertyGeneralCategory{lbprID, gcSo}},     //     [2] UMBRELLA WITH RAIN DROPS..HOT BEVERAGE
-	{runeRange{0x2616, 0x2617}, propertyGeneralCategory{lbprAI, gcSo}},     //     [2] WHITE SHOGI PIECE..BLACK SHOGI PIECE
-	{runeRange{0x2618, 0x2618}, propertyGeneralCategory{lbprID, gcSo}},     //         SHAMROCK
-	{runeRange{0x2619, 0x2619}, propertyGeneralCategory{lbprAL, gcSo}},     //         REVERSED ROTATED FLORAL HEART BULLET
-	{runeRange{0x261A, 0x261C}, propertyGeneralCategory{lbprID, gcSo}},     //     [3] BLACK LEFT POINTING INDEX..WHITE LEFT POINTING INDEX
-	{runeRange{0x261D, 0x261D}, propertyGeneralCategory{lbprEB, gcSo}},     //         WHITE UP POINTING INDEX
-	{runeRange{0x261E, 0x261F}, propertyGeneralCategory{lbprID, gcSo}},     //     [2] WHITE RIGHT POINTING INDEX..WHITE DOWN POINTING INDEX
-	{runeRange{0x2620, 0x2638}, propertyGeneralCategory{lbprAL, gcSo}},     //    [25] SKULL AND CROSSBONES..WHEEL OF DHARMA
-	{runeRange{0x2639, 0x263B}, propertyGeneralCategory{lbprID, gcSo}},     //     [3] WHITE FROWNING FACE..BLACK SMILING FACE
-	{runeRange{0x263C, 0x263F}, propertyGeneralCategory{lbprAL, gcSo}},     //     [4] WHITE SUN WITH RAYS..MERCURY
-	{runeRange{0x2640, 0x2640}, propertyGeneralCategory{lbprAI, gcSo}},     //         FEMALE SIGN
-	{runeRange{0x2641, 0x2641}, propertyGeneralCategory{lbprAL, gcSo}},     //         EARTH
-	{runeRange{0x2642, 0x2642}, propertyGeneralCategory{lbprAI, gcSo}},     //         MALE SIGN
-	{runeRange{0x2643, 0x265F}, propertyGeneralCategory{lbprAL, gcSo}},     //    [29] JUPITER..BLACK CHESS PAWN
-	{runeRange{0x2660, 0x2661}, propertyGeneralCategory{lbprAI, gcSo}},     //     [2] BLACK SPADE SUIT..WHITE HEART SUIT
-	{runeRange{0x2662, 0x2662}, propertyGeneralCategory{lbprAL, gcSo}},     //         WHITE DIAMOND SUIT
-	{runeRange{0x2663, 0x2665}, propertyGeneralCategory{lbprAI, gcSo}},     //     [3] BLACK CLUB SUIT..BLACK HEART SUIT
-	{runeRange{0x2666, 0x2666}, propertyGeneralCategory{lbprAL, gcSo}},     //         BLACK DIAMOND SUIT
-	{runeRange{0x2667, 0x2667}, propertyGeneralCategory{lbprAI, gcSo}},     //         WHITE CLUB SUIT
-	{runeRange{0x2668, 0x2668}, propertyGeneralCategory{lbprID, gcSo}},     //         HOT SPRINGS
-	{runeRange{0x2669, 0x266A}, propertyGeneralCategory{lbprAI, gcSo}},     //     [2] QUARTER NOTE..EIGHTH NOTE
-	{runeRange{0x266B, 0x266B}, propertyGeneralCategory{lbprAL, gcSo}},     //         BEAMED EIGHTH NOTES
-	{runeRange{0x266C, 0x266D}, propertyGeneralCategory{lbprAI, gcSo}},     //     [2] BEAMED SIXTEENTH NOTES..MUSIC FLAT SIGN
-	{runeRange{0x266E, 0x266E}, propertyGeneralCategory{lbprAL, gcSo}},     //         MUSIC NATURAL SIGN
-	{runeRange{0x266F, 0x266F}, propertyGeneralCategory{lbprAI, gcSm}},     //         MUSIC SHARP SIGN
-	{runeRange{0x2670, 0x267E}, propertyGeneralCategory{lbprAL, gcSo}},     //    [15] WEST SYRIAC CROSS..PERMANENT PAPER SIGN
-	{runeRange{0x267F, 0x267F}, propertyGeneralCategory{lbprID, gcSo}},     //         WHEELCHAIR SYMBOL
-	{runeRange{0x2680, 0x269D}, propertyGeneralCategory{lbprAL, gcSo}},     //    [30] DIE FACE-1..OUTLINED WHITE STAR
-	{runeRange{0x269E, 0x269F}, propertyGeneralCategory{lbprAI, gcSo}},     //     [2] THREE LINES CONVERGING RIGHT..THREE LINES CONVERGING LEFT
-	{runeRange{0x26A0, 0x26BC}, propertyGeneralCategory{lbprAL, gcSo}},     //    [29] WARNING SIGN..SESQUIQUADRATE
-	{runeRange{0x26BD, 0x26C8}, propertyGeneralCategory{lbprID, gcSo}},     //    [12] SOCCER BALL..THUNDER CLOUD AND RAIN
-	{runeRange{0x26C9, 0x26CC}, propertyGeneralCategory{lbprAI, gcSo}},     //     [4] TURNED WHITE SHOGI PIECE..CROSSING LANES
-	{runeRange{0x26CD, 0x26CD}, propertyGeneralCategory{lbprID, gcSo}},     //         DISABLED CAR
-	{runeRange{0x26CE, 0x26CE}, propertyGeneralCategory{lbprAL, gcSo}},     //         OPHIUCHUS
-	{runeRange{0x26CF, 0x26D1}, propertyGeneralCategory{lbprID, gcSo}},     //     [3] PICK..HELMET WITH WHITE CROSS
-	{runeRange{0x26D2, 0x26D2}, propertyGeneralCategory{lbprAI, gcSo}},     //         CIRCLED CROSSING LANES
-	{runeRange{0x26D3, 0x26D4}, propertyGeneralCategory{lbprID, gcSo}},     //     [2] CHAINS..NO ENTRY
-	{runeRange{0x26D5, 0x26D7}, propertyGeneralCategory{lbprAI, gcSo}},     //     [3] ALTERNATE ONE-WAY LEFT WAY TRAFFIC..WHITE TWO-WAY LEFT WAY TRAFFIC
-	{runeRange{0x26D8, 0x26D9}, propertyGeneralCategory{lbprID, gcSo}},     //     [2] BLACK LEFT LANE MERGE..WHITE LEFT LANE MERGE
-	{runeRange{0x26DA, 0x26DB}, propertyGeneralCategory{lbprAI, gcSo}},     //     [2] DRIVE SLOW SIGN..HEAVY WHITE DOWN-POINTING TRIANGLE
-	{runeRange{0x26DC, 0x26DC}, propertyGeneralCategory{lbprID, gcSo}},     //         LEFT CLOSED ENTRY
-	{runeRange{0x26DD, 0x26DE}, propertyGeneralCategory{lbprAI, gcSo}},     //     [2] SQUARED SALTIRE..FALLING DIAGONAL IN WHITE CIRCLE IN BLACK SQUARE
-	{runeRange{0x26DF, 0x26E1}, propertyGeneralCategory{lbprID, gcSo}},     //     [3] BLACK TRUCK..RESTRICTED LEFT ENTRY-2
-	{runeRange{0x26E2, 0x26E2}, propertyGeneralCategory{lbprAL, gcSo}},     //         ASTRONOMICAL SYMBOL FOR URANUS
-	{runeRange{0x26E3, 0x26E3}, propertyGeneralCategory{lbprAI, gcSo}},     //         HEAVY CIRCLE WITH STROKE AND TWO DOTS ABOVE
-	{runeRange{0x26E4, 0x26E7}, propertyGeneralCategory{lbprAL, gcSo}},     //     [4] PENTAGRAM..INVERTED PENTAGRAM
-	{runeRange{0x26E8, 0x26E9}, propertyGeneralCategory{lbprAI, gcSo}},     //     [2] BLACK CROSS ON SHIELD..SHINTO SHRINE
-	{runeRange{0x26EA, 0x26EA}, propertyGeneralCategory{lbprID, gcSo}},     //         CHURCH
-	{runeRange{0x26EB, 0x26F0}, propertyGeneralCategory{lbprAI, gcSo}},     //     [6] CASTLE..MOUNTAIN
-	{runeRange{0x26F1, 0x26F5}, propertyGeneralCategory{lbprID, gcSo}},     //     [5] UMBRELLA ON GROUND..SAILBOAT
-	{runeRange{0x26F6, 0x26F6}, propertyGeneralCategory{lbprAI, gcSo}},     //         SQUARE FOUR CORNERS
-	{runeRange{0x26F7, 0x26F8}, propertyGeneralCategory{lbprID, gcSo}},     //     [2] SKIER..ICE SKATE
-	{runeRange{0x26F9, 0x26F9}, propertyGeneralCategory{lbprEB, gcSo}},     //         PERSON WITH BALL
-	{runeRange{0x26FA, 0x26FA}, propertyGeneralCategory{lbprID, gcSo}},     //         TENT
-	{runeRange{0x26FB, 0x26FC}, propertyGeneralCategory{lbprAI, gcSo}},     //     [2] JAPANESE BANK SYMBOL..HEADSTONE GRAVEYARD SYMBOL
-	{runeRange{0x26FD, 0x26FF}, propertyGeneralCategory{lbprID, gcSo}},     //     [3] FUEL PUMP..WHITE FLAG WITH HORIZONTAL MIDDLE BLACK STRIPE
-	{runeRange{0x2700, 0x2704}, propertyGeneralCategory{lbprID, gcSo}},     //     [5] BLACK SAFETY SCISSORS..WHITE SCISSORS
-	{runeRange{0x2705, 0x2707}, propertyGeneralCategory{lbprAL, gcSo}},     //     [3] WHITE HEAVY CHECK MARK..TAPE DRIVE
-	{runeRange{0x2708, 0x2709}, propertyGeneralCategory{lbprID, gcSo}},     //     [2] AIRPLANE..ENVELOPE
-	{runeRange{0x270A, 0x270D}, propertyGeneralCategory{lbprEB, gcSo}},     //     [4] RAISED FIST..WRITING HAND
-	{runeRange{0x270E, 0x2756}, propertyGeneralCategory{lbprAL, gcSo}},     //    [73] LOWER RIGHT PENCIL..BLACK DIAMOND MINUS WHITE X
-	{runeRange{0x2757, 0x2757}, propertyGeneralCategory{lbprAI, gcSo}},     //         HEAVY EXCLAMATION MARK SYMBOL
-	{runeRange{0x2758, 0x275A}, propertyGeneralCategory{lbprAL, gcSo}},     //     [3] LIGHT VERTICAL BAR..HEAVY VERTICAL BAR
-	{runeRange{0x275B, 0x2760}, propertyGeneralCategory{lbprQU, gcSo}},     //     [6] HEAVY SINGLE TURNED COMMA QUOTATION MARK ORNAMENT..HEAVY LOW DOUBLE COMMA QUOTATION MARK ORNAMENT
-	{runeRange{0x2761, 0x2761}, propertyGeneralCategory{lbprAL, gcSo}},     //         CURVED STEM PARAGRAPH SIGN ORNAMENT
-	{runeRange{0x2762, 0x2763}, propertyGeneralCategory{lbprEX, gcSo}},     //     [2] HEAVY EXCLAMATION MARK ORNAMENT..HEAVY HEART EXCLAMATION MARK ORNAMENT
-	{runeRange{0x2764, 0x2764}, propertyGeneralCategory{lbprID, gcSo}},     //         HEAVY BLACK HEART
-	{runeRange{0x2765, 0x2767}, propertyGeneralCategory{lbprAL, gcSo}},     //     [3] ROTATED HEAVY BLACK HEART BULLET..ROTATED FLORAL HEART BULLET
-	{runeRange{0x2768, 0x2768}, propertyGeneralCategory{lbprOP, gcPs}},     //         MEDIUM LEFT PARENTHESIS ORNAMENT
-	{runeRange{0x2769, 0x2769}, propertyGeneralCategory{lbprCL, gcPe}},     //         MEDIUM RIGHT PARENTHESIS ORNAMENT
-	{runeRange{0x276A, 0x276A}, propertyGeneralCategory{lbprOP, gcPs}},     //         MEDIUM FLATTENED LEFT PARENTHESIS ORNAMENT
-	{runeRange{0x276B, 0x276B}, propertyGeneralCategory{lbprCL, gcPe}},     //         MEDIUM FLATTENED RIGHT PARENTHESIS ORNAMENT
-	{runeRange{0x276C, 0x276C}, propertyGeneralCategory{lbprOP, gcPs}},     //         MEDIUM LEFT-POINTING ANGLE BRACKET ORNAMENT
-	{runeRange{0x276D, 0x276D}, propertyGeneralCategory{lbprCL, gcPe}},     //         MEDIUM RIGHT-POINTING ANGLE BRACKET ORNAMENT
-	{runeRange{0x276E, 0x276E}, propertyGeneralCategory{lbprOP, gcPs}},     //         HEAVY LEFT-POINTING ANGLE QUOTATION MARK ORNAMENT
-	{runeRange{0x276F, 0x276F}, propertyGeneralCategory{lbprCL, gcPe}},     //         HEAVY RIGHT-POINTING ANGLE QUOTATION MARK ORNAMENT
-	{runeRange{0x2770, 0x2770}, propertyGeneralCategory{lbprOP, gcPs}},     //         HEAVY LEFT-POINTING ANGLE BRACKET ORNAMENT
-	{runeRange{0x2771, 0x2771}, propertyGeneralCategory{lbprCL, gcPe}},     //         HEAVY RIGHT-POINTING ANGLE BRACKET ORNAMENT
-	{runeRange{0x2772, 0x2772}, propertyGeneralCategory{lbprOP, gcPs}},     //         LIGHT LEFT TORTOISE SHELL BRACKET ORNAMENT
-	{runeRange{0x2773, 0x2773}, propertyGeneralCategory{lbprCL, gcPe}},     //         LIGHT RIGHT TORTOISE SHELL BRACKET ORNAMENT
-	{runeRange{0x2774, 0x2774}, propertyGeneralCategory{lbprOP, gcPs}},     //         MEDIUM LEFT CURLY BRACKET ORNAMENT
-	{runeRange{0x2775, 0x2775}, propertyGeneralCategory{lbprCL, gcPe}},     //         MEDIUM RIGHT CURLY BRACKET ORNAMENT
-	{runeRange{0x2776, 0x2793}, propertyGeneralCategory{lbprAI, gcNo}},     //    [30] DINGBAT NEGATIVE CIRCLED DIGIT ONE..DINGBAT NEGATIVE CIRCLED SANS-SERIF NUMBER TEN
-	{runeRange{0x2794, 0x27BF}, propertyGeneralCategory{lbprAL, gcSo}},     //    [44] HEAVY WIDE-HEADED RIGHTWARDS ARROW..DOUBLE CURLY LOOP
-	{runeRange{0x27C0, 0x27C4}, propertyGeneralCategory{lbprAL, gcSm}},     //     [5] THREE DIMENSIONAL ANGLE..OPEN SUPERSET
-	{runeRange{0x27C5, 0x27C5}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT S-SHAPED BAG DELIMITER
-	{runeRange{0x27C6, 0x27C6}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT S-SHAPED BAG DELIMITER
-	{runeRange{0x27C7, 0x27E5}, propertyGeneralCategory{lbprAL, gcSm}},     //    [31] OR WITH DOT INSIDE..WHITE SQUARE WITH RIGHTWARDS TICK
-	{runeRange{0x27E6, 0x27E6}, propertyGeneralCategory{lbprOP, gcPs}},     //         MATHEMATICAL LEFT WHITE SQUARE BRACKET
-	{runeRange{0x27E7, 0x27E7}, propertyGeneralCategory{lbprCL, gcPe}},     //         MATHEMATICAL RIGHT WHITE SQUARE BRACKET
-	{runeRange{0x27E8, 0x27E8}, propertyGeneralCategory{lbprOP, gcPs}},     //         MATHEMATICAL LEFT ANGLE BRACKET
-	{runeRange{0x27E9, 0x27E9}, propertyGeneralCategory{lbprCL, gcPe}},     //         MATHEMATICAL RIGHT ANGLE BRACKET
-	{runeRange{0x27EA, 0x27EA}, propertyGeneralCategory{lbprOP, gcPs}},     //         MATHEMATICAL LEFT DOUBLE ANGLE BRACKET
-	{runeRange{0x27EB, 0x27EB}, propertyGeneralCategory{lbprCL, gcPe}},     //         MATHEMATICAL RIGHT DOUBLE ANGLE BRACKET
-	{runeRange{0x27EC, 0x27EC}, propertyGeneralCategory{lbprOP, gcPs}},     //         MATHEMATICAL LEFT WHITE TORTOISE SHELL BRACKET
-	{runeRange{0x27ED, 0x27ED}, propertyGeneralCategory{lbprCL, gcPe}},     //         MATHEMATICAL RIGHT WHITE TORTOISE SHELL BRACKET
-	{runeRange{0x27EE, 0x27EE}, propertyGeneralCategory{lbprOP, gcPs}},     //         MATHEMATICAL LEFT FLATTENED PARENTHESIS
-	{runeRange{0x27EF, 0x27EF}, propertyGeneralCategory{lbprCL, gcPe}},     //         MATHEMATICAL RIGHT FLATTENED PARENTHESIS
-	{runeRange{0x27F0, 0x27FF}, propertyGeneralCategory{lbprAL, gcSm}},     //    [16] UPWARDS QUADRUPLE ARROW..LONG RIGHTWARDS SQUIGGLE ARROW
-	{runeRange{0x2800, 0x28FF}, propertyGeneralCategory{lbprAL, gcSo}},     //   [256] BRAILLE PATTERN BLANK..BRAILLE PATTERN DOTS-12345678
-	{runeRange{0x2900, 0x297F}, propertyGeneralCategory{lbprAL, gcSm}},     //   [128] RIGHTWARDS TWO-HEADED ARROW WITH VERTICAL STROKE..DOWN FISH TAIL
-	{runeRange{0x2980, 0x2982}, propertyGeneralCategory{lbprAL, gcSm}},     //     [3] TRIPLE VERTICAL BAR DELIMITER..Z NOTATION TYPE COLON
-	{runeRange{0x2983, 0x2983}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT WHITE CURLY BRACKET
-	{runeRange{0x2984, 0x2984}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT WHITE CURLY BRACKET
-	{runeRange{0x2985, 0x2985}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT WHITE PARENTHESIS
-	{runeRange{0x2986, 0x2986}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT WHITE PARENTHESIS
-	{runeRange{0x2987, 0x2987}, propertyGeneralCategory{lbprOP, gcPs}},     //         Z NOTATION LEFT IMAGE BRACKET
-	{runeRange{0x2988, 0x2988}, propertyGeneralCategory{lbprCL, gcPe}},     //         Z NOTATION RIGHT IMAGE BRACKET
-	{runeRange{0x2989, 0x2989}, propertyGeneralCategory{lbprOP, gcPs}},     //         Z NOTATION LEFT BINDING BRACKET
-	{runeRange{0x298A, 0x298A}, propertyGeneralCategory{lbprCL, gcPe}},     //         Z NOTATION RIGHT BINDING BRACKET
-	{runeRange{0x298B, 0x298B}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT SQUARE BRACKET WITH UNDERBAR
-	{runeRange{0x298C, 0x298C}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT SQUARE BRACKET WITH UNDERBAR
-	{runeRange{0x298D, 0x298D}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT SQUARE BRACKET WITH TICK IN TOP CORNER
-	{runeRange{0x298E, 0x298E}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT SQUARE BRACKET WITH TICK IN BOTTOM CORNER
-	{runeRange{0x298F, 0x298F}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT SQUARE BRACKET WITH TICK IN BOTTOM CORNER
-	{runeRange{0x2990, 0x2990}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT SQUARE BRACKET WITH TICK IN TOP CORNER
-	{runeRange{0x2991, 0x2991}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT ANGLE BRACKET WITH DOT
-	{runeRange{0x2992, 0x2992}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT ANGLE BRACKET WITH DOT
-	{runeRange{0x2993, 0x2993}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT ARC LESS-THAN BRACKET
-	{runeRange{0x2994, 0x2994}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT ARC GREATER-THAN BRACKET
-	{runeRange{0x2995, 0x2995}, propertyGeneralCategory{lbprOP, gcPs}},     //         DOUBLE LEFT ARC GREATER-THAN BRACKET
-	{runeRange{0x2996, 0x2996}, propertyGeneralCategory{lbprCL, gcPe}},     //         DOUBLE RIGHT ARC LESS-THAN BRACKET
-	{runeRange{0x2997, 0x2997}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT BLACK TORTOISE SHELL BRACKET
-	{runeRange{0x2998, 0x2998}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT BLACK TORTOISE SHELL BRACKET
-	{runeRange{0x2999, 0x29D7}, propertyGeneralCategory{lbprAL, gcSm}},     //    [63] DOTTED FENCE..BLACK HOURGLASS
-	{runeRange{0x29D8, 0x29D8}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT WIGGLY FENCE
-	{runeRange{0x29D9, 0x29D9}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT WIGGLY FENCE
-	{runeRange{0x29DA, 0x29DA}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT DOUBLE WIGGLY FENCE
-	{runeRange{0x29DB, 0x29DB}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT DOUBLE WIGGLY FENCE
-	{runeRange{0x29DC, 0x29FB}, propertyGeneralCategory{lbprAL, gcSm}},     //    [32] INCOMPLETE INFINITY..TRIPLE PLUS
-	{runeRange{0x29FC, 0x29FC}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT-POINTING CURVED ANGLE BRACKET
-	{runeRange{0x29FD, 0x29FD}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT-POINTING CURVED ANGLE BRACKET
-	{runeRange{0x29FE, 0x29FF}, propertyGeneralCategory{lbprAL, gcSm}},     //     [2] TINY..MINY
-	{runeRange{0x2A00, 0x2AFF}, propertyGeneralCategory{lbprAL, gcSm}},     //   [256] N-ARY CIRCLED DOT OPERATOR..N-ARY WHITE VERTICAL BAR
-	{runeRange{0x2B00, 0x2B2F}, propertyGeneralCategory{lbprAL, gcSo}},     //    [48] NORTH EAST WHITE ARROW..WHITE VERTICAL ELLIPSE
-	{runeRange{0x2B30, 0x2B44}, propertyGeneralCategory{lbprAL, gcSm}},     //    [21] LEFT ARROW WITH SMALL CIRCLE..RIGHTWARDS ARROW THROUGH SUPERSET
-	{runeRange{0x2B45, 0x2B46}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] LEFTWARDS QUADRUPLE ARROW..RIGHTWARDS QUADRUPLE ARROW
-	{runeRange{0x2B47, 0x2B4C}, propertyGeneralCategory{lbprAL, gcSm}},     //     [6] REVERSE TILDE OPERATOR ABOVE RIGHTWARDS ARROW..RIGHTWARDS ARROW ABOVE REVERSE TILDE OPERATOR
-	{runeRange{0x2B4D, 0x2B54}, propertyGeneralCategory{lbprAL, gcSo}},     //     [8] DOWNWARDS TRIANGLE-HEADED ZIGZAG ARROW..WHITE RIGHT-POINTING PENTAGON
-	{runeRange{0x2B55, 0x2B59}, propertyGeneralCategory{lbprAI, gcSo}},     //     [5] HEAVY LARGE CIRCLE..HEAVY CIRCLED SALTIRE
-	{runeRange{0x2B5A, 0x2B73}, propertyGeneralCategory{lbprAL, gcSo}},     //    [26] SLANTED NORTH ARROW WITH HOOKED HEAD..DOWNWARDS TRIANGLE-HEADED ARROW TO BAR
-	{runeRange{0x2B76, 0x2B95}, propertyGeneralCategory{lbprAL, gcSo}},     //    [32] NORTH WEST TRIANGLE-HEADED ARROW TO BAR..RIGHTWARDS BLACK ARROW
-	{runeRange{0x2B97, 0x2BFF}, propertyGeneralCategory{lbprAL, gcSo}},     //   [105] SYMBOL FOR TYPE A ELECTRONICS..HELLSCHREIBER PAUSE SYMBOL
-	{runeRange{0x2C00, 0x2C5F}, propertyGeneralCategory{lbprAL, gcLC}},     //    [96] GLAGOLITIC CAPITAL LETTER AZU..GLAGOLITIC SMALL LETTER CAUDATE CHRIVI
-	{runeRange{0x2C60, 0x2C7B}, propertyGeneralCategory{lbprAL, gcLC}},     //    [28] LATIN CAPITAL LETTER L WITH DOUBLE BAR..LATIN LETTER SMALL CAPITAL TURNED E
-	{runeRange{0x2C7C, 0x2C7D}, propertyGeneralCategory{lbprAL, gcLm}},     //     [2] LATIN SUBSCRIPT SMALL LETTER J..MODIFIER LETTER CAPITAL V
-	{runeRange{0x2C7E, 0x2C7F}, propertyGeneralCategory{lbprAL, gcLu}},     //     [2] LATIN CAPITAL LETTER S WITH SWASH TAIL..LATIN CAPITAL LETTER Z WITH SWASH TAIL
-	{runeRange{0x2C80, 0x2CE4}, propertyGeneralCategory{lbprAL, gcLC}},     //   [101] COPTIC CAPITAL LETTER ALFA..COPTIC SYMBOL KAI
-	{runeRange{0x2CE5, 0x2CEA}, propertyGeneralCategory{lbprAL, gcSo}},     //     [6] COPTIC SYMBOL MI RO..COPTIC SYMBOL SHIMA SIMA
-	{runeRange{0x2CEB, 0x2CEE}, propertyGeneralCategory{lbprAL, gcLC}},     //     [4] COPTIC CAPITAL LETTER CRYPTOGRAMMIC SHEI..COPTIC SMALL LETTER CRYPTOGRAMMIC GANGIA
-	{runeRange{0x2CEF, 0x2CF1}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] COPTIC COMBINING NI ABOVE..COPTIC COMBINING SPIRITUS LENIS
-	{runeRange{0x2CF2, 0x2CF3}, propertyGeneralCategory{lbprAL, gcLC}},     //     [2] COPTIC CAPITAL LETTER BOHAIRIC KHEI..COPTIC SMALL LETTER BOHAIRIC KHEI
-	{runeRange{0x2CF9, 0x2CF9}, propertyGeneralCategory{lbprEX, gcPo}},     //         COPTIC OLD NUBIAN FULL STOP
-	{runeRange{0x2CFA, 0x2CFC}, propertyGeneralCategory{lbprBA, gcPo}},     //     [3] COPTIC OLD NUBIAN DIRECT QUESTION MARK..COPTIC OLD NUBIAN VERSE DIVIDER
-	{runeRange{0x2CFD, 0x2CFD}, propertyGeneralCategory{lbprAL, gcNo}},     //         COPTIC FRACTION ONE HALF
-	{runeRange{0x2CFE, 0x2CFE}, propertyGeneralCategory{lbprEX, gcPo}},     //         COPTIC FULL STOP
-	{runeRange{0x2CFF, 0x2CFF}, propertyGeneralCategory{lbprBA, gcPo}},     //         COPTIC MORPHOLOGICAL DIVIDER
-	{runeRange{0x2D00, 0x2D25}, propertyGeneralCategory{lbprAL, gcLl}},     //    [38] GEORGIAN SMALL LETTER AN..GEORGIAN SMALL LETTER HOE
-	{runeRange{0x2D27, 0x2D27}, propertyGeneralCategory{lbprAL, gcLl}},     //         GEORGIAN SMALL LETTER YN
-	{runeRange{0x2D2D, 0x2D2D}, propertyGeneralCategory{lbprAL, gcLl}},     //         GEORGIAN SMALL LETTER AEN
-	{runeRange{0x2D30, 0x2D67}, propertyGeneralCategory{lbprAL, gcLo}},     //    [56] TIFINAGH LETTER YA..TIFINAGH LETTER YO
-	{runeRange{0x2D6F, 0x2D6F}, propertyGeneralCategory{lbprAL, gcLm}},     //         TIFINAGH MODIFIER LETTER LABIALIZATION MARK
-	{runeRange{0x2D70, 0x2D70}, propertyGeneralCategory{lbprBA, gcPo}},     //         TIFINAGH SEPARATOR MARK
-	{runeRange{0x2D7F, 0x2D7F}, propertyGeneralCategory{lbprCM, gcMn}},     //         TIFINAGH CONSONANT JOINER
-	{runeRange{0x2D80, 0x2D96}, propertyGeneralCategory{lbprAL, gcLo}},     //    [23] ETHIOPIC SYLLABLE LOA..ETHIOPIC SYLLABLE GGWE
-	{runeRange{0x2DA0, 0x2DA6}, propertyGeneralCategory{lbprAL, gcLo}},     //     [7] ETHIOPIC SYLLABLE SSA..ETHIOPIC SYLLABLE SSO
-	{runeRange{0x2DA8, 0x2DAE}, propertyGeneralCategory{lbprAL, gcLo}},     //     [7] ETHIOPIC SYLLABLE CCA..ETHIOPIC SYLLABLE CCO
-	{runeRange{0x2DB0, 0x2DB6}, propertyGeneralCategory{lbprAL, gcLo}},     //     [7] ETHIOPIC SYLLABLE ZZA..ETHIOPIC SYLLABLE ZZO
-	{runeRange{0x2DB8, 0x2DBE}, propertyGeneralCategory{lbprAL, gcLo}},     //     [7] ETHIOPIC SYLLABLE CCHA..ETHIOPIC SYLLABLE CCHO
-	{runeRange{0x2DC0, 0x2DC6}, propertyGeneralCategory{lbprAL, gcLo}},     //     [7] ETHIOPIC SYLLABLE QYA..ETHIOPIC SYLLABLE QYO
-	{runeRange{0x2DC8, 0x2DCE}, propertyGeneralCategory{lbprAL, gcLo}},     //     [7] ETHIOPIC SYLLABLE KYA..ETHIOPIC SYLLABLE KYO
-	{runeRange{0x2DD0, 0x2DD6}, propertyGeneralCategory{lbprAL, gcLo}},     //     [7] ETHIOPIC SYLLABLE XYA..ETHIOPIC SYLLABLE XYO
-	{runeRange{0x2DD8, 0x2DDE}, propertyGeneralCategory{lbprAL, gcLo}},     //     [7] ETHIOPIC SYLLABLE GYA..ETHIOPIC SYLLABLE GYO
-	{runeRange{0x2DE0, 0x2DFF}, propertyGeneralCategory{lbprCM, gcMn}},     //    [32] COMBINING CYRILLIC LETTER BE..COMBINING CYRILLIC LETTER IOTIFIED BIG YUS
-	{runeRange{0x2E00, 0x2E01}, propertyGeneralCategory{lbprQU, gcPo}},     //     [2] RIGHT ANGLE SUBSTITUTION MARKER..RIGHT ANGLE DOTTED SUBSTITUTION MARKER
-	{runeRange{0x2E02, 0x2E02}, propertyGeneralCategory{lbprQU, gcPi}},     //         LEFT SUBSTITUTION BRACKET
-	{runeRange{0x2E03, 0x2E03}, propertyGeneralCategory{lbprQU, gcPf}},     //         RIGHT SUBSTITUTION BRACKET
-	{runeRange{0x2E04, 0x2E04}, propertyGeneralCategory{lbprQU, gcPi}},     //         LEFT DOTTED SUBSTITUTION BRACKET
-	{runeRange{0x2E05, 0x2E05}, propertyGeneralCategory{lbprQU, gcPf}},     //         RIGHT DOTTED SUBSTITUTION BRACKET
-	{runeRange{0x2E06, 0x2E08}, propertyGeneralCategory{lbprQU, gcPo}},     //     [3] RAISED INTERPOLATION MARKER..DOTTED TRANSPOSITION MARKER
-	{runeRange{0x2E09, 0x2E09}, propertyGeneralCategory{lbprQU, gcPi}},     //         LEFT TRANSPOSITION BRACKET
-	{runeRange{0x2E0A, 0x2E0A}, propertyGeneralCategory{lbprQU, gcPf}},     //         RIGHT TRANSPOSITION BRACKET
-	{runeRange{0x2E0B, 0x2E0B}, propertyGeneralCategory{lbprQU, gcPo}},     //         RAISED SQUARE
-	{runeRange{0x2E0C, 0x2E0C}, propertyGeneralCategory{lbprQU, gcPi}},     //         LEFT RAISED OMISSION BRACKET
-	{runeRange{0x2E0D, 0x2E0D}, propertyGeneralCategory{lbprQU, gcPf}},     //         RIGHT RAISED OMISSION BRACKET
-	{runeRange{0x2E0E, 0x2E15}, propertyGeneralCategory{lbprBA, gcPo}},     //     [8] EDITORIAL CORONIS..UPWARDS ANCORA
-	{runeRange{0x2E16, 0x2E16}, propertyGeneralCategory{lbprAL, gcPo}},     //         DOTTED RIGHT-POINTING ANGLE
-	{runeRange{0x2E17, 0x2E17}, propertyGeneralCategory{lbprBA, gcPd}},     //         DOUBLE OBLIQUE HYPHEN
-	{runeRange{0x2E18, 0x2E18}, propertyGeneralCategory{lbprOP, gcPo}},     //         INVERTED INTERROBANG
-	{runeRange{0x2E19, 0x2E19}, propertyGeneralCategory{lbprBA, gcPo}},     //         PALM BRANCH
-	{runeRange{0x2E1A, 0x2E1A}, propertyGeneralCategory{lbprAL, gcPd}},     //         HYPHEN WITH DIAERESIS
-	{runeRange{0x2E1B, 0x2E1B}, propertyGeneralCategory{lbprAL, gcPo}},     //         TILDE WITH RING ABOVE
-	{runeRange{0x2E1C, 0x2E1C}, propertyGeneralCategory{lbprQU, gcPi}},     //         LEFT LOW PARAPHRASE BRACKET
-	{runeRange{0x2E1D, 0x2E1D}, propertyGeneralCategory{lbprQU, gcPf}},     //         RIGHT LOW PARAPHRASE BRACKET
-	{runeRange{0x2E1E, 0x2E1F}, propertyGeneralCategory{lbprAL, gcPo}},     //     [2] TILDE WITH DOT ABOVE..TILDE WITH DOT BELOW
-	{runeRange{0x2E20, 0x2E20}, propertyGeneralCategory{lbprQU, gcPi}},     //         LEFT VERTICAL BAR WITH QUILL
-	{runeRange{0x2E21, 0x2E21}, propertyGeneralCategory{lbprQU, gcPf}},     //         RIGHT VERTICAL BAR WITH QUILL
-	{runeRange{0x2E22, 0x2E22}, propertyGeneralCategory{lbprOP, gcPs}},     //         TOP LEFT HALF BRACKET
-	{runeRange{0x2E23, 0x2E23}, propertyGeneralCategory{lbprCL, gcPe}},     //         TOP RIGHT HALF BRACKET
-	{runeRange{0x2E24, 0x2E24}, propertyGeneralCategory{lbprOP, gcPs}},     //         BOTTOM LEFT HALF BRACKET
-	{runeRange{0x2E25, 0x2E25}, propertyGeneralCategory{lbprCL, gcPe}},     //         BOTTOM RIGHT HALF BRACKET
-	{runeRange{0x2E26, 0x2E26}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT SIDEWAYS U BRACKET
-	{runeRange{0x2E27, 0x2E27}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT SIDEWAYS U BRACKET
-	{runeRange{0x2E28, 0x2E28}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT DOUBLE PARENTHESIS
-	{runeRange{0x2E29, 0x2E29}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT DOUBLE PARENTHESIS
-	{runeRange{0x2E2A, 0x2E2D}, propertyGeneralCategory{lbprBA, gcPo}},     //     [4] TWO DOTS OVER ONE DOT PUNCTUATION..FIVE DOT MARK
-	{runeRange{0x2E2E, 0x2E2E}, propertyGeneralCategory{lbprEX, gcPo}},     //         REVERSED QUESTION MARK
-	{runeRange{0x2E2F, 0x2E2F}, propertyGeneralCategory{lbprAL, gcLm}},     //         VERTICAL TILDE
-	{runeRange{0x2E30, 0x2E31}, propertyGeneralCategory{lbprBA, gcPo}},     //     [2] RING POINT..WORD SEPARATOR MIDDLE DOT
-	{runeRange{0x2E32, 0x2E32}, propertyGeneralCategory{lbprAL, gcPo}},     //         TURNED COMMA
-	{runeRange{0x2E33, 0x2E34}, propertyGeneralCategory{lbprBA, gcPo}},     //     [2] RAISED DOT..RAISED COMMA
-	{runeRange{0x2E35, 0x2E39}, propertyGeneralCategory{lbprAL, gcPo}},     //     [5] TURNED SEMICOLON..TOP HALF SECTION SIGN
-	{runeRange{0x2E3A, 0x2E3B}, propertyGeneralCategory{lbprB2, gcPd}},     //     [2] TWO-EM DASH..THREE-EM DASH
-	{runeRange{0x2E3C, 0x2E3E}, propertyGeneralCategory{lbprBA, gcPo}},     //     [3] STENOGRAPHIC FULL STOP..WIGGLY VERTICAL LINE
-	{runeRange{0x2E3F, 0x2E3F}, propertyGeneralCategory{lbprAL, gcPo}},     //         CAPITULUM
-	{runeRange{0x2E40, 0x2E40}, propertyGeneralCategory{lbprBA, gcPd}},     //         DOUBLE HYPHEN
-	{runeRange{0x2E41, 0x2E41}, propertyGeneralCategory{lbprBA, gcPo}},     //         REVERSED COMMA
-	{runeRange{0x2E42, 0x2E42}, propertyGeneralCategory{lbprOP, gcPs}},     //         DOUBLE LOW-REVERSED-9 QUOTATION MARK
-	{runeRange{0x2E43, 0x2E4A}, propertyGeneralCategory{lbprBA, gcPo}},     //     [8] DASH WITH LEFT UPTURN..DOTTED SOLIDUS
-	{runeRange{0x2E4B, 0x2E4B}, propertyGeneralCategory{lbprAL, gcPo}},     //         TRIPLE DAGGER
-	{runeRange{0x2E4C, 0x2E4C}, propertyGeneralCategory{lbprBA, gcPo}},     //         MEDIEVAL COMMA
-	{runeRange{0x2E4D, 0x2E4D}, propertyGeneralCategory{lbprAL, gcPo}},     //         PARAGRAPHUS MARK
-	{runeRange{0x2E4E, 0x2E4F}, propertyGeneralCategory{lbprBA, gcPo}},     //     [2] PUNCTUS ELEVATUS MARK..CORNISH VERSE DIVIDER
-	{runeRange{0x2E50, 0x2E51}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] CROSS PATTY WITH RIGHT CROSSBAR..CROSS PATTY WITH LEFT CROSSBAR
-	{runeRange{0x2E52, 0x2E52}, propertyGeneralCategory{lbprAL, gcPo}},     //         TIRONIAN SIGN CAPITAL ET
-	{runeRange{0x2E53, 0x2E54}, propertyGeneralCategory{lbprEX, gcPo}},     //     [2] MEDIEVAL EXCLAMATION MARK..MEDIEVAL QUESTION MARK
-	{runeRange{0x2E55, 0x2E55}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT SQUARE BRACKET WITH STROKE
-	{runeRange{0x2E56, 0x2E56}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT SQUARE BRACKET WITH STROKE
-	{runeRange{0x2E57, 0x2E57}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT SQUARE BRACKET WITH DOUBLE STROKE
-	{runeRange{0x2E58, 0x2E58}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT SQUARE BRACKET WITH DOUBLE STROKE
-	{runeRange{0x2E59, 0x2E59}, propertyGeneralCategory{lbprOP, gcPs}},     //         TOP HALF LEFT PARENTHESIS
-	{runeRange{0x2E5A, 0x2E5A}, propertyGeneralCategory{lbprCL, gcPe}},     //         TOP HALF RIGHT PARENTHESIS
-	{runeRange{0x2E5B, 0x2E5B}, propertyGeneralCategory{lbprOP, gcPs}},     //         BOTTOM HALF LEFT PARENTHESIS
-	{runeRange{0x2E5C, 0x2E5C}, propertyGeneralCategory{lbprCL, gcPe}},     //         BOTTOM HALF RIGHT PARENTHESIS
-	{runeRange{0x2E5D, 0x2E5D}, propertyGeneralCategory{lbprBA, gcPd}},     //         OBLIQUE HYPHEN
-	{runeRange{0x2E80, 0x2E99}, propertyGeneralCategory{lbprID, gcSo}},     //    [26] CJK RADICAL REPEAT..CJK RADICAL RAP
-	{runeRange{0x2E9B, 0x2EF3}, propertyGeneralCategory{lbprID, gcSo}},     //    [89] CJK RADICAL CHOKE..CJK RADICAL C-SIMPLIFIED TURTLE
-	{runeRange{0x2F00, 0x2FD5}, propertyGeneralCategory{lbprID, gcSo}},     //   [214] KANGXI RADICAL ONE..KANGXI RADICAL FLUTE
-	{runeRange{0x2FF0, 0x2FFB}, propertyGeneralCategory{lbprID, gcSo}},     //    [12] IDEOGRAPHIC DESCRIPTION CHARACTER LEFT TO RIGHT..IDEOGRAPHIC DESCRIPTION CHARACTER OVERLAID
-	{runeRange{0x3000, 0x3000}, propertyGeneralCategory{lbprBA, gcZs}},     //         IDEOGRAPHIC SPACE
-	{runeRange{0x3001, 0x3002}, propertyGeneralCategory{lbprCL, gcPo}},     //     [2] IDEOGRAPHIC COMMA..IDEOGRAPHIC FULL STOP
-	{runeRange{0x3003, 0x3003}, propertyGeneralCategory{lbprID, gcPo}},     //         DITTO MARK
-	{runeRange{0x3004, 0x3004}, propertyGeneralCategory{lbprID, gcSo}},     //         JAPANESE INDUSTRIAL STANDARD SYMBOL
-	{runeRange{0x3005, 0x3005}, propertyGeneralCategory{lbprNS, gcLm}},     //         IDEOGRAPHIC ITERATION MARK
-	{runeRange{0x3006, 0x3006}, propertyGeneralCategory{lbprID, gcLo}},     //         IDEOGRAPHIC CLOSING MARK
-	{runeRange{0x3007, 0x3007}, propertyGeneralCategory{lbprID, gcNl}},     //         IDEOGRAPHIC NUMBER ZERO
-	{runeRange{0x3008, 0x3008}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT ANGLE BRACKET
-	{runeRange{0x3009, 0x3009}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT ANGLE BRACKET
-	{runeRange{0x300A, 0x300A}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT DOUBLE ANGLE BRACKET
-	{runeRange{0x300B, 0x300B}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT DOUBLE ANGLE BRACKET
-	{runeRange{0x300C, 0x300C}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT CORNER BRACKET
-	{runeRange{0x300D, 0x300D}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT CORNER BRACKET
-	{runeRange{0x300E, 0x300E}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT WHITE CORNER BRACKET
-	{runeRange{0x300F, 0x300F}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT WHITE CORNER BRACKET
-	{runeRange{0x3010, 0x3010}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT BLACK LENTICULAR BRACKET
-	{runeRange{0x3011, 0x3011}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT BLACK LENTICULAR BRACKET
-	{runeRange{0x3012, 0x3013}, propertyGeneralCategory{lbprID, gcSo}},     //     [2] POSTAL MARK..GETA MARK
-	{runeRange{0x3014, 0x3014}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT TORTOISE SHELL BRACKET
-	{runeRange{0x3015, 0x3015}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT TORTOISE SHELL BRACKET
-	{runeRange{0x3016, 0x3016}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT WHITE LENTICULAR BRACKET
-	{runeRange{0x3017, 0x3017}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT WHITE LENTICULAR BRACKET
-	{runeRange{0x3018, 0x3018}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT WHITE TORTOISE SHELL BRACKET
-	{runeRange{0x3019, 0x3019}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT WHITE TORTOISE SHELL BRACKET
-	{runeRange{0x301A, 0x301A}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT WHITE SQUARE BRACKET
-	{runeRange{0x301B, 0x301B}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT WHITE SQUARE BRACKET
-	{runeRange{0x301C, 0x301C}, propertyGeneralCategory{lbprNS, gcPd}},     //         WAVE DASH
-	{runeRange{0x301D, 0x301D}, propertyGeneralCategory{lbprOP, gcPs}},     //         REVERSED DOUBLE PRIME QUOTATION MARK
-	{runeRange{0x301E, 0x301F}, propertyGeneralCategory{lbprCL, gcPe}},     //     [2] DOUBLE PRIME QUOTATION MARK..LOW DOUBLE PRIME QUOTATION MARK
-	{runeRange{0x3020, 0x3020}, propertyGeneralCategory{lbprID, gcSo}},     //         POSTAL MARK FACE
-	{runeRange{0x3021, 0x3029}, propertyGeneralCategory{lbprID, gcNl}},     //     [9] HANGZHOU NUMERAL ONE..HANGZHOU NUMERAL NINE
-	{runeRange{0x302A, 0x302D}, propertyGeneralCategory{lbprCM, gcMn}},     //     [4] IDEOGRAPHIC LEVEL TONE MARK..IDEOGRAPHIC ENTERING TONE MARK
-	{runeRange{0x302E, 0x302F}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] HANGUL SINGLE DOT TONE MARK..HANGUL DOUBLE DOT TONE MARK
-	{runeRange{0x3030, 0x3030}, propertyGeneralCategory{lbprID, gcPd}},     //         WAVY DASH
-	{runeRange{0x3031, 0x3034}, propertyGeneralCategory{lbprID, gcLm}},     //     [4] VERTICAL KANA REPEAT MARK..VERTICAL KANA REPEAT WITH VOICED SOUND MARK UPPER HALF
-	{runeRange{0x3035, 0x3035}, propertyGeneralCategory{lbprCM, gcLm}},     //         VERTICAL KANA REPEAT MARK LOWER HALF
-	{runeRange{0x3036, 0x3037}, propertyGeneralCategory{lbprID, gcSo}},     //     [2] CIRCLED POSTAL MARK..IDEOGRAPHIC TELEGRAPH LINE FEED SEPARATOR SYMBOL
-	{runeRange{0x3038, 0x303A}, propertyGeneralCategory{lbprID, gcNl}},     //     [3] HANGZHOU NUMERAL TEN..HANGZHOU NUMERAL THIRTY
-	{runeRange{0x303B, 0x303B}, propertyGeneralCategory{lbprNS, gcLm}},     //         VERTICAL IDEOGRAPHIC ITERATION MARK
-	{runeRange{0x303C, 0x303C}, propertyGeneralCategory{lbprNS, gcLo}},     //         MASU MARK
-	{runeRange{0x303D, 0x303D}, propertyGeneralCategory{lbprID, gcPo}},     //         PART ALTERNATION MARK
-	{runeRange{0x303E, 0x303F}, propertyGeneralCategory{lbprID, gcSo}},     //     [2] IDEOGRAPHIC VARIATION INDICATOR..IDEOGRAPHIC HALF FILL SPACE
-	{runeRange{0x3041, 0x3041}, propertyGeneralCategory{lbprCJ, gcLo}},     //         HIRAGANA LETTER SMALL A
-	{runeRange{0x3042, 0x3042}, propertyGeneralCategory{lbprID, gcLo}},     //         HIRAGANA LETTER A
-	{runeRange{0x3043, 0x3043}, propertyGeneralCategory{lbprCJ, gcLo}},     //         HIRAGANA LETTER SMALL I
-	{runeRange{0x3044, 0x3044}, propertyGeneralCategory{lbprID, gcLo}},     //         HIRAGANA LETTER I
-	{runeRange{0x3045, 0x3045}, propertyGeneralCategory{lbprCJ, gcLo}},     //         HIRAGANA LETTER SMALL U
-	{runeRange{0x3046, 0x3046}, propertyGeneralCategory{lbprID, gcLo}},     //         HIRAGANA LETTER U
-	{runeRange{0x3047, 0x3047}, propertyGeneralCategory{lbprCJ, gcLo}},     //         HIRAGANA LETTER SMALL E
-	{runeRange{0x3048, 0x3048}, propertyGeneralCategory{lbprID, gcLo}},     //         HIRAGANA LETTER E
-	{runeRange{0x3049, 0x3049}, propertyGeneralCategory{lbprCJ, gcLo}},     //         HIRAGANA LETTER SMALL O
-	{runeRange{0x304A, 0x3062}, propertyGeneralCategory{lbprID, gcLo}},     //    [25] HIRAGANA LETTER O..HIRAGANA LETTER DI
-	{runeRange{0x3063, 0x3063}, propertyGeneralCategory{lbprCJ, gcLo}},     //         HIRAGANA LETTER SMALL TU
-	{runeRange{0x3064, 0x3082}, propertyGeneralCategory{lbprID, gcLo}},     //    [31] HIRAGANA LETTER TU..HIRAGANA LETTER MO
-	{runeRange{0x3083, 0x3083}, propertyGeneralCategory{lbprCJ, gcLo}},     //         HIRAGANA LETTER SMALL YA
-	{runeRange{0x3084, 0x3084}, propertyGeneralCategory{lbprID, gcLo}},     //         HIRAGANA LETTER YA
-	{runeRange{0x3085, 0x3085}, propertyGeneralCategory{lbprCJ, gcLo}},     //         HIRAGANA LETTER SMALL YU
-	{runeRange{0x3086, 0x3086}, propertyGeneralCategory{lbprID, gcLo}},     //         HIRAGANA LETTER YU
-	{runeRange{0x3087, 0x3087}, propertyGeneralCategory{lbprCJ, gcLo}},     //         HIRAGANA LETTER SMALL YO
-	{runeRange{0x3088, 0x308D}, propertyGeneralCategory{lbprID, gcLo}},     //     [6] HIRAGANA LETTER YO..HIRAGANA LETTER RO
-	{runeRange{0x308E, 0x308E}, propertyGeneralCategory{lbprCJ, gcLo}},     //         HIRAGANA LETTER SMALL WA
-	{runeRange{0x308F, 0x3094}, propertyGeneralCategory{lbprID, gcLo}},     //     [6] HIRAGANA LETTER WA..HIRAGANA LETTER VU
-	{runeRange{0x3095, 0x3096}, propertyGeneralCategory{lbprCJ, gcLo}},     //     [2] HIRAGANA LETTER SMALL KA..HIRAGANA LETTER SMALL KE
-	{runeRange{0x3099, 0x309A}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] COMBINING KATAKANA-HIRAGANA VOICED SOUND MARK..COMBINING KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK
-	{runeRange{0x309B, 0x309C}, propertyGeneralCategory{lbprNS, gcSk}},     //     [2] KATAKANA-HIRAGANA VOICED SOUND MARK..KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK
-	{runeRange{0x309D, 0x309E}, propertyGeneralCategory{lbprNS, gcLm}},     //     [2] HIRAGANA ITERATION MARK..HIRAGANA VOICED ITERATION MARK
-	{runeRange{0x309F, 0x309F}, propertyGeneralCategory{lbprID, gcLo}},     //         HIRAGANA DIGRAPH YORI
-	{runeRange{0x30A0, 0x30A0}, propertyGeneralCategory{lbprNS, gcPd}},     //         KATAKANA-HIRAGANA DOUBLE HYPHEN
-	{runeRange{0x30A1, 0x30A1}, propertyGeneralCategory{lbprCJ, gcLo}},     //         KATAKANA LETTER SMALL A
-	{runeRange{0x30A2, 0x30A2}, propertyGeneralCategory{lbprID, gcLo}},     //         KATAKANA LETTER A
-	{runeRange{0x30A3, 0x30A3}, propertyGeneralCategory{lbprCJ, gcLo}},     //         KATAKANA LETTER SMALL I
-	{runeRange{0x30A4, 0x30A4}, propertyGeneralCategory{lbprID, gcLo}},     //         KATAKANA LETTER I
-	{runeRange{0x30A5, 0x30A5}, propertyGeneralCategory{lbprCJ, gcLo}},     //         KATAKANA LETTER SMALL U
-	{runeRange{0x30A6, 0x30A6}, propertyGeneralCategory{lbprID, gcLo}},     //         KATAKANA LETTER U
-	{runeRange{0x30A7, 0x30A7}, propertyGeneralCategory{lbprCJ, gcLo}},     //         KATAKANA LETTER SMALL E
-	{runeRange{0x30A8, 0x30A8}, propertyGeneralCategory{lbprID, gcLo}},     //         KATAKANA LETTER E
-	{runeRange{0x30A9, 0x30A9}, propertyGeneralCategory{lbprCJ, gcLo}},     //         KATAKANA LETTER SMALL O
-	{runeRange{0x30AA, 0x30C2}, propertyGeneralCategory{lbprID, gcLo}},     //    [25] KATAKANA LETTER O..KATAKANA LETTER DI
-	{runeRange{0x30C3, 0x30C3}, propertyGeneralCategory{lbprCJ, gcLo}},     //         KATAKANA LETTER SMALL TU
-	{runeRange{0x30C4, 0x30E2}, propertyGeneralCategory{lbprID, gcLo}},     //    [31] KATAKANA LETTER TU..KATAKANA LETTER MO
-	{runeRange{0x30E3, 0x30E3}, propertyGeneralCategory{lbprCJ, gcLo}},     //         KATAKANA LETTER SMALL YA
-	{runeRange{0x30E4, 0x30E4}, propertyGeneralCategory{lbprID, gcLo}},     //         KATAKANA LETTER YA
-	{runeRange{0x30E5, 0x30E5}, propertyGeneralCategory{lbprCJ, gcLo}},     //         KATAKANA LETTER SMALL YU
-	{runeRange{0x30E6, 0x30E6}, propertyGeneralCategory{lbprID, gcLo}},     //         KATAKANA LETTER YU
-	{runeRange{0x30E7, 0x30E7}, propertyGeneralCategory{lbprCJ, gcLo}},     //         KATAKANA LETTER SMALL YO
-	{runeRange{0x30E8, 0x30ED}, propertyGeneralCategory{lbprID, gcLo}},     //     [6] KATAKANA LETTER YO..KATAKANA LETTER RO
-	{runeRange{0x30EE, 0x30EE}, propertyGeneralCategory{lbprCJ, gcLo}},     //         KATAKANA LETTER SMALL WA
-	{runeRange{0x30EF, 0x30F4}, propertyGeneralCategory{lbprID, gcLo}},     //     [6] KATAKANA LETTER WA..KATAKANA LETTER VU
-	{runeRange{0x30F5, 0x30F6}, propertyGeneralCategory{lbprCJ, gcLo}},     //     [2] KATAKANA LETTER SMALL KA..KATAKANA LETTER SMALL KE
-	{runeRange{0x30F7, 0x30FA}, propertyGeneralCategory{lbprID, gcLo}},     //     [4] KATAKANA LETTER VA..KATAKANA LETTER VO
-	{runeRange{0x30FB, 0x30FB}, propertyGeneralCategory{lbprNS, gcPo}},     //         KATAKANA MIDDLE DOT
-	{runeRange{0x30FC, 0x30FC}, propertyGeneralCategory{lbprCJ, gcLm}},     //         KATAKANA-HIRAGANA PROLONGED SOUND MARK
-	{runeRange{0x30FD, 0x30FE}, propertyGeneralCategory{lbprNS, gcLm}},     //     [2] KATAKANA ITERATION MARK..KATAKANA VOICED ITERATION MARK
-	{runeRange{0x30FF, 0x30FF}, propertyGeneralCategory{lbprID, gcLo}},     //         KATAKANA DIGRAPH KOTO
-	{runeRange{0x3105, 0x312F}, propertyGeneralCategory{lbprID, gcLo}},     //    [43] BOPOMOFO LETTER B..BOPOMOFO LETTER NN
-	{runeRange{0x3131, 0x318E}, propertyGeneralCategory{lbprID, gcLo}},     //    [94] HANGUL LETTER KIYEOK..HANGUL LETTER ARAEAE
-	{runeRange{0x3190, 0x3191}, propertyGeneralCategory{lbprID, gcSo}},     //     [2] IDEOGRAPHIC ANNOTATION LINKING MARK..IDEOGRAPHIC ANNOTATION REVERSE MARK
-	{runeRange{0x3192, 0x3195}, propertyGeneralCategory{lbprID, gcNo}},     //     [4] IDEOGRAPHIC ANNOTATION ONE MARK..IDEOGRAPHIC ANNOTATION FOUR MARK
-	{runeRange{0x3196, 0x319F}, propertyGeneralCategory{lbprID, gcSo}},     //    [10] IDEOGRAPHIC ANNOTATION TOP MARK..IDEOGRAPHIC ANNOTATION MAN MARK
-	{runeRange{0x31A0, 0x31BF}, propertyGeneralCategory{lbprID, gcLo}},     //    [32] BOPOMOFO LETTER BU..BOPOMOFO LETTER AH
-	{runeRange{0x31C0, 0x31E3}, propertyGeneralCategory{lbprID, gcSo}},     //    [36] CJK STROKE T..CJK STROKE Q
-	{runeRange{0x31F0, 0x31FF}, propertyGeneralCategory{lbprCJ, gcLo}},     //    [16] KATAKANA LETTER SMALL KU..KATAKANA LETTER SMALL RO
-	{runeRange{0x3200, 0x321E}, propertyGeneralCategory{lbprID, gcSo}},     //    [31] PARENTHESIZED HANGUL KIYEOK..PARENTHESIZED KOREAN CHARACTER O HU
-	{runeRange{0x3220, 0x3229}, propertyGeneralCategory{lbprID, gcNo}},     //    [10] PARENTHESIZED IDEOGRAPH ONE..PARENTHESIZED IDEOGRAPH TEN
-	{runeRange{0x322A, 0x3247}, propertyGeneralCategory{lbprID, gcSo}},     //    [30] PARENTHESIZED IDEOGRAPH MOON..CIRCLED IDEOGRAPH KOTO
-	{runeRange{0x3248, 0x324F}, propertyGeneralCategory{lbprAI, gcNo}},     //     [8] CIRCLED NUMBER TEN ON BLACK SQUARE..CIRCLED NUMBER EIGHTY ON BLACK SQUARE
-	{runeRange{0x3250, 0x3250}, propertyGeneralCategory{lbprID, gcSo}},     //         PARTNERSHIP SIGN
-	{runeRange{0x3251, 0x325F}, propertyGeneralCategory{lbprID, gcNo}},     //    [15] CIRCLED NUMBER TWENTY ONE..CIRCLED NUMBER THIRTY FIVE
-	{runeRange{0x3260, 0x327F}, propertyGeneralCategory{lbprID, gcSo}},     //    [32] CIRCLED HANGUL KIYEOK..KOREAN STANDARD SYMBOL
-	{runeRange{0x3280, 0x3289}, propertyGeneralCategory{lbprID, gcNo}},     //    [10] CIRCLED IDEOGRAPH ONE..CIRCLED IDEOGRAPH TEN
-	{runeRange{0x328A, 0x32B0}, propertyGeneralCategory{lbprID, gcSo}},     //    [39] CIRCLED IDEOGRAPH MOON..CIRCLED IDEOGRAPH NIGHT
-	{runeRange{0x32B1, 0x32BF}, propertyGeneralCategory{lbprID, gcNo}},     //    [15] CIRCLED NUMBER THIRTY SIX..CIRCLED NUMBER FIFTY
-	{runeRange{0x32C0, 0x32FF}, propertyGeneralCategory{lbprID, gcSo}},     //    [64] IDEOGRAPHIC TELEGRAPH SYMBOL FOR JANUARY..SQUARE ERA NAME REIWA
-	{runeRange{0x3300, 0x33FF}, propertyGeneralCategory{lbprID, gcSo}},     //   [256] SQUARE APAATO..SQUARE GAL
-	{runeRange{0x3400, 0x4DBF}, propertyGeneralCategory{lbprID, gcLo}},     //  [6592] CJK UNIFIED IDEOGRAPH-3400..CJK UNIFIED IDEOGRAPH-4DBF
-	{runeRange{0x4DC0, 0x4DFF}, propertyGeneralCategory{lbprAL, gcSo}},     //    [64] HEXAGRAM FOR THE CREATIVE HEAVEN..HEXAGRAM FOR BEFORE COMPLETION
-	{runeRange{0x4E00, 0x9FFF}, propertyGeneralCategory{lbprID, gcLo}},     // [20992] CJK UNIFIED IDEOGRAPH-4E00..CJK UNIFIED IDEOGRAPH-9FFF
-	{runeRange{0xA000, 0xA014}, propertyGeneralCategory{lbprID, gcLo}},     //    [21] YI SYLLABLE IT..YI SYLLABLE E
-	{runeRange{0xA015, 0xA015}, propertyGeneralCategory{lbprNS, gcLm}},     //         YI SYLLABLE WU
-	{runeRange{0xA016, 0xA48C}, propertyGeneralCategory{lbprID, gcLo}},     //  [1143] YI SYLLABLE BIT..YI SYLLABLE YYR
-	{runeRange{0xA490, 0xA4C6}, propertyGeneralCategory{lbprID, gcSo}},     //    [55] YI RADICAL QOT..YI RADICAL KE
-	{runeRange{0xA4D0, 0xA4F7}, propertyGeneralCategory{lbprAL, gcLo}},     //    [40] LISU LETTER BA..LISU LETTER OE
-	{runeRange{0xA4F8, 0xA4FD}, propertyGeneralCategory{lbprAL, gcLm}},     //     [6] LISU LETTER TONE MYA TI..LISU LETTER TONE MYA JEU
-	{runeRange{0xA4FE, 0xA4FF}, propertyGeneralCategory{lbprBA, gcPo}},     //     [2] LISU PUNCTUATION COMMA..LISU PUNCTUATION FULL STOP
-	{runeRange{0xA500, 0xA60B}, propertyGeneralCategory{lbprAL, gcLo}},     //   [268] VAI SYLLABLE EE..VAI SYLLABLE NG
-	{runeRange{0xA60C, 0xA60C}, propertyGeneralCategory{lbprAL, gcLm}},     //         VAI SYLLABLE LENGTHENER
-	{runeRange{0xA60D, 0xA60D}, propertyGeneralCategory{lbprBA, gcPo}},     //         VAI COMMA
-	{runeRange{0xA60E, 0xA60E}, propertyGeneralCategory{lbprEX, gcPo}},     //         VAI FULL STOP
-	{runeRange{0xA60F, 0xA60F}, propertyGeneralCategory{lbprBA, gcPo}},     //         VAI QUESTION MARK
-	{runeRange{0xA610, 0xA61F}, propertyGeneralCategory{lbprAL, gcLo}},     //    [16] VAI SYLLABLE NDOLE FA..VAI SYMBOL JONG
-	{runeRange{0xA620, 0xA629}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] VAI DIGIT ZERO..VAI DIGIT NINE
-	{runeRange{0xA62A, 0xA62B}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] VAI SYLLABLE NDOLE MA..VAI SYLLABLE NDOLE DO
-	{runeRange{0xA640, 0xA66D}, propertyGeneralCategory{lbprAL, gcLC}},     //    [46] CYRILLIC CAPITAL LETTER ZEMLYA..CYRILLIC SMALL LETTER DOUBLE MONOCULAR O
-	{runeRange{0xA66E, 0xA66E}, propertyGeneralCategory{lbprAL, gcLo}},     //         CYRILLIC LETTER MULTIOCULAR O
-	{runeRange{0xA66F, 0xA66F}, propertyGeneralCategory{lbprCM, gcMn}},     //         COMBINING CYRILLIC VZMET
-	{runeRange{0xA670, 0xA672}, propertyGeneralCategory{lbprCM, gcMe}},     //     [3] COMBINING CYRILLIC TEN MILLIONS SIGN..COMBINING CYRILLIC THOUSAND MILLIONS SIGN
-	{runeRange{0xA673, 0xA673}, propertyGeneralCategory{lbprAL, gcPo}},     //         SLAVONIC ASTERISK
-	{runeRange{0xA674, 0xA67D}, propertyGeneralCategory{lbprCM, gcMn}},     //    [10] COMBINING CYRILLIC LETTER UKRAINIAN IE..COMBINING CYRILLIC PAYEROK
-	{runeRange{0xA67E, 0xA67E}, propertyGeneralCategory{lbprAL, gcPo}},     //         CYRILLIC KAVYKA
-	{runeRange{0xA67F, 0xA67F}, propertyGeneralCategory{lbprAL, gcLm}},     //         CYRILLIC PAYEROK
-	{runeRange{0xA680, 0xA69B}, propertyGeneralCategory{lbprAL, gcLC}},     //    [28] CYRILLIC CAPITAL LETTER DWE..CYRILLIC SMALL LETTER CROSSED O
-	{runeRange{0xA69C, 0xA69D}, propertyGeneralCategory{lbprAL, gcLm}},     //     [2] MODIFIER LETTER CYRILLIC HARD SIGN..MODIFIER LETTER CYRILLIC SOFT SIGN
-	{runeRange{0xA69E, 0xA69F}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] COMBINING CYRILLIC LETTER EF..COMBINING CYRILLIC LETTER IOTIFIED E
-	{runeRange{0xA6A0, 0xA6E5}, propertyGeneralCategory{lbprAL, gcLo}},     //    [70] BAMUM LETTER A..BAMUM LETTER KI
-	{runeRange{0xA6E6, 0xA6EF}, propertyGeneralCategory{lbprAL, gcNl}},     //    [10] BAMUM LETTER MO..BAMUM LETTER KOGHOM
-	{runeRange{0xA6F0, 0xA6F1}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] BAMUM COMBINING MARK KOQNDON..BAMUM COMBINING MARK TUKWENTIS
-	{runeRange{0xA6F2, 0xA6F2}, propertyGeneralCategory{lbprAL, gcPo}},     //         BAMUM NJAEMLI
-	{runeRange{0xA6F3, 0xA6F7}, propertyGeneralCategory{lbprBA, gcPo}},     //     [5] BAMUM FULL STOP..BAMUM QUESTION MARK
-	{runeRange{0xA700, 0xA716}, propertyGeneralCategory{lbprAL, gcSk}},     //    [23] MODIFIER LETTER CHINESE TONE YIN PING..MODIFIER LETTER EXTRA-LOW LEFT-STEM TONE BAR
-	{runeRange{0xA717, 0xA71F}, propertyGeneralCategory{lbprAL, gcLm}},     //     [9] MODIFIER LETTER DOT VERTICAL BAR..MODIFIER LETTER LOW INVERTED EXCLAMATION MARK
-	{runeRange{0xA720, 0xA721}, propertyGeneralCategory{lbprAL, gcSk}},     //     [2] MODIFIER LETTER STRESS AND HIGH TONE..MODIFIER LETTER STRESS AND LOW TONE
-	{runeRange{0xA722, 0xA76F}, propertyGeneralCategory{lbprAL, gcLC}},     //    [78] LATIN CAPITAL LETTER EGYPTOLOGICAL ALEF..LATIN SMALL LETTER CON
-	{runeRange{0xA770, 0xA770}, propertyGeneralCategory{lbprAL, gcLm}},     //         MODIFIER LETTER US
-	{runeRange{0xA771, 0xA787}, propertyGeneralCategory{lbprAL, gcLC}},     //    [23] LATIN SMALL LETTER DUM..LATIN SMALL LETTER INSULAR T
-	{runeRange{0xA788, 0xA788}, propertyGeneralCategory{lbprAL, gcLm}},     //         MODIFIER LETTER LOW CIRCUMFLEX ACCENT
-	{runeRange{0xA789, 0xA78A}, propertyGeneralCategory{lbprAL, gcSk}},     //     [2] MODIFIER LETTER COLON..MODIFIER LETTER SHORT EQUALS SIGN
-	{runeRange{0xA78B, 0xA78E}, propertyGeneralCategory{lbprAL, gcLC}},     //     [4] LATIN CAPITAL LETTER SALTILLO..LATIN SMALL LETTER L WITH RETROFLEX HOOK AND BELT
-	{runeRange{0xA78F, 0xA78F}, propertyGeneralCategory{lbprAL, gcLo}},     //         LATIN LETTER SINOLOGICAL DOT
-	{runeRange{0xA790, 0xA7CA}, propertyGeneralCategory{lbprAL, gcLC}},     //    [59] LATIN CAPITAL LETTER N WITH DESCENDER..LATIN SMALL LETTER S WITH SHORT STROKE OVERLAY
-	{runeRange{0xA7D0, 0xA7D1}, propertyGeneralCategory{lbprAL, gcLC}},     //     [2] LATIN CAPITAL LETTER CLOSED INSULAR G..LATIN SMALL LETTER CLOSED INSULAR G
-	{runeRange{0xA7D3, 0xA7D3}, propertyGeneralCategory{lbprAL, gcLl}},     //         LATIN SMALL LETTER DOUBLE THORN
-	{runeRange{0xA7D5, 0xA7D9}, propertyGeneralCategory{lbprAL, gcLC}},     //     [5] LATIN SMALL LETTER DOUBLE WYNN..LATIN SMALL LETTER SIGMOID S
-	{runeRange{0xA7F2, 0xA7F4}, propertyGeneralCategory{lbprAL, gcLm}},     //     [3] MODIFIER LETTER CAPITAL C..MODIFIER LETTER CAPITAL Q
-	{runeRange{0xA7F5, 0xA7F6}, propertyGeneralCategory{lbprAL, gcLC}},     //     [2] LATIN CAPITAL LETTER REVERSED HALF H..LATIN SMALL LETTER REVERSED HALF H
-	{runeRange{0xA7F7, 0xA7F7}, propertyGeneralCategory{lbprAL, gcLo}},     //         LATIN EPIGRAPHIC LETTER SIDEWAYS I
-	{runeRange{0xA7F8, 0xA7F9}, propertyGeneralCategory{lbprAL, gcLm}},     //     [2] MODIFIER LETTER CAPITAL H WITH STROKE..MODIFIER LETTER SMALL LIGATURE OE
-	{runeRange{0xA7FA, 0xA7FA}, propertyGeneralCategory{lbprAL, gcLl}},     //         LATIN LETTER SMALL CAPITAL TURNED M
-	{runeRange{0xA7FB, 0xA7FF}, propertyGeneralCategory{lbprAL, gcLo}},     //     [5] LATIN EPIGRAPHIC LETTER REVERSED F..LATIN EPIGRAPHIC LETTER ARCHAIC M
-	{runeRange{0xA800, 0xA801}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] SYLOTI NAGRI LETTER A..SYLOTI NAGRI LETTER I
-	{runeRange{0xA802, 0xA802}, propertyGeneralCategory{lbprCM, gcMn}},     //         SYLOTI NAGRI SIGN DVISVARA
-	{runeRange{0xA803, 0xA805}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] SYLOTI NAGRI LETTER U..SYLOTI NAGRI LETTER O
-	{runeRange{0xA806, 0xA806}, propertyGeneralCategory{lbprCM, gcMn}},     //         SYLOTI NAGRI SIGN HASANTA
-	{runeRange{0xA807, 0xA80A}, propertyGeneralCategory{lbprAL, gcLo}},     //     [4] SYLOTI NAGRI LETTER KO..SYLOTI NAGRI LETTER GHO
-	{runeRange{0xA80B, 0xA80B}, propertyGeneralCategory{lbprCM, gcMn}},     //         SYLOTI NAGRI SIGN ANUSVARA
-	{runeRange{0xA80C, 0xA822}, propertyGeneralCategory{lbprAL, gcLo}},     //    [23] SYLOTI NAGRI LETTER CO..SYLOTI NAGRI LETTER HO
-	{runeRange{0xA823, 0xA824}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] SYLOTI NAGRI VOWEL SIGN A..SYLOTI NAGRI VOWEL SIGN I
-	{runeRange{0xA825, 0xA826}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] SYLOTI NAGRI VOWEL SIGN U..SYLOTI NAGRI VOWEL SIGN E
-	{runeRange{0xA827, 0xA827}, propertyGeneralCategory{lbprCM, gcMc}},     //         SYLOTI NAGRI VOWEL SIGN OO
-	{runeRange{0xA828, 0xA82B}, propertyGeneralCategory{lbprAL, gcSo}},     //     [4] SYLOTI NAGRI POETRY MARK-1..SYLOTI NAGRI POETRY MARK-4
-	{runeRange{0xA82C, 0xA82C}, propertyGeneralCategory{lbprCM, gcMn}},     //         SYLOTI NAGRI SIGN ALTERNATE HASANTA
-	{runeRange{0xA830, 0xA835}, propertyGeneralCategory{lbprAL, gcNo}},     //     [6] NORTH INDIC FRACTION ONE QUARTER..NORTH INDIC FRACTION THREE SIXTEENTHS
-	{runeRange{0xA836, 0xA837}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] NORTH INDIC QUARTER MARK..NORTH INDIC PLACEHOLDER MARK
-	{runeRange{0xA838, 0xA838}, propertyGeneralCategory{lbprPO, gcSc}},     //         NORTH INDIC RUPEE MARK
-	{runeRange{0xA839, 0xA839}, propertyGeneralCategory{lbprAL, gcSo}},     //         NORTH INDIC QUANTITY MARK
-	{runeRange{0xA840, 0xA873}, propertyGeneralCategory{lbprAL, gcLo}},     //    [52] PHAGS-PA LETTER KA..PHAGS-PA LETTER CANDRABINDU
-	{runeRange{0xA874, 0xA875}, propertyGeneralCategory{lbprBB, gcPo}},     //     [2] PHAGS-PA SINGLE HEAD MARK..PHAGS-PA DOUBLE HEAD MARK
-	{runeRange{0xA876, 0xA877}, propertyGeneralCategory{lbprEX, gcPo}},     //     [2] PHAGS-PA MARK SHAD..PHAGS-PA MARK DOUBLE SHAD
-	{runeRange{0xA880, 0xA881}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] SAURASHTRA SIGN ANUSVARA..SAURASHTRA SIGN VISARGA
-	{runeRange{0xA882, 0xA8B3}, propertyGeneralCategory{lbprAL, gcLo}},     //    [50] SAURASHTRA LETTER A..SAURASHTRA LETTER LLA
-	{runeRange{0xA8B4, 0xA8C3}, propertyGeneralCategory{lbprCM, gcMc}},     //    [16] SAURASHTRA CONSONANT SIGN HAARU..SAURASHTRA VOWEL SIGN AU
-	{runeRange{0xA8C4, 0xA8C5}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] SAURASHTRA SIGN VIRAMA..SAURASHTRA SIGN CANDRABINDU
-	{runeRange{0xA8CE, 0xA8CF}, propertyGeneralCategory{lbprBA, gcPo}},     //     [2] SAURASHTRA DANDA..SAURASHTRA DOUBLE DANDA
-	{runeRange{0xA8D0, 0xA8D9}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] SAURASHTRA DIGIT ZERO..SAURASHTRA DIGIT NINE
-	{runeRange{0xA8E0, 0xA8F1}, propertyGeneralCategory{lbprCM, gcMn}},     //    [18] COMBINING DEVANAGARI DIGIT ZERO..COMBINING DEVANAGARI SIGN AVAGRAHA
-	{runeRange{0xA8F2, 0xA8F7}, propertyGeneralCategory{lbprAL, gcLo}},     //     [6] DEVANAGARI SIGN SPACING CANDRABINDU..DEVANAGARI SIGN CANDRABINDU AVAGRAHA
-	{runeRange{0xA8F8, 0xA8FA}, propertyGeneralCategory{lbprAL, gcPo}},     //     [3] DEVANAGARI SIGN PUSHPIKA..DEVANAGARI CARET
-	{runeRange{0xA8FB, 0xA8FB}, propertyGeneralCategory{lbprAL, gcLo}},     //         DEVANAGARI HEADSTROKE
-	{runeRange{0xA8FC, 0xA8FC}, propertyGeneralCategory{lbprBB, gcPo}},     //         DEVANAGARI SIGN SIDDHAM
-	{runeRange{0xA8FD, 0xA8FE}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] DEVANAGARI JAIN OM..DEVANAGARI LETTER AY
-	{runeRange{0xA8FF, 0xA8FF}, propertyGeneralCategory{lbprCM, gcMn}},     //         DEVANAGARI VOWEL SIGN AY
-	{runeRange{0xA900, 0xA909}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] KAYAH LI DIGIT ZERO..KAYAH LI DIGIT NINE
-	{runeRange{0xA90A, 0xA925}, propertyGeneralCategory{lbprAL, gcLo}},     //    [28] KAYAH LI LETTER KA..KAYAH LI LETTER OO
-	{runeRange{0xA926, 0xA92D}, propertyGeneralCategory{lbprCM, gcMn}},     //     [8] KAYAH LI VOWEL UE..KAYAH LI TONE CALYA PLOPHU
-	{runeRange{0xA92E, 0xA92F}, propertyGeneralCategory{lbprBA, gcPo}},     //     [2] KAYAH LI SIGN CWI..KAYAH LI SIGN SHYA
-	{runeRange{0xA930, 0xA946}, propertyGeneralCategory{lbprAL, gcLo}},     //    [23] REJANG LETTER KA..REJANG LETTER A
-	{runeRange{0xA947, 0xA951}, propertyGeneralCategory{lbprCM, gcMn}},     //    [11] REJANG VOWEL SIGN I..REJANG CONSONANT SIGN R
-	{runeRange{0xA952, 0xA953}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] REJANG CONSONANT SIGN H..REJANG VIRAMA
-	{runeRange{0xA95F, 0xA95F}, propertyGeneralCategory{lbprAL, gcPo}},     //         REJANG SECTION MARK
-	{runeRange{0xA960, 0xA97C}, propertyGeneralCategory{lbprJL, gcLo}},     //    [29] HANGUL CHOSEONG TIKEUT-MIEUM..HANGUL CHOSEONG SSANGYEORINHIEUH
-	{runeRange{0xA980, 0xA982}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] JAVANESE SIGN PANYANGGA..JAVANESE SIGN LAYAR
-	{runeRange{0xA983, 0xA983}, propertyGeneralCategory{lbprCM, gcMc}},     //         JAVANESE SIGN WIGNYAN
-	{runeRange{0xA984, 0xA9B2}, propertyGeneralCategory{lbprAL, gcLo}},     //    [47] JAVANESE LETTER A..JAVANESE LETTER HA
-	{runeRange{0xA9B3, 0xA9B3}, propertyGeneralCategory{lbprCM, gcMn}},     //         JAVANESE SIGN CECAK TELU
-	{runeRange{0xA9B4, 0xA9B5}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] JAVANESE VOWEL SIGN TARUNG..JAVANESE VOWEL SIGN TOLONG
-	{runeRange{0xA9B6, 0xA9B9}, propertyGeneralCategory{lbprCM, gcMn}},     //     [4] JAVANESE VOWEL SIGN WULU..JAVANESE VOWEL SIGN SUKU MENDUT
-	{runeRange{0xA9BA, 0xA9BB}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] JAVANESE VOWEL SIGN TALING..JAVANESE VOWEL SIGN DIRGA MURE
-	{runeRange{0xA9BC, 0xA9BD}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] JAVANESE VOWEL SIGN PEPET..JAVANESE CONSONANT SIGN KERET
-	{runeRange{0xA9BE, 0xA9C0}, propertyGeneralCategory{lbprCM, gcMc}},     //     [3] JAVANESE CONSONANT SIGN PENGKAL..JAVANESE PANGKON
-	{runeRange{0xA9C1, 0xA9C6}, propertyGeneralCategory{lbprAL, gcPo}},     //     [6] JAVANESE LEFT RERENGGAN..JAVANESE PADA WINDU
-	{runeRange{0xA9C7, 0xA9C9}, propertyGeneralCategory{lbprBA, gcPo}},     //     [3] JAVANESE PADA PANGKAT..JAVANESE PADA LUNGSI
-	{runeRange{0xA9CA, 0xA9CD}, propertyGeneralCategory{lbprAL, gcPo}},     //     [4] JAVANESE PADA ADEG..JAVANESE TURNED PADA PISELEH
-	{runeRange{0xA9CF, 0xA9CF}, propertyGeneralCategory{lbprAL, gcLm}},     //         JAVANESE PANGRANGKEP
-	{runeRange{0xA9D0, 0xA9D9}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] JAVANESE DIGIT ZERO..JAVANESE DIGIT NINE
-	{runeRange{0xA9DE, 0xA9DF}, propertyGeneralCategory{lbprAL, gcPo}},     //     [2] JAVANESE PADA TIRTA TUMETES..JAVANESE PADA ISEN-ISEN
-	{runeRange{0xA9E0, 0xA9E4}, propertyGeneralCategory{lbprSA, gcLo}},     //     [5] MYANMAR LETTER SHAN GHA..MYANMAR LETTER SHAN BHA
-	{runeRange{0xA9E5, 0xA9E5}, propertyGeneralCategory{lbprSA, gcMn}},     //         MYANMAR SIGN SHAN SAW
-	{runeRange{0xA9E6, 0xA9E6}, propertyGeneralCategory{lbprSA, gcLm}},     //         MYANMAR MODIFIER LETTER SHAN REDUPLICATION
-	{runeRange{0xA9E7, 0xA9EF}, propertyGeneralCategory{lbprSA, gcLo}},     //     [9] MYANMAR LETTER TAI LAING NYA..MYANMAR LETTER TAI LAING NNA
-	{runeRange{0xA9F0, 0xA9F9}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] MYANMAR TAI LAING DIGIT ZERO..MYANMAR TAI LAING DIGIT NINE
-	{runeRange{0xA9FA, 0xA9FE}, propertyGeneralCategory{lbprSA, gcLo}},     //     [5] MYANMAR LETTER TAI LAING LLA..MYANMAR LETTER TAI LAING BHA
-	{runeRange{0xAA00, 0xAA28}, propertyGeneralCategory{lbprAL, gcLo}},     //    [41] CHAM LETTER A..CHAM LETTER HA
-	{runeRange{0xAA29, 0xAA2E}, propertyGeneralCategory{lbprCM, gcMn}},     //     [6] CHAM VOWEL SIGN AA..CHAM VOWEL SIGN OE
-	{runeRange{0xAA2F, 0xAA30}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] CHAM VOWEL SIGN O..CHAM VOWEL SIGN AI
-	{runeRange{0xAA31, 0xAA32}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] CHAM VOWEL SIGN AU..CHAM VOWEL SIGN UE
-	{runeRange{0xAA33, 0xAA34}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] CHAM CONSONANT SIGN YA..CHAM CONSONANT SIGN RA
-	{runeRange{0xAA35, 0xAA36}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] CHAM CONSONANT SIGN LA..CHAM CONSONANT SIGN WA
-	{runeRange{0xAA40, 0xAA42}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] CHAM LETTER FINAL K..CHAM LETTER FINAL NG
-	{runeRange{0xAA43, 0xAA43}, propertyGeneralCategory{lbprCM, gcMn}},     //         CHAM CONSONANT SIGN FINAL NG
-	{runeRange{0xAA44, 0xAA4B}, propertyGeneralCategory{lbprAL, gcLo}},     //     [8] CHAM LETTER FINAL CH..CHAM LETTER FINAL SS
-	{runeRange{0xAA4C, 0xAA4C}, propertyGeneralCategory{lbprCM, gcMn}},     //         CHAM CONSONANT SIGN FINAL M
-	{runeRange{0xAA4D, 0xAA4D}, propertyGeneralCategory{lbprCM, gcMc}},     //         CHAM CONSONANT SIGN FINAL H
-	{runeRange{0xAA50, 0xAA59}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] CHAM DIGIT ZERO..CHAM DIGIT NINE
-	{runeRange{0xAA5C, 0xAA5C}, propertyGeneralCategory{lbprAL, gcPo}},     //         CHAM PUNCTUATION SPIRAL
-	{runeRange{0xAA5D, 0xAA5F}, propertyGeneralCategory{lbprBA, gcPo}},     //     [3] CHAM PUNCTUATION DANDA..CHAM PUNCTUATION TRIPLE DANDA
-	{runeRange{0xAA60, 0xAA6F}, propertyGeneralCategory{lbprSA, gcLo}},     //    [16] MYANMAR LETTER KHAMTI GA..MYANMAR LETTER KHAMTI FA
-	{runeRange{0xAA70, 0xAA70}, propertyGeneralCategory{lbprSA, gcLm}},     //         MYANMAR MODIFIER LETTER KHAMTI REDUPLICATION
-	{runeRange{0xAA71, 0xAA76}, propertyGeneralCategory{lbprSA, gcLo}},     //     [6] MYANMAR LETTER KHAMTI XA..MYANMAR LOGOGRAM KHAMTI HM
-	{runeRange{0xAA77, 0xAA79}, propertyGeneralCategory{lbprSA, gcSo}},     //     [3] MYANMAR SYMBOL AITON EXCLAMATION..MYANMAR SYMBOL AITON TWO
-	{runeRange{0xAA7A, 0xAA7A}, propertyGeneralCategory{lbprSA, gcLo}},     //         MYANMAR LETTER AITON RA
-	{runeRange{0xAA7B, 0xAA7B}, propertyGeneralCategory{lbprSA, gcMc}},     //         MYANMAR SIGN PAO KAREN TONE
-	{runeRange{0xAA7C, 0xAA7C}, propertyGeneralCategory{lbprSA, gcMn}},     //         MYANMAR SIGN TAI LAING TONE-2
-	{runeRange{0xAA7D, 0xAA7D}, propertyGeneralCategory{lbprSA, gcMc}},     //         MYANMAR SIGN TAI LAING TONE-5
-	{runeRange{0xAA7E, 0xAA7F}, propertyGeneralCategory{lbprSA, gcLo}},     //     [2] MYANMAR LETTER SHWE PALAUNG CHA..MYANMAR LETTER SHWE PALAUNG SHA
-	{runeRange{0xAA80, 0xAAAF}, propertyGeneralCategory{lbprSA, gcLo}},     //    [48] TAI VIET LETTER LOW KO..TAI VIET LETTER HIGH O
-	{runeRange{0xAAB0, 0xAAB0}, propertyGeneralCategory{lbprSA, gcMn}},     //         TAI VIET MAI KANG
-	{runeRange{0xAAB1, 0xAAB1}, propertyGeneralCategory{lbprSA, gcLo}},     //         TAI VIET VOWEL AA
-	{runeRange{0xAAB2, 0xAAB4}, propertyGeneralCategory{lbprSA, gcMn}},     //     [3] TAI VIET VOWEL I..TAI VIET VOWEL U
-	{runeRange{0xAAB5, 0xAAB6}, propertyGeneralCategory{lbprSA, gcLo}},     //     [2] TAI VIET VOWEL E..TAI VIET VOWEL O
-	{runeRange{0xAAB7, 0xAAB8}, propertyGeneralCategory{lbprSA, gcMn}},     //     [2] TAI VIET MAI KHIT..TAI VIET VOWEL IA
-	{runeRange{0xAAB9, 0xAABD}, propertyGeneralCategory{lbprSA, gcLo}},     //     [5] TAI VIET VOWEL UEA..TAI VIET VOWEL AN
-	{runeRange{0xAABE, 0xAABF}, propertyGeneralCategory{lbprSA, gcMn}},     //     [2] TAI VIET VOWEL AM..TAI VIET TONE MAI EK
-	{runeRange{0xAAC0, 0xAAC0}, propertyGeneralCategory{lbprSA, gcLo}},     //         TAI VIET TONE MAI NUENG
-	{runeRange{0xAAC1, 0xAAC1}, propertyGeneralCategory{lbprSA, gcMn}},     //         TAI VIET TONE MAI THO
-	{runeRange{0xAAC2, 0xAAC2}, propertyGeneralCategory{lbprSA, gcLo}},     //         TAI VIET TONE MAI SONG
-	{runeRange{0xAADB, 0xAADC}, propertyGeneralCategory{lbprSA, gcLo}},     //     [2] TAI VIET SYMBOL KON..TAI VIET SYMBOL NUENG
-	{runeRange{0xAADD, 0xAADD}, propertyGeneralCategory{lbprSA, gcLm}},     //         TAI VIET SYMBOL SAM
-	{runeRange{0xAADE, 0xAADF}, propertyGeneralCategory{lbprSA, gcPo}},     //     [2] TAI VIET SYMBOL HO HOI..TAI VIET SYMBOL KOI KOI
-	{runeRange{0xAAE0, 0xAAEA}, propertyGeneralCategory{lbprAL, gcLo}},     //    [11] MEETEI MAYEK LETTER E..MEETEI MAYEK LETTER SSA
-	{runeRange{0xAAEB, 0xAAEB}, propertyGeneralCategory{lbprCM, gcMc}},     //         MEETEI MAYEK VOWEL SIGN II
-	{runeRange{0xAAEC, 0xAAED}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] MEETEI MAYEK VOWEL SIGN UU..MEETEI MAYEK VOWEL SIGN AAI
-	{runeRange{0xAAEE, 0xAAEF}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] MEETEI MAYEK VOWEL SIGN AU..MEETEI MAYEK VOWEL SIGN AAU
-	{runeRange{0xAAF0, 0xAAF1}, propertyGeneralCategory{lbprBA, gcPo}},     //     [2] MEETEI MAYEK CHEIKHAN..MEETEI MAYEK AHANG KHUDAM
-	{runeRange{0xAAF2, 0xAAF2}, propertyGeneralCategory{lbprAL, gcLo}},     //         MEETEI MAYEK ANJI
-	{runeRange{0xAAF3, 0xAAF4}, propertyGeneralCategory{lbprAL, gcLm}},     //     [2] MEETEI MAYEK SYLLABLE REPETITION MARK..MEETEI MAYEK WORD REPETITION MARK
-	{runeRange{0xAAF5, 0xAAF5}, propertyGeneralCategory{lbprCM, gcMc}},     //         MEETEI MAYEK VOWEL SIGN VISARGA
-	{runeRange{0xAAF6, 0xAAF6}, propertyGeneralCategory{lbprCM, gcMn}},     //         MEETEI MAYEK VIRAMA
-	{runeRange{0xAB01, 0xAB06}, propertyGeneralCategory{lbprAL, gcLo}},     //     [6] ETHIOPIC SYLLABLE TTHU..ETHIOPIC SYLLABLE TTHO
-	{runeRange{0xAB09, 0xAB0E}, propertyGeneralCategory{lbprAL, gcLo}},     //     [6] ETHIOPIC SYLLABLE DDHU..ETHIOPIC SYLLABLE DDHO
-	{runeRange{0xAB11, 0xAB16}, propertyGeneralCategory{lbprAL, gcLo}},     //     [6] ETHIOPIC SYLLABLE DZU..ETHIOPIC SYLLABLE DZO
-	{runeRange{0xAB20, 0xAB26}, propertyGeneralCategory{lbprAL, gcLo}},     //     [7] ETHIOPIC SYLLABLE CCHHA..ETHIOPIC SYLLABLE CCHHO
-	{runeRange{0xAB28, 0xAB2E}, propertyGeneralCategory{lbprAL, gcLo}},     //     [7] ETHIOPIC SYLLABLE BBA..ETHIOPIC SYLLABLE BBO
-	{runeRange{0xAB30, 0xAB5A}, propertyGeneralCategory{lbprAL, gcLl}},     //    [43] LATIN SMALL LETTER BARRED ALPHA..LATIN SMALL LETTER Y WITH SHORT RIGHT LEG
-	{runeRange{0xAB5B, 0xAB5B}, propertyGeneralCategory{lbprAL, gcSk}},     //         MODIFIER BREVE WITH INVERTED BREVE
-	{runeRange{0xAB5C, 0xAB5F}, propertyGeneralCategory{lbprAL, gcLm}},     //     [4] MODIFIER LETTER SMALL HENG..MODIFIER LETTER SMALL U WITH LEFT HOOK
-	{runeRange{0xAB60, 0xAB68}, propertyGeneralCategory{lbprAL, gcLl}},     //     [9] LATIN SMALL LETTER SAKHA YAT..LATIN SMALL LETTER TURNED R WITH MIDDLE TILDE
-	{runeRange{0xAB69, 0xAB69}, propertyGeneralCategory{lbprAL, gcLm}},     //         MODIFIER LETTER SMALL TURNED W
-	{runeRange{0xAB6A, 0xAB6B}, propertyGeneralCategory{lbprAL, gcSk}},     //     [2] MODIFIER LETTER LEFT TACK..MODIFIER LETTER RIGHT TACK
-	{runeRange{0xAB70, 0xABBF}, propertyGeneralCategory{lbprAL, gcLl}},     //    [80] CHEROKEE SMALL LETTER A..CHEROKEE SMALL LETTER YA
-	{runeRange{0xABC0, 0xABE2}, propertyGeneralCategory{lbprAL, gcLo}},     //    [35] MEETEI MAYEK LETTER KOK..MEETEI MAYEK LETTER I LONSUM
-	{runeRange{0xABE3, 0xABE4}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] MEETEI MAYEK VOWEL SIGN ONAP..MEETEI MAYEK VOWEL SIGN INAP
-	{runeRange{0xABE5, 0xABE5}, propertyGeneralCategory{lbprCM, gcMn}},     //         MEETEI MAYEK VOWEL SIGN ANAP
-	{runeRange{0xABE6, 0xABE7}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] MEETEI MAYEK VOWEL SIGN YENAP..MEETEI MAYEK VOWEL SIGN SOUNAP
-	{runeRange{0xABE8, 0xABE8}, propertyGeneralCategory{lbprCM, gcMn}},     //         MEETEI MAYEK VOWEL SIGN UNAP
-	{runeRange{0xABE9, 0xABEA}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] MEETEI MAYEK VOWEL SIGN CHEINAP..MEETEI MAYEK VOWEL SIGN NUNG
-	{runeRange{0xABEB, 0xABEB}, propertyGeneralCategory{lbprBA, gcPo}},     //         MEETEI MAYEK CHEIKHEI
-	{runeRange{0xABEC, 0xABEC}, propertyGeneralCategory{lbprCM, gcMc}},     //         MEETEI MAYEK LUM IYEK
-	{runeRange{0xABED, 0xABED}, propertyGeneralCategory{lbprCM, gcMn}},     //         MEETEI MAYEK APUN IYEK
-	{runeRange{0xABF0, 0xABF9}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] MEETEI MAYEK DIGIT ZERO..MEETEI MAYEK DIGIT NINE
-	{runeRange{0xAC00, 0xAC00}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GA
-	{runeRange{0xAC01, 0xAC1B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GAG..HANGUL SYLLABLE GAH
-	{runeRange{0xAC1C, 0xAC1C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GAE
-	{runeRange{0xAC1D, 0xAC37}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GAEG..HANGUL SYLLABLE GAEH
-	{runeRange{0xAC38, 0xAC38}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GYA
-	{runeRange{0xAC39, 0xAC53}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GYAG..HANGUL SYLLABLE GYAH
-	{runeRange{0xAC54, 0xAC54}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GYAE
-	{runeRange{0xAC55, 0xAC6F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GYAEG..HANGUL SYLLABLE GYAEH
-	{runeRange{0xAC70, 0xAC70}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GEO
-	{runeRange{0xAC71, 0xAC8B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GEOG..HANGUL SYLLABLE GEOH
-	{runeRange{0xAC8C, 0xAC8C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GE
-	{runeRange{0xAC8D, 0xACA7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GEG..HANGUL SYLLABLE GEH
-	{runeRange{0xACA8, 0xACA8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GYEO
-	{runeRange{0xACA9, 0xACC3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GYEOG..HANGUL SYLLABLE GYEOH
-	{runeRange{0xACC4, 0xACC4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GYE
-	{runeRange{0xACC5, 0xACDF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GYEG..HANGUL SYLLABLE GYEH
-	{runeRange{0xACE0, 0xACE0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GO
-	{runeRange{0xACE1, 0xACFB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GOG..HANGUL SYLLABLE GOH
-	{runeRange{0xACFC, 0xACFC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GWA
-	{runeRange{0xACFD, 0xAD17}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GWAG..HANGUL SYLLABLE GWAH
-	{runeRange{0xAD18, 0xAD18}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GWAE
-	{runeRange{0xAD19, 0xAD33}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GWAEG..HANGUL SYLLABLE GWAEH
-	{runeRange{0xAD34, 0xAD34}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GOE
-	{runeRange{0xAD35, 0xAD4F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GOEG..HANGUL SYLLABLE GOEH
-	{runeRange{0xAD50, 0xAD50}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GYO
-	{runeRange{0xAD51, 0xAD6B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GYOG..HANGUL SYLLABLE GYOH
-	{runeRange{0xAD6C, 0xAD6C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GU
-	{runeRange{0xAD6D, 0xAD87}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GUG..HANGUL SYLLABLE GUH
-	{runeRange{0xAD88, 0xAD88}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GWEO
-	{runeRange{0xAD89, 0xADA3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GWEOG..HANGUL SYLLABLE GWEOH
-	{runeRange{0xADA4, 0xADA4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GWE
-	{runeRange{0xADA5, 0xADBF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GWEG..HANGUL SYLLABLE GWEH
-	{runeRange{0xADC0, 0xADC0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GWI
-	{runeRange{0xADC1, 0xADDB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GWIG..HANGUL SYLLABLE GWIH
-	{runeRange{0xADDC, 0xADDC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GYU
-	{runeRange{0xADDD, 0xADF7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GYUG..HANGUL SYLLABLE GYUH
-	{runeRange{0xADF8, 0xADF8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GEU
-	{runeRange{0xADF9, 0xAE13}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GEUG..HANGUL SYLLABLE GEUH
-	{runeRange{0xAE14, 0xAE14}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GYI
-	{runeRange{0xAE15, 0xAE2F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GYIG..HANGUL SYLLABLE GYIH
-	{runeRange{0xAE30, 0xAE30}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GI
-	{runeRange{0xAE31, 0xAE4B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GIG..HANGUL SYLLABLE GIH
-	{runeRange{0xAE4C, 0xAE4C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGA
-	{runeRange{0xAE4D, 0xAE67}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGAG..HANGUL SYLLABLE GGAH
-	{runeRange{0xAE68, 0xAE68}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGAE
-	{runeRange{0xAE69, 0xAE83}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGAEG..HANGUL SYLLABLE GGAEH
-	{runeRange{0xAE84, 0xAE84}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGYA
-	{runeRange{0xAE85, 0xAE9F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGYAG..HANGUL SYLLABLE GGYAH
-	{runeRange{0xAEA0, 0xAEA0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGYAE
-	{runeRange{0xAEA1, 0xAEBB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGYAEG..HANGUL SYLLABLE GGYAEH
-	{runeRange{0xAEBC, 0xAEBC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGEO
-	{runeRange{0xAEBD, 0xAED7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGEOG..HANGUL SYLLABLE GGEOH
-	{runeRange{0xAED8, 0xAED8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGE
-	{runeRange{0xAED9, 0xAEF3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGEG..HANGUL SYLLABLE GGEH
-	{runeRange{0xAEF4, 0xAEF4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGYEO
-	{runeRange{0xAEF5, 0xAF0F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGYEOG..HANGUL SYLLABLE GGYEOH
-	{runeRange{0xAF10, 0xAF10}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGYE
-	{runeRange{0xAF11, 0xAF2B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGYEG..HANGUL SYLLABLE GGYEH
-	{runeRange{0xAF2C, 0xAF2C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGO
-	{runeRange{0xAF2D, 0xAF47}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGOG..HANGUL SYLLABLE GGOH
-	{runeRange{0xAF48, 0xAF48}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGWA
-	{runeRange{0xAF49, 0xAF63}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGWAG..HANGUL SYLLABLE GGWAH
-	{runeRange{0xAF64, 0xAF64}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGWAE
-	{runeRange{0xAF65, 0xAF7F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGWAEG..HANGUL SYLLABLE GGWAEH
-	{runeRange{0xAF80, 0xAF80}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGOE
-	{runeRange{0xAF81, 0xAF9B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGOEG..HANGUL SYLLABLE GGOEH
-	{runeRange{0xAF9C, 0xAF9C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGYO
-	{runeRange{0xAF9D, 0xAFB7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGYOG..HANGUL SYLLABLE GGYOH
-	{runeRange{0xAFB8, 0xAFB8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGU
-	{runeRange{0xAFB9, 0xAFD3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGUG..HANGUL SYLLABLE GGUH
-	{runeRange{0xAFD4, 0xAFD4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGWEO
-	{runeRange{0xAFD5, 0xAFEF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGWEOG..HANGUL SYLLABLE GGWEOH
-	{runeRange{0xAFF0, 0xAFF0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGWE
-	{runeRange{0xAFF1, 0xB00B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGWEG..HANGUL SYLLABLE GGWEH
-	{runeRange{0xB00C, 0xB00C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGWI
-	{runeRange{0xB00D, 0xB027}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGWIG..HANGUL SYLLABLE GGWIH
-	{runeRange{0xB028, 0xB028}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGYU
-	{runeRange{0xB029, 0xB043}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGYUG..HANGUL SYLLABLE GGYUH
-	{runeRange{0xB044, 0xB044}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGEU
-	{runeRange{0xB045, 0xB05F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGEUG..HANGUL SYLLABLE GGEUH
-	{runeRange{0xB060, 0xB060}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGYI
-	{runeRange{0xB061, 0xB07B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGYIG..HANGUL SYLLABLE GGYIH
-	{runeRange{0xB07C, 0xB07C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGI
-	{runeRange{0xB07D, 0xB097}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGIG..HANGUL SYLLABLE GGIH
-	{runeRange{0xB098, 0xB098}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NA
-	{runeRange{0xB099, 0xB0B3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NAG..HANGUL SYLLABLE NAH
-	{runeRange{0xB0B4, 0xB0B4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NAE
-	{runeRange{0xB0B5, 0xB0CF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NAEG..HANGUL SYLLABLE NAEH
-	{runeRange{0xB0D0, 0xB0D0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NYA
-	{runeRange{0xB0D1, 0xB0EB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NYAG..HANGUL SYLLABLE NYAH
-	{runeRange{0xB0EC, 0xB0EC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NYAE
-	{runeRange{0xB0ED, 0xB107}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NYAEG..HANGUL SYLLABLE NYAEH
-	{runeRange{0xB108, 0xB108}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NEO
-	{runeRange{0xB109, 0xB123}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NEOG..HANGUL SYLLABLE NEOH
-	{runeRange{0xB124, 0xB124}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NE
-	{runeRange{0xB125, 0xB13F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NEG..HANGUL SYLLABLE NEH
-	{runeRange{0xB140, 0xB140}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NYEO
-	{runeRange{0xB141, 0xB15B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NYEOG..HANGUL SYLLABLE NYEOH
-	{runeRange{0xB15C, 0xB15C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NYE
-	{runeRange{0xB15D, 0xB177}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NYEG..HANGUL SYLLABLE NYEH
-	{runeRange{0xB178, 0xB178}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NO
-	{runeRange{0xB179, 0xB193}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NOG..HANGUL SYLLABLE NOH
-	{runeRange{0xB194, 0xB194}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NWA
-	{runeRange{0xB195, 0xB1AF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NWAG..HANGUL SYLLABLE NWAH
-	{runeRange{0xB1B0, 0xB1B0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NWAE
-	{runeRange{0xB1B1, 0xB1CB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NWAEG..HANGUL SYLLABLE NWAEH
-	{runeRange{0xB1CC, 0xB1CC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NOE
-	{runeRange{0xB1CD, 0xB1E7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NOEG..HANGUL SYLLABLE NOEH
-	{runeRange{0xB1E8, 0xB1E8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NYO
-	{runeRange{0xB1E9, 0xB203}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NYOG..HANGUL SYLLABLE NYOH
-	{runeRange{0xB204, 0xB204}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NU
-	{runeRange{0xB205, 0xB21F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NUG..HANGUL SYLLABLE NUH
-	{runeRange{0xB220, 0xB220}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NWEO
-	{runeRange{0xB221, 0xB23B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NWEOG..HANGUL SYLLABLE NWEOH
-	{runeRange{0xB23C, 0xB23C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NWE
-	{runeRange{0xB23D, 0xB257}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NWEG..HANGUL SYLLABLE NWEH
-	{runeRange{0xB258, 0xB258}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NWI
-	{runeRange{0xB259, 0xB273}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NWIG..HANGUL SYLLABLE NWIH
-	{runeRange{0xB274, 0xB274}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NYU
-	{runeRange{0xB275, 0xB28F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NYUG..HANGUL SYLLABLE NYUH
-	{runeRange{0xB290, 0xB290}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NEU
-	{runeRange{0xB291, 0xB2AB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NEUG..HANGUL SYLLABLE NEUH
-	{runeRange{0xB2AC, 0xB2AC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NYI
-	{runeRange{0xB2AD, 0xB2C7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NYIG..HANGUL SYLLABLE NYIH
-	{runeRange{0xB2C8, 0xB2C8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NI
-	{runeRange{0xB2C9, 0xB2E3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NIG..HANGUL SYLLABLE NIH
-	{runeRange{0xB2E4, 0xB2E4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DA
-	{runeRange{0xB2E5, 0xB2FF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DAG..HANGUL SYLLABLE DAH
-	{runeRange{0xB300, 0xB300}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DAE
-	{runeRange{0xB301, 0xB31B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DAEG..HANGUL SYLLABLE DAEH
-	{runeRange{0xB31C, 0xB31C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DYA
-	{runeRange{0xB31D, 0xB337}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DYAG..HANGUL SYLLABLE DYAH
-	{runeRange{0xB338, 0xB338}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DYAE
-	{runeRange{0xB339, 0xB353}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DYAEG..HANGUL SYLLABLE DYAEH
-	{runeRange{0xB354, 0xB354}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DEO
-	{runeRange{0xB355, 0xB36F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DEOG..HANGUL SYLLABLE DEOH
-	{runeRange{0xB370, 0xB370}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DE
-	{runeRange{0xB371, 0xB38B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DEG..HANGUL SYLLABLE DEH
-	{runeRange{0xB38C, 0xB38C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DYEO
-	{runeRange{0xB38D, 0xB3A7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DYEOG..HANGUL SYLLABLE DYEOH
-	{runeRange{0xB3A8, 0xB3A8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DYE
-	{runeRange{0xB3A9, 0xB3C3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DYEG..HANGUL SYLLABLE DYEH
-	{runeRange{0xB3C4, 0xB3C4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DO
-	{runeRange{0xB3C5, 0xB3DF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DOG..HANGUL SYLLABLE DOH
-	{runeRange{0xB3E0, 0xB3E0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DWA
-	{runeRange{0xB3E1, 0xB3FB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DWAG..HANGUL SYLLABLE DWAH
-	{runeRange{0xB3FC, 0xB3FC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DWAE
-	{runeRange{0xB3FD, 0xB417}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DWAEG..HANGUL SYLLABLE DWAEH
-	{runeRange{0xB418, 0xB418}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DOE
-	{runeRange{0xB419, 0xB433}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DOEG..HANGUL SYLLABLE DOEH
-	{runeRange{0xB434, 0xB434}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DYO
-	{runeRange{0xB435, 0xB44F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DYOG..HANGUL SYLLABLE DYOH
-	{runeRange{0xB450, 0xB450}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DU
-	{runeRange{0xB451, 0xB46B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DUG..HANGUL SYLLABLE DUH
-	{runeRange{0xB46C, 0xB46C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DWEO
-	{runeRange{0xB46D, 0xB487}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DWEOG..HANGUL SYLLABLE DWEOH
-	{runeRange{0xB488, 0xB488}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DWE
-	{runeRange{0xB489, 0xB4A3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DWEG..HANGUL SYLLABLE DWEH
-	{runeRange{0xB4A4, 0xB4A4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DWI
-	{runeRange{0xB4A5, 0xB4BF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DWIG..HANGUL SYLLABLE DWIH
-	{runeRange{0xB4C0, 0xB4C0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DYU
-	{runeRange{0xB4C1, 0xB4DB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DYUG..HANGUL SYLLABLE DYUH
-	{runeRange{0xB4DC, 0xB4DC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DEU
-	{runeRange{0xB4DD, 0xB4F7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DEUG..HANGUL SYLLABLE DEUH
-	{runeRange{0xB4F8, 0xB4F8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DYI
-	{runeRange{0xB4F9, 0xB513}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DYIG..HANGUL SYLLABLE DYIH
-	{runeRange{0xB514, 0xB514}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DI
-	{runeRange{0xB515, 0xB52F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DIG..HANGUL SYLLABLE DIH
-	{runeRange{0xB530, 0xB530}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDA
-	{runeRange{0xB531, 0xB54B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDAG..HANGUL SYLLABLE DDAH
-	{runeRange{0xB54C, 0xB54C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDAE
-	{runeRange{0xB54D, 0xB567}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDAEG..HANGUL SYLLABLE DDAEH
-	{runeRange{0xB568, 0xB568}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDYA
-	{runeRange{0xB569, 0xB583}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDYAG..HANGUL SYLLABLE DDYAH
-	{runeRange{0xB584, 0xB584}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDYAE
-	{runeRange{0xB585, 0xB59F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDYAEG..HANGUL SYLLABLE DDYAEH
-	{runeRange{0xB5A0, 0xB5A0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDEO
-	{runeRange{0xB5A1, 0xB5BB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDEOG..HANGUL SYLLABLE DDEOH
-	{runeRange{0xB5BC, 0xB5BC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDE
-	{runeRange{0xB5BD, 0xB5D7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDEG..HANGUL SYLLABLE DDEH
-	{runeRange{0xB5D8, 0xB5D8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDYEO
-	{runeRange{0xB5D9, 0xB5F3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDYEOG..HANGUL SYLLABLE DDYEOH
-	{runeRange{0xB5F4, 0xB5F4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDYE
-	{runeRange{0xB5F5, 0xB60F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDYEG..HANGUL SYLLABLE DDYEH
-	{runeRange{0xB610, 0xB610}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDO
-	{runeRange{0xB611, 0xB62B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDOG..HANGUL SYLLABLE DDOH
-	{runeRange{0xB62C, 0xB62C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDWA
-	{runeRange{0xB62D, 0xB647}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDWAG..HANGUL SYLLABLE DDWAH
-	{runeRange{0xB648, 0xB648}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDWAE
-	{runeRange{0xB649, 0xB663}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDWAEG..HANGUL SYLLABLE DDWAEH
-	{runeRange{0xB664, 0xB664}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDOE
-	{runeRange{0xB665, 0xB67F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDOEG..HANGUL SYLLABLE DDOEH
-	{runeRange{0xB680, 0xB680}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDYO
-	{runeRange{0xB681, 0xB69B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDYOG..HANGUL SYLLABLE DDYOH
-	{runeRange{0xB69C, 0xB69C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDU
-	{runeRange{0xB69D, 0xB6B7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDUG..HANGUL SYLLABLE DDUH
-	{runeRange{0xB6B8, 0xB6B8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDWEO
-	{runeRange{0xB6B9, 0xB6D3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDWEOG..HANGUL SYLLABLE DDWEOH
-	{runeRange{0xB6D4, 0xB6D4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDWE
-	{runeRange{0xB6D5, 0xB6EF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDWEG..HANGUL SYLLABLE DDWEH
-	{runeRange{0xB6F0, 0xB6F0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDWI
-	{runeRange{0xB6F1, 0xB70B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDWIG..HANGUL SYLLABLE DDWIH
-	{runeRange{0xB70C, 0xB70C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDYU
-	{runeRange{0xB70D, 0xB727}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDYUG..HANGUL SYLLABLE DDYUH
-	{runeRange{0xB728, 0xB728}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDEU
-	{runeRange{0xB729, 0xB743}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDEUG..HANGUL SYLLABLE DDEUH
-	{runeRange{0xB744, 0xB744}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDYI
-	{runeRange{0xB745, 0xB75F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDYIG..HANGUL SYLLABLE DDYIH
-	{runeRange{0xB760, 0xB760}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDI
-	{runeRange{0xB761, 0xB77B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDIG..HANGUL SYLLABLE DDIH
-	{runeRange{0xB77C, 0xB77C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RA
-	{runeRange{0xB77D, 0xB797}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE RAG..HANGUL SYLLABLE RAH
-	{runeRange{0xB798, 0xB798}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RAE
-	{runeRange{0xB799, 0xB7B3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE RAEG..HANGUL SYLLABLE RAEH
-	{runeRange{0xB7B4, 0xB7B4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RYA
-	{runeRange{0xB7B5, 0xB7CF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE RYAG..HANGUL SYLLABLE RYAH
-	{runeRange{0xB7D0, 0xB7D0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RYAE
-	{runeRange{0xB7D1, 0xB7EB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE RYAEG..HANGUL SYLLABLE RYAEH
-	{runeRange{0xB7EC, 0xB7EC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE REO
-	{runeRange{0xB7ED, 0xB807}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE REOG..HANGUL SYLLABLE REOH
-	{runeRange{0xB808, 0xB808}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RE
-	{runeRange{0xB809, 0xB823}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE REG..HANGUL SYLLABLE REH
-	{runeRange{0xB824, 0xB824}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RYEO
-	{runeRange{0xB825, 0xB83F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE RYEOG..HANGUL SYLLABLE RYEOH
-	{runeRange{0xB840, 0xB840}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RYE
-	{runeRange{0xB841, 0xB85B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE RYEG..HANGUL SYLLABLE RYEH
-	{runeRange{0xB85C, 0xB85C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RO
-	{runeRange{0xB85D, 0xB877}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE ROG..HANGUL SYLLABLE ROH
-	{runeRange{0xB878, 0xB878}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RWA
-	{runeRange{0xB879, 0xB893}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE RWAG..HANGUL SYLLABLE RWAH
-	{runeRange{0xB894, 0xB894}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RWAE
-	{runeRange{0xB895, 0xB8AF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE RWAEG..HANGUL SYLLABLE RWAEH
-	{runeRange{0xB8B0, 0xB8B0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE ROE
-	{runeRange{0xB8B1, 0xB8CB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE ROEG..HANGUL SYLLABLE ROEH
-	{runeRange{0xB8CC, 0xB8CC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RYO
-	{runeRange{0xB8CD, 0xB8E7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE RYOG..HANGUL SYLLABLE RYOH
-	{runeRange{0xB8E8, 0xB8E8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RU
-	{runeRange{0xB8E9, 0xB903}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE RUG..HANGUL SYLLABLE RUH
-	{runeRange{0xB904, 0xB904}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RWEO
-	{runeRange{0xB905, 0xB91F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE RWEOG..HANGUL SYLLABLE RWEOH
-	{runeRange{0xB920, 0xB920}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RWE
-	{runeRange{0xB921, 0xB93B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE RWEG..HANGUL SYLLABLE RWEH
-	{runeRange{0xB93C, 0xB93C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RWI
-	{runeRange{0xB93D, 0xB957}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE RWIG..HANGUL SYLLABLE RWIH
-	{runeRange{0xB958, 0xB958}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RYU
-	{runeRange{0xB959, 0xB973}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE RYUG..HANGUL SYLLABLE RYUH
-	{runeRange{0xB974, 0xB974}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE REU
-	{runeRange{0xB975, 0xB98F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE REUG..HANGUL SYLLABLE REUH
-	{runeRange{0xB990, 0xB990}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RYI
-	{runeRange{0xB991, 0xB9AB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE RYIG..HANGUL SYLLABLE RYIH
-	{runeRange{0xB9AC, 0xB9AC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RI
-	{runeRange{0xB9AD, 0xB9C7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE RIG..HANGUL SYLLABLE RIH
-	{runeRange{0xB9C8, 0xB9C8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MA
-	{runeRange{0xB9C9, 0xB9E3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MAG..HANGUL SYLLABLE MAH
-	{runeRange{0xB9E4, 0xB9E4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MAE
-	{runeRange{0xB9E5, 0xB9FF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MAEG..HANGUL SYLLABLE MAEH
-	{runeRange{0xBA00, 0xBA00}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MYA
-	{runeRange{0xBA01, 0xBA1B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MYAG..HANGUL SYLLABLE MYAH
-	{runeRange{0xBA1C, 0xBA1C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MYAE
-	{runeRange{0xBA1D, 0xBA37}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MYAEG..HANGUL SYLLABLE MYAEH
-	{runeRange{0xBA38, 0xBA38}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MEO
-	{runeRange{0xBA39, 0xBA53}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MEOG..HANGUL SYLLABLE MEOH
-	{runeRange{0xBA54, 0xBA54}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE ME
-	{runeRange{0xBA55, 0xBA6F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MEG..HANGUL SYLLABLE MEH
-	{runeRange{0xBA70, 0xBA70}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MYEO
-	{runeRange{0xBA71, 0xBA8B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MYEOG..HANGUL SYLLABLE MYEOH
-	{runeRange{0xBA8C, 0xBA8C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MYE
-	{runeRange{0xBA8D, 0xBAA7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MYEG..HANGUL SYLLABLE MYEH
-	{runeRange{0xBAA8, 0xBAA8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MO
-	{runeRange{0xBAA9, 0xBAC3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MOG..HANGUL SYLLABLE MOH
-	{runeRange{0xBAC4, 0xBAC4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MWA
-	{runeRange{0xBAC5, 0xBADF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MWAG..HANGUL SYLLABLE MWAH
-	{runeRange{0xBAE0, 0xBAE0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MWAE
-	{runeRange{0xBAE1, 0xBAFB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MWAEG..HANGUL SYLLABLE MWAEH
-	{runeRange{0xBAFC, 0xBAFC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MOE
-	{runeRange{0xBAFD, 0xBB17}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MOEG..HANGUL SYLLABLE MOEH
-	{runeRange{0xBB18, 0xBB18}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MYO
-	{runeRange{0xBB19, 0xBB33}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MYOG..HANGUL SYLLABLE MYOH
-	{runeRange{0xBB34, 0xBB34}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MU
-	{runeRange{0xBB35, 0xBB4F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MUG..HANGUL SYLLABLE MUH
-	{runeRange{0xBB50, 0xBB50}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MWEO
-	{runeRange{0xBB51, 0xBB6B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MWEOG..HANGUL SYLLABLE MWEOH
-	{runeRange{0xBB6C, 0xBB6C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MWE
-	{runeRange{0xBB6D, 0xBB87}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MWEG..HANGUL SYLLABLE MWEH
-	{runeRange{0xBB88, 0xBB88}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MWI
-	{runeRange{0xBB89, 0xBBA3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MWIG..HANGUL SYLLABLE MWIH
-	{runeRange{0xBBA4, 0xBBA4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MYU
-	{runeRange{0xBBA5, 0xBBBF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MYUG..HANGUL SYLLABLE MYUH
-	{runeRange{0xBBC0, 0xBBC0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MEU
-	{runeRange{0xBBC1, 0xBBDB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MEUG..HANGUL SYLLABLE MEUH
-	{runeRange{0xBBDC, 0xBBDC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MYI
-	{runeRange{0xBBDD, 0xBBF7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MYIG..HANGUL SYLLABLE MYIH
-	{runeRange{0xBBF8, 0xBBF8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MI
-	{runeRange{0xBBF9, 0xBC13}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MIG..HANGUL SYLLABLE MIH
-	{runeRange{0xBC14, 0xBC14}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BA
-	{runeRange{0xBC15, 0xBC2F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BAG..HANGUL SYLLABLE BAH
-	{runeRange{0xBC30, 0xBC30}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BAE
-	{runeRange{0xBC31, 0xBC4B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BAEG..HANGUL SYLLABLE BAEH
-	{runeRange{0xBC4C, 0xBC4C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BYA
-	{runeRange{0xBC4D, 0xBC67}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BYAG..HANGUL SYLLABLE BYAH
-	{runeRange{0xBC68, 0xBC68}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BYAE
-	{runeRange{0xBC69, 0xBC83}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BYAEG..HANGUL SYLLABLE BYAEH
-	{runeRange{0xBC84, 0xBC84}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BEO
-	{runeRange{0xBC85, 0xBC9F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BEOG..HANGUL SYLLABLE BEOH
-	{runeRange{0xBCA0, 0xBCA0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BE
-	{runeRange{0xBCA1, 0xBCBB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BEG..HANGUL SYLLABLE BEH
-	{runeRange{0xBCBC, 0xBCBC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BYEO
-	{runeRange{0xBCBD, 0xBCD7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BYEOG..HANGUL SYLLABLE BYEOH
-	{runeRange{0xBCD8, 0xBCD8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BYE
-	{runeRange{0xBCD9, 0xBCF3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BYEG..HANGUL SYLLABLE BYEH
-	{runeRange{0xBCF4, 0xBCF4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BO
-	{runeRange{0xBCF5, 0xBD0F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BOG..HANGUL SYLLABLE BOH
-	{runeRange{0xBD10, 0xBD10}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BWA
-	{runeRange{0xBD11, 0xBD2B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BWAG..HANGUL SYLLABLE BWAH
-	{runeRange{0xBD2C, 0xBD2C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BWAE
-	{runeRange{0xBD2D, 0xBD47}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BWAEG..HANGUL SYLLABLE BWAEH
-	{runeRange{0xBD48, 0xBD48}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BOE
-	{runeRange{0xBD49, 0xBD63}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BOEG..HANGUL SYLLABLE BOEH
-	{runeRange{0xBD64, 0xBD64}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BYO
-	{runeRange{0xBD65, 0xBD7F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BYOG..HANGUL SYLLABLE BYOH
-	{runeRange{0xBD80, 0xBD80}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BU
-	{runeRange{0xBD81, 0xBD9B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BUG..HANGUL SYLLABLE BUH
-	{runeRange{0xBD9C, 0xBD9C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BWEO
-	{runeRange{0xBD9D, 0xBDB7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BWEOG..HANGUL SYLLABLE BWEOH
-	{runeRange{0xBDB8, 0xBDB8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BWE
-	{runeRange{0xBDB9, 0xBDD3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BWEG..HANGUL SYLLABLE BWEH
-	{runeRange{0xBDD4, 0xBDD4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BWI
-	{runeRange{0xBDD5, 0xBDEF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BWIG..HANGUL SYLLABLE BWIH
-	{runeRange{0xBDF0, 0xBDF0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BYU
-	{runeRange{0xBDF1, 0xBE0B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BYUG..HANGUL SYLLABLE BYUH
-	{runeRange{0xBE0C, 0xBE0C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BEU
-	{runeRange{0xBE0D, 0xBE27}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BEUG..HANGUL SYLLABLE BEUH
-	{runeRange{0xBE28, 0xBE28}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BYI
-	{runeRange{0xBE29, 0xBE43}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BYIG..HANGUL SYLLABLE BYIH
-	{runeRange{0xBE44, 0xBE44}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BI
-	{runeRange{0xBE45, 0xBE5F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BIG..HANGUL SYLLABLE BIH
-	{runeRange{0xBE60, 0xBE60}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBA
-	{runeRange{0xBE61, 0xBE7B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBAG..HANGUL SYLLABLE BBAH
-	{runeRange{0xBE7C, 0xBE7C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBAE
-	{runeRange{0xBE7D, 0xBE97}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBAEG..HANGUL SYLLABLE BBAEH
-	{runeRange{0xBE98, 0xBE98}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBYA
-	{runeRange{0xBE99, 0xBEB3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBYAG..HANGUL SYLLABLE BBYAH
-	{runeRange{0xBEB4, 0xBEB4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBYAE
-	{runeRange{0xBEB5, 0xBECF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBYAEG..HANGUL SYLLABLE BBYAEH
-	{runeRange{0xBED0, 0xBED0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBEO
-	{runeRange{0xBED1, 0xBEEB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBEOG..HANGUL SYLLABLE BBEOH
-	{runeRange{0xBEEC, 0xBEEC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBE
-	{runeRange{0xBEED, 0xBF07}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBEG..HANGUL SYLLABLE BBEH
-	{runeRange{0xBF08, 0xBF08}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBYEO
-	{runeRange{0xBF09, 0xBF23}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBYEOG..HANGUL SYLLABLE BBYEOH
-	{runeRange{0xBF24, 0xBF24}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBYE
-	{runeRange{0xBF25, 0xBF3F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBYEG..HANGUL SYLLABLE BBYEH
-	{runeRange{0xBF40, 0xBF40}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBO
-	{runeRange{0xBF41, 0xBF5B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBOG..HANGUL SYLLABLE BBOH
-	{runeRange{0xBF5C, 0xBF5C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBWA
-	{runeRange{0xBF5D, 0xBF77}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBWAG..HANGUL SYLLABLE BBWAH
-	{runeRange{0xBF78, 0xBF78}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBWAE
-	{runeRange{0xBF79, 0xBF93}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBWAEG..HANGUL SYLLABLE BBWAEH
-	{runeRange{0xBF94, 0xBF94}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBOE
-	{runeRange{0xBF95, 0xBFAF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBOEG..HANGUL SYLLABLE BBOEH
-	{runeRange{0xBFB0, 0xBFB0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBYO
-	{runeRange{0xBFB1, 0xBFCB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBYOG..HANGUL SYLLABLE BBYOH
-	{runeRange{0xBFCC, 0xBFCC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBU
-	{runeRange{0xBFCD, 0xBFE7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBUG..HANGUL SYLLABLE BBUH
-	{runeRange{0xBFE8, 0xBFE8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBWEO
-	{runeRange{0xBFE9, 0xC003}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBWEOG..HANGUL SYLLABLE BBWEOH
-	{runeRange{0xC004, 0xC004}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBWE
-	{runeRange{0xC005, 0xC01F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBWEG..HANGUL SYLLABLE BBWEH
-	{runeRange{0xC020, 0xC020}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBWI
-	{runeRange{0xC021, 0xC03B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBWIG..HANGUL SYLLABLE BBWIH
-	{runeRange{0xC03C, 0xC03C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBYU
-	{runeRange{0xC03D, 0xC057}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBYUG..HANGUL SYLLABLE BBYUH
-	{runeRange{0xC058, 0xC058}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBEU
-	{runeRange{0xC059, 0xC073}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBEUG..HANGUL SYLLABLE BBEUH
-	{runeRange{0xC074, 0xC074}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBYI
-	{runeRange{0xC075, 0xC08F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBYIG..HANGUL SYLLABLE BBYIH
-	{runeRange{0xC090, 0xC090}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBI
-	{runeRange{0xC091, 0xC0AB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBIG..HANGUL SYLLABLE BBIH
-	{runeRange{0xC0AC, 0xC0AC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SA
-	{runeRange{0xC0AD, 0xC0C7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SAG..HANGUL SYLLABLE SAH
-	{runeRange{0xC0C8, 0xC0C8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SAE
-	{runeRange{0xC0C9, 0xC0E3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SAEG..HANGUL SYLLABLE SAEH
 	{runeRange{0xC0E4, 0xC0E4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SYA
-	{runeRange{0xC0E5, 0xC0FF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SYAG..HANGUL SYLLABLE SYAH
-	{runeRange{0xC100, 0xC100}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SYAE
-	{runeRange{0xC101, 0xC11B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SYAEG..HANGUL SYLLABLE SYAEH
-	{runeRange{0xC11C, 0xC11C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SEO
-	{runeRange{0xC11D, 0xC137}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SEOG..HANGUL SYLLABLE SEOH
-	{runeRange{0xC138, 0xC138}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SE
-	{runeRange{0xC139, 0xC153}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SEG..HANGUL SYLLABLE SEH
-	{runeRange{0xC154, 0xC154}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SYEO
-	{runeRange{0xC155, 0xC16F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SYEOG..HANGUL SYLLABLE SYEOH
-	{runeRange{0xC170, 0xC170}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SYE
-	{runeRange{0xC171, 0xC18B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SYEG..HANGUL SYLLABLE SYEH
-	{runeRange{0xC18C, 0xC18C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SO
-	{runeRange{0xC18D, 0xC1A7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SOG..HANGUL SYLLABLE SOH
-	{runeRange{0xC1A8, 0xC1A8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SWA
-	{runeRange{0xC1A9, 0xC1C3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SWAG..HANGUL SYLLABLE SWAH
-	{runeRange{0xC1C4, 0xC1C4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SWAE
-	{runeRange{0xC1C5, 0xC1DF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SWAEG..HANGUL SYLLABLE SWAEH
-	{runeRange{0xC1E0, 0xC1E0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SOE
-	{runeRange{0xC1E1, 0xC1FB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SOEG..HANGUL SYLLABLE SOEH
-	{runeRange{0xC1FC, 0xC1FC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SYO
-	{runeRange{0xC1FD, 0xC217}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SYOG..HANGUL SYLLABLE SYOH
-	{runeRange{0xC218, 0xC218}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SU
-	{runeRange{0xC219, 0xC233}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SUG..HANGUL SYLLABLE SUH
-	{runeRange{0xC234, 0xC234}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SWEO
-	{runeRange{0xC235, 0xC24F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SWEOG..HANGUL SYLLABLE SWEOH
-	{runeRange{0xC250, 0xC250}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SWE
-	{runeRange{0xC251, 0xC26B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SWEG..HANGUL SYLLABLE SWEH
-	{runeRange{0xC26C, 0xC26C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SWI
-	{runeRange{0xC26D, 0xC287}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SWIG..HANGUL SYLLABLE SWIH
-	{runeRange{0xC288, 0xC288}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SYU
-	{runeRange{0xC289, 0xC2A3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SYUG..HANGUL SYLLABLE SYUH
-	{runeRange{0xC2A4, 0xC2A4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SEU
-	{runeRange{0xC2A5, 0xC2BF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SEUG..HANGUL SYLLABLE SEUH
-	{runeRange{0xC2C0, 0xC2C0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SYI
-	{runeRange{0xC2C1, 0xC2DB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SYIG..HANGUL SYLLABLE SYIH
-	{runeRange{0xC2DC, 0xC2DC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SI
-	{runeRange{0xC2DD, 0xC2F7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SIG..HANGUL SYLLABLE SIH
-	{runeRange{0xC2F8, 0xC2F8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSA
-	{runeRange{0xC2F9, 0xC313}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSAG..HANGUL SYLLABLE SSAH
-	{runeRange{0xC314, 0xC314}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSAE
-	{runeRange{0xC315, 0xC32F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSAEG..HANGUL SYLLABLE SSAEH
-	{runeRange{0xC330, 0xC330}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSYA
-	{runeRange{0xC331, 0xC34B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSYAG..HANGUL SYLLABLE SSYAH
-	{runeRange{0xC34C, 0xC34C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSYAE
-	{runeRange{0xC34D, 0xC367}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSYAEG..HANGUL SYLLABLE SSYAEH
-	{runeRange{0xC368, 0xC368}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSEO
-	{runeRange{0xC369, 0xC383}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSEOG..HANGUL SYLLABLE SSEOH
-	{runeRange{0xC384, 0xC384}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSE
-	{runeRange{0xC385, 0xC39F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSEG..HANGUL SYLLABLE SSEH
-	{runeRange{0xC3A0, 0xC3A0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSYEO
-	{runeRange{0xC3A1, 0xC3BB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSYEOG..HANGUL SYLLABLE SSYEOH
-	{runeRange{0xC3BC, 0xC3BC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSYE
-	{runeRange{0xC3BD, 0xC3D7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSYEG..HANGUL SYLLABLE SSYEH
-	{runeRange{0xC3D8, 0xC3D8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSO
-	{runeRange{0xC3D9, 0xC3F3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSOG..HANGUL SYLLABLE SSOH
-	{runeRange{0xC3F4, 0xC3F4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSWA
-	{runeRange{0xC3F5, 0xC40F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSWAG..HANGUL SYLLABLE SSWAH
-	{runeRange{0xC410, 0xC410}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSWAE
-	{runeRange{0xC411, 0xC42B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSWAEG..HANGUL SYLLABLE SSWAEH
-	{runeRange{0xC42C, 0xC42C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSOE
-	{runeRange{0xC42D, 0xC447}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSOEG..HANGUL SYLLABLE SSOEH
-	{runeRange{0xC448, 0xC448}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSYO
-	{runeRange{0xC449, 0xC463}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSYOG..HANGUL SYLLABLE SSYOH
-	{runeRange{0xC464, 0xC464}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSU
-	{runeRange{0xC465, 0xC47F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSUG..HANGUL SYLLABLE SSUH
-	{runeRange{0xC480, 0xC480}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSWEO
-	{runeRange{0xC481, 0xC49B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSWEOG..HANGUL SYLLABLE SSWEOH
-	{runeRange{0xC49C, 0xC49C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSWE
-	{runeRange{0xC49D, 0xC4B7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSWEG..HANGUL SYLLABLE SSWEH
-	{runeRange{0xC4B8, 0xC4B8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSWI
-	{runeRange{0xC4B9, 0xC4D3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSWIG..HANGUL SYLLABLE SSWIH
-	{runeRange{0xC4D4, 0xC4D4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSYU
-	{runeRange{0xC4D5, 0xC4EF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSYUG..HANGUL SYLLABLE SSYUH
-	{runeRange{0xC4F0, 0xC4F0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSEU
-	{runeRange{0xC4F1, 0xC50B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSEUG..HANGUL SYLLABLE SSEUH
-	{runeRange{0xC50C, 0xC50C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSYI
-	{runeRange{0xC50D, 0xC527}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSYIG..HANGUL SYLLABLE SSYIH
-	{runeRange{0xC528, 0xC528}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSI
-	{runeRange{0xC529, 0xC543}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSIG..HANGUL SYLLABLE SSIH
-	{runeRange{0xC544, 0xC544}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE A
-	{runeRange{0xC545, 0xC55F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE AG..HANGUL SYLLABLE AH
-	{runeRange{0xC560, 0xC560}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE AE
-	{runeRange{0xC561, 0xC57B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE AEG..HANGUL SYLLABLE AEH
-	{runeRange{0xC57C, 0xC57C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE YA
-	{runeRange{0xC57D, 0xC597}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE YAG..HANGUL SYLLABLE YAH
-	{runeRange{0xC598, 0xC598}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE YAE
-	{runeRange{0xC599, 0xC5B3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE YAEG..HANGUL SYLLABLE YAEH
-	{runeRange{0xC5B4, 0xC5B4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE EO
-	{runeRange{0xC5B5, 0xC5CF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE EOG..HANGUL SYLLABLE EOH
-	{runeRange{0xC5D0, 0xC5D0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE E
-	{runeRange{0xC5D1, 0xC5EB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE EG..HANGUL SYLLABLE EH
-	{runeRange{0xC5EC, 0xC5EC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE YEO
-	{runeRange{0xC5ED, 0xC607}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE YEOG..HANGUL SYLLABLE YEOH
-	{runeRange{0xC608, 0xC608}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE YE
-	{runeRange{0xC609, 0xC623}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE YEG..HANGUL SYLLABLE YEH
-	{runeRange{0xC624, 0xC624}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE O
-	{runeRange{0xC625, 0xC63F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE OG..HANGUL SYLLABLE OH
-	{runeRange{0xC640, 0xC640}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE WA
-	{runeRange{0xC641, 0xC65B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE WAG..HANGUL SYLLABLE WAH
-	{runeRange{0xC65C, 0xC65C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE WAE
-	{runeRange{0xC65D, 0xC677}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE WAEG..HANGUL SYLLABLE WAEH
-	{runeRange{0xC678, 0xC678}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE OE
-	{runeRange{0xC679, 0xC693}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE OEG..HANGUL SYLLABLE OEH
-	{runeRange{0xC694, 0xC694}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE YO
-	{runeRange{0xC695, 0xC6AF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE YOG..HANGUL SYLLABLE YOH
-	{runeRange{0xC6B0, 0xC6B0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE U
-	{runeRange{0xC6B1, 0xC6CB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE UG..HANGUL SYLLABLE UH
-	{runeRange{0xC6CC, 0xC6CC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE WEO
-	{runeRange{0xC6CD, 0xC6E7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE WEOG..HANGUL SYLLABLE WEOH
-	{runeRange{0xC6E8, 0xC6E8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE WE
-	{runeRange{0xC6E9, 0xC703}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE WEG..HANGUL SYLLABLE WEH
-	{runeRange{0xC704, 0xC704}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE WI
-	{runeRange{0xC705, 0xC71F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE WIG..HANGUL SYLLABLE WIH
-	{runeRange{0xC720, 0xC720}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE YU
-	{runeRange{0xC721, 0xC73B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE YUG..HANGUL SYLLABLE YUH
-	{runeRange{0xC73C, 0xC73C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE EU
-	{runeRange{0xC73D, 0xC757}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE EUG..HANGUL SYLLABLE EUH
-	{runeRange{0xC758, 0xC758}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE YI
-	{runeRange{0xC759, 0xC773}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE YIG..HANGUL SYLLABLE YIH
-	{runeRange{0xC774, 0xC774}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE I
-	{runeRange{0xC775, 0xC78F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE IG..HANGUL SYLLABLE IH
-	{runeRange{0xC790, 0xC790}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JA
-	{runeRange{0xC791, 0xC7AB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JAG..HANGUL SYLLABLE JAH
-	{runeRange{0xC7AC, 0xC7AC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JAE
-	{runeRange{0xC7AD, 0xC7C7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JAEG..HANGUL SYLLABLE JAEH
-	{runeRange{0xC7C8, 0xC7C8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JYA
-	{runeRange{0xC7C9, 0xC7E3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JYAG..HANGUL SYLLABLE JYAH
-	{runeRange{0xC7E4, 0xC7E4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JYAE
-	{runeRange{0xC7E5, 0xC7FF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JYAEG..HANGUL SYLLABLE JYAEH
-	{runeRange{0xC800, 0xC800}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JEO
-	{runeRange{0xC801, 0xC81B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JEOG..HANGUL SYLLABLE JEOH
-	{runeRange{0xC81C, 0xC81C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JE
-	{runeRange{0xC81D, 0xC837}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JEG..HANGUL SYLLABLE JEH
-	{runeRange{0xC838, 0xC838}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JYEO
-	{runeRange{0xC839, 0xC853}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JYEOG..HANGUL SYLLABLE JYEOH
-	{runeRange{0xC854, 0xC854}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JYE
-	{runeRange{0xC855, 0xC86F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JYEG..HANGUL SYLLABLE JYEH
-	{runeRange{0xC870, 0xC870}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JO
-	{runeRange{0xC871, 0xC88B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JOG..HANGUL SYLLABLE JOH
-	{runeRange{0xC88C, 0xC88C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JWA
-	{runeRange{0xC88D, 0xC8A7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JWAG..HANGUL SYLLABLE JWAH
-	{runeRange{0xC8A8, 0xC8A8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JWAE
-	{runeRange{0xC8A9, 0xC8C3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JWAEG..HANGUL SYLLABLE JWAEH
-	{runeRange{0xC8C4, 0xC8C4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JOE
-	{runeRange{0xC8C5, 0xC8DF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JOEG..HANGUL SYLLABLE JOEH
-	{runeRange{0xC8E0, 0xC8E0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JYO
-	{runeRange{0xC8E1, 0xC8FB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JYOG..HANGUL SYLLABLE JYOH
-	{runeRange{0xC8FC, 0xC8FC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JU
-	{runeRange{0xC8FD, 0xC917}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JUG..HANGUL SYLLABLE JUH
-	{runeRange{0xC918, 0xC918}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JWEO
-	{runeRange{0xC919, 0xC933}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JWEOG..HANGUL SYLLABLE JWEOH
-	{runeRange{0xC934, 0xC934}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JWE
-	{runeRange{0xC935, 0xC94F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JWEG..HANGUL SYLLABLE JWEH
-	{runeRange{0xC950, 0xC950}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JWI
-	{runeRange{0xC951, 0xC96B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JWIG..HANGUL SYLLABLE JWIH
-	{runeRange{0xC96C, 0xC96C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JYU
-	{runeRange{0xC96D, 0xC987}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JYUG..HANGUL SYLLABLE JYUH
-	{runeRange{0xC988, 0xC988}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JEU
-	{runeRange{0xC989, 0xC9A3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JEUG..HANGUL SYLLABLE JEUH
-	{runeRange{0xC9A4, 0xC9A4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JYI
-	{runeRange{0xC9A5, 0xC9BF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JYIG..HANGUL SYLLABLE JYIH
-	{runeRange{0xC9C0, 0xC9C0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JI
-	{runeRange{0xC9C1, 0xC9DB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JIG..HANGUL SYLLABLE JIH
-	{runeRange{0xC9DC, 0xC9DC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJA
-	{runeRange{0xC9DD, 0xC9F7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJAG..HANGUL SYLLABLE JJAH
-	{runeRange{0xC9F8, 0xC9F8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJAE
-	{runeRange{0xC9F9, 0xCA13}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJAEG..HANGUL SYLLABLE JJAEH
-	{runeRange{0xCA14, 0xCA14}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJYA
-	{runeRange{0xCA15, 0xCA2F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJYAG..HANGUL SYLLABLE JJYAH
-	{runeRange{0xCA30, 0xCA30}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJYAE
-	{runeRange{0xCA31, 0xCA4B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJYAEG..HANGUL SYLLABLE JJYAEH
-	{runeRange{0xCA4C, 0xCA4C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJEO
-	{runeRange{0xCA4D, 0xCA67}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJEOG..HANGUL SYLLABLE JJEOH
-	{runeRange{0xCA68, 0xCA68}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJE
-	{runeRange{0xCA69, 0xCA83}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJEG..HANGUL SYLLABLE JJEH
-	{runeRange{0xCA84, 0xCA84}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJYEO
-	{runeRange{0xCA85, 0xCA9F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJYEOG..HANGUL SYLLABLE JJYEOH
-	{runeRange{0xCAA0, 0xCAA0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJYE
-	{runeRange{0xCAA1, 0xCABB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJYEG..HANGUL SYLLABLE JJYEH
-	{runeRange{0xCABC, 0xCABC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJO
-	{runeRange{0xCABD, 0xCAD7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJOG..HANGUL SYLLABLE JJOH
-	{runeRange{0xCAD8, 0xCAD8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJWA
-	{runeRange{0xCAD9, 0xCAF3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJWAG..HANGUL SYLLABLE JJWAH
-	{runeRange{0xCAF4, 0xCAF4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJWAE
-	{runeRange{0xCAF5, 0xCB0F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJWAEG..HANGUL SYLLABLE JJWAEH
-	{runeRange{0xCB10, 0xCB10}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJOE
-	{runeRange{0xCB11, 0xCB2B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJOEG..HANGUL SYLLABLE JJOEH
-	{runeRange{0xCB2C, 0xCB2C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJYO
-	{runeRange{0xCB2D, 0xCB47}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJYOG..HANGUL SYLLABLE JJYOH
-	{runeRange{0xCB48, 0xCB48}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJU
-	{runeRange{0xCB49, 0xCB63}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJUG..HANGUL SYLLABLE JJUH
-	{runeRange{0xCB64, 0xCB64}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJWEO
-	{runeRange{0xCB65, 0xCB7F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJWEOG..HANGUL SYLLABLE JJWEOH
-	{runeRange{0xCB80, 0xCB80}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJWE
-	{runeRange{0xCB81, 0xCB9B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJWEG..HANGUL SYLLABLE JJWEH
-	{runeRange{0xCB9C, 0xCB9C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJWI
-	{runeRange{0xCB9D, 0xCBB7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJWIG..HANGUL SYLLABLE JJWIH
-	{runeRange{0xCBB8, 0xCBB8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJYU
-	{runeRange{0xCBB9, 0xCBD3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJYUG..HANGUL SYLLABLE JJYUH
-	{runeRange{0xCBD4, 0xCBD4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJEU
-	{runeRange{0xCBD5, 0xCBEF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJEUG..HANGUL SYLLABLE JJEUH
-	{runeRange{0xCBF0, 0xCBF0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJYI
-	{runeRange{0xCBF1, 0xCC0B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJYIG..HANGUL SYLLABLE JJYIH
-	{runeRange{0xCC0C, 0xCC0C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJI
-	{runeRange{0xCC0D, 0xCC27}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJIG..HANGUL SYLLABLE JJIH
-	{runeRange{0xCC28, 0xCC28}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CA
-	{runeRange{0xCC29, 0xCC43}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CAG..HANGUL SYLLABLE CAH
-	{runeRange{0xCC44, 0xCC44}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CAE
-	{runeRange{0xCC45, 0xCC5F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CAEG..HANGUL SYLLABLE CAEH
-	{runeRange{0xCC60, 0xCC60}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CYA
-	{runeRange{0xCC61, 0xCC7B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CYAG..HANGUL SYLLABLE CYAH
-	{runeRange{0xCC7C, 0xCC7C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CYAE
-	{runeRange{0xCC7D, 0xCC97}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CYAEG..HANGUL SYLLABLE CYAEH
-	{runeRange{0xCC98, 0xCC98}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CEO
-	{runeRange{0xCC99, 0xCCB3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CEOG..HANGUL SYLLABLE CEOH
-	{runeRange{0xCCB4, 0xCCB4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CE
-	{runeRange{0xCCB5, 0xCCCF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CEG..HANGUL SYLLABLE CEH
-	{runeRange{0xCCD0, 0xCCD0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CYEO
-	{runeRange{0xCCD1, 0xCCEB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CYEOG..HANGUL SYLLABLE CYEOH
-	{runeRange{0xCCEC, 0xCCEC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CYE
-	{runeRange{0xCCED, 0xCD07}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CYEG..HANGUL SYLLABLE CYEH
-	{runeRange{0xCD08, 0xCD08}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CO
-	{runeRange{0xCD09, 0xCD23}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE COG..HANGUL SYLLABLE COH
-	{runeRange{0xCD24, 0xCD24}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CWA
-	{runeRange{0xCD25, 0xCD3F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CWAG..HANGUL SYLLABLE CWAH
-	{runeRange{0xCD40, 0xCD40}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CWAE
-	{runeRange{0xCD41, 0xCD5B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CWAEG..HANGUL SYLLABLE CWAEH
-	{runeRange{0xCD5C, 0xCD5C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE COE
-	{runeRange{0xCD5D, 0xCD77}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE COEG..HANGUL SYLLABLE COEH
-	{runeRange{0xCD78, 0xCD78}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CYO
-	{runeRange{0xCD79, 0xCD93}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CYOG..HANGUL SYLLABLE CYOH
-	{runeRange{0xCD94, 0xCD94}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CU
-	{runeRange{0xCD95, 0xCDAF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CUG..HANGUL SYLLABLE CUH
-	{runeRange{0xCDB0, 0xCDB0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CWEO
-	{runeRange{0xCDB1, 0xCDCB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CWEOG..HANGUL SYLLABLE CWEOH
-	{runeRange{0xCDCC, 0xCDCC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CWE
-	{runeRange{0xCDCD, 0xCDE7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CWEG..HANGUL SYLLABLE CWEH
-	{runeRange{0xCDE8, 0xCDE8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CWI
-	{runeRange{0xCDE9, 0xCE03}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CWIG..HANGUL SYLLABLE CWIH
-	{runeRange{0xCE04, 0xCE04}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CYU
-	{runeRange{0xCE05, 0xCE1F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CYUG..HANGUL SYLLABLE CYUH
-	{runeRange{0xCE20, 0xCE20}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CEU
-	{runeRange{0xCE21, 0xCE3B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CEUG..HANGUL SYLLABLE CEUH
-	{runeRange{0xCE3C, 0xCE3C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CYI
-	{runeRange{0xCE3D, 0xCE57}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CYIG..HANGUL SYLLABLE CYIH
-	{runeRange{0xCE58, 0xCE58}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CI
-	{runeRange{0xCE59, 0xCE73}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CIG..HANGUL SYLLABLE CIH
-	{runeRange{0xCE74, 0xCE74}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KA
-	{runeRange{0xCE75, 0xCE8F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KAG..HANGUL SYLLABLE KAH
-	{runeRange{0xCE90, 0xCE90}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KAE
-	{runeRange{0xCE91, 0xCEAB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KAEG..HANGUL SYLLABLE KAEH
-	{runeRange{0xCEAC, 0xCEAC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KYA
-	{runeRange{0xCEAD, 0xCEC7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KYAG..HANGUL SYLLABLE KYAH
-	{runeRange{0xCEC8, 0xCEC8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KYAE
-	{runeRange{0xCEC9, 0xCEE3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KYAEG..HANGUL SYLLABLE KYAEH
-	{runeRange{0xCEE4, 0xCEE4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KEO
-	{runeRange{0xCEE5, 0xCEFF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KEOG..HANGUL SYLLABLE KEOH
-	{runeRange{0xCF00, 0xCF00}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KE
-	{runeRange{0xCF01, 0xCF1B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KEG..HANGUL SYLLABLE KEH
-	{runeRange{0xCF1C, 0xCF1C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KYEO
-	{runeRange{0xCF1D, 0xCF37}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KYEOG..HANGUL SYLLABLE KYEOH
-	{runeRange{0xCF38, 0xCF38}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KYE
-	{runeRange{0xCF39, 0xCF53}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KYEG..HANGUL SYLLABLE KYEH
-	{runeRange{0xCF54, 0xCF54}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KO
-	{runeRange{0xCF55, 0xCF6F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KOG..HANGUL SYLLABLE KOH
-	{runeRange{0xCF70, 0xCF70}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KWA
-	{runeRange{0xCF71, 0xCF8B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KWAG..HANGUL SYLLABLE KWAH
-	{runeRange{0xCF8C, 0xCF8C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KWAE
-	{runeRange{0xCF8D, 0xCFA7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KWAEG..HANGUL SYLLABLE KWAEH
-	{runeRange{0xCFA8, 0xCFA8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KOE
-	{runeRange{0xCFA9, 0xCFC3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KOEG..HANGUL SYLLABLE KOEH
-	{runeRange{0xCFC4, 0xCFC4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KYO
-	{runeRange{0xCFC5, 0xCFDF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KYOG..HANGUL SYLLABLE KYOH
-	{runeRange{0xCFE0, 0xCFE0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KU
-	{runeRange{0xCFE1, 0xCFFB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KUG..HANGUL SYLLABLE KUH
-	{runeRange{0xCFFC, 0xCFFC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KWEO
-	{runeRange{0xCFFD, 0xD017}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KWEOG..HANGUL SYLLABLE KWEOH
-	{runeRange{0xD018, 0xD018}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KWE
-	{runeRange{0xD019, 0xD033}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KWEG..HANGUL SYLLABLE KWEH
-	{runeRange{0xD034, 0xD034}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KWI
-	{runeRange{0xD035, 0xD04F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KWIG..HANGUL SYLLABLE KWIH
-	{runeRange{0xD050, 0xD050}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KYU
-	{runeRange{0xD051, 0xD06B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KYUG..HANGUL SYLLABLE KYUH
-	{runeRange{0xD06C, 0xD06C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KEU
-	{runeRange{0xD06D, 0xD087}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KEUG..HANGUL SYLLABLE KEUH
-	{runeRange{0xD088, 0xD088}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KYI
-	{runeRange{0xD089, 0xD0A3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KYIG..HANGUL SYLLABLE KYIH
-	{runeRange{0xD0A4, 0xD0A4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KI
-	{runeRange{0xD0A5, 0xD0BF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KIG..HANGUL SYLLABLE KIH
-	{runeRange{0xD0C0, 0xD0C0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TA
-	{runeRange{0xD0C1, 0xD0DB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TAG..HANGUL SYLLABLE TAH
-	{runeRange{0xD0DC, 0xD0DC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TAE
-	{runeRange{0xD0DD, 0xD0F7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TAEG..HANGUL SYLLABLE TAEH
-	{runeRange{0xD0F8, 0xD0F8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TYA
-	{runeRange{0xD0F9, 0xD113}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TYAG..HANGUL SYLLABLE TYAH
-	{runeRange{0xD114, 0xD114}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TYAE
-	{runeRange{0xD115, 0xD12F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TYAEG..HANGUL SYLLABLE TYAEH
-	{runeRange{0xD130, 0xD130}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TEO
-	{runeRange{0xD131, 0xD14B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TEOG..HANGUL SYLLABLE TEOH
-	{runeRange{0xD14C, 0xD14C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TE
-	{runeRange{0xD14D, 0xD167}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TEG..HANGUL SYLLABLE TEH
-	{runeRange{0xD168, 0xD168}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TYEO
-	{runeRange{0xD169, 0xD183}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TYEOG..HANGUL SYLLABLE TYEOH
-	{runeRange{0xD184, 0xD184}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TYE
-	{runeRange{0xD185, 0xD19F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TYEG..HANGUL SYLLABLE TYEH
-	{runeRange{0xD1A0, 0xD1A0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TO
-	{runeRange{0xD1A1, 0xD1BB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TOG..HANGUL SYLLABLE TOH
-	{runeRange{0xD1BC, 0xD1BC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TWA
-	{runeRange{0xD1BD, 0xD1D7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TWAG..HANGUL SYLLABLE TWAH
-	{runeRange{0xD1D8, 0xD1D8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TWAE
-	{runeRange{0xD1D9, 0xD1F3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TWAEG..HANGUL SYLLABLE TWAEH
-	{runeRange{0xD1F4, 0xD1F4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TOE
-	{runeRange{0xD1F5, 0xD20F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TOEG..HANGUL SYLLABLE TOEH
-	{runeRange{0xD210, 0xD210}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TYO
-	{runeRange{0xD211, 0xD22B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TYOG..HANGUL SYLLABLE TYOH
-	{runeRange{0xD22C, 0xD22C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TU
-	{runeRange{0xD22D, 0xD247}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TUG..HANGUL SYLLABLE TUH
-	{runeRange{0xD248, 0xD248}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TWEO
-	{runeRange{0xD249, 0xD263}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TWEOG..HANGUL SYLLABLE TWEOH
-	{runeRange{0xD264, 0xD264}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TWE
-	{runeRange{0xD265, 0xD27F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TWEG..HANGUL SYLLABLE TWEH
-	{runeRange{0xD280, 0xD280}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TWI
-	{runeRange{0xD281, 0xD29B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TWIG..HANGUL SYLLABLE TWIH
-	{runeRange{0xD29C, 0xD29C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TYU
-	{runeRange{0xD29D, 0xD2B7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TYUG..HANGUL SYLLABLE TYUH
-	{runeRange{0xD2B8, 0xD2B8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TEU
-	{runeRange{0xD2B9, 0xD2D3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TEUG..HANGUL SYLLABLE TEUH
-	{runeRange{0xD2D4, 0xD2D4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TYI
-	{runeRange{0xD2D5, 0xD2EF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TYIG..HANGUL SYLLABLE TYIH
-	{runeRange{0xD2F0, 0xD2F0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TI
-	{runeRange{0xD2F1, 0xD30B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TIG..HANGUL SYLLABLE TIH
-	{runeRange{0xD30C, 0xD30C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PA
-	{runeRange{0xD30D, 0xD327}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PAG..HANGUL SYLLABLE PAH
-	{runeRange{0xD328, 0xD328}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PAE
-	{runeRange{0xD329, 0xD343}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PAEG..HANGUL SYLLABLE PAEH
-	{runeRange{0xD344, 0xD344}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PYA
-	{runeRange{0xD345, 0xD35F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PYAG..HANGUL SYLLABLE PYAH
-	{runeRange{0xD360, 0xD360}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PYAE
-	{runeRange{0xD361, 0xD37B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PYAEG..HANGUL SYLLABLE PYAEH
-	{runeRange{0xD37C, 0xD37C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PEO
-	{runeRange{0xD37D, 0xD397}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PEOG..HANGUL SYLLABLE PEOH
-	{runeRange{0xD398, 0xD398}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PE
-	{runeRange{0xD399, 0xD3B3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PEG..HANGUL SYLLABLE PEH
-	{runeRange{0xD3B4, 0xD3B4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PYEO
-	{runeRange{0xD3B5, 0xD3CF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PYEOG..HANGUL SYLLABLE PYEOH
-	{runeRange{0xD3D0, 0xD3D0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PYE
-	{runeRange{0xD3D1, 0xD3EB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PYEG..HANGUL SYLLABLE PYEH
-	{runeRange{0xD3EC, 0xD3EC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PO
-	{runeRange{0xD3ED, 0xD407}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE POG..HANGUL SYLLABLE POH
-	{runeRange{0xD408, 0xD408}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PWA
-	{runeRange{0xD409, 0xD423}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PWAG..HANGUL SYLLABLE PWAH
-	{runeRange{0xD424, 0xD424}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PWAE
-	{runeRange{0xD425, 0xD43F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PWAEG..HANGUL SYLLABLE PWAEH
-	{runeRange{0xD440, 0xD440}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE POE
-	{runeRange{0xD441, 0xD45B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE POEG..HANGUL SYLLABLE POEH
-	{runeRange{0xD45C, 0xD45C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PYO
-	{runeRange{0xD45D, 0xD477}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PYOG..HANGUL SYLLABLE PYOH
-	{runeRange{0xD478, 0xD478}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PU
-	{runeRange{0xD479, 0xD493}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PUG..HANGUL SYLLABLE PUH
-	{runeRange{0xD494, 0xD494}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PWEO
-	{runeRange{0xD495, 0xD4AF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PWEOG..HANGUL SYLLABLE PWEOH
-	{runeRange{0xD4B0, 0xD4B0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PWE
-	{runeRange{0xD4B1, 0xD4CB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PWEG..HANGUL SYLLABLE PWEH
-	{runeRange{0xD4CC, 0xD4CC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PWI
-	{runeRange{0xD4CD, 0xD4E7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PWIG..HANGUL SYLLABLE PWIH
-	{runeRange{0xD4E8, 0xD4E8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PYU
-	{runeRange{0xD4E9, 0xD503}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PYUG..HANGUL SYLLABLE PYUH
-	{runeRange{0xD504, 0xD504}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PEU
-	{runeRange{0xD505, 0xD51F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PEUG..HANGUL SYLLABLE PEUH
-	{runeRange{0xD520, 0xD520}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PYI
-	{runeRange{0xD521, 0xD53B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PYIG..HANGUL SYLLABLE PYIH
-	{runeRange{0xD53C, 0xD53C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PI
-	{runeRange{0xD53D, 0xD557}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PIG..HANGUL SYLLABLE PIH
-	{runeRange{0xD558, 0xD558}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HA
-	{runeRange{0xD559, 0xD573}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HAG..HANGUL SYLLABLE HAH
-	{runeRange{0xD574, 0xD574}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HAE
-	{runeRange{0xD575, 0xD58F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HAEG..HANGUL SYLLABLE HAEH
-	{runeRange{0xD590, 0xD590}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HYA
-	{runeRange{0xD591, 0xD5AB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HYAG..HANGUL SYLLABLE HYAH
-	{runeRange{0xD5AC, 0xD5AC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HYAE
-	{runeRange{0xD5AD, 0xD5C7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HYAEG..HANGUL SYLLABLE HYAEH
-	{runeRange{0xD5C8, 0xD5C8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HEO
-	{runeRange{0xD5C9, 0xD5E3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HEOG..HANGUL SYLLABLE HEOH
-	{runeRange{0xD5E4, 0xD5E4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HE
-	{runeRange{0xD5E5, 0xD5FF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HEG..HANGUL SYLLABLE HEH
-	{runeRange{0xD600, 0xD600}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HYEO
-	{runeRange{0xD601, 0xD61B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HYEOG..HANGUL SYLLABLE HYEOH
-	{runeRange{0xD61C, 0xD61C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HYE
-	{runeRange{0xD61D, 0xD637}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HYEG..HANGUL SYLLABLE HYEH
-	{runeRange{0xD638, 0xD638}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HO
-	{runeRange{0xD639, 0xD653}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HOG..HANGUL SYLLABLE HOH
-	{runeRange{0xD654, 0xD654}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HWA
-	{runeRange{0xD655, 0xD66F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HWAG..HANGUL SYLLABLE HWAH
-	{runeRange{0xD670, 0xD670}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HWAE
-	{runeRange{0xD671, 0xD68B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HWAEG..HANGUL SYLLABLE HWAEH
-	{runeRange{0xD68C, 0xD68C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HOE
-	{runeRange{0xD68D, 0xD6A7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HOEG..HANGUL SYLLABLE HOEH
-	{runeRange{0xD6A8, 0xD6A8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HYO
-	{runeRange{0xD6A9, 0xD6C3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HYOG..HANGUL SYLLABLE HYOH
-	{runeRange{0xD6C4, 0xD6C4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HU
-	{runeRange{0xD6C5, 0xD6DF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HUG..HANGUL SYLLABLE HUH
-	{runeRange{0xD6E0, 0xD6E0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HWEO
-	{runeRange{0xD6E1, 0xD6FB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HWEOG..HANGUL SYLLABLE HWEOH
-	{runeRange{0xD6FC, 0xD6FC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HWE
-	{runeRange{0xD6FD, 0xD717}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HWEG..HANGUL SYLLABLE HWEH
-	{runeRange{0xD718, 0xD718}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HWI
-	{runeRange{0xD719, 0xD733}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HWIG..HANGUL SYLLABLE HWIH
-	{runeRange{0xD734, 0xD734}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HYU
-	{runeRange{0xD735, 0xD74F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HYUG..HANGUL SYLLABLE HYUH
-	{runeRange{0xD750, 0xD750}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HEU
-	{runeRange{0xD751, 0xD76B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HEUG..HANGUL SYLLABLE HEUH
-	{runeRange{0xD76C, 0xD76C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HYI
-	{runeRange{0xD76D, 0xD787}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HYIG..HANGUL SYLLABLE HYIH
-	{runeRange{0xD788, 0xD788}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HI
-	{runeRange{0xD789, 0xD7A3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HIG..HANGUL SYLLABLE HIH
-	{runeRange{0xD7B0, 0xD7C6}, propertyGeneralCategory{lbprJV, gcLo}},     //    [23] HANGUL JUNGSEONG O-YEO..HANGUL JUNGSEONG ARAEA-E
-	{runeRange{0xD7CB, 0xD7FB}, propertyGeneralCategory{lbprJT, gcLo}},     //    [49] HANGUL JONGSEONG NIEUN-RIEUL..HANGUL JONGSEONG PHIEUPH-THIEUTH
-	{runeRange{0xD800, 0xDB7F}, propertyGeneralCategory{lbprSG, gcCs}},     //   [896] <surrogate-D800>..<surrogate-DB7F>
-	{runeRange{0xDB80, 0xDBFF}, propertyGeneralCategory{lbprSG, gcCs}},     //   [128] <surrogate-DB80>..<surrogate-DBFF>
-	{runeRange{0xDC00, 0xDFFF}, propertyGeneralCategory{lbprSG, gcCs}},     //  [1024] <surrogate-DC00>..<surrogate-DFFF>
-	{runeRange{0xE000, 0xF8FF}, propertyGeneralCategory{lbprXX, gcCo}},     //  [6400] <private-use-E000>..<private-use-F8FF>
-	{runeRange{0xF900, 0xFA6D}, propertyGeneralCategory{lbprID, gcLo}},     //   [366] CJK COMPATIBILITY IDEOGRAPH-F900..CJK COMPATIBILITY IDEOGRAPH-FA6D
-	{runeRange{0xFA6E, 0xFA6F}, propertyGeneralCategory{lbprID, gcCn}},     //     [2] <reserved-FA6E>..<reserved-FA6F>
-	{runeRange{0xFA70, 0xFAD9}, propertyGeneralCategory{lbprID, gcLo}},     //   [106] CJK COMPATIBILITY IDEOGRAPH-FA70..CJK COMPATIBILITY IDEOGRAPH-FAD9
-	{runeRange{0xFADA, 0xFAFF}, propertyGeneralCategory{lbprID, gcCn}},     //    [38] <reserved-FADA>..<reserved-FAFF>
-	{runeRange{0xFB00, 0xFB06}, propertyGeneralCategory{lbprAL, gcLl}},     //     [7] LATIN SMALL LIGATURE FF..LATIN SMALL LIGATURE ST
-	{runeRange{0xFB13, 0xFB17}, propertyGeneralCategory{lbprAL, gcLl}},     //     [5] ARMENIAN SMALL LIGATURE MEN NOW..ARMENIAN SMALL LIGATURE MEN XEH
-	{runeRange{0xFB1D, 0xFB1D}, propertyGeneralCategory{lbprHL, gcLo}},     //         HEBREW LETTER YOD WITH HIRIQ
-	{runeRange{0xFB1E, 0xFB1E}, propertyGeneralCategory{lbprCM, gcMn}},     //         HEBREW POINT JUDEO-SPANISH VARIKA
-	{runeRange{0xFB1F, 0xFB28}, propertyGeneralCategory{lbprHL, gcLo}},     //    [10] HEBREW LIGATURE YIDDISH YOD YOD PATAH..HEBREW LETTER WIDE TAV
-	{runeRange{0xFB29, 0xFB29}, propertyGeneralCategory{lbprAL, gcSm}},     //         HEBREW LETTER ALTERNATIVE PLUS SIGN
-	{runeRange{0xFB2A, 0xFB36}, propertyGeneralCategory{lbprHL, gcLo}},     //    [13] HEBREW LETTER SHIN WITH SHIN DOT..HEBREW LETTER ZAYIN WITH DAGESH
-	{runeRange{0xFB38, 0xFB3C}, propertyGeneralCategory{lbprHL, gcLo}},     //     [5] HEBREW LETTER TET WITH DAGESH..HEBREW LETTER LAMED WITH DAGESH
-	{runeRange{0xFB3E, 0xFB3E}, propertyGeneralCategory{lbprHL, gcLo}},     //         HEBREW LETTER MEM WITH DAGESH
-	{runeRange{0xFB40, 0xFB41}, propertyGeneralCategory{lbprHL, gcLo}},     //     [2] HEBREW LETTER NUN WITH DAGESH..HEBREW LETTER SAMEKH WITH DAGESH
-	{runeRange{0xFB43, 0xFB44}, propertyGeneralCategory{lbprHL, gcLo}},     //     [2] HEBREW LETTER FINAL PE WITH DAGESH..HEBREW LETTER PE WITH DAGESH
-	{runeRange{0xFB46, 0xFB4F}, propertyGeneralCategory{lbprHL, gcLo}},     //    [10] HEBREW LETTER TSADI WITH DAGESH..HEBREW LIGATURE ALEF LAMED
-	{runeRange{0xFB50, 0xFBB1}, propertyGeneralCategory{lbprAL, gcLo}},     //    [98] ARABIC LETTER ALEF WASLA ISOLATED FORM..ARABIC LETTER YEH BARREE WITH HAMZA ABOVE FINAL FORM
-	{runeRange{0xFBB2, 0xFBC2}, propertyGeneralCategory{lbprAL, gcSk}},     //    [17] ARABIC SYMBOL DOT ABOVE..ARABIC SYMBOL WASLA ABOVE
-	{runeRange{0xFBD3, 0xFD3D}, propertyGeneralCategory{lbprAL, gcLo}},     //   [363] ARABIC LETTER NG ISOLATED FORM..ARABIC LIGATURE ALEF WITH FATHATAN ISOLATED FORM
-	{runeRange{0xFD3E, 0xFD3E}, propertyGeneralCategory{lbprCL, gcPe}},     //         ORNATE LEFT PARENTHESIS
-	{runeRange{0xFD3F, 0xFD3F}, propertyGeneralCategory{lbprOP, gcPs}},     //         ORNATE RIGHT PARENTHESIS
-	{runeRange{0xFD40, 0xFD4F}, propertyGeneralCategory{lbprAL, gcSo}},     //    [16] ARABIC LIGATURE RAHIMAHU ALLAAH..ARABIC LIGATURE RAHIMAHUM ALLAAH
-	{runeRange{0xFD50, 0xFD8F}, propertyGeneralCategory{lbprAL, gcLo}},     //    [64] ARABIC LIGATURE TEH WITH JEEM WITH MEEM INITIAL FORM..ARABIC LIGATURE MEEM WITH KHAH WITH MEEM INITIAL FORM
-	{runeRange{0xFD92, 0xFDC7}, propertyGeneralCategory{lbprAL, gcLo}},     //    [54] ARABIC LIGATURE MEEM WITH JEEM WITH KHAH INITIAL FORM..ARABIC LIGATURE NOON WITH JEEM WITH YEH FINAL FORM
-	{runeRange{0xFDCF, 0xFDCF}, propertyGeneralCategory{lbprAL, gcSo}},     //         ARABIC LIGATURE SALAAMUHU ALAYNAA
-	{runeRange{0xFDF0, 0xFDFB}, propertyGeneralCategory{lbprAL, gcLo}},     //    [12] ARABIC LIGATURE SALLA USED AS KORANIC STOP SIGN ISOLATED FORM..ARABIC LIGATURE JALLAJALALOUHOU
-	{runeRange{0xFDFC, 0xFDFC}, propertyGeneralCategory{lbprPO, gcSc}},     //         RIAL SIGN
-	{runeRange{0xFDFD, 0xFDFF}, propertyGeneralCategory{lbprAL, gcSo}},     //     [3] ARABIC LIGATURE BISMILLAH AR-RAHMAN AR-RAHEEM..ARABIC LIGATURE AZZA WA JALL
-	{runeRange{0xFE00, 0xFE0F}, propertyGeneralCategory{lbprCM, gcMn}},     //    [16] VARIATION SELECTOR-1..VARIATION SELECTOR-16
-	{runeRange{0xFE10, 0xFE10}, propertyGeneralCategory{lbprIS, gcPo}},     //         PRESENTATION FORM FOR VERTICAL COMMA
-	{runeRange{0xFE11, 0xFE12}, propertyGeneralCategory{lbprCL, gcPo}},     //     [2] PRESENTATION FORM FOR VERTICAL IDEOGRAPHIC COMMA..PRESENTATION FORM FOR VERTICAL IDEOGRAPHIC FULL STOP
-	{runeRange{0xFE13, 0xFE14}, propertyGeneralCategory{lbprIS, gcPo}},     //     [2] PRESENTATION FORM FOR VERTICAL COLON..PRESENTATION FORM FOR VERTICAL SEMICOLON
-	{runeRange{0xFE15, 0xFE16}, propertyGeneralCategory{lbprEX, gcPo}},     //     [2] PRESENTATION FORM FOR VERTICAL EXCLAMATION MARK..PRESENTATION FORM FOR VERTICAL QUESTION MARK
-	{runeRange{0xFE17, 0xFE17}, propertyGeneralCategory{lbprOP, gcPs}},     //         PRESENTATION FORM FOR VERTICAL LEFT WHITE LENTICULAR BRACKET
-	{runeRange{0xFE18, 0xFE18}, propertyGeneralCategory{lbprCL, gcPe}},     //         PRESENTATION FORM FOR VERTICAL RIGHT WHITE LENTICULAR BRAKCET
-	{runeRange{0xFE19, 0xFE19}, propertyGeneralCategory{lbprIN, gcPo}},     //         PRESENTATION FORM FOR VERTICAL HORIZONTAL ELLIPSIS
-	{runeRange{0xFE20, 0xFE2F}, propertyGeneralCategory{lbprCM, gcMn}},     //    [16] COMBINING LIGATURE LEFT HALF..COMBINING CYRILLIC TITLO RIGHT HALF
-	{runeRange{0xFE30, 0xFE30}, propertyGeneralCategory{lbprID, gcPo}},     //         PRESENTATION FORM FOR VERTICAL TWO DOT LEADER
-	{runeRange{0xFE31, 0xFE32}, propertyGeneralCategory{lbprID, gcPd}},     //     [2] PRESENTATION FORM FOR VERTICAL EM DASH..PRESENTATION FORM FOR VERTICAL EN DASH
-	{runeRange{0xFE33, 0xFE34}, propertyGeneralCategory{lbprID, gcPc}},     //     [2] PRESENTATION FORM FOR VERTICAL LOW LINE..PRESENTATION FORM FOR VERTICAL WAVY LOW LINE
-	{runeRange{0xFE35, 0xFE35}, propertyGeneralCategory{lbprOP, gcPs}},     //         PRESENTATION FORM FOR VERTICAL LEFT PARENTHESIS
-	{runeRange{0xFE36, 0xFE36}, propertyGeneralCategory{lbprCL, gcPe}},     //         PRESENTATION FORM FOR VERTICAL RIGHT PARENTHESIS
-	{runeRange{0xFE37, 0xFE37}, propertyGeneralCategory{lbprOP, gcPs}},     //         PRESENTATION FORM FOR VERTICAL LEFT CURLY BRACKET
-	{runeRange{0xFE38, 0xFE38}, propertyGeneralCategory{lbprCL, gcPe}},     //         PRESENTATION FORM FOR VERTICAL RIGHT CURLY BRACKET
-	{runeRange{0xFE39, 0xFE39}, propertyGeneralCategory{lbprOP, gcPs}},     //         PRESENTATION FORM FOR VERTICAL LEFT TORTOISE SHELL BRACKET
-	{runeRange{0xFE3A, 0xFE3A}, propertyGeneralCategory{lbprCL, gcPe}},     //         PRESENTATION FORM FOR VERTICAL RIGHT TORTOISE SHELL BRACKET
-	{runeRange{0xFE3B, 0xFE3B}, propertyGeneralCategory{lbprOP, gcPs}},     //         PRESENTATION FORM FOR VERTICAL LEFT BLACK LENTICULAR BRACKET
-	{runeRange{0xFE3C, 0xFE3C}, propertyGeneralCategory{lbprCL, gcPe}},     //         PRESENTATION FORM FOR VERTICAL RIGHT BLACK LENTICULAR BRACKET
-	{runeRange{0xFE3D, 0xFE3D}, propertyGeneralCategory{lbprOP, gcPs}},     //         PRESENTATION FORM FOR VERTICAL LEFT DOUBLE ANGLE BRACKET
-	{runeRange{0xFE3E, 0xFE3E}, propertyGeneralCategory{lbprCL, gcPe}},     //         PRESENTATION FORM FOR VERTICAL RIGHT DOUBLE ANGLE BRACKET
-	{runeRange{0xFE3F, 0xFE3F}, propertyGeneralCategory{lbprOP, gcPs}},     //         PRESENTATION FORM FOR VERTICAL LEFT ANGLE BRACKET
-	{runeRange{0xFE40, 0xFE40}, propertyGeneralCategory{lbprCL, gcPe}},     //         PRESENTATION FORM FOR VERTICAL RIGHT ANGLE BRACKET
-	{runeRange{0xFE41, 0xFE41}, propertyGeneralCategory{lbprOP, gcPs}},     //         PRESENTATION FORM FOR VERTICAL LEFT CORNER BRACKET
-	{runeRange{0xFE42, 0xFE42}, propertyGeneralCategory{lbprCL, gcPe}},     //         PRESENTATION FORM FOR VERTICAL RIGHT CORNER BRACKET
-	{runeRange{0xFE43, 0xFE43}, propertyGeneralCategory{lbprOP, gcPs}},     //         PRESENTATION FORM FOR VERTICAL LEFT WHITE CORNER BRACKET
-	{runeRange{0xFE44, 0xFE44}, propertyGeneralCategory{lbprCL, gcPe}},     //         PRESENTATION FORM FOR VERTICAL RIGHT WHITE CORNER BRACKET
-	{runeRange{0xFE45, 0xFE46}, propertyGeneralCategory{lbprID, gcPo}},     //     [2] SESAME DOT..WHITE SESAME DOT
-	{runeRange{0xFE47, 0xFE47}, propertyGeneralCategory{lbprOP, gcPs}},     //         PRESENTATION FORM FOR VERTICAL LEFT SQUARE BRACKET
-	{runeRange{0xFE48, 0xFE48}, propertyGeneralCategory{lbprCL, gcPe}},     //         PRESENTATION FORM FOR VERTICAL RIGHT SQUARE BRACKET
-	{runeRange{0xFE49, 0xFE4C}, propertyGeneralCategory{lbprID, gcPo}},     //     [4] DASHED OVERLINE..DOUBLE WAVY OVERLINE
-	{runeRange{0xFE4D, 0xFE4F}, propertyGeneralCategory{lbprID, gcPc}},     //     [3] DASHED LOW LINE..WAVY LOW LINE
-	{runeRange{0xFE50, 0xFE50}, propertyGeneralCategory{lbprCL, gcPo}},     //         SMALL COMMA
-	{runeRange{0xFE51, 0xFE51}, propertyGeneralCategory{lbprID, gcPo}},     //         SMALL IDEOGRAPHIC COMMA
-	{runeRange{0xFE52, 0xFE52}, propertyGeneralCategory{lbprCL, gcPo}},     //         SMALL FULL STOP
-	{runeRange{0xFE54, 0xFE55}, propertyGeneralCategory{lbprNS, gcPo}},     //     [2] SMALL SEMICOLON..SMALL COLON
-	{runeRange{0xFE56, 0xFE57}, propertyGeneralCategory{lbprEX, gcPo}},     //     [2] SMALL QUESTION MARK..SMALL EXCLAMATION MARK
-	{runeRange{0xFE58, 0xFE58}, propertyGeneralCategory{lbprID, gcPd}},     //         SMALL EM DASH
-	{runeRange{0xFE59, 0xFE59}, propertyGeneralCategory{lbprOP, gcPs}},     //         SMALL LEFT PARENTHESIS
-	{runeRange{0xFE5A, 0xFE5A}, propertyGeneralCategory{lbprCL, gcPe}},     //         SMALL RIGHT PARENTHESIS
-	{runeRange{0xFE5B, 0xFE5B}, propertyGeneralCategory{lbprOP, gcPs}},     //         SMALL LEFT CURLY BRACKET
-	{runeRange{0xFE5C, 0xFE5C}, propertyGeneralCategory{lbprCL, gcPe}},     //         SMALL RIGHT CURLY BRACKET
-	{runeRange{0xFE5D, 0xFE5D}, propertyGeneralCategory{lbprOP, gcPs}},     //         SMALL LEFT TORTOISE SHELL BRACKET
-	{runeRange{0xFE5E, 0xFE5E}, propertyGeneralCategory{lbprCL, gcPe}},     //         SMALL RIGHT TORTOISE SHELL BRACKET
-	{runeRange{0xFE5F, 0xFE61}, propertyGeneralCategory{lbprID, gcPo}},     //     [3] SMALL NUMBER SIGN..SMALL ASTERISK
-	{runeRange{0xFE62, 0xFE62}, propertyGeneralCategory{lbprID, gcSm}},     //         SMALL PLUS SIGN
-	{runeRange{0xFE63, 0xFE63}, propertyGeneralCategory{lbprID, gcPd}},     //         SMALL HYPHEN-MINUS
-	{runeRange{0xFE64, 0xFE66}, propertyGeneralCategory{lbprID, gcSm}},     //     [3] SMALL LESS-THAN SIGN..SMALL EQUALS SIGN
-	{runeRange{0xFE68, 0xFE68}, propertyGeneralCategory{lbprID, gcPo}},     //         SMALL REVERSE SOLIDUS
-	{runeRange{0xFE69, 0xFE69}, propertyGeneralCategory{lbprPR, gcSc}},     //         SMALL DOLLAR SIGN
-	{runeRange{0xFE6A, 0xFE6A}, propertyGeneralCategory{lbprPO, gcPo}},     //         SMALL PERCENT SIGN
-	{runeRange{0xFE6B, 0xFE6B}, propertyGeneralCategory{lbprID, gcPo}},     //         SMALL COMMERCIAL AT
-	{runeRange{0xFE70, 0xFE74}, propertyGeneralCategory{lbprAL, gcLo}},     //     [5] ARABIC FATHATAN ISOLATED FORM..ARABIC KASRATAN ISOLATED FORM
-	{runeRange{0xFE76, 0xFEFC}, propertyGeneralCategory{lbprAL, gcLo}},     //   [135] ARABIC FATHA ISOLATED FORM..ARABIC LIGATURE LAM WITH ALEF FINAL FORM
-	{runeRange{0xFEFF, 0xFEFF}, propertyGeneralCategory{lbprWJ, gcCf}},     //         ZERO WIDTH NO-BREAK SPACE
-	{runeRange{0xFF01, 0xFF01}, propertyGeneralCategory{lbprEX, gcPo}},     //         FULLWIDTH EXCLAMATION MARK
-	{runeRange{0xFF02, 0xFF03}, propertyGeneralCategory{lbprID, gcPo}},     //     [2] FULLWIDTH QUOTATION MARK..FULLWIDTH NUMBER SIGN
-	{runeRange{0xFF04, 0xFF04}, propertyGeneralCategory{lbprPR, gcSc}},     //         FULLWIDTH DOLLAR SIGN
-	{runeRange{0xFF05, 0xFF05}, propertyGeneralCategory{lbprPO, gcPo}},     //         FULLWIDTH PERCENT SIGN
-	{runeRange{0xFF06, 0xFF07}, propertyGeneralCategory{lbprID, gcPo}},     //     [2] FULLWIDTH AMPERSAND..FULLWIDTH APOSTROPHE
-	{runeRange{0xFF08, 0xFF08}, propertyGeneralCategory{lbprOP, gcPs}},     //         FULLWIDTH LEFT PARENTHESIS
-	{runeRange{0xFF09, 0xFF09}, propertyGeneralCategory{lbprCL, gcPe}},     //         FULLWIDTH RIGHT PARENTHESIS
-	{runeRange{0xFF0A, 0xFF0A}, propertyGeneralCategory{lbprID, gcPo}},     //         FULLWIDTH ASTERISK
-	{runeRange{0xFF0B, 0xFF0B}, propertyGeneralCategory{lbprID, gcSm}},     //         FULLWIDTH PLUS SIGN
-	{runeRange{0xFF0C, 0xFF0C}, propertyGeneralCategory{lbprCL, gcPo}},     //         FULLWIDTH COMMA
-	{runeRange{0xFF0D, 0xFF0D}, propertyGeneralCategory{lbprID, gcPd}},     //         FULLWIDTH HYPHEN-MINUS
-	{runeRange{0xFF0E, 0xFF0E}, propertyGeneralCategory{lbprCL, gcPo}},     //         FULLWIDTH FULL STOP
-	{runeRange{0xFF0F, 0xFF0F}, propertyGeneralCategory{lbprID, gcPo}},     //         FULLWIDTH SOLIDUS
-	{runeRange{0xFF10, 0xFF19}, propertyGeneralCategory{lbprID, gcNd}},     //    [10] FULLWIDTH DIGIT ZERO..FULLWIDTH DIGIT NINE
-	{runeRange{0xFF1A, 0xFF1B}, propertyGeneralCategory{lbprNS, gcPo}},     //     [2] FULLWIDTH COLON..FULLWIDTH SEMICOLON
-	{runeRange{0xFF1C, 0xFF1E}, propertyGeneralCategory{lbprID, gcSm}},     //     [3] FULLWIDTH LESS-THAN SIGN..FULLWIDTH GREATER-THAN SIGN
-	{runeRange{0xFF1F, 0xFF1F}, propertyGeneralCategory{lbprEX, gcPo}},     //         FULLWIDTH QUESTION MARK
-	{runeRange{0xFF20, 0xFF20}, propertyGeneralCategory{lbprID, gcPo}},     //         FULLWIDTH COMMERCIAL AT
-	{runeRange{0xFF21, 0xFF3A}, propertyGeneralCategory{lbprID, gcLu}},     //    [26] FULLWIDTH LATIN CAPITAL LETTER A..FULLWIDTH LATIN CAPITAL LETTER Z
-	{runeRange{0xFF3B, 0xFF3B}, propertyGeneralCategory{lbprOP, gcPs}},     //         FULLWIDTH LEFT SQUARE BRACKET
-	{runeRange{0xFF3C, 0xFF3C}, propertyGeneralCategory{lbprID, gcPo}},     //         FULLWIDTH REVERSE SOLIDUS
-	{runeRange{0xFF3D, 0xFF3D}, propertyGeneralCategory{lbprCL, gcPe}},     //         FULLWIDTH RIGHT SQUARE BRACKET
-	{runeRange{0xFF3E, 0xFF3E}, propertyGeneralCategory{lbprID, gcSk}},     //         FULLWIDTH CIRCUMFLEX ACCENT
-	{runeRange{0xFF3F, 0xFF3F}, propertyGeneralCategory{lbprID, gcPc}},     //         FULLWIDTH LOW LINE
-	{runeRange{0xFF40, 0xFF40}, propertyGeneralCategory{lbprID, gcSk}},     //         FULLWIDTH GRAVE ACCENT
-	{runeRange{0xFF41, 0xFF5A}, propertyGeneralCategory{lbprID, gcLl}},     //    [26] FULLWIDTH LATIN SMALL LETTER A..FULLWIDTH LATIN SMALL LETTER Z
-	{runeRange{0xFF5B, 0xFF5B}, propertyGeneralCategory{lbprOP, gcPs}},     //         FULLWIDTH LEFT CURLY BRACKET
-	{runeRange{0xFF5C, 0xFF5C}, propertyGeneralCategory{lbprID, gcSm}},     //         FULLWIDTH VERTICAL LINE
-	{runeRange{0xFF5D, 0xFF5D}, propertyGeneralCategory{lbprCL, gcPe}},     //         FULLWIDTH RIGHT CURLY BRACKET
-	{runeRange{0xFF5E, 0xFF5E}, propertyGeneralCategory{lbprID, gcSm}},     //         FULLWIDTH TILDE
-	{runeRange{0xFF5F, 0xFF5F}, propertyGeneralCategory{lbprOP, gcPs}},     //         FULLWIDTH LEFT WHITE PARENTHESIS
-	{runeRange{0xFF60, 0xFF60}, propertyGeneralCategory{lbprCL, gcPe}},     //         FULLWIDTH RIGHT WHITE PARENTHESIS
-	{runeRange{0xFF61, 0xFF61}, propertyGeneralCategory{lbprCL, gcPo}},     //         HALFWIDTH IDEOGRAPHIC FULL STOP
-	{runeRange{0xFF62, 0xFF62}, propertyGeneralCategory{lbprOP, gcPs}},     //         HALFWIDTH LEFT CORNER BRACKET
-	{runeRange{0xFF63, 0xFF63}, propertyGeneralCategory{lbprCL, gcPe}},     //         HALFWIDTH RIGHT CORNER BRACKET
-	{runeRange{0xFF64, 0xFF64}, propertyGeneralCategory{lbprCL, gcPo}},     //         HALFWIDTH IDEOGRAPHIC COMMA
-	{runeRange{0xFF65, 0xFF65}, propertyGeneralCategory{lbprNS, gcPo}},     //         HALFWIDTH KATAKANA MIDDLE DOT
-	{runeRange{0xFF66, 0xFF66}, propertyGeneralCategory{lbprID, gcLo}},     //         HALFWIDTH KATAKANA LETTER WO
-	{runeRange{0xFF67, 0xFF6F}, propertyGeneralCategory{lbprCJ, gcLo}},     //     [9] HALFWIDTH KATAKANA LETTER SMALL A..HALFWIDTH KATAKANA LETTER SMALL TU
-	{runeRange{0xFF70, 0xFF70}, propertyGeneralCategory{lbprCJ, gcLm}},     //         HALFWIDTH KATAKANA-HIRAGANA PROLONGED SOUND MARK
-	{runeRange{0xFF71, 0xFF9D}, propertyGeneralCategory{lbprID, gcLo}},     //    [45] HALFWIDTH KATAKANA LETTER A..HALFWIDTH KATAKANA LETTER N
-	{runeRange{0xFF9E, 0xFF9F}, propertyGeneralCategory{lbprNS, gcLm}},     //     [2] HALFWIDTH KATAKANA VOICED SOUND MARK..HALFWIDTH KATAKANA SEMI-VOICED SOUND MARK
-	{runeRange{0xFFA0, 0xFFBE}, propertyGeneralCategory{lbprID, gcLo}},     //    [31] HALFWIDTH HANGUL FILLER..HALFWIDTH HANGUL LETTER HIEUH
-	{runeRange{0xFFC2, 0xFFC7}, propertyGeneralCategory{lbprID, gcLo}},     //     [6] HALFWIDTH HANGUL LETTER A..HALFWIDTH HANGUL LETTER E
-	{runeRange{0xFFCA, 0xFFCF}, propertyGeneralCategory{lbprID, gcLo}},     //     [6] HALFWIDTH HANGUL LETTER YEO..HALFWIDTH HANGUL LETTER OE
-	{runeRange{0xFFD2, 0xFFD7}, propertyGeneralCategory{lbprID, gcLo}},     //     [6] HALFWIDTH HANGUL LETTER YO..HALFWIDTH HANGUL LETTER YU
-	{runeRange{0xFFDA, 0xFFDC}, propertyGeneralCategory{lbprID, gcLo}},     //     [3] HALFWIDTH HANGUL LETTER EU..HALFWIDTH HANGUL LETTER I
-	{runeRange{0xFFE0, 0xFFE0}, propertyGeneralCategory{lbprPO, gcSc}},     //         FULLWIDTH CENT SIGN
-	{runeRange{0xFFE1, 0xFFE1}, propertyGeneralCategory{lbprPR, gcSc}},     //         FULLWIDTH POUND SIGN
-	{runeRange{0xFFE2, 0xFFE2}, propertyGeneralCategory{lbprID, gcSm}},     //         FULLWIDTH NOT SIGN
-	{runeRange{0xFFE3, 0xFFE3}, propertyGeneralCategory{lbprID, gcSk}},     //         FULLWIDTH MACRON
-	{runeRange{0xFFE4, 0xFFE4}, propertyGeneralCategory{lbprID, gcSo}},     //         FULLWIDTH BROKEN BAR
-	{runeRange{0xFFE5, 0xFFE6}, propertyGeneralCategory{lbprPR, gcSc}},     //     [2] FULLWIDTH YEN SIGN..FULLWIDTH WON SIGN
-	{runeRange{0xFFE8, 0xFFE8}, propertyGeneralCategory{lbprAL, gcSo}},     //         HALFWIDTH FORMS LIGHT VERTICAL
-	{runeRange{0xFFE9, 0xFFEC}, propertyGeneralCategory{lbprAL, gcSm}},     //     [4] HALFWIDTH LEFTWARDS ARROW..HALFWIDTH DOWNWARDS ARROW
-	{runeRange{0xFFED, 0xFFEE}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] HALFWIDTH BLACK SQUARE..HALFWIDTH WHITE CIRCLE
-	{runeRange{0xFFF9, 0xFFFB}, propertyGeneralCategory{lbprCM, gcCf}},     //     [3] INTERLINEAR ANNOTATION ANCHOR..INTERLINEAR ANNOTATION TERMINATOR
-	{runeRange{0xFFFC, 0xFFFC}, propertyGeneralCategory{lbprCB, gcSo}},     //         OBJECT REPLACEMENT CHARACTER
-	{runeRange{0xFFFD, 0xFFFD}, propertyGeneralCategory{lbprAI, gcSo}},     //         REPLACEMENT CHARACTER
-	{runeRange{0x10000, 0x1000B}, propertyGeneralCategory{lbprAL, gcLo}},   //    [12] LINEAR B SYLLABLE B008 A..LINEAR B SYLLABLE B046 JE
-	{runeRange{0x1000D, 0x10026}, propertyGeneralCategory{lbprAL, gcLo}},   //    [26] LINEAR B SYLLABLE B036 JO..LINEAR B SYLLABLE B032 QO
-	{runeRange{0x10028, 0x1003A}, propertyGeneralCategory{lbprAL, gcLo}},   //    [19] LINEAR B SYLLABLE B060 RA..LINEAR B SYLLABLE B042 WO
-	{runeRange{0x1003C, 0x1003D}, propertyGeneralCategory{lbprAL, gcLo}},   //     [2] LINEAR B SYLLABLE B017 ZA..LINEAR B SYLLABLE B074 ZE
-	{runeRange{0x1003F, 0x1004D}, propertyGeneralCategory{lbprAL, gcLo}},   //    [15] LINEAR B SYLLABLE B020 ZO..LINEAR B SYLLABLE B091 TWO
-	{runeRange{0x10050, 0x1005D}, propertyGeneralCategory{lbprAL, gcLo}},   //    [14] LINEAR B SYMBOL B018..LINEAR B SYMBOL B089
-	{runeRange{0x10080, 0x100FA}, propertyGeneralCategory{lbprAL, gcLo}},   //   [123] LINEAR B IDEOGRAM B100 MAN..LINEAR B IDEOGRAM VESSEL B305
-	{runeRange{0x10100, 0x10102}, propertyGeneralCategory{lbprBA, gcPo}},   //     [3] AEGEAN WORD SEPARATOR LINE..AEGEAN CHECK MARK
-	{runeRange{0x10107, 0x10133}, propertyGeneralCategory{lbprAL, gcNo}},   //    [45] AEGEAN NUMBER ONE..AEGEAN NUMBER NINETY THOUSAND
-	{runeRange{0x10137, 0x1013F}, propertyGeneralCategory{lbprAL, gcSo}},   //     [9] AEGEAN WEIGHT BASE UNIT..AEGEAN MEASURE THIRD SUBUNIT
-	{runeRange{0x10140, 0x10174}, propertyGeneralCategory{lbprAL, gcNl}},   //    [53] GREEK ACROPHONIC ATTIC ONE QUARTER..GREEK ACROPHONIC STRATIAN FIFTY MNAS
-	{runeRange{0x10175, 0x10178}, propertyGeneralCategory{lbprAL, gcNo}},   //     [4] GREEK ONE HALF SIGN..GREEK THREE QUARTERS SIGN
-	{runeRange{0x10179, 0x10189}, propertyGeneralCategory{lbprAL, gcSo}},   //    [17] GREEK YEAR SIGN..GREEK TRYBLION BASE SIGN
-	{runeRange{0x1018A, 0x1018B}, propertyGeneralCategory{lbprAL, gcNo}},   //     [2] GREEK ZERO SIGN..GREEK ONE QUARTER SIGN
-	{runeRange{0x1018C, 0x1018E}, propertyGeneralCategory{lbprAL, gcSo}},   //     [3] GREEK SINUSOID SIGN..NOMISMA SIGN
-	{runeRange{0x10190, 0x1019C}, propertyGeneralCategory{lbprAL, gcSo}},   //    [13] ROMAN SEXTANS SIGN..ASCIA SYMBOL
-	{runeRange{0x101A0, 0x101A0}, propertyGeneralCategory{lbprAL, gcSo}},   //         GREEK SYMBOL TAU RHO
-	{runeRange{0x101D0, 0x101FC}, propertyGeneralCategory{lbprAL, gcSo}},   //    [45] PHAISTOS DISC SIGN PEDESTRIAN..PHAISTOS DISC SIGN WAVY BAND
-	{runeRange{0x101FD, 0x101FD}, propertyGeneralCategory{lbprCM, gcMn}},   //         PHAISTOS DISC SIGN COMBINING OBLIQUE STROKE
-	{runeRange{0x10280, 0x1029C}, propertyGeneralCategory{lbprAL, gcLo}},   //    [29] LYCIAN LETTER A..LYCIAN LETTER X
-	{runeRange{0x102A0, 0x102D0}, propertyGeneralCategory{lbprAL, gcLo}},   //    [49] CARIAN LETTER A..CARIAN LETTER UUU3
-	{runeRange{0x102E0, 0x102E0}, propertyGeneralCategory{lbprCM, gcMn}},   //         COPTIC EPACT THOUSANDS MARK
-	{runeRange{0x102E1, 0x102FB}, propertyGeneralCategory{lbprAL, gcNo}},   //    [27] COPTIC EPACT DIGIT ONE..COPTIC EPACT NUMBER NINE HUNDRED
-	{runeRange{0x10300, 0x1031F}, propertyGeneralCategory{lbprAL, gcLo}},   //    [32] OLD ITALIC LETTER A..OLD ITALIC LETTER ESS
-	{runeRange{0x10320, 0x10323}, propertyGeneralCategory{lbprAL, gcNo}},   //     [4] OLD ITALIC NUMERAL ONE..OLD ITALIC NUMERAL FIFTY
-	{runeRange{0x1032D, 0x1032F}, propertyGeneralCategory{lbprAL, gcLo}},   //     [3] OLD ITALIC LETTER YE..OLD ITALIC LETTER SOUTHERN TSE
-	{runeRange{0x10330, 0x10340}, propertyGeneralCategory{lbprAL, gcLo}},   //    [17] GOTHIC LETTER AHSA..GOTHIC LETTER PAIRTHRA
-	{runeRange{0x10341, 0x10341}, propertyGeneralCategory{lbprAL, gcNl}},   //         GOTHIC LETTER NINETY
-	{runeRange{0x10342, 0x10349}, propertyGeneralCategory{lbprAL, gcLo}},   //     [8] GOTHIC LETTER RAIDA..GOTHIC LETTER OTHAL
-	{runeRange{0x1034A, 0x1034A}, propertyGeneralCategory{lbprAL, gcNl}},   //         GOTHIC LETTER NINE HUNDRED
-	{runeRange{0x10350, 0x10375}, propertyGeneralCategory{lbprAL, gcLo}},   //    [38] OLD PERMIC LETTER AN..OLD PERMIC LETTER IA
-	{runeRange{0x10376, 0x1037A}, propertyGeneralCategory{lbprCM, gcMn}},   //     [5] COMBINING OLD PERMIC LETTER AN..COMBINING OLD PERMIC LETTER SII
-	{runeRange{0x10380, 0x1039D}, propertyGeneralCategory{lbprAL, gcLo}},   //    [30] UGARITIC LETTER ALPA..UGARITIC LETTER SSU
-	{runeRange{0x1039F, 0x1039F}, propertyGeneralCategory{lbprBA, gcPo}},   //         UGARITIC WORD DIVIDER
-	{runeRange{0x103A0, 0x103C3}, propertyGeneralCategory{lbprAL, gcLo}},   //    [36] OLD PERSIAN SIGN A..OLD PERSIAN SIGN HA
-	{runeRange{0x103C8, 0x103CF}, propertyGeneralCategory{lbprAL, gcLo}},   //     [8] OLD PERSIAN SIGN AURAMAZDAA..OLD PERSIAN SIGN BUUMISH
-	{runeRange{0x103D0, 0x103D0}, propertyGeneralCategory{lbprBA, gcPo}},   //         OLD PERSIAN WORD DIVIDER
-	{runeRange{0x103D1, 0x103D5}, propertyGeneralCategory{lbprAL, gcNl}},   //     [5] OLD PERSIAN NUMBER ONE..OLD PERSIAN NUMBER HUNDRED
-	{runeRange{0x10400, 0x1044F}, propertyGeneralCategory{lbprAL, gcLC}},   //    [80] DESERET CAPITAL LETTER LONG I..DESERET SMALL LETTER EW
-	{runeRange{0x10450, 0x1047F}, propertyGeneralCategory{lbprAL, gcLo}},   //    [48] SHAVIAN LETTER PEEP..SHAVIAN LETTER YEW
-	{runeRange{0x10480, 0x1049D}, propertyGeneralCategory{lbprAL, gcLo}},   //    [30] OSMANYA LETTER ALEF..OSMANYA LETTER OO
-	{runeRange{0x104A0, 0x104A9}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] OSMANYA DIGIT ZERO..OSMANYA DIGIT NINE
-	{runeRange{0x104B0, 0x104D3}, propertyGeneralCategory{lbprAL, gcLu}},   //    [36] OSAGE CAPITAL LETTER A..OSAGE CAPITAL LETTER ZHA
-	{runeRange{0x104D8, 0x104FB}, propertyGeneralCategory{lbprAL, gcLl}},   //    [36] OSAGE SMALL LETTER A..OSAGE SMALL LETTER ZHA
-	{runeRange{0x10500, 0x10527}, propertyGeneralCategory{lbprAL, gcLo}},   //    [40] ELBASAN LETTER A..ELBASAN LETTER KHE
-	{runeRange{0x10530, 0x10563}, propertyGeneralCategory{lbprAL, gcLo}},   //    [52] CAUCASIAN ALBANIAN LETTER ALT..CAUCASIAN ALBANIAN LETTER KIW
-	{runeRange{0x1056F, 0x1056F}, propertyGeneralCategory{lbprAL, gcPo}},   //         CAUCASIAN ALBANIAN CITATION MARK
-	{runeRange{0x10570, 0x1057A}, propertyGeneralCategory{lbprAL, gcLu}},   //    [11] VITHKUQI CAPITAL LETTER A..VITHKUQI CAPITAL LETTER GA
-	{runeRange{0x1057C, 0x1058A}, propertyGeneralCategory{lbprAL, gcLu}},   //    [15] VITHKUQI CAPITAL LETTER HA..VITHKUQI CAPITAL LETTER RE
-	{runeRange{0x1058C, 0x10592}, propertyGeneralCategory{lbprAL, gcLu}},   //     [7] VITHKUQI CAPITAL LETTER SE..VITHKUQI CAPITAL LETTER XE
-	{runeRange{0x10594, 0x10595}, propertyGeneralCategory{lbprAL, gcLu}},   //     [2] VITHKUQI CAPITAL LETTER Y..VITHKUQI CAPITAL LETTER ZE
-	{runeRange{0x10597, 0x105A1}, propertyGeneralCategory{lbprAL, gcLl}},   //    [11] VITHKUQI SMALL LETTER A..VITHKUQI SMALL LETTER GA
-	{runeRange{0x105A3, 0x105B1}, propertyGeneralCategory{lbprAL, gcLl}},   //    [15] VITHKUQI SMALL LETTER HA..VITHKUQI SMALL LETTER RE
-	{runeRange{0x105B3, 0x105B9}, propertyGeneralCategory{lbprAL, gcLl}},   //     [7] VITHKUQI SMALL LETTER SE..VITHKUQI SMALL LETTER XE
-	{runeRange{0x105BB, 0x105BC}, propertyGeneralCategory{lbprAL, gcLl}},   //     [2] VITHKUQI SMALL LETTER Y..VITHKUQI SMALL LETTER ZE
-	{runeRange{0x10600, 0x10736}, propertyGeneralCategory{lbprAL, gcLo}},   //   [311] LINEAR A SIGN AB001..LINEAR A SIGN A664
-	{runeRange{0x10740, 0x10755}, propertyGeneralCategory{lbprAL, gcLo}},   //    [22] LINEAR A SIGN A701 A..LINEAR A SIGN A732 JE
-	{runeRange{0x10760, 0x10767}, propertyGeneralCategory{lbprAL, gcLo}},   //     [8] LINEAR A SIGN A800..LINEAR A SIGN A807
-	{runeRange{0x10780, 0x10785}, propertyGeneralCategory{lbprAL, gcLm}},   //     [6] MODIFIER LETTER SMALL CAPITAL AA..MODIFIER LETTER SMALL B WITH HOOK
-	{runeRange{0x10787, 0x107B0}, propertyGeneralCategory{lbprAL, gcLm}},   //    [42] MODIFIER LETTER SMALL DZ DIGRAPH..MODIFIER LETTER SMALL V WITH RIGHT HOOK
-	{runeRange{0x107B2, 0x107BA}, propertyGeneralCategory{lbprAL, gcLm}},   //     [9] MODIFIER LETTER SMALL CAPITAL Y..MODIFIER LETTER SMALL S WITH CURL
-	{runeRange{0x10800, 0x10805}, propertyGeneralCategory{lbprAL, gcLo}},   //     [6] CYPRIOT SYLLABLE A..CYPRIOT SYLLABLE JA
-	{runeRange{0x10808, 0x10808}, propertyGeneralCategory{lbprAL, gcLo}},   //         CYPRIOT SYLLABLE JO
-	{runeRange{0x1080A, 0x10835}, propertyGeneralCategory{lbprAL, gcLo}},   //    [44] CYPRIOT SYLLABLE KA..CYPRIOT SYLLABLE WO
-	{runeRange{0x10837, 0x10838}, propertyGeneralCategory{lbprAL, gcLo}},   //     [2] CYPRIOT SYLLABLE XA..CYPRIOT SYLLABLE XE
-	{runeRange{0x1083C, 0x1083C}, propertyGeneralCategory{lbprAL, gcLo}},   //         CYPRIOT SYLLABLE ZA
-	{runeRange{0x1083F, 0x1083F}, propertyGeneralCategory{lbprAL, gcLo}},   //         CYPRIOT SYLLABLE ZO
-	{runeRange{0x10840, 0x10855}, propertyGeneralCategory{lbprAL, gcLo}},   //    [22] IMPERIAL ARAMAIC LETTER ALEPH..IMPERIAL ARAMAIC LETTER TAW
-	{runeRange{0x10857, 0x10857}, propertyGeneralCategory{lbprBA, gcPo}},   //         IMPERIAL ARAMAIC SECTION SIGN
-	{runeRange{0x10858, 0x1085F}, propertyGeneralCategory{lbprAL, gcNo}},   //     [8] IMPERIAL ARAMAIC NUMBER ONE..IMPERIAL ARAMAIC NUMBER TEN THOUSAND
-	{runeRange{0x10860, 0x10876}, propertyGeneralCategory{lbprAL, gcLo}},   //    [23] PALMYRENE LETTER ALEPH..PALMYRENE LETTER TAW
-	{runeRange{0x10877, 0x10878}, propertyGeneralCategory{lbprAL, gcSo}},   //     [2] PALMYRENE LEFT-POINTING FLEURON..PALMYRENE RIGHT-POINTING FLEURON
-	{runeRange{0x10879, 0x1087F}, propertyGeneralCategory{lbprAL, gcNo}},   //     [7] PALMYRENE NUMBER ONE..PALMYRENE NUMBER TWENTY
-	{runeRange{0x10880, 0x1089E}, propertyGeneralCategory{lbprAL, gcLo}},   //    [31] NABATAEAN LETTER FINAL ALEPH..NABATAEAN LETTER TAW
-	{runeRange{0x108A7, 0x108AF}, propertyGeneralCategory{lbprAL, gcNo}},   //     [9] NABATAEAN NUMBER ONE..NABATAEAN NUMBER ONE HUNDRED
-	{runeRange{0x108E0, 0x108F2}, propertyGeneralCategory{lbprAL, gcLo}},   //    [19] HATRAN LETTER ALEPH..HATRAN LETTER QOPH
-	{runeRange{0x108F4, 0x108F5}, propertyGeneralCategory{lbprAL, gcLo}},   //     [2] HATRAN LETTER SHIN..HATRAN LETTER TAW
-	{runeRange{0x108FB, 0x108FF}, propertyGeneralCategory{lbprAL, gcNo}},   //     [5] HATRAN NUMBER ONE..HATRAN NUMBER ONE HUNDRED
-	{runeRange{0x10900, 0x10915}, propertyGeneralCategory{lbprAL, gcLo}},   //    [22] PHOENICIAN LETTER ALF..PHOENICIAN LETTER TAU
-	{runeRange{0x10916, 0x1091B}, propertyGeneralCategory{lbprAL, gcNo}},   //     [6] PHOENICIAN NUMBER ONE..PHOENICIAN NUMBER THREE
-	{runeRange{0x1091F, 0x1091F}, propertyGeneralCategory{lbprBA, gcPo}},   //         PHOENICIAN WORD SEPARATOR
-	{runeRange{0x10920, 0x10939}, propertyGeneralCategory{lbprAL, gcLo}},   //    [26] LYDIAN LETTER A..LYDIAN LETTER C
-	{runeRange{0x1093F, 0x1093F}, propertyGeneralCategory{lbprAL, gcPo}},   //         LYDIAN TRIANGULAR MARK
-	{runeRange{0x10980, 0x1099F}, propertyGeneralCategory{lbprAL, gcLo}},   //    [32] MEROITIC HIEROGLYPHIC LETTER A..MEROITIC HIEROGLYPHIC SYMBOL VIDJ-2
-	{runeRange{0x109A0, 0x109B7}, propertyGeneralCategory{lbprAL, gcLo}},   //    [24] MEROITIC CURSIVE LETTER A..MEROITIC CURSIVE LETTER DA
-	{runeRange{0x109BC, 0x109BD}, propertyGeneralCategory{lbprAL, gcNo}},   //     [2] MEROITIC CURSIVE FRACTION ELEVEN TWELFTHS..MEROITIC CURSIVE FRACTION ONE HALF
-	{runeRange{0x109BE, 0x109BF}, propertyGeneralCategory{lbprAL, gcLo}},   //     [2] MEROITIC CURSIVE LOGOGRAM RMT..MEROITIC CURSIVE LOGOGRAM IMN
-	{runeRange{0x109C0, 0x109CF}, propertyGeneralCategory{lbprAL, gcNo}},   //    [16] MEROITIC CURSIVE NUMBER ONE..MEROITIC CURSIVE NUMBER SEVENTY
-	{runeRange{0x109D2, 0x109FF}, propertyGeneralCategory{lbprAL, gcNo}},   //    [46] MEROITIC CURSIVE NUMBER ONE HUNDRED..MEROITIC CURSIVE FRACTION TEN TWELFTHS
-	{runeRange{0x10A00, 0x10A00}, propertyGeneralCategory{lbprAL, gcLo}},   //         KHAROSHTHI LETTER A
-	{runeRange{0x10A01, 0x10A03}, propertyGeneralCategory{lbprCM, gcMn}},   //     [3] KHAROSHTHI VOWEL SIGN I..KHAROSHTHI VOWEL SIGN VOCALIC R
-	{runeRange{0x10A05, 0x10A06}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] KHAROSHTHI VOWEL SIGN E..KHAROSHTHI VOWEL SIGN O
-	{runeRange{0x10A0C, 0x10A0F}, propertyGeneralCategory{lbprCM, gcMn}},   //     [4] KHAROSHTHI VOWEL LENGTH MARK..KHAROSHTHI SIGN VISARGA
-	{runeRange{0x10A10, 0x10A13}, propertyGeneralCategory{lbprAL, gcLo}},   //     [4] KHAROSHTHI LETTER KA..KHAROSHTHI LETTER GHA
-	{runeRange{0x10A15, 0x10A17}, propertyGeneralCategory{lbprAL, gcLo}},   //     [3] KHAROSHTHI LETTER CA..KHAROSHTHI LETTER JA
-	{runeRange{0x10A19, 0x10A35}, propertyGeneralCategory{lbprAL, gcLo}},   //    [29] KHAROSHTHI LETTER NYA..KHAROSHTHI LETTER VHA
-	{runeRange{0x10A38, 0x10A3A}, propertyGeneralCategory{lbprCM, gcMn}},   //     [3] KHAROSHTHI SIGN BAR ABOVE..KHAROSHTHI SIGN DOT BELOW
-	{runeRange{0x10A3F, 0x10A3F}, propertyGeneralCategory{lbprCM, gcMn}},   //         KHAROSHTHI VIRAMA
-	{runeRange{0x10A40, 0x10A48}, propertyGeneralCategory{lbprAL, gcNo}},   //     [9] KHAROSHTHI DIGIT ONE..KHAROSHTHI FRACTION ONE HALF
-	{runeRange{0x10A50, 0x10A57}, propertyGeneralCategory{lbprBA, gcPo}},   //     [8] KHAROSHTHI PUNCTUATION DOT..KHAROSHTHI PUNCTUATION DOUBLE DANDA
-	{runeRange{0x10A58, 0x10A58}, propertyGeneralCategory{lbprAL, gcPo}},   //         KHAROSHTHI PUNCTUATION LINES
-	{runeRange{0x10A60, 0x10A7C}, propertyGeneralCategory{lbprAL, gcLo}},   //    [29] OLD SOUTH ARABIAN LETTER HE..OLD SOUTH ARABIAN LETTER THETH
-	{runeRange{0x10A7D, 0x10A7E}, propertyGeneralCategory{lbprAL, gcNo}},   //     [2] OLD SOUTH ARABIAN NUMBER ONE..OLD SOUTH ARABIAN NUMBER FIFTY
-	{runeRange{0x10A7F, 0x10A7F}, propertyGeneralCategory{lbprAL, gcPo}},   //         OLD SOUTH ARABIAN NUMERIC INDICATOR
-	{runeRange{0x10A80, 0x10A9C}, propertyGeneralCategory{lbprAL, gcLo}},   //    [29] OLD NORTH ARABIAN LETTER HEH..OLD NORTH ARABIAN LETTER ZAH
-	{runeRange{0x10A9D, 0x10A9F}, propertyGeneralCategory{lbprAL, gcNo}},   //     [3] OLD NORTH ARABIAN NUMBER ONE..OLD NORTH ARABIAN NUMBER TWENTY
-	{runeRange{0x10AC0, 0x10AC7}, propertyGeneralCategory{lbprAL, gcLo}},   //     [8] MANICHAEAN LETTER ALEPH..MANICHAEAN LETTER WAW
-	{runeRange{0x10AC8, 0x10AC8}, propertyGeneralCategory{lbprAL, gcSo}},   //         MANICHAEAN SIGN UD
-	{runeRange{0x10AC9, 0x10AE4}, propertyGeneralCategory{lbprAL, gcLo}},   //    [28] MANICHAEAN LETTER ZAYIN..MANICHAEAN LETTER TAW
-	{runeRange{0x10AE5, 0x10AE6}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] MANICHAEAN ABBREVIATION MARK ABOVE..MANICHAEAN ABBREVIATION MARK BELOW
-	{runeRange{0x10AEB, 0x10AEF}, propertyGeneralCategory{lbprAL, gcNo}},   //     [5] MANICHAEAN NUMBER ONE..MANICHAEAN NUMBER ONE HUNDRED
-	{runeRange{0x10AF0, 0x10AF5}, propertyGeneralCategory{lbprBA, gcPo}},   //     [6] MANICHAEAN PUNCTUATION STAR..MANICHAEAN PUNCTUATION TWO DOTS
-	{runeRange{0x10AF6, 0x10AF6}, propertyGeneralCategory{lbprIN, gcPo}},   //         MANICHAEAN PUNCTUATION LINE FILLER
-	{runeRange{0x10B00, 0x10B35}, propertyGeneralCategory{lbprAL, gcLo}},   //    [54] AVESTAN LETTER A..AVESTAN LETTER HE
-	{runeRange{0x10B39, 0x10B3F}, propertyGeneralCategory{lbprBA, gcPo}},   //     [7] AVESTAN ABBREVIATION MARK..LARGE ONE RING OVER TWO RINGS PUNCTUATION
-	{runeRange{0x10B40, 0x10B55}, propertyGeneralCategory{lbprAL, gcLo}},   //    [22] INSCRIPTIONAL PARTHIAN LETTER ALEPH..INSCRIPTIONAL PARTHIAN LETTER TAW
-	{runeRange{0x10B58, 0x10B5F}, propertyGeneralCategory{lbprAL, gcNo}},   //     [8] INSCRIPTIONAL PARTHIAN NUMBER ONE..INSCRIPTIONAL PARTHIAN NUMBER ONE THOUSAND
-	{runeRange{0x10B60, 0x10B72}, propertyGeneralCategory{lbprAL, gcLo}},   //    [19] INSCRIPTIONAL PAHLAVI LETTER ALEPH..INSCRIPTIONAL PAHLAVI LETTER TAW
-	{runeRange{0x10B78, 0x10B7F}, propertyGeneralCategory{lbprAL, gcNo}},   //     [8] INSCRIPTIONAL PAHLAVI NUMBER ONE..INSCRIPTIONAL PAHLAVI NUMBER ONE THOUSAND
-	{runeRange{0x10B80, 0x10B91}, propertyGeneralCategory{lbprAL, gcLo}},   //    [18] PSALTER PAHLAVI LETTER ALEPH..PSALTER PAHLAVI LETTER TAW
-	{runeRange{0x10B99, 0x10B9C}, propertyGeneralCategory{lbprAL, gcPo}},   //     [4] PSALTER PAHLAVI SECTION MARK..PSALTER PAHLAVI FOUR DOTS WITH DOT
-	{runeRange{0x10BA9, 0x10BAF}, propertyGeneralCategory{lbprAL, gcNo}},   //     [7] PSALTER PAHLAVI NUMBER ONE..PSALTER PAHLAVI NUMBER ONE HUNDRED
-	{runeRange{0x10C00, 0x10C48}, propertyGeneralCategory{lbprAL, gcLo}},   //    [73] OLD TURKIC LETTER ORKHON A..OLD TURKIC LETTER ORKHON BASH
-	{runeRange{0x10C80, 0x10CB2}, propertyGeneralCategory{lbprAL, gcLu}},   //    [51] OLD HUNGARIAN CAPITAL LETTER A..OLD HUNGARIAN CAPITAL LETTER US
-	{runeRange{0x10CC0, 0x10CF2}, propertyGeneralCategory{lbprAL, gcLl}},   //    [51] OLD HUNGARIAN SMALL LETTER A..OLD HUNGARIAN SMALL LETTER US
-	{runeRange{0x10CFA, 0x10CFF}, propertyGeneralCategory{lbprAL, gcNo}},   //     [6] OLD HUNGARIAN NUMBER ONE..OLD HUNGARIAN NUMBER ONE THOUSAND
-	{runeRange{0x10D00, 0x10D23}, propertyGeneralCategory{lbprAL, gcLo}},   //    [36] HANIFI ROHINGYA LETTER A..HANIFI ROHINGYA MARK NA KHONNA
-	{runeRange{0x10D24, 0x10D27}, propertyGeneralCategory{lbprCM, gcMn}},   //     [4] HANIFI ROHINGYA SIGN HARBAHAY..HANIFI ROHINGYA SIGN TASSI
-	{runeRange{0x10D30, 0x10D39}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] HANIFI ROHINGYA DIGIT ZERO..HANIFI ROHINGYA DIGIT NINE
-	{runeRange{0x10E60, 0x10E7E}, propertyGeneralCategory{lbprAL, gcNo}},   //    [31] RUMI DIGIT ONE..RUMI FRACTION TWO THIRDS
-	{runeRange{0x10E80, 0x10EA9}, propertyGeneralCategory{lbprAL, gcLo}},   //    [42] YEZIDI LETTER ELIF..YEZIDI LETTER ET
-	{runeRange{0x10EAB, 0x10EAC}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] YEZIDI COMBINING HAMZA MARK..YEZIDI COMBINING MADDA MARK
-	{runeRange{0x10EAD, 0x10EAD}, propertyGeneralCategory{lbprBA, gcPd}},   //         YEZIDI HYPHENATION MARK
-	{runeRange{0x10EB0, 0x10EB1}, propertyGeneralCategory{lbprAL, gcLo}},   //     [2] YEZIDI LETTER LAM WITH DOT ABOVE..YEZIDI LETTER YOT WITH CIRCUMFLEX ABOVE
-	{runeRange{0x10EFD, 0x10EFF}, propertyGeneralCategory{lbprCM, gcMn}},   //     [3] ARABIC SMALL LOW WORD SAKTA..ARABIC SMALL LOW WORD MADDA
-	{runeRange{0x10F00, 0x10F1C}, propertyGeneralCategory{lbprAL, gcLo}},   //    [29] OLD SOGDIAN LETTER ALEPH..OLD SOGDIAN LETTER FINAL TAW WITH VERTICAL TAIL
-	{runeRange{0x10F1D, 0x10F26}, propertyGeneralCategory{lbprAL, gcNo}},   //    [10] OLD SOGDIAN NUMBER ONE..OLD SOGDIAN FRACTION ONE HALF
-	{runeRange{0x10F27, 0x10F27}, propertyGeneralCategory{lbprAL, gcLo}},   //         OLD SOGDIAN LIGATURE AYIN-DALETH
-	{runeRange{0x10F30, 0x10F45}, propertyGeneralCategory{lbprAL, gcLo}},   //    [22] SOGDIAN LETTER ALEPH..SOGDIAN INDEPENDENT SHIN
-	{runeRange{0x10F46, 0x10F50}, propertyGeneralCategory{lbprCM, gcMn}},   //    [11] SOGDIAN COMBINING DOT BELOW..SOGDIAN COMBINING STROKE BELOW
-	{runeRange{0x10F51, 0x10F54}, propertyGeneralCategory{lbprAL, gcNo}},   //     [4] SOGDIAN NUMBER ONE..SOGDIAN NUMBER ONE HUNDRED
-	{runeRange{0x10F55, 0x10F59}, propertyGeneralCategory{lbprAL, gcPo}},   //     [5] SOGDIAN PUNCTUATION TWO VERTICAL BARS..SOGDIAN PUNCTUATION HALF CIRCLE WITH DOT
-	{runeRange{0x10F70, 0x10F81}, propertyGeneralCategory{lbprAL, gcLo}},   //    [18] OLD UYGHUR LETTER ALEPH..OLD UYGHUR LETTER LESH
-	{runeRange{0x10F82, 0x10F85}, propertyGeneralCategory{lbprCM, gcMn}},   //     [4] OLD UYGHUR COMBINING DOT ABOVE..OLD UYGHUR COMBINING TWO DOTS BELOW
-	{runeRange{0x10F86, 0x10F89}, propertyGeneralCategory{lbprAL, gcPo}},   //     [4] OLD UYGHUR PUNCTUATION BAR..OLD UYGHUR PUNCTUATION FOUR DOTS
-	{runeRange{0x10FB0, 0x10FC4}, propertyGeneralCategory{lbprAL, gcLo}},   //    [21] CHORASMIAN LETTER ALEPH..CHORASMIAN LETTER TAW
-	{runeRange{0x10FC5, 0x10FCB}, propertyGeneralCategory{lbprAL, gcNo}},   //     [7] CHORASMIAN NUMBER ONE..CHORASMIAN NUMBER ONE HUNDRED
-	{runeRange{0x10FE0, 0x10FF6}, propertyGeneralCategory{lbprAL, gcLo}},   //    [23] ELYMAIC LETTER ALEPH..ELYMAIC LIGATURE ZAYIN-YODH
-	{runeRange{0x11000, 0x11000}, propertyGeneralCategory{lbprCM, gcMc}},   //         BRAHMI SIGN CANDRABINDU
-	{runeRange{0x11001, 0x11001}, propertyGeneralCategory{lbprCM, gcMn}},   //         BRAHMI SIGN ANUSVARA
-	{runeRange{0x11002, 0x11002}, propertyGeneralCategory{lbprCM, gcMc}},   //         BRAHMI SIGN VISARGA
-	{runeRange{0x11003, 0x11037}, propertyGeneralCategory{lbprAL, gcLo}},   //    [53] BRAHMI SIGN JIHVAMULIYA..BRAHMI LETTER OLD TAMIL NNNA
-	{runeRange{0x11038, 0x11046}, propertyGeneralCategory{lbprCM, gcMn}},   //    [15] BRAHMI VOWEL SIGN AA..BRAHMI VIRAMA
-	{runeRange{0x11047, 0x11048}, propertyGeneralCategory{lbprBA, gcPo}},   //     [2] BRAHMI DANDA..BRAHMI DOUBLE DANDA
-	{runeRange{0x11049, 0x1104D}, propertyGeneralCategory{lbprAL, gcPo}},   //     [5] BRAHMI PUNCTUATION DOT..BRAHMI PUNCTUATION LOTUS
-	{runeRange{0x11052, 0x11065}, propertyGeneralCategory{lbprAL, gcNo}},   //    [20] BRAHMI NUMBER ONE..BRAHMI NUMBER ONE THOUSAND
-	{runeRange{0x11066, 0x1106F}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] BRAHMI DIGIT ZERO..BRAHMI DIGIT NINE
-	{runeRange{0x11070, 0x11070}, propertyGeneralCategory{lbprCM, gcMn}},   //         BRAHMI SIGN OLD TAMIL VIRAMA
-	{runeRange{0x11071, 0x11072}, propertyGeneralCategory{lbprAL, gcLo}},   //     [2] BRAHMI LETTER OLD TAMIL SHORT E..BRAHMI LETTER OLD TAMIL SHORT O
-	{runeRange{0x11073, 0x11074}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] BRAHMI VOWEL SIGN OLD TAMIL SHORT E..BRAHMI VOWEL SIGN OLD TAMIL SHORT O
-	{runeRange{0x11075, 0x11075}, propertyGeneralCategory{lbprAL, gcLo}},   //         BRAHMI LETTER OLD TAMIL LLA
-	{runeRange{0x1107F, 0x1107F}, propertyGeneralCategory{lbprCM, gcMn}},   //         BRAHMI NUMBER JOINER
-	{runeRange{0x11080, 0x11081}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] KAITHI SIGN CANDRABINDU..KAITHI SIGN ANUSVARA
-	{runeRange{0x11082, 0x11082}, propertyGeneralCategory{lbprCM, gcMc}},   //         KAITHI SIGN VISARGA
-	{runeRange{0x11083, 0x110AF}, propertyGeneralCategory{lbprAL, gcLo}},   //    [45] KAITHI LETTER A..KAITHI LETTER HA
-	{runeRange{0x110B0, 0x110B2}, propertyGeneralCategory{lbprCM, gcMc}},   //     [3] KAITHI VOWEL SIGN AA..KAITHI VOWEL SIGN II
-	{runeRange{0x110B3, 0x110B6}, propertyGeneralCategory{lbprCM, gcMn}},   //     [4] KAITHI VOWEL SIGN U..KAITHI VOWEL SIGN AI
-	{runeRange{0x110B7, 0x110B8}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] KAITHI VOWEL SIGN O..KAITHI VOWEL SIGN AU
-	{runeRange{0x110B9, 0x110BA}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] KAITHI SIGN VIRAMA..KAITHI SIGN NUKTA
-	{runeRange{0x110BB, 0x110BC}, propertyGeneralCategory{lbprAL, gcPo}},   //     [2] KAITHI ABBREVIATION SIGN..KAITHI ENUMERATION SIGN
-	{runeRange{0x110BD, 0x110BD}, propertyGeneralCategory{lbprAL, gcCf}},   //         KAITHI NUMBER SIGN
-	{runeRange{0x110BE, 0x110C1}, propertyGeneralCategory{lbprBA, gcPo}},   //     [4] KAITHI SECTION MARK..KAITHI DOUBLE DANDA
-	{runeRange{0x110C2, 0x110C2}, propertyGeneralCategory{lbprCM, gcMn}},   //         KAITHI VOWEL SIGN VOCALIC R
-	{runeRange{0x110CD, 0x110CD}, propertyGeneralCategory{lbprAL, gcCf}},   //         KAITHI NUMBER SIGN ABOVE
-	{runeRange{0x110D0, 0x110E8}, propertyGeneralCategory{lbprAL, gcLo}},   //    [25] SORA SOMPENG LETTER SAH..SORA SOMPENG LETTER MAE
-	{runeRange{0x110F0, 0x110F9}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] SORA SOMPENG DIGIT ZERO..SORA SOMPENG DIGIT NINE
-	{runeRange{0x11100, 0x11102}, propertyGeneralCategory{lbprCM, gcMn}},   //     [3] CHAKMA SIGN CANDRABINDU..CHAKMA SIGN VISARGA
-	{runeRange{0x11103, 0x11126}, propertyGeneralCategory{lbprAL, gcLo}},   //    [36] CHAKMA LETTER AA..CHAKMA LETTER HAA
-	{runeRange{0x11127, 0x1112B}, propertyGeneralCategory{lbprCM, gcMn}},   //     [5] CHAKMA VOWEL SIGN A..CHAKMA VOWEL SIGN UU
-	{runeRange{0x1112C, 0x1112C}, propertyGeneralCategory{lbprCM, gcMc}},   //         CHAKMA VOWEL SIGN E
-	{runeRange{0x1112D, 0x11134}, propertyGeneralCategory{lbprCM, gcMn}},   //     [8] CHAKMA VOWEL SIGN AI..CHAKMA MAAYYAA
-	{runeRange{0x11136, 0x1113F}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] CHAKMA DIGIT ZERO..CHAKMA DIGIT NINE
-	{runeRange{0x11140, 0x11143}, propertyGeneralCategory{lbprBA, gcPo}},   //     [4] CHAKMA SECTION MARK..CHAKMA QUESTION MARK
-	{runeRange{0x11144, 0x11144}, propertyGeneralCategory{lbprAL, gcLo}},   //         CHAKMA LETTER LHAA
-	{runeRange{0x11145, 0x11146}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] CHAKMA VOWEL SIGN AA..CHAKMA VOWEL SIGN EI
-	{runeRange{0x11147, 0x11147}, propertyGeneralCategory{lbprAL, gcLo}},   //         CHAKMA LETTER VAA
-	{runeRange{0x11150, 0x11172}, propertyGeneralCategory{lbprAL, gcLo}},   //    [35] MAHAJANI LETTER A..MAHAJANI LETTER RRA
-	{runeRange{0x11173, 0x11173}, propertyGeneralCategory{lbprCM, gcMn}},   //         MAHAJANI SIGN NUKTA
-	{runeRange{0x11174, 0x11174}, propertyGeneralCategory{lbprAL, gcPo}},   //         MAHAJANI ABBREVIATION SIGN
-	{runeRange{0x11175, 0x11175}, propertyGeneralCategory{lbprBB, gcPo}},   //         MAHAJANI SECTION MARK
-	{runeRange{0x11176, 0x11176}, propertyGeneralCategory{lbprAL, gcLo}},   //         MAHAJANI LIGATURE SHRI
-	{runeRange{0x11180, 0x11181}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] SHARADA SIGN CANDRABINDU..SHARADA SIGN ANUSVARA
-	{runeRange{0x11182, 0x11182}, propertyGeneralCategory{lbprCM, gcMc}},   //         SHARADA SIGN VISARGA
-	{runeRange{0x11183, 0x111B2}, propertyGeneralCategory{lbprAL, gcLo}},   //    [48] SHARADA LETTER A..SHARADA LETTER HA
-	{runeRange{0x111B3, 0x111B5}, propertyGeneralCategory{lbprCM, gcMc}},   //     [3] SHARADA VOWEL SIGN AA..SHARADA VOWEL SIGN II
-	{runeRange{0x111B6, 0x111BE}, propertyGeneralCategory{lbprCM, gcMn}},   //     [9] SHARADA VOWEL SIGN U..SHARADA VOWEL SIGN O
-	{runeRange{0x111BF, 0x111C0}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] SHARADA VOWEL SIGN AU..SHARADA SIGN VIRAMA
-	{runeRange{0x111C1, 0x111C4}, propertyGeneralCategory{lbprAL, gcLo}},   //     [4] SHARADA SIGN AVAGRAHA..SHARADA OM
-	{runeRange{0x111C5, 0x111C6}, propertyGeneralCategory{lbprBA, gcPo}},   //     [2] SHARADA DANDA..SHARADA DOUBLE DANDA
-	{runeRange{0x111C7, 0x111C7}, propertyGeneralCategory{lbprAL, gcPo}},   //         SHARADA ABBREVIATION SIGN
-	{runeRange{0x111C8, 0x111C8}, propertyGeneralCategory{lbprBA, gcPo}},   //         SHARADA SEPARATOR
-	{runeRange{0x111C9, 0x111CC}, propertyGeneralCategory{lbprCM, gcMn}},   //     [4] SHARADA SANDHI MARK..SHARADA EXTRA SHORT VOWEL MARK
-	{runeRange{0x111CD, 0x111CD}, propertyGeneralCategory{lbprAL, gcPo}},   //         SHARADA SUTRA MARK
-	{runeRange{0x111CE, 0x111CE}, propertyGeneralCategory{lbprCM, gcMc}},   //         SHARADA VOWEL SIGN PRISHTHAMATRA E
-	{runeRange{0x111CF, 0x111CF}, propertyGeneralCategory{lbprCM, gcMn}},   //         SHARADA SIGN INVERTED CANDRABINDU
-	{runeRange{0x111D0, 0x111D9}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] SHARADA DIGIT ZERO..SHARADA DIGIT NINE
-	{runeRange{0x111DA, 0x111DA}, propertyGeneralCategory{lbprAL, gcLo}},   //         SHARADA EKAM
-	{runeRange{0x111DB, 0x111DB}, propertyGeneralCategory{lbprBB, gcPo}},   //         SHARADA SIGN SIDDHAM
-	{runeRange{0x111DC, 0x111DC}, propertyGeneralCategory{lbprAL, gcLo}},   //         SHARADA HEADSTROKE
-	{runeRange{0x111DD, 0x111DF}, propertyGeneralCategory{lbprBA, gcPo}},   //     [3] SHARADA CONTINUATION SIGN..SHARADA SECTION MARK-2
-	{runeRange{0x111E1, 0x111F4}, propertyGeneralCategory{lbprAL, gcNo}},   //    [20] SINHALA ARCHAIC DIGIT ONE..SINHALA ARCHAIC NUMBER ONE THOUSAND
-	{runeRange{0x11200, 0x11211}, propertyGeneralCategory{lbprAL, gcLo}},   //    [18] KHOJKI LETTER A..KHOJKI LETTER JJA
-	{runeRange{0x11213, 0x1122B}, propertyGeneralCategory{lbprAL, gcLo}},   //    [25] KHOJKI LETTER NYA..KHOJKI LETTER LLA
-	{runeRange{0x1122C, 0x1122E}, propertyGeneralCategory{lbprCM, gcMc}},   //     [3] KHOJKI VOWEL SIGN AA..KHOJKI VOWEL SIGN II
-	{runeRange{0x1122F, 0x11231}, propertyGeneralCategory{lbprCM, gcMn}},   //     [3] KHOJKI VOWEL SIGN U..KHOJKI VOWEL SIGN AI
-	{runeRange{0x11232, 0x11233}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] KHOJKI VOWEL SIGN O..KHOJKI VOWEL SIGN AU
-	{runeRange{0x11234, 0x11234}, propertyGeneralCategory{lbprCM, gcMn}},   //         KHOJKI SIGN ANUSVARA
-	{runeRange{0x11235, 0x11235}, propertyGeneralCategory{lbprCM, gcMc}},   //         KHOJKI SIGN VIRAMA
-	{runeRange{0x11236, 0x11237}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] KHOJKI SIGN NUKTA..KHOJKI SIGN SHADDA
-	{runeRange{0x11238, 0x11239}, propertyGeneralCategory{lbprBA, gcPo}},   //     [2] KHOJKI DANDA..KHOJKI DOUBLE DANDA
-	{runeRange{0x1123A, 0x1123A}, propertyGeneralCategory{lbprAL, gcPo}},   //         KHOJKI WORD SEPARATOR
-	{runeRange{0x1123B, 0x1123C}, propertyGeneralCategory{lbprBA, gcPo}},   //     [2] KHOJKI SECTION MARK..KHOJKI DOUBLE SECTION MARK
-	{runeRange{0x1123D, 0x1123D}, propertyGeneralCategory{lbprAL, gcPo}},   //         KHOJKI ABBREVIATION SIGN
-	{runeRange{0x1123E, 0x1123E}, propertyGeneralCategory{lbprCM, gcMn}},   //         KHOJKI SIGN SUKUN
-	{runeRange{0x1123F, 0x11240}, propertyGeneralCategory{lbprAL, gcLo}},   //     [2] KHOJKI LETTER QA..KHOJKI LETTER SHORT I
-	{runeRange{0x11241, 0x11241}, propertyGeneralCategory{lbprCM, gcMn}},   //         KHOJKI VOWEL SIGN VOCALIC R
-	{runeRange{0x11280, 0x11286}, propertyGeneralCategory{lbprAL, gcLo}},   //     [7] MULTANI LETTER A..MULTANI LETTER GA
-	{runeRange{0x11288, 0x11288}, propertyGeneralCategory{lbprAL, gcLo}},   //         MULTANI LETTER GHA
-	{runeRange{0x1128A, 0x1128D}, propertyGeneralCategory{lbprAL, gcLo}},   //     [4] MULTANI LETTER CA..MULTANI LETTER JJA
-	{runeRange{0x1128F, 0x1129D}, propertyGeneralCategory{lbprAL, gcLo}},   //    [15] MULTANI LETTER NYA..MULTANI LETTER BA
-	{runeRange{0x1129F, 0x112A8}, propertyGeneralCategory{lbprAL, gcLo}},   //    [10] MULTANI LETTER BHA..MULTANI LETTER RHA
-	{runeRange{0x112A9, 0x112A9}, propertyGeneralCategory{lbprBA, gcPo}},   //         MULTANI SECTION MARK
-	{runeRange{0x112B0, 0x112DE}, propertyGeneralCategory{lbprAL, gcLo}},   //    [47] KHUDAWADI LETTER A..KHUDAWADI LETTER HA
-	{runeRange{0x112DF, 0x112DF}, propertyGeneralCategory{lbprCM, gcMn}},   //         KHUDAWADI SIGN ANUSVARA
-	{runeRange{0x112E0, 0x112E2}, propertyGeneralCategory{lbprCM, gcMc}},   //     [3] KHUDAWADI VOWEL SIGN AA..KHUDAWADI VOWEL SIGN II
-	{runeRange{0x112E3, 0x112EA}, propertyGeneralCategory{lbprCM, gcMn}},   //     [8] KHUDAWADI VOWEL SIGN U..KHUDAWADI SIGN VIRAMA
-	{runeRange{0x112F0, 0x112F9}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] KHUDAWADI DIGIT ZERO..KHUDAWADI DIGIT NINE
-	{runeRange{0x11300, 0x11301}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] GRANTHA SIGN COMBINING ANUSVARA ABOVE..GRANTHA SIGN CANDRABINDU
-	{runeRange{0x11302, 0x11303}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] GRANTHA SIGN ANUSVARA..GRANTHA SIGN VISARGA
-	{runeRange{0x11305, 0x1130C}, propertyGeneralCategory{lbprAL, gcLo}},   //     [8] GRANTHA LETTER A..GRANTHA LETTER VOCALIC L
-	{runeRange{0x1130F, 0x11310}, propertyGeneralCategory{lbprAL, gcLo}},   //     [2] GRANTHA LETTER EE..GRANTHA LETTER AI
-	{runeRange{0x11313, 0x11328}, propertyGeneralCategory{lbprAL, gcLo}},   //    [22] GRANTHA LETTER OO..GRANTHA LETTER NA
-	{runeRange{0x1132A, 0x11330}, propertyGeneralCategory{lbprAL, gcLo}},   //     [7] GRANTHA LETTER PA..GRANTHA LETTER RA
-	{runeRange{0x11332, 0x11333}, propertyGeneralCategory{lbprAL, gcLo}},   //     [2] GRANTHA LETTER LA..GRANTHA LETTER LLA
-	{runeRange{0x11335, 0x11339}, propertyGeneralCategory{lbprAL, gcLo}},   //     [5] GRANTHA LETTER VA..GRANTHA LETTER HA
-	{runeRange{0x1133B, 0x1133C}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] COMBINING BINDU BELOW..GRANTHA SIGN NUKTA
-	{runeRange{0x1133D, 0x1133D}, propertyGeneralCategory{lbprAL, gcLo}},   //         GRANTHA SIGN AVAGRAHA
-	{runeRange{0x1133E, 0x1133F}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] GRANTHA VOWEL SIGN AA..GRANTHA VOWEL SIGN I
-	{runeRange{0x11340, 0x11340}, propertyGeneralCategory{lbprCM, gcMn}},   //         GRANTHA VOWEL SIGN II
-	{runeRange{0x11341, 0x11344}, propertyGeneralCategory{lbprCM, gcMc}},   //     [4] GRANTHA VOWEL SIGN U..GRANTHA VOWEL SIGN VOCALIC RR
-	{runeRange{0x11347, 0x11348}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] GRANTHA VOWEL SIGN EE..GRANTHA VOWEL SIGN AI
-	{runeRange{0x1134B, 0x1134D}, propertyGeneralCategory{lbprCM, gcMc}},   //     [3] GRANTHA VOWEL SIGN OO..GRANTHA SIGN VIRAMA
-	{runeRange{0x11350, 0x11350}, propertyGeneralCategory{lbprAL, gcLo}},   //         GRANTHA OM
-	{runeRange{0x11357, 0x11357}, propertyGeneralCategory{lbprCM, gcMc}},   //         GRANTHA AU LENGTH MARK
-	{runeRange{0x1135D, 0x11361}, propertyGeneralCategory{lbprAL, gcLo}},   //     [5] GRANTHA SIGN PLUTA..GRANTHA LETTER VOCALIC LL
-	{runeRange{0x11362, 0x11363}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] GRANTHA VOWEL SIGN VOCALIC L..GRANTHA VOWEL SIGN VOCALIC LL
-	{runeRange{0x11366, 0x1136C}, propertyGeneralCategory{lbprCM, gcMn}},   //     [7] COMBINING GRANTHA DIGIT ZERO..COMBINING GRANTHA DIGIT SIX
-	{runeRange{0x11370, 0x11374}, propertyGeneralCategory{lbprCM, gcMn}},   //     [5] COMBINING GRANTHA LETTER A..COMBINING GRANTHA LETTER PA
-	{runeRange{0x11400, 0x11434}, propertyGeneralCategory{lbprAL, gcLo}},   //    [53] NEWA LETTER A..NEWA LETTER HA
-	{runeRange{0x11435, 0x11437}, propertyGeneralCategory{lbprCM, gcMc}},   //     [3] NEWA VOWEL SIGN AA..NEWA VOWEL SIGN II
-	{runeRange{0x11438, 0x1143F}, propertyGeneralCategory{lbprCM, gcMn}},   //     [8] NEWA VOWEL SIGN U..NEWA VOWEL SIGN AI
-	{runeRange{0x11440, 0x11441}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] NEWA VOWEL SIGN O..NEWA VOWEL SIGN AU
-	{runeRange{0x11442, 0x11444}, propertyGeneralCategory{lbprCM, gcMn}},   //     [3] NEWA SIGN VIRAMA..NEWA SIGN ANUSVARA
-	{runeRange{0x11445, 0x11445}, propertyGeneralCategory{lbprCM, gcMc}},   //         NEWA SIGN VISARGA
-	{runeRange{0x11446, 0x11446}, propertyGeneralCategory{lbprCM, gcMn}},   //         NEWA SIGN NUKTA
-	{runeRange{0x11447, 0x1144A}, propertyGeneralCategory{lbprAL, gcLo}},   //     [4] NEWA SIGN AVAGRAHA..NEWA SIDDHI
-	{runeRange{0x1144B, 0x1144E}, propertyGeneralCategory{lbprBA, gcPo}},   //     [4] NEWA DANDA..NEWA GAP FILLER
-	{runeRange{0x1144F, 0x1144F}, propertyGeneralCategory{lbprAL, gcPo}},   //         NEWA ABBREVIATION SIGN
-	{runeRange{0x11450, 0x11459}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] NEWA DIGIT ZERO..NEWA DIGIT NINE
-	{runeRange{0x1145A, 0x1145B}, propertyGeneralCategory{lbprBA, gcPo}},   //     [2] NEWA DOUBLE COMMA..NEWA PLACEHOLDER MARK
-	{runeRange{0x1145D, 0x1145D}, propertyGeneralCategory{lbprAL, gcPo}},   //         NEWA INSERTION SIGN
-	{runeRange{0x1145E, 0x1145E}, propertyGeneralCategory{lbprCM, gcMn}},   //         NEWA SANDHI MARK
-	{runeRange{0x1145F, 0x11461}, propertyGeneralCategory{lbprAL, gcLo}},   //     [3] NEWA LETTER VEDIC ANUSVARA..NEWA SIGN UPADHMANIYA
-	{runeRange{0x11480, 0x114AF}, propertyGeneralCategory{lbprAL, gcLo}},   //    [48] TIRHUTA ANJI..TIRHUTA LETTER HA
-	{runeRange{0x114B0, 0x114B2}, propertyGeneralCategory{lbprCM, gcMc}},   //     [3] TIRHUTA VOWEL SIGN AA..TIRHUTA VOWEL SIGN II
-	{runeRange{0x114B3, 0x114B8}, propertyGeneralCategory{lbprCM, gcMn}},   //     [6] TIRHUTA VOWEL SIGN U..TIRHUTA VOWEL SIGN VOCALIC LL
-	{runeRange{0x114B9, 0x114B9}, propertyGeneralCategory{lbprCM, gcMc}},   //         TIRHUTA VOWEL SIGN E
-	{runeRange{0x114BA, 0x114BA}, propertyGeneralCategory{lbprCM, gcMn}},   //         TIRHUTA VOWEL SIGN SHORT E
-	{runeRange{0x114BB, 0x114BE}, propertyGeneralCategory{lbprCM, gcMc}},   //     [4] TIRHUTA VOWEL SIGN AI..TIRHUTA VOWEL SIGN AU
-	{runeRange{0x114BF, 0x114C0}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] TIRHUTA SIGN CANDRABINDU..TIRHUTA SIGN ANUSVARA
-	{runeRange{0x114C1, 0x114C1}, propertyGeneralCategory{lbprCM, gcMc}},   //         TIRHUTA SIGN VISARGA
-	{runeRange{0x114C2, 0x114C3}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] TIRHUTA SIGN VIRAMA..TIRHUTA SIGN NUKTA
-	{runeRange{0x114C4, 0x114C5}, propertyGeneralCategory{lbprAL, gcLo}},   //     [2] TIRHUTA SIGN AVAGRAHA..TIRHUTA GVANG
-	{runeRange{0x114C6, 0x114C6}, propertyGeneralCategory{lbprAL, gcPo}},   //         TIRHUTA ABBREVIATION SIGN
-	{runeRange{0x114C7, 0x114C7}, propertyGeneralCategory{lbprAL, gcLo}},   //         TIRHUTA OM
-	{runeRange{0x114D0, 0x114D9}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] TIRHUTA DIGIT ZERO..TIRHUTA DIGIT NINE
-	{runeRange{0x11580, 0x115AE}, propertyGeneralCategory{lbprAL, gcLo}},   //    [47] SIDDHAM LETTER A..SIDDHAM LETTER HA
-	{runeRange{0x115AF, 0x115B1}, propertyGeneralCategory{lbprCM, gcMc}},   //     [3] SIDDHAM VOWEL SIGN AA..SIDDHAM VOWEL SIGN II
-	{runeRange{0x115B2, 0x115B5}, propertyGeneralCategory{lbprCM, gcMn}},   //     [4] SIDDHAM VOWEL SIGN U..SIDDHAM VOWEL SIGN VOCALIC RR
-	{runeRange{0x115B8, 0x115BB}, propertyGeneralCategory{lbprCM, gcMc}},   //     [4] SIDDHAM VOWEL SIGN E..SIDDHAM VOWEL SIGN AU
-	{runeRange{0x115BC, 0x115BD}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] SIDDHAM SIGN CANDRABINDU..SIDDHAM SIGN ANUSVARA
-	{runeRange{0x115BE, 0x115BE}, propertyGeneralCategory{lbprCM, gcMc}},   //         SIDDHAM SIGN VISARGA
-	{runeRange{0x115BF, 0x115C0}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] SIDDHAM SIGN VIRAMA..SIDDHAM SIGN NUKTA
-	{runeRange{0x115C1, 0x115C1}, propertyGeneralCategory{lbprBB, gcPo}},   //         SIDDHAM SIGN SIDDHAM
-	{runeRange{0x115C2, 0x115C3}, propertyGeneralCategory{lbprBA, gcPo}},   //     [2] SIDDHAM DANDA..SIDDHAM DOUBLE DANDA
-	{runeRange{0x115C4, 0x115C5}, propertyGeneralCategory{lbprEX, gcPo}},   //     [2] SIDDHAM SEPARATOR DOT..SIDDHAM SEPARATOR BAR
-	{runeRange{0x115C6, 0x115C8}, propertyGeneralCategory{lbprAL, gcPo}},   //     [3] SIDDHAM REPETITION MARK-1..SIDDHAM REPETITION MARK-3
-	{runeRange{0x115C9, 0x115D7}, propertyGeneralCategory{lbprBA, gcPo}},   //    [15] SIDDHAM END OF TEXT MARK..SIDDHAM SECTION MARK WITH CIRCLES AND FOUR ENCLOSURES
-	{runeRange{0x115D8, 0x115DB}, propertyGeneralCategory{lbprAL, gcLo}},   //     [4] SIDDHAM LETTER THREE-CIRCLE ALTERNATE I..SIDDHAM LETTER ALTERNATE U
-	{runeRange{0x115DC, 0x115DD}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] SIDDHAM VOWEL SIGN ALTERNATE U..SIDDHAM VOWEL SIGN ALTERNATE UU
-	{runeRange{0x11600, 0x1162F}, propertyGeneralCategory{lbprAL, gcLo}},   //    [48] MODI LETTER A..MODI LETTER LLA
-	{runeRange{0x11630, 0x11632}, propertyGeneralCategory{lbprCM, gcMc}},   //     [3] MODI VOWEL SIGN AA..MODI VOWEL SIGN II
-	{runeRange{0x11633, 0x1163A}, propertyGeneralCategory{lbprCM, gcMn}},   //     [8] MODI VOWEL SIGN U..MODI VOWEL SIGN AI
-	{runeRange{0x1163B, 0x1163C}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] MODI VOWEL SIGN O..MODI VOWEL SIGN AU
-	{runeRange{0x1163D, 0x1163D}, propertyGeneralCategory{lbprCM, gcMn}},   //         MODI SIGN ANUSVARA
-	{runeRange{0x1163E, 0x1163E}, propertyGeneralCategory{lbprCM, gcMc}},   //         MODI SIGN VISARGA
-	{runeRange{0x1163F, 0x11640}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] MODI SIGN VIRAMA..MODI SIGN ARDHACANDRA
-	{runeRange{0x11641, 0x11642}, propertyGeneralCategory{lbprBA, gcPo}},   //     [2] MODI DANDA..MODI DOUBLE DANDA
-	{runeRange{0x11643, 0x11643}, propertyGeneralCategory{lbprAL, gcPo}},   //         MODI ABBREVIATION SIGN
-	{runeRange{0x11644, 0x11644}, propertyGeneralCategory{lbprAL, gcLo}},   //         MODI SIGN HUVA
-	{runeRange{0x11650, 0x11659}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] MODI DIGIT ZERO..MODI DIGIT NINE
-	{runeRange{0x11660, 0x1166C}, propertyGeneralCategory{lbprBB, gcPo}},   //    [13] MONGOLIAN BIRGA WITH ORNAMENT..MONGOLIAN TURNED SWIRL BIRGA WITH DOUBLE ORNAMENT
-	{runeRange{0x11680, 0x116AA}, propertyGeneralCategory{lbprAL, gcLo}},   //    [43] TAKRI LETTER A..TAKRI LETTER RRA
-	{runeRange{0x116AB, 0x116AB}, propertyGeneralCategory{lbprCM, gcMn}},   //         TAKRI SIGN ANUSVARA
-	{runeRange{0x116AC, 0x116AC}, propertyGeneralCategory{lbprCM, gcMc}},   //         TAKRI SIGN VISARGA
-	{runeRange{0x116AD, 0x116AD}, propertyGeneralCategory{lbprCM, gcMn}},   //         TAKRI VOWEL SIGN AA
-	{runeRange{0x116AE, 0x116AF}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] TAKRI VOWEL SIGN I..TAKRI VOWEL SIGN II
-	{runeRange{0x116B0, 0x116B5}, propertyGeneralCategory{lbprCM, gcMn}},   //     [6] TAKRI VOWEL SIGN U..TAKRI VOWEL SIGN AU
-	{runeRange{0x116B6, 0x116B6}, propertyGeneralCategory{lbprCM, gcMc}},   //         TAKRI SIGN VIRAMA
-	{runeRange{0x116B7, 0x116B7}, propertyGeneralCategory{lbprCM, gcMn}},   //         TAKRI SIGN NUKTA
-	{runeRange{0x116B8, 0x116B8}, propertyGeneralCategory{lbprAL, gcLo}},   //         TAKRI LETTER ARCHAIC KHA
-	{runeRange{0x116B9, 0x116B9}, propertyGeneralCategory{lbprAL, gcPo}},   //         TAKRI ABBREVIATION SIGN
-	{runeRange{0x116C0, 0x116C9}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] TAKRI DIGIT ZERO..TAKRI DIGIT NINE
-	{runeRange{0x11700, 0x1171A}, propertyGeneralCategory{lbprSA, gcLo}},   //    [27] AHOM LETTER KA..AHOM LETTER ALTERNATE BA
-	{runeRange{0x1171D, 0x1171F}, propertyGeneralCategory{lbprSA, gcMn}},   //     [3] AHOM CONSONANT SIGN MEDIAL LA..AHOM CONSONANT SIGN MEDIAL LIGATING RA
-	{runeRange{0x11720, 0x11721}, propertyGeneralCategory{lbprSA, gcMc}},   //     [2] AHOM VOWEL SIGN A..AHOM VOWEL SIGN AA
-	{runeRange{0x11722, 0x11725}, propertyGeneralCategory{lbprSA, gcMn}},   //     [4] AHOM VOWEL SIGN I..AHOM VOWEL SIGN UU
-	{runeRange{0x11726, 0x11726}, propertyGeneralCategory{lbprSA, gcMc}},   //         AHOM VOWEL SIGN E
-	{runeRange{0x11727, 0x1172B}, propertyGeneralCategory{lbprSA, gcMn}},   //     [5] AHOM VOWEL SIGN AW..AHOM SIGN KILLER
-	{runeRange{0x11730, 0x11739}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] AHOM DIGIT ZERO..AHOM DIGIT NINE
-	{runeRange{0x1173A, 0x1173B}, propertyGeneralCategory{lbprSA, gcNo}},   //     [2] AHOM NUMBER TEN..AHOM NUMBER TWENTY
-	{runeRange{0x1173C, 0x1173E}, propertyGeneralCategory{lbprBA, gcPo}},   //     [3] AHOM SIGN SMALL SECTION..AHOM SIGN RULAI
-	{runeRange{0x1173F, 0x1173F}, propertyGeneralCategory{lbprSA, gcSo}},   //         AHOM SYMBOL VI
-	{runeRange{0x11740, 0x11746}, propertyGeneralCategory{lbprSA, gcLo}},   //     [7] AHOM LETTER CA..AHOM LETTER LLA
-	{runeRange{0x11800, 0x1182B}, propertyGeneralCategory{lbprAL, gcLo}},   //    [44] DOGRA LETTER A..DOGRA LETTER RRA
-	{runeRange{0x1182C, 0x1182E}, propertyGeneralCategory{lbprCM, gcMc}},   //     [3] DOGRA VOWEL SIGN AA..DOGRA VOWEL SIGN II
-	{runeRange{0x1182F, 0x11837}, propertyGeneralCategory{lbprCM, gcMn}},   //     [9] DOGRA VOWEL SIGN U..DOGRA SIGN ANUSVARA
-	{runeRange{0x11838, 0x11838}, propertyGeneralCategory{lbprCM, gcMc}},   //         DOGRA SIGN VISARGA
-	{runeRange{0x11839, 0x1183A}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] DOGRA SIGN VIRAMA..DOGRA SIGN NUKTA
-	{runeRange{0x1183B, 0x1183B}, propertyGeneralCategory{lbprAL, gcPo}},   //         DOGRA ABBREVIATION SIGN
-	{runeRange{0x118A0, 0x118DF}, propertyGeneralCategory{lbprAL, gcLC}},   //    [64] WARANG CITI CAPITAL LETTER NGAA..WARANG CITI SMALL LETTER VIYO
-	{runeRange{0x118E0, 0x118E9}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] WARANG CITI DIGIT ZERO..WARANG CITI DIGIT NINE
-	{runeRange{0x118EA, 0x118F2}, propertyGeneralCategory{lbprAL, gcNo}},   //     [9] WARANG CITI NUMBER TEN..WARANG CITI NUMBER NINETY
-	{runeRange{0x118FF, 0x118FF}, propertyGeneralCategory{lbprAL, gcLo}},   //         WARANG CITI OM
-	{runeRange{0x11900, 0x11906}, propertyGeneralCategory{lbprAL, gcLo}},   //     [7] DIVES AKURU LETTER A..DIVES AKURU LETTER E
-	{runeRange{0x11909, 0x11909}, propertyGeneralCategory{lbprAL, gcLo}},   //         DIVES AKURU LETTER O
-	{runeRange{0x1190C, 0x11913}, propertyGeneralCategory{lbprAL, gcLo}},   //     [8] DIVES AKURU LETTER KA..DIVES AKURU LETTER JA
-	{runeRange{0x11915, 0x11916}, propertyGeneralCategory{lbprAL, gcLo}},   //     [2] DIVES AKURU LETTER NYA..DIVES AKURU LETTER TTA
-	{runeRange{0x11918, 0x1192F}, propertyGeneralCategory{lbprAL, gcLo}},   //    [24] DIVES AKURU LETTER DDA..DIVES AKURU LETTER ZA
-	{runeRange{0x11930, 0x11935}, propertyGeneralCategory{lbprCM, gcMc}},   //     [6] DIVES AKURU VOWEL SIGN AA..DIVES AKURU VOWEL SIGN E
-	{runeRange{0x11937, 0x11938}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] DIVES AKURU VOWEL SIGN AI..DIVES AKURU VOWEL SIGN O
-	{runeRange{0x1193B, 0x1193C}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] DIVES AKURU SIGN ANUSVARA..DIVES AKURU SIGN CANDRABINDU
-	{runeRange{0x1193D, 0x1193D}, propertyGeneralCategory{lbprCM, gcMc}},   //         DIVES AKURU SIGN HALANTA
-	{runeRange{0x1193E, 0x1193E}, propertyGeneralCategory{lbprCM, gcMn}},   //         DIVES AKURU VIRAMA
-	{runeRange{0x1193F, 0x1193F}, propertyGeneralCategory{lbprAL, gcLo}},   //         DIVES AKURU PREFIXED NASAL SIGN
-	{runeRange{0x11940, 0x11940}, propertyGeneralCategory{lbprCM, gcMc}},   //         DIVES AKURU MEDIAL YA
-	{runeRange{0x11941, 0x11941}, propertyGeneralCategory{lbprAL, gcLo}},   //         DIVES AKURU INITIAL RA
-	{runeRange{0x11942, 0x11942}, propertyGeneralCategory{lbprCM, gcMc}},   //         DIVES AKURU MEDIAL RA
-	{runeRange{0x11943, 0x11943}, propertyGeneralCategory{lbprCM, gcMn}},   //         DIVES AKURU SIGN NUKTA
-	{runeRange{0x11944, 0x11946}, propertyGeneralCategory{lbprBA, gcPo}},   //     [3] DIVES AKURU DOUBLE DANDA..DIVES AKURU END OF TEXT MARK
-	{runeRange{0x11950, 0x11959}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] DIVES AKURU DIGIT ZERO..DIVES AKURU DIGIT NINE
-	{runeRange{0x119A0, 0x119A7}, propertyGeneralCategory{lbprAL, gcLo}},   //     [8] NANDINAGARI LETTER A..NANDINAGARI LETTER VOCALIC RR
-	{runeRange{0x119AA, 0x119D0}, propertyGeneralCategory{lbprAL, gcLo}},   //    [39] NANDINAGARI LETTER E..NANDINAGARI LETTER RRA
-	{runeRange{0x119D1, 0x119D3}, propertyGeneralCategory{lbprCM, gcMc}},   //     [3] NANDINAGARI VOWEL SIGN AA..NANDINAGARI VOWEL SIGN II
-	{runeRange{0x119D4, 0x119D7}, propertyGeneralCategory{lbprCM, gcMn}},   //     [4] NANDINAGARI VOWEL SIGN U..NANDINAGARI VOWEL SIGN VOCALIC RR
-	{runeRange{0x119DA, 0x119DB}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] NANDINAGARI VOWEL SIGN E..NANDINAGARI VOWEL SIGN AI
-	{runeRange{0x119DC, 0x119DF}, propertyGeneralCategory{lbprCM, gcMc}},   //     [4] NANDINAGARI VOWEL SIGN O..NANDINAGARI SIGN VISARGA
-	{runeRange{0x119E0, 0x119E0}, propertyGeneralCategory{lbprCM, gcMn}},   //         NANDINAGARI SIGN VIRAMA
-	{runeRange{0x119E1, 0x119E1}, propertyGeneralCategory{lbprAL, gcLo}},   //         NANDINAGARI SIGN AVAGRAHA
-	{runeRange{0x119E2, 0x119E2}, propertyGeneralCategory{lbprBB, gcPo}},   //         NANDINAGARI SIGN SIDDHAM
-	{runeRange{0x119E3, 0x119E3}, propertyGeneralCategory{lbprAL, gcLo}},   //         NANDINAGARI HEADSTROKE
-	{runeRange{0x119E4, 0x119E4}, propertyGeneralCategory{lbprCM, gcMc}},   //         NANDINAGARI VOWEL SIGN PRISHTHAMATRA E
-	{runeRange{0x11A00, 0x11A00}, propertyGeneralCategory{lbprAL, gcLo}},   //         ZANABAZAR SQUARE LETTER A
-	{runeRange{0x11A01, 0x11A0A}, propertyGeneralCategory{lbprCM, gcMn}},   //    [10] ZANABAZAR SQUARE VOWEL SIGN I..ZANABAZAR SQUARE VOWEL LENGTH MARK
-	{runeRange{0x11A0B, 0x11A32}, propertyGeneralCategory{lbprAL, gcLo}},   //    [40] ZANABAZAR SQUARE LETTER KA..ZANABAZAR SQUARE LETTER KSSA
-	{runeRange{0x11A33, 0x11A38}, propertyGeneralCategory{lbprCM, gcMn}},   //     [6] ZANABAZAR SQUARE FINAL CONSONANT MARK..ZANABAZAR SQUARE SIGN ANUSVARA
-	{runeRange{0x11A39, 0x11A39}, propertyGeneralCategory{lbprCM, gcMc}},   //         ZANABAZAR SQUARE SIGN VISARGA
-	{runeRange{0x11A3A, 0x11A3A}, propertyGeneralCategory{lbprAL, gcLo}},   //         ZANABAZAR SQUARE CLUSTER-INITIAL LETTER RA
-	{runeRange{0x11A3B, 0x11A3E}, propertyGeneralCategory{lbprCM, gcMn}},   //     [4] ZANABAZAR SQUARE CLUSTER-FINAL LETTER YA..ZANABAZAR SQUARE CLUSTER-FINAL LETTER VA
-	{runeRange{0x11A3F, 0x11A3F}, propertyGeneralCategory{lbprBB, gcPo}},   //         ZANABAZAR SQUARE INITIAL HEAD MARK
-	{runeRange{0x11A40, 0x11A40}, propertyGeneralCategory{lbprAL, gcPo}},   //         ZANABAZAR SQUARE CLOSING HEAD MARK
-	{runeRange{0x11A41, 0x11A44}, propertyGeneralCategory{lbprBA, gcPo}},   //     [4] ZANABAZAR SQUARE MARK TSHEG..ZANABAZAR SQUARE MARK LONG TSHEG
-	{runeRange{0x11A45, 0x11A45}, propertyGeneralCategory{lbprBB, gcPo}},   //         ZANABAZAR SQUARE INITIAL DOUBLE-LINED HEAD MARK
-	{runeRange{0x11A46, 0x11A46}, propertyGeneralCategory{lbprAL, gcPo}},   //         ZANABAZAR SQUARE CLOSING DOUBLE-LINED HEAD MARK
-	{runeRange{0x11A47, 0x11A47}, propertyGeneralCategory{lbprCM, gcMn}},   //         ZANABAZAR SQUARE SUBJOINER
-	{runeRange{0x11A50, 0x11A50}, propertyGeneralCategory{lbprAL, gcLo}},   //         SOYOMBO LETTER A
-	{runeRange{0x11A51, 0x11A56}, propertyGeneralCategory{lbprCM, gcMn}},   //     [6] SOYOMBO VOWEL SIGN I..SOYOMBO VOWEL SIGN OE
-	{runeRange{0x11A57, 0x11A58}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] SOYOMBO VOWEL SIGN AI..SOYOMBO VOWEL SIGN AU
-	{runeRange{0x11A59, 0x11A5B}, propertyGeneralCategory{lbprCM, gcMn}},   //     [3] SOYOMBO VOWEL SIGN VOCALIC R..SOYOMBO VOWEL LENGTH MARK
-	{runeRange{0x11A5C, 0x11A89}, propertyGeneralCategory{lbprAL, gcLo}},   //    [46] SOYOMBO LETTER KA..SOYOMBO CLUSTER-INITIAL LETTER SA
-	{runeRange{0x11A8A, 0x11A96}, propertyGeneralCategory{lbprCM, gcMn}},   //    [13] SOYOMBO FINAL CONSONANT SIGN G..SOYOMBO SIGN ANUSVARA
-	{runeRange{0x11A97, 0x11A97}, propertyGeneralCategory{lbprCM, gcMc}},   //         SOYOMBO SIGN VISARGA
-	{runeRange{0x11A98, 0x11A99}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] SOYOMBO GEMINATION MARK..SOYOMBO SUBJOINER
-	{runeRange{0x11A9A, 0x11A9C}, propertyGeneralCategory{lbprBA, gcPo}},   //     [3] SOYOMBO MARK TSHEG..SOYOMBO MARK DOUBLE SHAD
-	{runeRange{0x11A9D, 0x11A9D}, propertyGeneralCategory{lbprAL, gcLo}},   //         SOYOMBO MARK PLUTA
-	{runeRange{0x11A9E, 0x11AA0}, propertyGeneralCategory{lbprBB, gcPo}},   //     [3] SOYOMBO HEAD MARK WITH MOON AND SUN AND TRIPLE FLAME..SOYOMBO HEAD MARK WITH MOON AND SUN
-	{runeRange{0x11AA1, 0x11AA2}, propertyGeneralCategory{lbprBA, gcPo}},   //     [2] SOYOMBO TERMINAL MARK-1..SOYOMBO TERMINAL MARK-2
-	{runeRange{0x11AB0, 0x11ABF}, propertyGeneralCategory{lbprAL, gcLo}},   //    [16] CANADIAN SYLLABICS NATTILIK HI..CANADIAN SYLLABICS SPA
-	{runeRange{0x11AC0, 0x11AF8}, propertyGeneralCategory{lbprAL, gcLo}},   //    [57] PAU CIN HAU LETTER PA..PAU CIN HAU GLOTTAL STOP FINAL
-	{runeRange{0x11B00, 0x11B09}, propertyGeneralCategory{lbprBB, gcPo}},   //    [10] DEVANAGARI HEAD MARK..DEVANAGARI SIGN MINDU
-	{runeRange{0x11C00, 0x11C08}, propertyGeneralCategory{lbprAL, gcLo}},   //     [9] BHAIKSUKI LETTER A..BHAIKSUKI LETTER VOCALIC L
-	{runeRange{0x11C0A, 0x11C2E}, propertyGeneralCategory{lbprAL, gcLo}},   //    [37] BHAIKSUKI LETTER E..BHAIKSUKI LETTER HA
-	{runeRange{0x11C2F, 0x11C2F}, propertyGeneralCategory{lbprCM, gcMc}},   //         BHAIKSUKI VOWEL SIGN AA
-	{runeRange{0x11C30, 0x11C36}, propertyGeneralCategory{lbprCM, gcMn}},   //     [7] BHAIKSUKI VOWEL SIGN I..BHAIKSUKI VOWEL SIGN VOCALIC L
-	{runeRange{0x11C38, 0x11C3D}, propertyGeneralCategory{lbprCM, gcMn}},   //     [6] BHAIKSUKI VOWEL SIGN E..BHAIKSUKI SIGN ANUSVARA
-	{runeRange{0x11C3E, 0x11C3E}, propertyGeneralCategory{lbprCM, gcMc}},   //         BHAIKSUKI SIGN VISARGA
-	{runeRange{0x11C3F, 0x11C3F}, propertyGeneralCategory{lbprCM, gcMn}},   //         BHAIKSUKI SIGN VIRAMA
-	{runeRange{0x11C40, 0x11C40}, propertyGeneralCategory{lbprAL, gcLo}},   //         BHAIKSUKI SIGN AVAGRAHA
-	{runeRange{0x11C41, 0x11C45}, propertyGeneralCategory{lbprBA, gcPo}},   //     [5] BHAIKSUKI DANDA..BHAIKSUKI GAP FILLER-2
-	{runeRange{0x11C50, 0x11C59}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] BHAIKSUKI DIGIT ZERO..BHAIKSUKI DIGIT NINE
-	{runeRange{0x11C5A, 0x11C6C}, propertyGeneralCategory{lbprAL, gcNo}},   //    [19] BHAIKSUKI NUMBER ONE..BHAIKSUKI HUNDREDS UNIT MARK
-	{runeRange{0x11C70, 0x11C70}, propertyGeneralCategory{lbprBB, gcPo}},   //         MARCHEN HEAD MARK
-	{runeRange{0x11C71, 0x11C71}, propertyGeneralCategory{lbprEX, gcPo}},   //         MARCHEN MARK SHAD
-	{runeRange{0x11C72, 0x11C8F}, propertyGeneralCategory{lbprAL, gcLo}},   //    [30] MARCHEN LETTER KA..MARCHEN LETTER A
-	{runeRange{0x11C92, 0x11CA7}, propertyGeneralCategory{lbprCM, gcMn}},   //    [22] MARCHEN SUBJOINED LETTER KA..MARCHEN SUBJOINED LETTER ZA
-	{runeRange{0x11CA9, 0x11CA9}, propertyGeneralCategory{lbprCM, gcMc}},   //         MARCHEN SUBJOINED LETTER YA
-	{runeRange{0x11CAA, 0x11CB0}, propertyGeneralCategory{lbprCM, gcMn}},   //     [7] MARCHEN SUBJOINED LETTER RA..MARCHEN VOWEL SIGN AA
+	{runeRange{0x222D, 0x222D}, propertyGeneralCategory{lbprAL, gcSm}},     //         TRIPLE INTEGRAL
 	{runeRange{0x11CB1, 0x11CB1}, propertyGeneralCategory{lbprCM, gcMc}},   //         MARCHEN VOWEL SIGN I
-	{runeRange{0x11CB2, 0x11CB3}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] MARCHEN VOWEL SIGN U..MARCHEN VOWEL SIGN E
-	{runeRange{0x11CB4, 0x11CB4}, propertyGeneralCategory{lbprCM, gcMc}},   //         MARCHEN VOWEL SIGN O
-	{runeRange{0x11CB5, 0x11CB6}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] MARCHEN SIGN ANUSVARA..MARCHEN SIGN CANDRABINDU
-	{runeRange{0x11D00, 0x11D06}, propertyGeneralCategory{lbprAL, gcLo}},   //     [7] MASARAM GONDI LETTER A..MASARAM GONDI LETTER E
-	{runeRange{0x11D08, 0x11D09}, propertyGeneralCategory{lbprAL, gcLo}},   //     [2] MASARAM GONDI LETTER AI..MASARAM GONDI LETTER O
-	{runeRange{0x11D0B, 0x11D30}, propertyGeneralCategory{lbprAL, gcLo}},   //    [38] MASARAM GONDI LETTER AU..MASARAM GONDI LETTER TRA
-	{runeRange{0x11D31, 0x11D36}, propertyGeneralCategory{lbprCM, gcMn}},   //     [6] MASARAM GONDI VOWEL SIGN AA..MASARAM GONDI VOWEL SIGN VOCALIC R
-	{runeRange{0x11D3A, 0x11D3A}, propertyGeneralCategory{lbprCM, gcMn}},   //         MASARAM GONDI VOWEL SIGN E
-	{runeRange{0x11D3C, 0x11D3D}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] MASARAM GONDI VOWEL SIGN AI..MASARAM GONDI VOWEL SIGN O
-	{runeRange{0x11D3F, 0x11D45}, propertyGeneralCategory{lbprCM, gcMn}},   //     [7] MASARAM GONDI VOWEL SIGN AU..MASARAM GONDI VIRAMA
-	{runeRange{0x11D46, 0x11D46}, propertyGeneralCategory{lbprAL, gcLo}},   //         MASARAM GONDI REPHA
-	{runeRange{0x11D47, 0x11D47}, propertyGeneralCategory{lbprCM, gcMn}},   //         MASARAM GONDI RA-KARA
-	{runeRange{0x11D50, 0x11D59}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] MASARAM GONDI DIGIT ZERO..MASARAM GONDI DIGIT NINE
-	{runeRange{0x11D60, 0x11D65}, propertyGeneralCategory{lbprAL, gcLo}},   //     [6] GUNJALA GONDI LETTER A..GUNJALA GONDI LETTER UU
-	{runeRange{0x11D67, 0x11D68}, propertyGeneralCategory{lbprAL, gcLo}},   //     [2] GUNJALA GONDI LETTER EE..GUNJALA GONDI LETTER AI
-	{runeRange{0x11D6A, 0x11D89}, propertyGeneralCategory{lbprAL, gcLo}},   //    [32] GUNJALA GONDI LETTER OO..GUNJALA GONDI LETTER SA
-	{runeRange{0x11D8A, 0x11D8E}, propertyGeneralCategory{lbprCM, gcMc}},   //     [5] GUNJALA GONDI VOWEL SIGN AA..GUNJALA GONDI VOWEL SIGN UU
-	{runeRange{0x11D90, 0x11D91}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] GUNJALA GONDI VOWEL SIGN EE..GUNJALA GONDI VOWEL SIGN AI
-	{runeRange{0x11D93, 0x11D94}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] GUNJALA GONDI VOWEL SIGN OO..GUNJALA GONDI VOWEL SIGN AU
-	{runeRange{0x11D95, 0x11D95}, propertyGeneralCategory{lbprCM, gcMn}},   //         GUNJALA GONDI SIGN ANUSVARA
-	{runeRange{0x11D96, 0x11D96}, propertyGeneralCategory{lbprCM, gcMc}},   //         GUNJALA GONDI SIGN VISARGA
-	{runeRange{0x11D97, 0x11D97}, propertyGeneralCategory{lbprCM, gcMn}},   //         GUNJALA GONDI VIRAMA
-	{runeRange{0x11D98, 0x11D98}, propertyGeneralCategory{lbprAL, gcLo}},   //         GUNJALA GONDI OM
-	{runeRange{0x11DA0, 0x11DA9}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] GUNJALA GONDI DIGIT ZERO..GUNJALA GONDI DIGIT NINE
-	{runeRange{0x11EE0, 0x11EF2}, propertyGeneralCategory{lbprAL, gcLo}},   //    [19] MAKASAR LETTER KA..MAKASAR ANGKA
-	{runeRange{0x11EF3, 0x11EF4}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] MAKASAR VOWEL SIGN I..MAKASAR VOWEL SIGN U
-	{runeRange{0x11EF5, 0x11EF6}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] MAKASAR VOWEL SIGN E..MAKASAR VOWEL SIGN O
-	{runeRange{0x11EF7, 0x11EF8}, propertyGeneralCategory{lbprAL, gcPo}},   //     [2] MAKASAR PASSIMBANG..MAKASAR END OF SECTION
-	{runeRange{0x11F00, 0x11F01}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] KAWI SIGN CANDRABINDU..KAWI SIGN ANUSVARA
-	{runeRange{0x11F02, 0x11F02}, propertyGeneralCategory{lbprAL, gcLo}},   //         KAWI SIGN REPHA
-	{runeRange{0x11F03, 0x11F03}, propertyGeneralCategory{lbprCM, gcMc}},   //         KAWI SIGN VISARGA
-	{runeRange{0x11F04, 0x11F10}, propertyGeneralCategory{lbprAL, gcLo}},   //    [13] KAWI LETTER A..KAWI LETTER O
-	{runeRange{0x11F12, 0x11F33}, propertyGeneralCategory{lbprAL, gcLo}},   //    [34] KAWI LETTER KA..KAWI LETTER JNYA
-	{runeRange{0x11F34, 0x11F35}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] KAWI VOWEL SIGN AA..KAWI VOWEL SIGN ALTERNATE AA
-	{runeRange{0x11F36, 0x11F3A}, propertyGeneralCategory{lbprCM, gcMn}},   //     [5] KAWI VOWEL SIGN I..KAWI VOWEL SIGN VOCALIC R
-	{runeRange{0x11F3E, 0x11F3F}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] KAWI VOWEL SIGN E..KAWI VOWEL SIGN AI
-	{runeRange{0x11F40, 0x11F40}, propertyGeneralCategory{lbprCM, gcMn}},   //         KAWI VOWEL SIGN EU
-	{runeRange{0x11F41, 0x11F41}, propertyGeneralCategory{lbprCM, gcMc}},   //         KAWI SIGN KILLER
-	{runeRange{0x11F42, 0x11F42}, propertyGeneralCategory{lbprCM, gcMn}},   //         KAWI CONJOINER
-	{runeRange{0x11F43, 0x11F44}, propertyGeneralCategory{lbprBA, gcPo}},   //     [2] KAWI DANDA..KAWI DOUBLE DANDA
-	{runeRange{0x11F45, 0x11F4F}, propertyGeneralCategory{lbprID, gcPo}},   //    [11] KAWI PUNCTUATION SECTION MARKER..KAWI PUNCTUATION CLOSING SPIRAL
-	{runeRange{0x11F50, 0x11F59}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] KAWI DIGIT ZERO..KAWI DIGIT NINE
-	{runeRange{0x11FB0, 0x11FB0}, propertyGeneralCategory{lbprAL, gcLo}},   //         LISU LETTER YHA
-	{runeRange{0x11FC0, 0x11FD4}, propertyGeneralCategory{lbprAL, gcNo}},   //    [21] TAMIL FRACTION ONE THREE-HUNDRED-AND-TWENTIETH..TAMIL FRACTION DOWNSCALING FACTOR KIIZH
-	{runeRange{0x11FD5, 0x11FDC}, propertyGeneralCategory{lbprAL, gcSo}},   //     [8] TAMIL SIGN NEL..TAMIL SIGN MUKKURUNI
-	{runeRange{0x11FDD, 0x11FE0}, propertyGeneralCategory{lbprPO, gcSc}},   //     [4] TAMIL SIGN KAACU..TAMIL SIGN VARAAKAN
-	{runeRange{0x11FE1, 0x11FF1}, propertyGeneralCategory{lbprAL, gcSo}},   //    [17] TAMIL SIGN PAARAM..TAMIL SIGN VAKAIYARAA
-	{runeRange{0x11FFF, 0x11FFF}, propertyGeneralCategory{lbprBA, gcPo}},   //         TAMIL PUNCTUATION END OF TEXT
-	{runeRange{0x12000, 0x12399}, propertyGeneralCategory{lbprAL, gcLo}},   //   [922] CUNEIFORM SIGN A..CUNEIFORM SIGN U U
-	{runeRange{0x12400, 0x1246E}, propertyGeneralCategory{lbprAL, gcNl}},   //   [111] CUNEIFORM NUMERIC SIGN TWO ASH..CUNEIFORM NUMERIC SIGN NINE U VARIANT FORM
-	{runeRange{0x12470, 0x12474}, propertyGeneralCategory{lbprBA, gcPo}},   //     [5] CUNEIFORM PUNCTUATION SIGN OLD ASSYRIAN WORD DIVIDER..CUNEIFORM PUNCTUATION SIGN DIAGONAL QUADCOLON
-	{runeRange{0x12480, 0x12543}, propertyGeneralCategory{lbprAL, gcLo}},   //   [196] CUNEIFORM SIGN AB TIMES NUN TENU..CUNEIFORM SIGN ZU5 TIMES THREE DISH TENU
-	{runeRange{0x12F90, 0x12FF0}, propertyGeneralCategory{lbprAL, gcLo}},   //    [97] CYPRO-MINOAN SIGN CM001..CYPRO-MINOAN SIGN CM114
-	{runeRange{0x12FF1, 0x12FF2}, propertyGeneralCategory{lbprAL, gcPo}},   //     [2] CYPRO-MINOAN SIGN CM301..CYPRO-MINOAN SIGN CM302
-	{runeRange{0x13000, 0x13257}, propertyGeneralCategory{lbprAL, gcLo}},   //   [600] EGYPTIAN HIEROGLYPH A001..EGYPTIAN HIEROGLYPH O006
-	{runeRange{0x13258, 0x1325A}, propertyGeneralCategory{lbprOP, gcLo}},   //     [3] EGYPTIAN HIEROGLYPH O006A..EGYPTIAN HIEROGLYPH O006C
-	{runeRange{0x1325B, 0x1325D}, propertyGeneralCategory{lbprCL, gcLo}},   //     [3] EGYPTIAN HIEROGLYPH O006D..EGYPTIAN HIEROGLYPH O006F
-	{runeRange{0x1325E, 0x13281}, propertyGeneralCategory{lbprAL, gcLo}},   //    [36] EGYPTIAN HIEROGLYPH O007..EGYPTIAN HIEROGLYPH O033
-	{runeRange{0x13282, 0x13282}, propertyGeneralCategory{lbprCL, gcLo}},   //         EGYPTIAN HIEROGLYPH O033A
-	{runeRange{0x13283, 0x13285}, propertyGeneralCategory{lbprAL, gcLo}},   //     [3] EGYPTIAN HIEROGLYPH O034..EGYPTIAN HIEROGLYPH O036
-	{runeRange{0x13286, 0x13286}, propertyGeneralCategory{lbprOP, gcLo}},   //         EGYPTIAN HIEROGLYPH O036A
-	{runeRange{0x13287, 0x13287}, propertyGeneralCategory{lbprCL, gcLo}},   //         EGYPTIAN HIEROGLYPH O036B
-	{runeRange{0x13288, 0x13288}, propertyGeneralCategory{lbprOP, gcLo}},   //         EGYPTIAN HIEROGLYPH O036C
-	{runeRange{0x13289, 0x13289}, propertyGeneralCategory{lbprCL, gcLo}},   //         EGYPTIAN HIEROGLYPH O036D
-	{runeRange{0x1328A, 0x13378}, propertyGeneralCategory{lbprAL, gcLo}},   //   [239] EGYPTIAN HIEROGLYPH O037..EGYPTIAN HIEROGLYPH V011
-	{runeRange{0x13379, 0x13379}, propertyGeneralCategory{lbprOP, gcLo}},   //         EGYPTIAN HIEROGLYPH V011A
-	{runeRange{0x1337A, 0x1337B}, propertyGeneralCategory{lbprCL, gcLo}},   //     [2] EGYPTIAN HIEROGLYPH V011B..EGYPTIAN HIEROGLYPH V011C
-	{runeRange{0x1337C, 0x1342F}, propertyGeneralCategory{lbprAL, gcLo}},   //   [180] EGYPTIAN HIEROGLYPH V012..EGYPTIAN HIEROGLYPH V011D
-	{runeRange{0x13430, 0x13436}, propertyGeneralCategory{lbprGL, gcCf}},   //     [7] EGYPTIAN HIEROGLYPH VERTICAL JOINER..EGYPTIAN HIEROGLYPH OVERLAY MIDDLE
-	{runeRange{0x13437, 0x13437}, propertyGeneralCategory{lbprOP, gcCf}},   //         EGYPTIAN HIEROGLYPH BEGIN SEGMENT
-	{runeRange{0x13438, 0x13438}, propertyGeneralCategory{lbprCL, gcCf}},   //         EGYPTIAN HIEROGLYPH END SEGMENT
-	{runeRange{0x13439, 0x1343B}, propertyGeneralCategory{lbprGL, gcCf}},   //     [3] EGYPTIAN HIEROGLYPH INSERT AT MIDDLE..EGYPTIAN HIEROGLYPH INSERT AT BOTTOM
-	{runeRange{0x1343C, 0x1343C}, propertyGeneralCategory{lbprOP, gcCf}},   //         EGYPTIAN HIEROGLYPH BEGIN ENCLOSURE
-	{runeRange{0x1343D, 0x1343D}, propertyGeneralCategory{lbprCL, gcCf}},   //         EGYPTIAN HIEROGLYPH END ENCLOSURE
-	{runeRange{0x1343E, 0x1343E}, propertyGeneralCategory{lbprOP, gcCf}},   //         EGYPTIAN HIEROGLYPH BEGIN WALLED ENCLOSURE
-	{runeRange{0x1343F, 0x1343F}, propertyGeneralCategory{lbprCL, gcCf}},   //         EGYPTIAN HIEROGLYPH END WALLED ENCLOSURE
-	{runeRange{0x13440, 0x13440}, propertyGeneralCategory{lbprCM, gcMn}},   //         EGYPTIAN HIEROGLYPH MIRROR HORIZONTALLY
-	{runeRange{0x13441, 0x13446}, propertyGeneralCategory{lbprAL, gcLo}},   //     [6] EGYPTIAN HIEROGLYPH FULL BLANK..EGYPTIAN HIEROGLYPH WIDE LOST SIGN
-	{runeRange{0x13447, 0x13455}, propertyGeneralCategory{lbprCM, gcMn}},   //    [15] EGYPTIAN HIEROGLYPH MODIFIER DAMAGED AT TOP START..EGYPTIAN HIEROGLYPH MODIFIER DAMAGED
-	{runeRange{0x14400, 0x145CD}, propertyGeneralCategory{lbprAL, gcLo}},   //   [462] ANATOLIAN HIEROGLYPH A001..ANATOLIAN HIEROGLYPH A409
-	{runeRange{0x145CE, 0x145CE}, propertyGeneralCategory{lbprOP, gcLo}},   //         ANATOLIAN HIEROGLYPH A410 BEGIN LOGOGRAM MARK
-	{runeRange{0x145CF, 0x145CF}, propertyGeneralCategory{lbprCL, gcLo}},   //         ANATOLIAN HIEROGLYPH A410A END LOGOGRAM MARK
-	{runeRange{0x145D0, 0x14646}, propertyGeneralCategory{lbprAL, gcLo}},   //   [119] ANATOLIAN HIEROGLYPH A411..ANATOLIAN HIEROGLYPH A530
-	{runeRange{0x16800, 0x16A38}, propertyGeneralCategory{lbprAL, gcLo}},   //   [569] BAMUM LETTER PHASE-A NGKUE MFON..BAMUM LETTER PHASE-F VUEQ
-	{runeRange{0x16A40, 0x16A5E}, propertyGeneralCategory{lbprAL, gcLo}},   //    [31] MRO LETTER TA..MRO LETTER TEK
-	{runeRange{0x16A60, 0x16A69}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] MRO DIGIT ZERO..MRO DIGIT NINE
-	{runeRange{0x16A6E, 0x16A6F}, propertyGeneralCategory{lbprBA, gcPo}},   //     [2] MRO DANDA..MRO DOUBLE DANDA
-	{runeRange{0x16A70, 0x16ABE}, propertyGeneralCategory{lbprAL, gcLo}},   //    [79] TANGSA LETTER OZ..TANGSA LETTER ZA
-	{runeRange{0x16AC0, 0x16AC9}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] TANGSA DIGIT ZERO..TANGSA DIGIT NINE
-	{runeRange{0x16AD0, 0x16AED}, propertyGeneralCategory{lbprAL, gcLo}},   //    [30] BASSA VAH LETTER ENNI..BASSA VAH LETTER I
-	{runeRange{0x16AF0, 0x16AF4}, propertyGeneralCategory{lbprCM, gcMn}},   //     [5] BASSA VAH COMBINING HIGH TONE..BASSA VAH COMBINING HIGH-LOW TONE
-	{runeRange{0x16AF5, 0x16AF5}, propertyGeneralCategory{lbprBA, gcPo}},   //         BASSA VAH FULL STOP
-	{runeRange{0x16B00, 0x16B2F}, propertyGeneralCategory{lbprAL, gcLo}},   //    [48] PAHAWH HMONG VOWEL KEEB..PAHAWH HMONG CONSONANT CAU
-	{runeRange{0x16B30, 0x16B36}, propertyGeneralCategory{lbprCM, gcMn}},   //     [7] PAHAWH HMONG MARK CIM TUB..PAHAWH HMONG MARK CIM TAUM
-	{runeRange{0x16B37, 0x16B39}, propertyGeneralCategory{lbprBA, gcPo}},   //     [3] PAHAWH HMONG SIGN VOS THOM..PAHAWH HMONG SIGN CIM CHEEM
-	{runeRange{0x16B3A, 0x16B3B}, propertyGeneralCategory{lbprAL, gcPo}},   //     [2] PAHAWH HMONG SIGN VOS THIAB..PAHAWH HMONG SIGN VOS FEEM
-	{runeRange{0x16B3C, 0x16B3F}, propertyGeneralCategory{lbprAL, gcSo}},   //     [4] PAHAWH HMONG SIGN XYEEM NTXIV..PAHAWH HMONG SIGN XYEEM FAIB
-	{runeRange{0x16B40, 0x16B43}, propertyGeneralCategory{lbprAL, gcLm}},   //     [4] PAHAWH HMONG SIGN VOS SEEV..PAHAWH HMONG SIGN IB YAM
-	{runeRange{0x16B44, 0x16B44}, propertyGeneralCategory{lbprBA, gcPo}},   //         PAHAWH HMONG SIGN XAUS
-	{runeRange{0x16B45, 0x16B45}, propertyGeneralCategory{lbprAL, gcSo}},   //         PAHAWH HMONG SIGN CIM TSOV ROG
-	{runeRange{0x16B50, 0x16B59}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] PAHAWH HMONG DIGIT ZERO..PAHAWH HMONG DIGIT NINE
-	{runeRange{0x16B5B, 0x16B61}, propertyGeneralCategory{lbprAL, gcNo}},   //     [7] PAHAWH HMONG NUMBER TENS..PAHAWH HMONG NUMBER TRILLIONS
-	{runeRange{0x16B63, 0x16B77}, propertyGeneralCategory{lbprAL, gcLo}},   //    [21] PAHAWH HMONG SIGN VOS LUB..PAHAWH HMONG SIGN CIM NRES TOS
-	{runeRange{0x16B7D, 0x16B8F}, propertyGeneralCategory{lbprAL, gcLo}},   //    [19] PAHAWH HMONG CLAN SIGN TSHEEJ..PAHAWH HMONG CLAN SIGN VWJ
-	{runeRange{0x16E40, 0x16E7F}, propertyGeneralCategory{lbprAL, gcLC}},   //    [64] MEDEFAIDRIN CAPITAL LETTER M..MEDEFAIDRIN SMALL LETTER Y
-	{runeRange{0x16E80, 0x16E96}, propertyGeneralCategory{lbprAL, gcNo}},   //    [23] MEDEFAIDRIN DIGIT ZERO..MEDEFAIDRIN DIGIT THREE ALTERNATE FORM
-	{runeRange{0x16E97, 0x16E98}, propertyGeneralCategory{lbprBA, gcPo}},   //     [2] MEDEFAIDRIN COMMA..MEDEFAIDRIN FULL STOP
-	{runeRange{0x16E99, 0x16E9A}, propertyGeneralCategory{lbprAL, gcPo}},   //     [2] MEDEFAIDRIN SYMBOL AIVA..MEDEFAIDRIN EXCLAMATION OH
-	{runeRange{0x16F00, 0x16F4A}, propertyGeneralCategory{lbprAL, gcLo}},   //    [75] MIAO LETTER PA..MIAO LETTER RTE
-	{runeRange{0x16F4F, 0x16F4F}, propertyGeneralCategory{lbprCM, gcMn}},   //         MIAO SIGN CONSONANT MODIFIER BAR
-	{runeRange{0x16F50, 0x16F50}, propertyGeneralCategory{lbprAL, gcLo}},   //         MIAO LETTER NASALIZATION
-	{runeRange{0x16F51, 0x16F87}, propertyGeneralCategory{lbprCM, gcMc}},   //    [55] MIAO SIGN ASPIRATION..MIAO VOWEL SIGN UI
-	{runeRange{0x16F8F, 0x16F92}, propertyGeneralCategory{lbprCM, gcMn}},   //     [4] MIAO TONE RIGHT..MIAO TONE BELOW
-	{runeRange{0x16F93, 0x16F9F}, propertyGeneralCategory{lbprAL, gcLm}},   //    [13] MIAO LETTER TONE-2..MIAO LETTER REFORMED TONE-8
-	{runeRange{0x16FE0, 0x16FE1}, propertyGeneralCategory{lbprNS, gcLm}},   //     [2] TANGUT ITERATION MARK..NUSHU ITERATION MARK
-	{runeRange{0x16FE2, 0x16FE2}, propertyGeneralCategory{lbprNS, gcPo}},   //         OLD CHINESE HOOK MARK
-	{runeRange{0x16FE3, 0x16FE3}, propertyGeneralCategory{lbprNS, gcLm}},   //         OLD CHINESE ITERATION MARK
-	{runeRange{0x16FE4, 0x16FE4}, propertyGeneralCategory{lbprGL, gcMn}},   //         KHITAN SMALL SCRIPT FILLER
-	{runeRange{0x16FF0, 0x16FF1}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] VIETNAMESE ALTERNATE READING MARK CA..VIETNAMESE ALTERNATE READING MARK NHAY
-	{runeRange{0x17000, 0x187F7}, propertyGeneralCategory{lbprID, gcLo}},   //  [6136] TANGUT IDEOGRAPH-17000..TANGUT IDEOGRAPH-187F7
-	{runeRange{0x18800, 0x18AFF}, propertyGeneralCategory{lbprID, gcLo}},   //   [768] TANGUT COMPONENT-001..TANGUT COMPONENT-768
-	{runeRange{0x18B00, 0x18CD5}, propertyGeneralCategory{lbprAL, gcLo}},   //   [470] KHITAN SMALL SCRIPT CHARACTER-18B00..KHITAN SMALL SCRIPT CHARACTER-18CD5
-	{runeRange{0x18D00, 0x18D08}, propertyGeneralCategory{lbprID, gcLo}},   //     [9] TANGUT IDEOGRAPH-18D00..TANGUT IDEOGRAPH-18D08
-	{runeRange{0x1AFF0, 0x1AFF3}, propertyGeneralCategory{lbprAL, gcLm}},   //     [4] KATAKANA LETTER MINNAN TONE-2..KATAKANA LETTER MINNAN TONE-5
-	{runeRange{0x1AFF5, 0x1AFFB}, propertyGeneralCategory{lbprAL, gcLm}},   //     [7] KATAKANA LETTER MINNAN TONE-7..KATAKANA LETTER MINNAN NASALIZED TONE-5
-	{runeRange{0x1AFFD, 0x1AFFE}, propertyGeneralCategory{lbprAL, gcLm}},   //     [2] KATAKANA LETTER MINNAN NASALIZED TONE-7..KATAKANA LETTER MINNAN NASALIZED TONE-8
-	{runeRange{0x1B000, 0x1B0FF}, propertyGeneralCategory{lbprID, gcLo}},   //   [256] KATAKANA LETTER ARCHAIC E..HENTAIGANA LETTER RE-2
-	{runeRange{0x1B100, 0x1B122}, propertyGeneralCategory{lbprID, gcLo}},   //    [35] HENTAIGANA LETTER RE-3..KATAKANA LETTER ARCHAIC WU
-	{runeRange{0x1B132, 0x1B132}, propertyGeneralCategory{lbprCJ, gcLo}},   //         HIRAGANA LETTER SMALL KO
-	{runeRange{0x1B150, 0x1B152}, propertyGeneralCategory{lbprCJ, gcLo}},   //     [3] HIRAGANA LETTER SMALL WI..HIRAGANA LETTER SMALL WO
-	{runeRange{0x1B155, 0x1B155}, propertyGeneralCategory{lbprCJ, gcLo}},   //         KATAKANA LETTER SMALL KO
-	{runeRange{0x1B164, 0x1B167}, propertyGeneralCategory{lbprCJ, gcLo}},   //     [4] KATAKANA LETTER SMALL WI..KATAKANA LETTER SMALL N
-	{runeRange{0x1B170, 0x1B2FB}, propertyGeneralCategory{lbprID, gcLo}},   //   [396] NUSHU CHARACTER-1B170..NUSHU CHARACTER-1B2FB
-	{runeRange{0x1BC00, 0x1BC6A}, propertyGeneralCategory{lbprAL, gcLo}},   //   [107] DUPLOYAN LETTER H..DUPLOYAN LETTER VOCALIC M
-	{runeRange{0x1BC70, 0x1BC7C}, propertyGeneralCategory{lbprAL, gcLo}},   //    [13] DUPLOYAN AFFIX LEFT HORIZONTAL SECANT..DUPLOYAN AFFIX ATTACHED TANGENT HOOK
-	{runeRange{0x1BC80, 0x1BC88}, propertyGeneralCategory{lbprAL, gcLo}},   //     [9] DUPLOYAN AFFIX HIGH ACUTE..DUPLOYAN AFFIX HIGH VERTICAL
-	{runeRange{0x1BC90, 0x1BC99}, propertyGeneralCategory{lbprAL, gcLo}},   //    [10] DUPLOYAN AFFIX LOW ACUTE..DUPLOYAN AFFIX LOW ARROW
-	{runeRange{0x1BC9C, 0x1BC9C}, propertyGeneralCategory{lbprAL, gcSo}},   //         DUPLOYAN SIGN O WITH CROSS
-	{runeRange{0x1BC9D, 0x1BC9E}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] DUPLOYAN THICK LETTER SELECTOR..DUPLOYAN DOUBLE MARK
-	{runeRange{0x1BC9F, 0x1BC9F}, propertyGeneralCategory{lbprBA, gcPo}},   //         DUPLOYAN PUNCTUATION CHINOOK FULL STOP
-	{runeRange{0x1BCA0, 0x1BCA3}, propertyGeneralCategory{lbprCM, gcCf}},   //     [4] SHORTHAND FORMAT LETTER OVERLAP..SHORTHAND FORMAT UP STEP
-	{runeRange{0x1CF00, 0x1CF2D}, propertyGeneralCategory{lbprCM, gcMn}},   //    [46] ZNAMENNY COMBINING MARK GORAZDO NIZKO S KRYZHEM ON LEFT..ZNAMENNY COMBINING MARK KRYZH ON LEFT
-	{runeRange{0x1CF30, 0x1CF46}, propertyGeneralCategory{lbprCM, gcMn}},   //    [23] ZNAMENNY COMBINING TONAL RANGE MARK MRACHNO..ZNAMENNY PRIZNAK MODIFIER ROG
-	{runeRange{0x1CF50, 0x1CFC3}, propertyGeneralCategory{lbprAL, gcSo}},   //   [116] ZNAMENNY NEUME KRYUK..ZNAMENNY NEUME PAUK
-	{runeRange{0x1D000, 0x1D0F5}, propertyGeneralCategory{lbprAL, gcSo}},   //   [246] BYZANTINE MUSICAL SYMBOL PSILI..BYZANTINE MUSICAL SYMBOL GORGON NEO KATO
-	{runeRange{0x1D100, 0x1D126}, propertyGeneralCategory{lbprAL, gcSo}},   //    [39] MUSICAL SYMBOL SINGLE BARLINE..MUSICAL SYMBOL DRUM CLEF-2
-	{runeRange{0x1D129, 0x1D164}, propertyGeneralCategory{lbprAL, gcSo}},   //    [60] MUSICAL SYMBOL MULTIPLE MEASURE REST..MUSICAL SYMBOL ONE HUNDRED TWENTY-EIGHTH NOTE
-	{runeRange{0x1D165, 0x1D166}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] MUSICAL SYMBOL COMBINING STEM..MUSICAL SYMBOL COMBINING SPRECHGESANG STEM
-	{runeRange{0x1D167, 0x1D169}, propertyGeneralCategory{lbprCM, gcMn}},   //     [3] MUSICAL SYMBOL COMBINING TREMOLO-1..MUSICAL SYMBOL COMBINING TREMOLO-3
-	{runeRange{0x1D16A, 0x1D16C}, propertyGeneralCategory{lbprAL, gcSo}},   //     [3] MUSICAL SYMBOL FINGERED TREMOLO-1..MUSICAL SYMBOL FINGERED TREMOLO-3
-	{runeRange{0x1D16D, 0x1D172}, propertyGeneralCategory{lbprCM, gcMc}},   //     [6] MUSICAL SYMBOL COMBINING AUGMENTATION DOT..MUSICAL SYMBOL COMBINING FLAG-5
-	{runeRange{0x1D173, 0x1D17A}, propertyGeneralCategory{lbprCM, gcCf}},   //     [8] MUSICAL SYMBOL BEGIN BEAM..MUSICAL SYMBOL END PHRASE
-	{runeRange{0x1D17B, 0x1D182}, propertyGeneralCategory{lbprCM, gcMn}},   //     [8] MUSICAL SYMBOL COMBINING ACCENT..MUSICAL SYMBOL COMBINING LOURE
-	{runeRange{0x1D183, 0x1D184}, propertyGeneralCategory{lbprAL, gcSo}},   //     [2] MUSICAL SYMBOL ARPEGGIATO UP..MUSICAL SYMBOL ARPEGGIATO DOWN
-	{runeRange{0x1D185, 0x1D18B}, propertyGeneralCategory{lbprCM, gcMn}},   //     [7] MUSICAL SYMBOL COMBINING DOIT..MUSICAL SYMBOL COMBINING TRIPLE TONGUE
-	{runeRange{0x1D18C, 0x1D1A9}, propertyGeneralCategory{lbprAL, gcSo}},   //    [30] MUSICAL SYMBOL RINFORZANDO..MUSICAL SYMBOL DEGREE SLASH
-	{runeRange{0x1D1AA, 0x1D1AD}, propertyGeneralCategory{lbprCM, gcMn}},   //     [4] MUSICAL SYMBOL COMBINING DOWN BOW..MUSICAL SYMBOL COMBINING SNAP PIZZICATO
-	{runeRange{0x1D1AE, 0x1D1EA}, propertyGeneralCategory{lbprAL, gcSo}},   //    [61] MUSICAL SYMBOL PEDAL MARK..MUSICAL SYMBOL KORON
-	{runeRange{0x1D200, 0x1D241}, propertyGeneralCategory{lbprAL, gcSo}},   //    [66] GREEK VOCAL NOTATION SYMBOL-1..GREEK INSTRUMENTAL NOTATION SYMBOL-54
-	{runeRange{0x1D242, 0x1D244}, propertyGeneralCategory{lbprCM, gcMn}},   //     [3] COMBINING GREEK MUSICAL TRISEME..COMBINING GREEK MUSICAL PENTASEME
-	{runeRange{0x1D245, 0x1D245}, propertyGeneralCategory{lbprAL, gcSo}},   //         GREEK MUSICAL LEIMMA
-	{runeRange{0x1D2C0, 0x1D2D3}, propertyGeneralCategory{lbprAL, gcNo}},   //    [20] KAKTOVIK NUMERAL ZERO..KAKTOVIK NUMERAL NINETEEN
-	{runeRange{0x1D2E0, 0x1D2F3}, propertyGeneralCategory{lbprAL, gcNo}},   //    [20] MAYAN NUMERAL ZERO..MAYAN NUMERAL NINETEEN
-	{runeRange{0x1D300, 0x1D356}, propertyGeneralCategory{lbprAL, gcSo}},   //    [87] MONOGRAM FOR EARTH..TETRAGRAM FOR FOSTERING
-	{runeRange{0x1D360, 0x1D378}, propertyGeneralCategory{lbprAL, gcNo}},   //    [25] COUNTING ROD UNIT DIGIT ONE..TALLY MARK FIVE
-	{runeRange{0x1D400, 0x1D454}, propertyGeneralCategory{lbprAL, gcLC}},   //    [85] MATHEMATICAL BOLD CAPITAL A..MATHEMATICAL ITALIC SMALL G
-	{runeRange{0x1D456, 0x1D49C}, propertyGeneralCategory{lbprAL, gcLC}},   //    [71] MATHEMATICAL ITALIC SMALL I..MATHEMATICAL SCRIPT CAPITAL A
-	{runeRange{0x1D49E, 0x1D49F}, propertyGeneralCategory{lbprAL, gcLu}},   //     [2] MATHEMATICAL SCRIPT CAPITAL C..MATHEMATICAL SCRIPT CAPITAL D
-	{runeRange{0x1D4A2, 0x1D4A2}, propertyGeneralCategory{lbprAL, gcLu}},   //         MATHEMATICAL SCRIPT CAPITAL G
-	{runeRange{0x1D4A5, 0x1D4A6}, propertyGeneralCategory{lbprAL, gcLu}},   //     [2] MATHEMATICAL SCRIPT CAPITAL J..MATHEMATICAL SCRIPT CAPITAL K
-	{runeRange{0x1D4A9, 0x1D4AC}, propertyGeneralCategory{lbprAL, gcLu}},   //     [4] MATHEMATICAL SCRIPT CAPITAL N..MATHEMATICAL SCRIPT CAPITAL Q
-	{runeRange{0x1D4AE, 0x1D4B9}, propertyGeneralCategory{lbprAL, gcLC}},   //    [12] MATHEMATICAL SCRIPT CAPITAL S..MATHEMATICAL SCRIPT SMALL D
-	{runeRange{0x1D4BB, 0x1D4BB}, propertyGeneralCategory{lbprAL, gcLl}},   //         MATHEMATICAL SCRIPT SMALL F
-	{runeRange{0x1D4BD, 0x1D4C3}, propertyGeneralCategory{lbprAL, gcLl}},   //     [7] MATHEMATICAL SCRIPT SMALL H..MATHEMATICAL SCRIPT SMALL N
-	{runeRange{0x1D4C5, 0x1D505}, propertyGeneralCategory{lbprAL, gcLC}},   //    [65] MATHEMATICAL SCRIPT SMALL P..MATHEMATICAL FRAKTUR CAPITAL B
-	{runeRange{0x1D507, 0x1D50A}, propertyGeneralCategory{lbprAL, gcLu}},   //     [4] MATHEMATICAL FRAKTUR CAPITAL D..MATHEMATICAL FRAKTUR CAPITAL G
-	{runeRange{0x1D50D, 0x1D514}, propertyGeneralCategory{lbprAL, gcLu}},   //     [8] MATHEMATICAL FRAKTUR CAPITAL J..MATHEMATICAL FRAKTUR CAPITAL Q
-	{runeRange{0x1D516, 0x1D51C}, propertyGeneralCategory{lbprAL, gcLu}},   //     [7] MATHEMATICAL FRAKTUR CAPITAL S..MATHEMATICAL FRAKTUR CAPITAL Y
-	{runeRange{0x1D51E, 0x1D539}, propertyGeneralCategory{lbprAL, gcLC}},   //    [28] MATHEMATICAL FRAKTUR SMALL A..MATHEMATICAL DOUBLE-STRUCK CAPITAL B
-	{runeRange{0x1D53B, 0x1D53E}, propertyGeneralCategory{lbprAL, gcLu}},   //     [4] MATHEMATICAL DOUBLE-STRUCK CAPITAL D..MATHEMATICAL DOUBLE-STRUCK CAPITAL G
-	{runeRange{0x1D540, 0x1D544}, propertyGeneralCategory{lbprAL, gcLu}},   //     [5] MATHEMATICAL DOUBLE-STRUCK CAPITAL I..MATHEMATICAL DOUBLE-STRUCK CAPITAL M
-	{runeRange{0x1D546, 0x1D546}, propertyGeneralCategory{lbprAL, gcLu}},   //         MATHEMATICAL DOUBLE-STRUCK CAPITAL O
-	{runeRange{0x1D54A, 0x1D550}, propertyGeneralCategory{lbprAL, gcLu}},   //     [7] MATHEMATICAL DOUBLE-STRUCK CAPITAL S..MATHEMATICAL DOUBLE-STRUCK CAPITAL Y
-	{runeRange{0x1D552, 0x1D6A5}, propertyGeneralCategory{lbprAL, gcLC}},   //   [340] MATHEMATICAL DOUBLE-STRUCK SMALL A..MATHEMATICAL ITALIC SMALL DOTLESS J
-	{runeRange{0x1D6A8, 0x1D6C0}, propertyGeneralCategory{lbprAL, gcLu}},   //    [25] MATHEMATICAL BOLD CAPITAL ALPHA..MATHEMATICAL BOLD CAPITAL OMEGA
-	{runeRange{0x1D6C1, 0x1D6C1}, propertyGeneralCategory{lbprAL, gcSm}},   //         MATHEMATICAL BOLD NABLA
-	{runeRange{0x1D6C2, 0x1D6DA}, propertyGeneralCategory{lbprAL, gcLl}},   //    [25] MATHEMATICAL BOLD SMALL ALPHA..MATHEMATICAL BOLD SMALL OMEGA
-	{runeRange{0x1D6DB, 0x1D6DB}, propertyGeneralCategory{lbprAL, gcSm}},   //         MATHEMATICAL BOLD PARTIAL DIFFERENTIAL
-	{runeRange{0x1D6DC, 0x1D6FA}, propertyGeneralCategory{lbprAL, gcLC}},   //    [31] MATHEMATICAL BOLD EPSILON SYMBOL..MATHEMATICAL ITALIC CAPITAL OMEGA
-	{runeRange{0x1D6FB, 0x1D6FB}, propertyGeneralCategory{lbprAL, gcSm}},   //         MATHEMATICAL ITALIC NABLA
-	{runeRange{0x1D6FC, 0x1D714}, propertyGeneralCategory{lbprAL, gcLl}},   //    [25] MATHEMATICAL ITALIC SMALL ALPHA..MATHEMATICAL ITALIC SMALL OMEGA
-	{runeRange{0x1D715, 0x1D715}, propertyGeneralCategory{lbprAL, gcSm}},   //         MATHEMATICAL ITALIC PARTIAL DIFFERENTIAL
-	{runeRange{0x1D716, 0x1D734}, propertyGeneralCategory{lbprAL, gcLC}},   //    [31] MATHEMATICAL ITALIC EPSILON SYMBOL..MATHEMATICAL BOLD ITALIC CAPITAL OMEGA
-	{runeRange{0x1D735, 0x1D735}, propertyGeneralCategory{lbprAL, gcSm}},   //         MATHEMATICAL BOLD ITALIC NABLA
-	{runeRange{0x1D736, 0x1D74E}, propertyGeneralCategory{lbprAL, gcLl}},   //    [25] MATHEMATICAL BOLD ITALIC SMALL ALPHA..MATHEMATICAL BOLD ITALIC SMALL OMEGA
-	{runeRange{0x1D74F, 0x1D74F}, propertyGeneralCategory{lbprAL, gcSm}},   //         MATHEMATICAL BOLD ITALIC PARTIAL DIFFERENTIAL
-	{runeRange{0x1D750, 0x1D76E}, propertyGeneralCategory{lbprAL, gcLC}},   //    [31] MATHEMATICAL BOLD ITALIC EPSILON SYMBOL..MATHEMATICAL SANS-SERIF BOLD CAPITAL OMEGA
-	{runeRange{0x1D76F, 0x1D76F}, propertyGeneralCategory{lbprAL, gcSm}},   //         MATHEMATICAL SANS-SERIF BOLD NABLA
-	{runeRange{0x1D770, 0x1D788}, propertyGeneralCategory{lbprAL, gcLl}},   //    [25] MATHEMATICAL SANS-SERIF BOLD SMALL ALPHA..MATHEMATICAL SANS-SERIF BOLD SMALL OMEGA
-	{runeRange{0x1D789, 0x1D789}, propertyGeneralCategory{lbprAL, gcSm}},   //         MATHEMATICAL SANS-SERIF BOLD PARTIAL DIFFERENTIAL
-	{runeRange{0x1D78A, 0x1D7A8}, propertyGeneralCategory{lbprAL, gcLC}},   //    [31] MATHEMATICAL SANS-SERIF BOLD EPSILON SYMBOL..MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL OMEGA
-	{runeRange{0x1D7A9, 0x1D7A9}, propertyGeneralCategory{lbprAL, gcSm}},   //         MATHEMATICAL SANS-SERIF BOLD ITALIC NABLA
-	{runeRange{0x1D7AA, 0x1D7C2}, propertyGeneralCategory{lbprAL, gcLl}},   //    [25] MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL ALPHA..MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL OMEGA
-	{runeRange{0x1D7C3, 0x1D7C3}, propertyGeneralCategory{lbprAL, gcSm}},   //         MATHEMATICAL SANS-SERIF BOLD ITALIC PARTIAL DIFFERENTIAL
-	{runeRange{0x1D7C4, 0x1D7CB}, propertyGeneralCategory{lbprAL, gcLC}},   //     [8] MATHEMATICAL SANS-SERIF BOLD ITALIC EPSILON SYMBOL..MATHEMATICAL BOLD SMALL DIGAMMA
-	{runeRange{0x1D7CE, 0x1D7FF}, propertyGeneralCategory{lbprNU, gcNd}},   //    [50] MATHEMATICAL BOLD DIGIT ZERO..MATHEMATICAL MONOSPACE DIGIT NINE
-	{runeRange{0x1D800, 0x1D9FF}, propertyGeneralCategory{lbprAL, gcSo}},   //   [512] SIGNWRITING HAND-FIST INDEX..SIGNWRITING HEAD
-	{runeRange{0x1DA00, 0x1DA36}, propertyGeneralCategory{lbprCM, gcMn}},   //    [55] SIGNWRITING HEAD RIM..SIGNWRITING AIR SUCKING IN
-	{runeRange{0x1DA37, 0x1DA3A}, propertyGeneralCategory{lbprAL, gcSo}},   //     [4] SIGNWRITING AIR BLOW SMALL ROTATIONS..SIGNWRITING BREATH EXHALE
-	{runeRange{0x1DA3B, 0x1DA6C}, propertyGeneralCategory{lbprCM, gcMn}},   //    [50] SIGNWRITING MOUTH CLOSED NEUTRAL..SIGNWRITING EXCITEMENT
-	{runeRange{0x1DA6D, 0x1DA74}, propertyGeneralCategory{lbprAL, gcSo}},   //     [8] SIGNWRITING SHOULDER HIP SPINE..SIGNWRITING TORSO-FLOORPLANE TWISTING
-	{runeRange{0x1DA75, 0x1DA75}, propertyGeneralCategory{lbprCM, gcMn}},   //         SIGNWRITING UPPER BODY TILTING FROM HIP JOINTS
-	{runeRange{0x1DA76, 0x1DA83}, propertyGeneralCategory{lbprAL, gcSo}},   //    [14] SIGNWRITING LIMB COMBINATION..SIGNWRITING LOCATION DEPTH
-	{runeRange{0x1DA84, 0x1DA84}, propertyGeneralCategory{lbprCM, gcMn}},   //         SIGNWRITING LOCATION HEAD NECK
-	{runeRange{0x1DA85, 0x1DA86}, propertyGeneralCategory{lbprAL, gcSo}},   //     [2] SIGNWRITING LOCATION TORSO..SIGNWRITING LOCATION LIMBS DIGITS
-	{runeRange{0x1DA87, 0x1DA8A}, propertyGeneralCategory{lbprBA, gcPo}},   //     [4] SIGNWRITING COMMA..SIGNWRITING COLON
-	{runeRange{0x1DA8B, 0x1DA8B}, propertyGeneralCategory{lbprAL, gcPo}},   //         SIGNWRITING PARENTHESIS
-	{runeRange{0x1DA9B, 0x1DA9F}, propertyGeneralCategory{lbprCM, gcMn}},   //     [5] SIGNWRITING FILL MODIFIER-2..SIGNWRITING FILL MODIFIER-6
-	{runeRange{0x1DAA1, 0x1DAAF}, propertyGeneralCategory{lbprCM, gcMn}},   //    [15] SIGNWRITING ROTATION MODIFIER-2..SIGNWRITING ROTATION MODIFIER-16
-	{runeRange{0x1DF00, 0x1DF09}, propertyGeneralCategory{lbprAL, gcLl}},   //    [10] LATIN SMALL LETTER FENG DIGRAPH WITH TRILL..LATIN SMALL LETTER T WITH HOOK AND RETROFLEX HOOK
-	{runeRange{0x1DF0A, 0x1DF0A}, propertyGeneralCategory{lbprAL, gcLo}},   //         LATIN LETTER RETROFLEX CLICK WITH RETROFLEX HOOK
-	{runeRange{0x1DF0B, 0x1DF1E}, propertyGeneralCategory{lbprAL, gcLl}},   //    [20] LATIN SMALL LETTER ESH WITH DOUBLE BAR..LATIN SMALL LETTER S WITH CURL
-	{runeRange{0x1DF25, 0x1DF2A}, propertyGeneralCategory{lbprAL, gcLl}},   //     [6] LATIN SMALL LETTER D WITH MID-HEIGHT LEFT HOOK..LATIN SMALL LETTER T WITH MID-HEIGHT LEFT HOOK
-	{runeRange{0x1E000, 0x1E006}, propertyGeneralCategory{lbprCM, gcMn}},   //     [7] COMBINING GLAGOLITIC LETTER AZU..COMBINING GLAGOLITIC LETTER ZHIVETE
-	{runeRange{0x1E008, 0x1E018}, propertyGeneralCategory{lbprCM, gcMn}},   //    [17] COMBINING GLAGOLITIC LETTER ZEMLJA..COMBINING GLAGOLITIC LETTER HERU
-	{runeRange{0x1E01B, 0x1E021}, propertyGeneralCategory{lbprCM, gcMn}},   //     [7] COMBINING GLAGOLITIC LETTER SHTA..COMBINING GLAGOLITIC LETTER YATI
-	{runeRange{0x1E023, 0x1E024}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] COMBINING GLAGOLITIC LETTER YU..COMBINING GLAGOLITIC LETTER SMALL YUS
-	{runeRange{0x1E026, 0x1E02A}, propertyGeneralCategory{lbprCM, gcMn}},   //     [5] COMBINING GLAGOLITIC LETTER YO..COMBINING GLAGOLITIC LETTER FITA
-	{runeRange{0x1E030, 0x1E06D}, propertyGeneralCategory{lbprAL, gcLm}},   //    [62] MODIFIER LETTER CYRILLIC SMALL A..MODIFIER LETTER CYRILLIC SMALL STRAIGHT U WITH STROKE
-	{runeRange{0x1E08F, 0x1E08F}, propertyGeneralCategory{lbprCM, gcMn}},   //         COMBINING CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I
-	{runeRange{0x1E100, 0x1E12C}, propertyGeneralCategory{lbprAL, gcLo}},   //    [45] NYIAKENG PUACHUE HMONG LETTER MA..NYIAKENG PUACHUE HMONG LETTER W
-	{runeRange{0x1E130, 0x1E136}, propertyGeneralCategory{lbprCM, gcMn}},   //     [7] NYIAKENG PUACHUE HMONG TONE-B..NYIAKENG PUACHUE HMONG TONE-D
-	{runeRange{0x1E137, 0x1E13D}, propertyGeneralCategory{lbprAL, gcLm}},   //     [7] NYIAKENG PUACHUE HMONG SIGN FOR PERSON..NYIAKENG PUACHUE HMONG SYLLABLE LENGTHENER
-	{runeRange{0x1E140, 0x1E149}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] NYIAKENG PUACHUE HMONG DIGIT ZERO..NYIAKENG PUACHUE HMONG DIGIT NINE
-	{runeRange{0x1E14E, 0x1E14E}, propertyGeneralCategory{lbprAL, gcLo}},   //         NYIAKENG PUACHUE HMONG LOGOGRAM NYAJ
-	{runeRange{0x1E14F, 0x1E14F}, propertyGeneralCategory{lbprAL, gcSo}},   //         NYIAKENG PUACHUE HMONG CIRCLED CA
-	{runeRange{0x1E290, 0x1E2AD}, propertyGeneralCategory{lbprAL, gcLo}},   //    [30] TOTO LETTER PA..TOTO LETTER A
-	{runeRange{0x1E2AE, 0x1E2AE}, propertyGeneralCategory{lbprCM, gcMn}},   //         TOTO SIGN RISING TONE
-	{runeRange{0x1E2C0, 0x1E2EB}, propertyGeneralCategory{lbprAL, gcLo}},   //    [44] WANCHO LETTER AA..WANCHO LETTER YIH
-	{runeRange{0x1E2EC, 0x1E2EF}, propertyGeneralCategory{lbprCM, gcMn}},   //     [4] WANCHO TONE TUP..WANCHO TONE KOINI
-	{runeRange{0x1E2F0, 0x1E2F9}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] WANCHO DIGIT ZERO..WANCHO DIGIT NINE
-	{runeRange{0x1E2FF, 0x1E2FF}, propertyGeneralCategory{lbprPR, gcSc}},   //         WANCHO NGUN SIGN
-	{runeRange{0x1E4D0, 0x1E4EA}, propertyGeneralCategory{lbprAL, gcLo}},   //    [27] NAG MUNDARI LETTER O..NAG MUNDARI LETTER ELL
-	{runeRange{0x1E4EB, 0x1E4EB}, propertyGeneralCategory{lbprAL, gcLm}},   //         NAG MUNDARI SIGN OJOD
-	{runeRange{0x1E4EC, 0x1E4EF}, propertyGeneralCategory{lbprCM, gcMn}},   //     [4] NAG MUNDARI SIGN MUHOR..NAG MUNDARI SIGN SUTUH
-	{runeRange{0x1E4F0, 0x1E4F9}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] NAG MUNDARI DIGIT ZERO..NAG MUNDARI DIGIT NINE
-	{runeRange{0x1E7E0, 0x1E7E6}, propertyGeneralCategory{lbprAL, gcLo}},   //     [7] ETHIOPIC SYLLABLE HHYA..ETHIOPIC SYLLABLE HHYO
-	{runeRange{0x1E7E8, 0x1E7EB}, propertyGeneralCategory{lbprAL, gcLo}},   //     [4] ETHIOPIC SYLLABLE GURAGE HHWA..ETHIOPIC SYLLABLE HHWE
-	{runeRange{0x1E7ED, 0x1E7EE}, propertyGeneralCategory{lbprAL, gcLo}},   //     [2] ETHIOPIC SYLLABLE GURAGE MWI..ETHIOPIC SYLLABLE GURAGE MWEE
-	{runeRange{0x1E7F0, 0x1E7FE}, propertyGeneralCategory{lbprAL, gcLo}},   //    [15] ETHIOPIC SYLLABLE GURAGE QWI..ETHIOPIC SYLLABLE GURAGE PWEE
-	{runeRange{0x1E800, 0x1E8C4}, propertyGeneralCategory{lbprAL, gcLo}},   //   [197] MENDE KIKAKUI SYLLABLE M001 KI..MENDE KIKAKUI SYLLABLE M060 NYON
-	{runeRange{0x1E8C7, 0x1E8CF}, propertyGeneralCategory{lbprAL, gcNo}},   //     [9] MENDE KIKAKUI DIGIT ONE..MENDE KIKAKUI DIGIT NINE
-	{runeRange{0x1E8D0, 0x1E8D6}, propertyGeneralCategory{lbprCM, gcMn}},   //     [7] MENDE KIKAKUI COMBINING NUMBER TEENS..MENDE KIKAKUI COMBINING NUMBER MILLIONS
-	{runeRange{0x1E900, 0x1E943}, propertyGeneralCategory{lbprAL, gcLC}},   //    [68] ADLAM CAPITAL LETTER ALIF..ADLAM SMALL LETTER SHA
-	{runeRange{0x1E944, 0x1E94A}, propertyGeneralCategory{lbprCM, gcMn}},   //     [7] ADLAM ALIF LENGTHENER..ADLAM NUKTA
+	{runeRange{0x0F2A, 0x0F33}, propertyGeneralCategory{lbprAL, gcNo}},     //    [10] TIBETAN DIGIT HALF ONE..TIBETAN DIGIT HALF ZERO
+	{runeRange{0xA800, 0xA801}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] SYLOTI NAGRI LETTER A..SYLOTI NAGRI LETTER I
+	{runeRange{0xFF09, 0xFF09}, propertyGeneralCategory{lbprCL, gcPe}},     //         FULLWIDTH RIGHT PARENTHESIS
 	{runeRange{0x1E94B, 0x1E94B}, propertyGeneralCategory{lbprAL, gcLm}},   //         ADLAM NASALIZATION MARK
-	{runeRange{0x1E950, 0x1E959}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] ADLAM DIGIT ZERO..ADLAM DIGIT NINE
-	{runeRange{0x1E95E, 0x1E95F}, propertyGeneralCategory{lbprOP, gcPo}},   //     [2] ADLAM INITIAL EXCLAMATION MARK..ADLAM INITIAL QUESTION MARK
-	{runeRange{0x1EC71, 0x1ECAB}, propertyGeneralCategory{lbprAL, gcNo}},   //    [59] INDIC SIYAQ NUMBER ONE..INDIC SIYAQ NUMBER PREFIXED NINE
-	{runeRange{0x1ECAC, 0x1ECAC}, propertyGeneralCategory{lbprPO, gcSo}},   //         INDIC SIYAQ PLACEHOLDER
-	{runeRange{0x1ECAD, 0x1ECAF}, propertyGeneralCategory{lbprAL, gcNo}},   //     [3] INDIC SIYAQ FRACTION ONE QUARTER..INDIC SIYAQ FRACTION THREE QUARTERS
-	{runeRange{0x1ECB0, 0x1ECB0}, propertyGeneralCategory{lbprPO, gcSc}},   //         INDIC SIYAQ RUPEE MARK
-	{runeRange{0x1ECB1, 0x1ECB4}, propertyGeneralCategory{lbprAL, gcNo}},   //     [4] INDIC SIYAQ NUMBER ALTERNATE ONE..INDIC SIYAQ ALTERNATE LAKH MARK
-	{runeRange{0x1ED01, 0x1ED2D}, propertyGeneralCategory{lbprAL, gcNo}},   //    [45] OTTOMAN SIYAQ NUMBER ONE..OTTOMAN SIYAQ NUMBER NINETY THOUSAND
-	{runeRange{0x1ED2E, 0x1ED2E}, propertyGeneralCategory{lbprAL, gcSo}},   //         OTTOMAN SIYAQ MARRATAN
-	{runeRange{0x1ED2F, 0x1ED3D}, propertyGeneralCategory{lbprAL, gcNo}},   //    [15] OTTOMAN SIYAQ ALTERNATE NUMBER TWO..OTTOMAN SIYAQ FRACTION ONE SIXTH
-	{runeRange{0x1EE00, 0x1EE03}, propertyGeneralCategory{lbprAL, gcLo}},   //     [4] ARABIC MATHEMATICAL ALEF..ARABIC MATHEMATICAL DAL
-	{runeRange{0x1EE05, 0x1EE1F}, propertyGeneralCategory{lbprAL, gcLo}},   //    [27] ARABIC MATHEMATICAL WAW..ARABIC MATHEMATICAL DOTLESS QAF
-	{runeRange{0x1EE21, 0x1EE22}, propertyGeneralCategory{lbprAL, gcLo}},   //     [2] ARABIC MATHEMATICAL INITIAL BEH..ARABIC MATHEMATICAL INITIAL JEEM
-	{runeRange{0x1EE24, 0x1EE24}, propertyGeneralCategory{lbprAL, gcLo}},   //         ARABIC MATHEMATICAL INITIAL HEH
-	{runeRange{0x1EE27, 0x1EE27}, propertyGeneralCategory{lbprAL, gcLo}},   //         ARABIC MATHEMATICAL INITIAL HAH
-	{runeRange{0x1EE29, 0x1EE32}, propertyGeneralCategory{lbprAL, gcLo}},   //    [10] ARABIC MATHEMATICAL INITIAL YEH..ARABIC MATHEMATICAL INITIAL QAF
-	{runeRange{0x1EE34, 0x1EE37}, propertyGeneralCategory{lbprAL, gcLo}},   //     [4] ARABIC MATHEMATICAL INITIAL SHEEN..ARABIC MATHEMATICAL INITIAL KHAH
-	{runeRange{0x1EE39, 0x1EE39}, propertyGeneralCategory{lbprAL, gcLo}},   //         ARABIC MATHEMATICAL INITIAL DAD
-	{runeRange{0x1EE3B, 0x1EE3B}, propertyGeneralCategory{lbprAL, gcLo}},   //         ARABIC MATHEMATICAL INITIAL GHAIN
-	{runeRange{0x1EE42, 0x1EE42}, propertyGeneralCategory{lbprAL, gcLo}},   //         ARABIC MATHEMATICAL TAILED JEEM
-	{runeRange{0x1EE47, 0x1EE47}, propertyGeneralCategory{lbprAL, gcLo}},   //         ARABIC MATHEMATICAL TAILED HAH
-	{runeRange{0x1EE49, 0x1EE49}, propertyGeneralCategory{lbprAL, gcLo}},   //         ARABIC MATHEMATICAL TAILED YEH
-	{runeRange{0x1EE4B, 0x1EE4B}, propertyGeneralCategory{lbprAL, gcLo}},   //         ARABIC MATHEMATICAL TAILED LAM
-	{runeRange{0x1EE4D, 0x1EE4F}, propertyGeneralCategory{lbprAL, gcLo}},   //     [3] ARABIC MATHEMATICAL TAILED NOON..ARABIC MATHEMATICAL TAILED AIN
-	{runeRange{0x1EE51, 0x1EE52}, propertyGeneralCategory{lbprAL, gcLo}},   //     [2] ARABIC MATHEMATICAL TAILED SAD..ARABIC MATHEMATICAL TAILED QAF
-	{runeRange{0x1EE54, 0x1EE54}, propertyGeneralCategory{lbprAL, gcLo}},   //         ARABIC MATHEMATICAL TAILED SHEEN
-	{runeRange{0x1EE57, 0x1EE57}, propertyGeneralCategory{lbprAL, gcLo}},   //         ARABIC MATHEMATICAL TAILED KHAH
-	{runeRange{0x1EE59, 0x1EE59}, propertyGeneralCategory{lbprAL, gcLo}},   //         ARABIC MATHEMATICAL TAILED DAD
-	{runeRange{0x1EE5B, 0x1EE5B}, propertyGeneralCategory{lbprAL, gcLo}},   //         ARABIC MATHEMATICAL TAILED GHAIN
-	{runeRange{0x1EE5D, 0x1EE5D}, propertyGeneralCategory{lbprAL, gcLo}},   //         ARABIC MATHEMATICAL TAILED DOTLESS NOON
-	{runeRange{0x1EE5F, 0x1EE5F}, propertyGeneralCategory{lbprAL, gcLo}},   //         ARABIC MATHEMATICAL TAILED DOTLESS QAF
-	{runeRange{0x1EE61, 0x1EE62}, propertyGeneralCategory{lbprAL, gcLo}},   //     [2] ARABIC MATHEMATICAL STRETCHED BEH..ARABIC MATHEMATICAL STRETCHED JEEM
-	{runeRange{0x1EE64, 0x1EE64}, propertyGeneralCategory{lbprAL, gcLo}},   //         ARABIC MATHEMATICAL STRETCHED HEH
-	{runeRange{0x1EE67, 0x1EE6A}, propertyGeneralCategory{lbprAL, gcLo}},   //     [4] ARABIC MATHEMATICAL STRETCHED HAH..ARABIC MATHEMATICAL STRETCHED KAF
-	{runeRange{0x1EE6C, 0x1EE72}, propertyGeneralCategory{lbprAL, gcLo}},   //     [7] ARABIC MATHEMATICAL STRETCHED MEEM..ARABIC MATHEMATICAL STRETCHED QAF
-	{runeRange{0x1EE74, 0x1EE77}, propertyGeneralCategory{lbprAL, gcLo}},   //     [4] ARABIC MATHEMATICAL STRETCHED SHEEN..ARABIC MATHEMATICAL STRETCHED KHAH
-	{runeRange{0x1EE79, 0x1EE7C}, propertyGeneralCategory{lbprAL, gcLo}},   //     [4] ARABIC MATHEMATICAL STRETCHED DAD..ARABIC MATHEMATICAL STRETCHED DOTLESS BEH
-	{runeRange{0x1EE7E, 0x1EE7E}, propertyGeneralCategory{lbprAL, gcLo}},   //         ARABIC MATHEMATICAL STRETCHED DOTLESS FEH
-	{runeRange{0x1EE80, 0x1EE89}, propertyGeneralCategory{lbprAL, gcLo}},   //    [10] ARABIC MATHEMATICAL LOOPED ALEF..ARABIC MATHEMATICAL LOOPED YEH
-	{runeRange{0x1EE8B, 0x1EE9B}, propertyGeneralCategory{lbprAL, gcLo}},   //    [17] ARABIC MATHEMATICAL LOOPED LAM..ARABIC MATHEMATICAL LOOPED GHAIN
-	{runeRange{0x1EEA1, 0x1EEA3}, propertyGeneralCategory{lbprAL, gcLo}},   //     [3] ARABIC MATHEMATICAL DOUBLE-STRUCK BEH..ARABIC MATHEMATICAL DOUBLE-STRUCK DAL
-	{runeRange{0x1EEA5, 0x1EEA9}, propertyGeneralCategory{lbprAL, gcLo}},   //     [5] ARABIC MATHEMATICAL DOUBLE-STRUCK WAW..ARABIC MATHEMATICAL DOUBLE-STRUCK YEH
-	{runeRange{0x1EEAB, 0x1EEBB}, propertyGeneralCategory{lbprAL, gcLo}},   //    [17] ARABIC MATHEMATICAL DOUBLE-STRUCK LAM..ARABIC MATHEMATICAL DOUBLE-STRUCK GHAIN
-	{runeRange{0x1EEF0, 0x1EEF1}, propertyGeneralCategory{lbprAL, gcSm}},   //     [2] ARABIC MATHEMATICAL OPERATOR MEEM WITH HAH WITH TATWEEL..ARABIC MATHEMATICAL OPERATOR HAH WITH DAL
-	{runeRange{0x1F000, 0x1F02B}, propertyGeneralCategory{lbprID, gcSo}},   //    [44] MAHJONG TILE EAST WIND..MAHJONG TILE BACK
-	{runeRange{0x1F02C, 0x1F02F}, propertyGeneralCategory{lbprID, gcCn}},   //     [4] <reserved-1F02C>..<reserved-1F02F>
-	{runeRange{0x1F030, 0x1F093}, propertyGeneralCategory{lbprID, gcSo}},   //   [100] DOMINO TILE HORIZONTAL BACK..DOMINO TILE VERTICAL-06-06
-	{runeRange{0x1F094, 0x1F09F}, propertyGeneralCategory{lbprID, gcCn}},   //    [12] <reserved-1F094>..<reserved-1F09F>
-	{runeRange{0x1F0A0, 0x1F0AE}, propertyGeneralCategory{lbprID, gcSo}},   //    [15] PLAYING CARD BACK..PLAYING CARD KING OF SPADES
-	{runeRange{0x1F0AF, 0x1F0B0}, propertyGeneralCategory{lbprID, gcCn}},   //     [2] <reserved-1F0AF>..<reserved-1F0B0>
-	{runeRange{0x1F0B1, 0x1F0BF}, propertyGeneralCategory{lbprID, gcSo}},   //    [15] PLAYING CARD ACE OF HEARTS..PLAYING CARD RED JOKER
-	{runeRange{0x1F0C0, 0x1F0C0}, propertyGeneralCategory{lbprID, gcCn}},   //         <reserved-1F0C0>
-	{runeRange{0x1F0C1, 0x1F0CF}, propertyGeneralCategory{lbprID, gcSo}},   //    [15] PLAYING CARD ACE OF DIAMONDS..PLAYING CARD BLACK JOKER
-	{runeRange{0x1F0D0, 0x1F0D0}, propertyGeneralCategory{lbprID, gcCn}},   //         <reserved-1F0D0>
-	{runeRange{0x1F0D1, 0x1F0F5}, propertyGeneralCategory{lbprID, gcSo}},   //    [37] PLAYING CARD ACE OF CLUBS..PLAYING CARD TRUMP-21
-	{runeRange{0x1F0F6, 0x1F0FF}, propertyGeneralCategory{lbprID, gcCn}},   //    [10] <reserved-1F0F6>..<reserved-1F0FF>
-	{runeRange{0x1F100, 0x1F10C}, propertyGeneralCategory{lbprAI, gcNo}},   //    [13] DIGIT ZERO FULL STOP..DINGBAT NEGATIVE CIRCLED SANS-SERIF DIGIT ZERO
-	{runeRange{0x1F10D, 0x1F10F}, propertyGeneralCategory{lbprID, gcSo}},   //     [3] CIRCLED ZERO WITH SLASH..CIRCLED DOLLAR SIGN WITH OVERLAID BACKSLASH
-	{runeRange{0x1F110, 0x1F12D}, propertyGeneralCategory{lbprAI, gcSo}},   //    [30] PARENTHESIZED LATIN CAPITAL LETTER A..CIRCLED CD
-	{runeRange{0x1F12E, 0x1F12F}, propertyGeneralCategory{lbprAL, gcSo}},   //     [2] CIRCLED WZ..COPYLEFT SYMBOL
-	{runeRange{0x1F130, 0x1F169}, propertyGeneralCategory{lbprAI, gcSo}},   //    [58] SQUARED LATIN CAPITAL LETTER A..NEGATIVE CIRCLED LATIN CAPITAL LETTER Z
-	{runeRange{0x1F16A, 0x1F16C}, propertyGeneralCategory{lbprAL, gcSo}},   //     [3] RAISED MC SIGN..RAISED MR SIGN
-	{runeRange{0x1F16D, 0x1F16F}, propertyGeneralCategory{lbprID, gcSo}},   //     [3] CIRCLED CC..CIRCLED HUMAN FIGURE
-	{runeRange{0x1F170, 0x1F1AC}, propertyGeneralCategory{lbprAI, gcSo}},   //    [61] NEGATIVE SQUARED LATIN CAPITAL LETTER A..SQUARED VOD
-	{runeRange{0x1F1AD, 0x1F1AD}, propertyGeneralCategory{lbprID, gcSo}},   //         MASK WORK SYMBOL
-	{runeRange{0x1F1AE, 0x1F1E5}, propertyGeneralCategory{lbprID, gcCn}},   //    [56] <reserved-1F1AE>..<reserved-1F1E5>
-	{runeRange{0x1F1E6, 0x1F1FF}, propertyGeneralCategory{lbprRI, gcSo}},   //    [26] REGIONAL INDICATOR SYMBOL LETTER A..REGIONAL INDICATOR SYMBOL LETTER Z
-	{runeRange{0x1F200, 0x1F202}, propertyGeneralCategory{lbprID, gcSo}},   //     [3] SQUARE HIRAGANA HOKA..SQUARED KATAKANA SA
-	{runeRange{0x1F203, 0x1F20F}, propertyGeneralCategory{lbprID, gcCn}},   //    [13] <reserved-1F203>..<reserved-1F20F>
-	{runeRange{0x1F210, 0x1F23B}, propertyGeneralCategory{lbprID, gcSo}},   //    [44] SQUARED CJK UNIFIED IDEOGRAPH-624B..SQUARED CJK UNIFIED IDEOGRAPH-914D
-	{runeRange{0x1F23C, 0x1F23F}, propertyGeneralCategory{lbprID, gcCn}},   //     [4] <reserved-1F23C>..<reserved-1F23F>
-	{runeRange{0x1F240, 0x1F248}, propertyGeneralCategory{lbprID, gcSo}},   //     [9] TORTOISE SHELL BRACKETED CJK UNIFIED IDEOGRAPH-672C..TORTOISE SHELL BRACKETED CJK UNIFIED IDEOGRAPH-6557
-	{runeRange{0x1F249, 0x1F24F}, propertyGeneralCategory{lbprID, gcCn}},   //     [7] <reserved-1F249>..<reserved-1F24F>
-	{runeRange{0x1F250, 0x1F251}, propertyGeneralCategory{lbprID, gcSo}},   //     [2] CIRCLED IDEOGRAPH ADVANTAGE..CIRCLED IDEOGRAPH ACCEPT
-	{runeRange{0x1F252, 0x1F25F}, propertyGeneralCategory{lbprID, gcCn}},   //    [14] <reserved-1F252>..<reserved-1F25F>
-	{runeRange{0x1F260, 0x1F265}, propertyGeneralCategory{lbprID, gcSo}},   //     [6] ROUNDED SYMBOL FOR FU..ROUNDED SYMBOL FOR CAI
-	{runeRange{0x1F266, 0x1F2FF}, propertyGeneralCategory{lbprID, gcCn}},   //   [154] <reserved-1F266>..<reserved-1F2FF>
-	{runeRange{0x1F300, 0x1F384}, propertyGeneralCategory{lbprID, gcSo}},   //   [133] CYCLONE..CHRISTMAS TREE
-	{runeRange{0x1F385, 0x1F385}, propertyGeneralCategory{lbprEB, gcSo}},   //         FATHER CHRISTMAS
-	{runeRange{0x1F386, 0x1F39B}, propertyGeneralCategory{lbprID, gcSo}},   //    [22] FIREWORKS..CONTROL KNOBS
-	{runeRange{0x1F39C, 0x1F39D}, propertyGeneralCategory{lbprAL, gcSo}},   //     [2] BEAMED ASCENDING MUSICAL NOTES..BEAMED DESCENDING MUSICAL NOTES
-	{runeRange{0x1F39E, 0x1F3B4}, propertyGeneralCategory{lbprID, gcSo}},   //    [23] FILM FRAMES..FLOWER PLAYING CARDS
-	{runeRange{0x1F3B5, 0x1F3B6}, propertyGeneralCategory{lbprAL, gcSo}},   //     [2] MUSICAL NOTE..MULTIPLE MUSICAL NOTES
-	{runeRange{0x1F3B7, 0x1F3BB}, propertyGeneralCategory{lbprID, gcSo}},   //     [5] SAXOPHONE..VIOLIN
-	{runeRange{0x1F3BC, 0x1F3BC}, propertyGeneralCategory{lbprAL, gcSo}},   //         MUSICAL SCORE
-	{runeRange{0x1F3BD, 0x1F3C1}, propertyGeneralCategory{lbprID, gcSo}},   //     [5] RUNNING SHIRT WITH SASH..CHEQUERED FLAG
-	{runeRange{0x1F3C2, 0x1F3C4}, propertyGeneralCategory{lbprEB, gcSo}},   //     [3] SNOWBOARDER..SURFER
-	{runeRange{0x1F3C5, 0x1F3C6}, propertyGeneralCategory{lbprID, gcSo}},   //     [2] SPORTS MEDAL..TROPHY
-	{runeRange{0x1F3C7, 0x1F3C7}, propertyGeneralCategory{lbprEB, gcSo}},   //         HORSE RACING
-	{runeRange{0x1F3C8, 0x1F3C9}, propertyGeneralCategory{lbprID, gcSo}},   //     [2] AMERICAN FOOTBALL..RUGBY FOOTBALL
-	{runeRange{0x1F3CA, 0x1F3CC}, propertyGeneralCategory{lbprEB, gcSo}},   //     [3] SWIMMER..GOLFER
-	{runeRange{0x1F3CD, 0x1F3FA}, propertyGeneralCategory{lbprID, gcSo}},   //    [46] RACING MOTORCYCLE..AMPHORA
-	{runeRange{0x1F3FB, 0x1F3FF}, propertyGeneralCategory{lbprEM, gcSk}},   //     [5] EMOJI MODIFIER FITZPATRICK TYPE-1-2..EMOJI MODIFIER FITZPATRICK TYPE-6
-	{runeRange{0x1F400, 0x1F441}, propertyGeneralCategory{lbprID, gcSo}},   //    [66] RAT..EYE
-	{runeRange{0x1F442, 0x1F443}, propertyGeneralCategory{lbprEB, gcSo}},   //     [2] EAR..NOSE
-	{runeRange{0x1F444, 0x1F445}, propertyGeneralCategory{lbprID, gcSo}},   //     [2] MOUTH..TONGUE
-	{runeRange{0x1F446, 0x1F450}, propertyGeneralCategory{lbprEB, gcSo}},   //    [11] WHITE UP POINTING BACKHAND INDEX..OPEN HANDS SIGN
-	{runeRange{0x1F451, 0x1F465}, propertyGeneralCategory{lbprID, gcSo}},   //    [21] CROWN..BUSTS IN SILHOUETTE
-	{runeRange{0x1F466, 0x1F478}, propertyGeneralCategory{lbprEB, gcSo}},   //    [19] BOY..PRINCESS
-	{runeRange{0x1F479, 0x1F47B}, propertyGeneralCategory{lbprID, gcSo}},   //     [3] JAPANESE OGRE..GHOST
-	{runeRange{0x1F47C, 0x1F47C}, propertyGeneralCategory{lbprEB, gcSo}},   //         BABY ANGEL
-	{runeRange{0x1F47D, 0x1F480}, propertyGeneralCategory{lbprID, gcSo}},   //     [4] EXTRATERRESTRIAL ALIEN..SKULL
-	{runeRange{0x1F481, 0x1F483}, propertyGeneralCategory{lbprEB, gcSo}},   //     [3] INFORMATION DESK PERSON..DANCER
-	{runeRange{0x1F484, 0x1F484}, propertyGeneralCategory{lbprID, gcSo}},   //         LIPSTICK
-	{runeRange{0x1F485, 0x1F487}, propertyGeneralCategory{lbprEB, gcSo}},   //     [3] NAIL POLISH..HAIRCUT
-	{runeRange{0x1F488, 0x1F48E}, propertyGeneralCategory{lbprID, gcSo}},   //     [7] BARBER POLE..GEM STONE
-	{runeRange{0x1F48F, 0x1F48F}, propertyGeneralCategory{lbprEB, gcSo}},   //         KISS
-	{runeRange{0x1F490, 0x1F490}, propertyGeneralCategory{lbprID, gcSo}},   //         BOUQUET
-	{runeRange{0x1F491, 0x1F491}, propertyGeneralCategory{lbprEB, gcSo}},   //         COUPLE WITH HEART
-	{runeRange{0x1F492, 0x1F49F}, propertyGeneralCategory{lbprID, gcSo}},   //    [14] WEDDING..HEART DECORATION
-	{runeRange{0x1F4A0, 0x1F4A0}, propertyGeneralCategory{lbprAL, gcSo}},   //         DIAMOND SHAPE WITH A DOT INSIDE
-	{runeRange{0x1F4A1, 0x1F4A1}, propertyGeneralCategory{lbprID, gcSo}},   //         ELECTRIC LIGHT BULB
-	{runeRange{0x1F4A2, 0x1F4A2}, propertyGeneralCategory{lbprAL, gcSo}},   //         ANGER SYMBOL
-	{runeRange{0x1F4A3, 0x1F4A3}, propertyGeneralCategory{lbprID, gcSo}},   //         BOMB
-	{runeRange{0x1F4A4, 0x1F4A4}, propertyGeneralCategory{lbprAL, gcSo}},   //         SLEEPING SYMBOL
-	{runeRange{0x1F4A5, 0x1F4A9}, propertyGeneralCategory{lbprID, gcSo}},   //     [5] COLLISION SYMBOL..PILE OF POO
-	{runeRange{0x1F4AA, 0x1F4AA}, propertyGeneralCategory{lbprEB, gcSo}},   //         FLEXED BICEPS
-	{runeRange{0x1F4AB, 0x1F4AE}, propertyGeneralCategory{lbprID, gcSo}},   //     [4] DIZZY SYMBOL..WHITE FLOWER
-	{runeRange{0x1F4AF, 0x1F4AF}, propertyGeneralCategory{lbprAL, gcSo}},   //         HUNDRED POINTS SYMBOL
-	{runeRange{0x1F4B0, 0x1F4B0}, propertyGeneralCategory{lbprID, gcSo}},   //         MONEY BAG
-	{runeRange{0x1F4B1, 0x1F4B2}, propertyGeneralCategory{lbprAL, gcSo}},   //     [2] CURRENCY EXCHANGE..HEAVY DOLLAR SIGN
-	{runeRange{0x1F4B3, 0x1F4FF}, propertyGeneralCategory{lbprID, gcSo}},   //    [77] CREDIT CARD..PRAYER BEADS
-	{runeRange{0x1F500, 0x1F506}, propertyGeneralCategory{lbprAL, gcSo}},   //     [7] TWISTED RIGHTWARDS ARROWS..HIGH BRIGHTNESS SYMBOL
-	{runeRange{0x1F507, 0x1F516}, propertyGeneralCategory{lbprID, gcSo}},   //    [16] SPEAKER WITH CANCELLATION STROKE..BOOKMARK
-	{runeRange{0x1F517, 0x1F524}, propertyGeneralCategory{lbprAL, gcSo}},   //    [14] LINK SYMBOL..INPUT SYMBOL FOR LATIN LETTERS
-	{runeRange{0x1F525, 0x1F531}, propertyGeneralCategory{lbprID, gcSo}},   //    [13] FIRE..TRIDENT EMBLEM
-	{runeRange{0x1F532, 0x1F549}, propertyGeneralCategory{lbprAL, gcSo}},   //    [24] BLACK SQUARE BUTTON..OM SYMBOL
+	{runeRange{0x0972, 0x097F}, propertyGeneralCategory{lbprAL, gcLo}},     //    [14] DEVANAGARI LETTER CANDRA A..DEVANAGARI LETTER BBA
+	{runeRange{0x1BFC, 0x1BFF}, propertyGeneralCategory{lbprAL, gcPo}},     //     [4] BATAK SYMBOL BINDU NA METEK..BATAK SYMBOL BINDU PANGOLAT
+	{runeRange{0x2CF2, 0x2CF3}, propertyGeneralCategory{lbprAL, gcLC}},     //     [2] COPTIC CAPITAL LETTER BOHAIRIC KHEI..COPTIC SMALL LETTER BOHAIRIC KHEI
+	{runeRange{0xB2E4, 0xB2E4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DA
+	{runeRange{0xCEE4, 0xCEE4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KEO
+	{runeRange{0x111CE, 0x111CE}, propertyGeneralCategory{lbprCM, gcMc}},   //         SHARADA VOWEL SIGN PRISHTHAMATRA E
+	{runeRange{0x1B100, 0x1B122}, propertyGeneralCategory{lbprID, gcLo}},   //    [35] HENTAIGANA LETTER RE-3..KATAKANA LETTER ARCHAIC WU
 	{runeRange{0x1F54A, 0x1F573}, propertyGeneralCategory{lbprID, gcSo}},   //    [42] DOVE OF PEACE..HOLE
-	{runeRange{0x1F574, 0x1F575}, propertyGeneralCategory{lbprEB, gcSo}},   //     [2] MAN IN BUSINESS SUIT LEVITATING..SLEUTH OR SPY
-	{runeRange{0x1F576, 0x1F579}, propertyGeneralCategory{lbprID, gcSo}},   //     [4] DARK SUNGLASSES..JOYSTICK
-	{runeRange{0x1F57A, 0x1F57A}, propertyGeneralCategory{lbprEB, gcSo}},   //         MAN DANCING
-	{runeRange{0x1F57B, 0x1F58F}, propertyGeneralCategory{lbprID, gcSo}},   //    [21] LEFT HAND TELEPHONE RECEIVER..TURNED OK HAND SIGN
-	{runeRange{0x1F590, 0x1F590}, propertyGeneralCategory{lbprEB, gcSo}},   //         RAISED HAND WITH FINGERS SPLAYED
-	{runeRange{0x1F591, 0x1F594}, propertyGeneralCategory{lbprID, gcSo}},   //     [4] REVERSED RAISED HAND WITH FINGERS SPLAYED..REVERSED VICTORY HAND
-	{runeRange{0x1F595, 0x1F596}, propertyGeneralCategory{lbprEB, gcSo}},   //     [2] REVERSED HAND WITH MIDDLE FINGER EXTENDED..RAISED HAND WITH PART BETWEEN MIDDLE AND RING FINGERS
-	{runeRange{0x1F597, 0x1F5D3}, propertyGeneralCategory{lbprID, gcSo}},   //    [61] WHITE DOWN POINTING LEFT HAND INDEX..SPIRAL CALENDAR PAD
-	{runeRange{0x1F5D4, 0x1F5DB}, propertyGeneralCategory{lbprAL, gcSo}},   //     [8] DESKTOP WINDOW..DECREASE FONT SIZE SYMBOL
-	{runeRange{0x1F5DC, 0x1F5F3}, propertyGeneralCategory{lbprID, gcSo}},   //    [24] COMPRESSION..BALLOT BOX WITH BALLOT
-	{runeRange{0x1F5F4, 0x1F5F9}, propertyGeneralCategory{lbprAL, gcSo}},   //     [6] BALLOT SCRIPT X..BALLOT BOX WITH BOLD CHECK
-	{runeRange{0x1F5FA, 0x1F5FF}, propertyGeneralCategory{lbprID, gcSo}},   //     [6] WORLD MAP..MOYAI
-	{runeRange{0x1F600, 0x1F644}, propertyGeneralCategory{lbprID, gcSo}},   //    [69] GRINNING FACE..FACE WITH ROLLING EYES
-	{runeRange{0x1F645, 0x1F647}, propertyGeneralCategory{lbprEB, gcSo}},   //     [3] FACE WITH NO GOOD GESTURE..PERSON BOWING DEEPLY
-	{runeRange{0x1F648, 0x1F64A}, propertyGeneralCategory{lbprID, gcSo}},   //     [3] SEE-NO-EVIL MONKEY..SPEAK-NO-EVIL MONKEY
-	{runeRange{0x1F64B, 0x1F64F}, propertyGeneralCategory{lbprEB, gcSo}},   //     [5] HAPPY PERSON RAISING ONE HAND..PERSON WITH FOLDED HANDS
-	{runeRange{0x1F650, 0x1F675}, propertyGeneralCategory{lbprAL, gcSo}},   //    [38] NORTH WEST POINTING LEAF..SWASH AMPERSAND ORNAMENT
-	{runeRange{0x1F676, 0x1F678}, propertyGeneralCategory{lbprQU, gcSo}},   //     [3] SANS-SERIF HEAVY DOUBLE TURNED COMMA QUOTATION MARK ORNAMENT..SANS-SERIF HEAVY LOW DOUBLE COMMA QUOTATION MARK ORNAMENT
-	{runeRange{0x1F679, 0x1F67B}, propertyGeneralCategory{lbprNS, gcSo}},   //     [3] HEAVY INTERROBANG ORNAMENT..HEAVY SANS-SERIF INTERROBANG ORNAMENT
-	{runeRange{0x1F67C, 0x1F67F}, propertyGeneralCategory{lbprAL, gcSo}},   //     [4] VERY HEAVY SOLIDUS..REVERSE CHECKER BOARD
-	{runeRange{0x1F680, 0x1F6A2}, propertyGeneralCategory{lbprID, gcSo}},   //    [35] ROCKET..SHIP
-	{runeRange{0x1F6A3, 0x1F6A3}, propertyGeneralCategory{lbprEB, gcSo}},   //         ROWBOAT
-	{runeRange{0x1F6A4, 0x1F6B3}, propertyGeneralCategory{lbprID, gcSo}},   //    [16] SPEEDBOAT..NO BICYCLES
-	{runeRange{0x1F6B4, 0x1F6B6}, propertyGeneralCategory{lbprEB, gcSo}},   //     [3] BICYCLIST..PEDESTRIAN
-	{runeRange{0x1F6B7, 0x1F6BF}, propertyGeneralCategory{lbprID, gcSo}},   //     [9] NO PEDESTRIANS..SHOWER
-	{runeRange{0x1F6C0, 0x1F6C0}, propertyGeneralCategory{lbprEB, gcSo}},   //         BATH
-	{runeRange{0x1F6C1, 0x1F6CB}, propertyGeneralCategory{lbprID, gcSo}},   //    [11] BATHTUB..COUCH AND LAMP
-	{runeRange{0x1F6CC, 0x1F6CC}, propertyGeneralCategory{lbprEB, gcSo}},   //         SLEEPING ACCOMMODATION
-	{runeRange{0x1F6CD, 0x1F6D7}, propertyGeneralCategory{lbprID, gcSo}},   //    [11] SHOPPING BAGS..ELEVATOR
-	{runeRange{0x1F6D8, 0x1F6DB}, propertyGeneralCategory{lbprID, gcCn}},   //     [4] <reserved-1F6D8>..<reserved-1F6DB>
-	{runeRange{0x1F6DC, 0x1F6EC}, propertyGeneralCategory{lbprID, gcSo}},   //    [17] WIRELESS..AIRPLANE ARRIVING
-	{runeRange{0x1F6ED, 0x1F6EF}, propertyGeneralCategory{lbprID, gcCn}},   //     [3] <reserved-1F6ED>..<reserved-1F6EF>
-	{runeRange{0x1F6F0, 0x1F6FC}, propertyGeneralCategory{lbprID, gcSo}},   //    [13] SATELLITE..ROLLER SKATE
-	{runeRange{0x1F6FD, 0x1F6FF}, propertyGeneralCategory{lbprID, gcCn}},   //     [3] <reserved-1F6FD>..<reserved-1F6FF>
-	{runeRange{0x1F700, 0x1F773}, propertyGeneralCategory{lbprAL, gcSo}},   //   [116] ALCHEMICAL SYMBOL FOR QUINTESSENCE..ALCHEMICAL SYMBOL FOR HALF OUNCE
-	{runeRange{0x1F774, 0x1F776}, propertyGeneralCategory{lbprID, gcSo}},   //     [3] LOT OF FORTUNE..LUNAR ECLIPSE
-	{runeRange{0x1F777, 0x1F77A}, propertyGeneralCategory{lbprID, gcCn}},   //     [4] <reserved-1F777>..<reserved-1F77A>
-	{runeRange{0x1F77B, 0x1F77F}, propertyGeneralCategory{lbprID, gcSo}},   //     [5] HAUMEA..ORCUS
-	{runeRange{0x1F780, 0x1F7D4}, propertyGeneralCategory{lbprAL, gcSo}},   //    [85] BLACK LEFT-POINTING ISOSCELES RIGHT TRIANGLE..HEAVY TWELVE POINTED PINWHEEL STAR
-	{runeRange{0x1F7D5, 0x1F7D9}, propertyGeneralCategory{lbprID, gcSo}},   //     [5] CIRCLED TRIANGLE..NINE POINTED WHITE STAR
-	{runeRange{0x1F7DA, 0x1F7DF}, propertyGeneralCategory{lbprID, gcCn}},   //     [6] <reserved-1F7DA>..<reserved-1F7DF>
-	{runeRange{0x1F7E0, 0x1F7EB}, propertyGeneralCategory{lbprID, gcSo}},   //    [12] LARGE ORANGE CIRCLE..LARGE BROWN SQUARE
-	{runeRange{0x1F7EC, 0x1F7EF}, propertyGeneralCategory{lbprID, gcCn}},   //     [4] <reserved-1F7EC>..<reserved-1F7EF>
-	{runeRange{0x1F7F0, 0x1F7F0}, propertyGeneralCategory{lbprID, gcSo}},   //         HEAVY EQUALS SIGN
-	{runeRange{0x1F7F1, 0x1F7FF}, propertyGeneralCategory{lbprID, gcCn}},   //    [15] <reserved-1F7F1>..<reserved-1F7FF>
-	{runeRange{0x1F800, 0x1F80B}, propertyGeneralCategory{lbprAL, gcSo}},   //    [12] LEFTWARDS ARROW WITH SMALL TRIANGLE ARROWHEAD..DOWNWARDS ARROW WITH LARGE TRIANGLE ARROWHEAD
-	{runeRange{0x1F80C, 0x1F80F}, propertyGeneralCategory{lbprID, gcCn}},   //     [4] <reserved-1F80C>..<reserved-1F80F>
-	{runeRange{0x1F810, 0x1F847}, propertyGeneralCategory{lbprAL, gcSo}},   //    [56] LEFTWARDS ARROW WITH SMALL EQUILATERAL ARROWHEAD..DOWNWARDS HEAVY ARROW
-	{runeRange{0x1F848, 0x1F84F}, propertyGeneralCategory{lbprID, gcCn}},   //     [8] <reserved-1F848>..<reserved-1F84F>
-	{runeRange{0x1F850, 0x1F859}, propertyGeneralCategory{lbprAL, gcSo}},   //    [10] LEFTWARDS SANS-SERIF ARROW..UP DOWN SANS-SERIF ARROW
-	{runeRange{0x1F85A, 0x1F85F}, propertyGeneralCategory{lbprID, gcCn}},   //     [6] <reserved-1F85A>..<reserved-1F85F>
-	{runeRange{0x1F860, 0x1F887}, propertyGeneralCategory{lbprAL, gcSo}},   //    [40] WIDE-HEADED LEFTWARDS LIGHT BARB ARROW..WIDE-HEADED SOUTH WEST VERY HEAVY BARB ARROW
-	{runeRange{0x1F888, 0x1F88F}, propertyGeneralCategory{lbprID, gcCn}},   //     [8] <reserved-1F888>..<reserved-1F88F>
-	{runeRange{0x1F890, 0x1F8AD}, propertyGeneralCategory{lbprAL, gcSo}},   //    [30] LEFTWARDS TRIANGLE ARROWHEAD..WHITE ARROW SHAFT WIDTH TWO THIRDS
-	{runeRange{0x1F8AE, 0x1F8AF}, propertyGeneralCategory{lbprID, gcCn}},   //     [2] <reserved-1F8AE>..<reserved-1F8AF>
-	{runeRange{0x1F8B0, 0x1F8B1}, propertyGeneralCategory{lbprID, gcSo}},   //     [2] ARROW POINTING UPWARDS THEN NORTH WEST..ARROW POINTING RIGHTWARDS THEN CURVING SOUTH WEST
-	{runeRange{0x1F8B2, 0x1F8FF}, propertyGeneralCategory{lbprID, gcCn}},   //    [78] <reserved-1F8B2>..<reserved-1F8FF>
-	{runeRange{0x1F900, 0x1F90B}, propertyGeneralCategory{lbprAL, gcSo}},   //    [12] CIRCLED CROSS FORMEE WITH FOUR DOTS..DOWNWARD FACING NOTCHED HOOK WITH DOT
-	{runeRange{0x1F90C, 0x1F90C}, propertyGeneralCategory{lbprEB, gcSo}},   //         PINCHED FINGERS
-	{runeRange{0x1F90D, 0x1F90E}, propertyGeneralCategory{lbprID, gcSo}},   //     [2] WHITE HEART..BROWN HEART
-	{runeRange{0x1F90F, 0x1F90F}, propertyGeneralCategory{lbprEB, gcSo}},   //         PINCHING HAND
-	{runeRange{0x1F910, 0x1F917}, propertyGeneralCategory{lbprID, gcSo}},   //     [8] ZIPPER-MOUTH FACE..HUGGING FACE
-	{runeRange{0x1F918, 0x1F91F}, propertyGeneralCategory{lbprEB, gcSo}},   //     [8] SIGN OF THE HORNS..I LOVE YOU HAND SIGN
+	{runeRange{0x03F7, 0x03FF}, propertyGeneralCategory{lbprAL, gcLC}},     //     [9] GREEK CAPITAL LETTER SHO..GREEK CAPITAL REVERSED DOTTED LUNATE SIGMA SYMBOL
+	{runeRange{0x0C00, 0x0C00}, propertyGeneralCategory{lbprCM, gcMn}},     //         TELUGU SIGN COMBINING CANDRABINDU ABOVE
+	{runeRange{0x176E, 0x1770}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] TAGBANWA LETTER LA..TAGBANWA LETTER SA
+	{runeRange{0x2075, 0x2079}, propertyGeneralCategory{lbprAL, gcNo}},     //     [5] SUPERSCRIPT FIVE..SUPERSCRIPT NINE
+	{runeRange{0x266E, 0x266E}, propertyGeneralCategory{lbprAL, gcSo}},     //         MUSIC NATURAL SIGN
+	{runeRange{0x303D, 0x303D}, propertyGeneralCategory{lbprID, gcPo}},     //         PART ALTERNATION MARK
+	{runeRange{0xABED, 0xABED}, propertyGeneralCategory{lbprCM, gcMn}},     //         MEETEI MAYEK APUN IYEK
+	{runeRange{0xB9E4, 0xB9E4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MAE
+	{runeRange{0xC7E4, 0xC7E4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JYAE
+	{runeRange{0xD5E4, 0xD5E4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HE
+	{runeRange{0x108E0, 0x108F2}, propertyGeneralCategory{lbprAL, gcLo}},   //    [19] HATRAN LETTER ALEPH..HATRAN LETTER QOPH
+	{runeRange{0x1173C, 0x1173E}, propertyGeneralCategory{lbprBA, gcPo}},   //     [3] AHOM SIGN SMALL SECTION..AHOM SIGN RULAI
+	{runeRange{0x13289, 0x13289}, propertyGeneralCategory{lbprCL, gcLo}},   //         EGYPTIAN HIEROGLYPH O036D
+	{runeRange{0x1D715, 0x1D715}, propertyGeneralCategory{lbprAL, gcSm}},   //         MATHEMATICAL ITALIC PARTIAL DIFFERENTIAL
+	{runeRange{0x1F170, 0x1F1AC}, propertyGeneralCategory{lbprAI, gcSo}},   //    [61] NEGATIVE SQUARED LATIN CAPITAL LETTER A..SQUARED VOD
 	{runeRange{0x1F920, 0x1F925}, propertyGeneralCategory{lbprID, gcSo}},   //     [6] FACE WITH COWBOY HAT..LYING FACE
-	{runeRange{0x1F926, 0x1F926}, propertyGeneralCategory{lbprEB, gcSo}},   //         FACE PALM
-	{runeRange{0x1F927, 0x1F92F}, propertyGeneralCategory{lbprID, gcSo}},   //     [9] SNEEZING FACE..SHOCKED FACE WITH EXPLODING HEAD
-	{runeRange{0x1F930, 0x1F939}, propertyGeneralCategory{lbprEB, gcSo}},   //    [10] PREGNANT WOMAN..JUGGLING
-	{runeRange{0x1F93A, 0x1F93B}, propertyGeneralCategory{lbprID, gcSo}},   //     [2] FENCER..MODERN PENTATHLON
-	{runeRange{0x1F93C, 0x1F93E}, propertyGeneralCategory{lbprEB, gcSo}},   //     [3] WRESTLERS..HANDBALL
-	{runeRange{0x1F93F, 0x1F976}, propertyGeneralCategory{lbprID, gcSo}},   //    [56] DIVING MASK..FREEZING FACE
-	{runeRange{0x1F977, 0x1F977}, propertyGeneralCategory{lbprEB, gcSo}},   //         NINJA
-	{runeRange{0x1F978, 0x1F9B4}, propertyGeneralCategory{lbprID, gcSo}},   //    [61] DISGUISED FACE..BONE
-	{runeRange{0x1F9B5, 0x1F9B6}, propertyGeneralCategory{lbprEB, gcSo}},   //     [2] LEG..FOOT
-	{runeRange{0x1F9B7, 0x1F9B7}, propertyGeneralCategory{lbprID, gcSo}},   //         TOOTH
-	{runeRange{0x1F9B8, 0x1F9B9}, propertyGeneralCategory{lbprEB, gcSo}},   //     [2] SUPERHERO..SUPERVILLAIN
-	{runeRange{0x1F9BA, 0x1F9BA}, propertyGeneralCategory{lbprID, gcSo}},   //         SAFETY VEST
-	{runeRange{0x1F9BB, 0x1F9BB}, propertyGeneralCategory{lbprEB, gcSo}},   //         EAR WITH HEARING AID
-	{runeRange{0x1F9BC, 0x1F9CC}, propertyGeneralCategory{lbprID, gcSo}},   //    [17] MOTORIZED WHEELCHAIR..TROLL
-	{runeRange{0x1F9CD, 0x1F9CF}, propertyGeneralCategory{lbprEB, gcSo}},   //     [3] STANDING PERSON..DEAF PERSON
-	{runeRange{0x1F9D0, 0x1F9D0}, propertyGeneralCategory{lbprID, gcSo}},   //         FACE WITH MONOCLE
-	{runeRange{0x1F9D1, 0x1F9DD}, propertyGeneralCategory{lbprEB, gcSo}},   //    [13] ADULT..ELF
-	{runeRange{0x1F9DE, 0x1F9FF}, propertyGeneralCategory{lbprID, gcSo}},   //    [34] GENIE..NAZAR AMULET
-	{runeRange{0x1FA00, 0x1FA53}, propertyGeneralCategory{lbprAL, gcSo}},   //    [84] NEUTRAL CHESS KING..BLACK CHESS KNIGHT-BISHOP
-	{runeRange{0x1FA54, 0x1FA5F}, propertyGeneralCategory{lbprID, gcCn}},   //    [12] <reserved-1FA54>..<reserved-1FA5F>
-	{runeRange{0x1FA60, 0x1FA6D}, propertyGeneralCategory{lbprID, gcSo}},   //    [14] XIANGQI RED GENERAL..XIANGQI BLACK SOLDIER
-	{runeRange{0x1FA6E, 0x1FA6F}, propertyGeneralCategory{lbprID, gcCn}},   //     [2] <reserved-1FA6E>..<reserved-1FA6F>
-	{runeRange{0x1FA70, 0x1FA7C}, propertyGeneralCategory{lbprID, gcSo}},   //    [13] BALLET SHOES..CRUTCH
-	{runeRange{0x1FA7D, 0x1FA7F}, propertyGeneralCategory{lbprID, gcCn}},   //     [3] <reserved-1FA7D>..<reserved-1FA7F>
-	{runeRange{0x1FA80, 0x1FA88}, propertyGeneralCategory{lbprID, gcSo}},   //     [9] YO-YO..FLUTE
-	{runeRange{0x1FA89, 0x1FA8F}, propertyGeneralCategory{lbprID, gcCn}},   //     [7] <reserved-1FA89>..<reserved-1FA8F>
-	{runeRange{0x1FA90, 0x1FABD}, propertyGeneralCategory{lbprID, gcSo}},   //    [46] RINGED PLANET..WING
-	{runeRange{0x1FABE, 0x1FABE}, propertyGeneralCategory{lbprID, gcCn}},   //         <reserved-1FABE>
-	{runeRange{0x1FABF, 0x1FAC2}, propertyGeneralCategory{lbprID, gcSo}},   //     [4] GOOSE..PEOPLE HUGGING
-	{runeRange{0x1FAC3, 0x1FAC5}, propertyGeneralCategory{lbprEB, gcSo}},   //     [3] PREGNANT MAN..PERSON WITH CROWN
-	{runeRange{0x1FAC6, 0x1FACD}, propertyGeneralCategory{lbprID, gcCn}},   //     [8] <reserved-1FAC6>..<reserved-1FACD>
+	{runeRange{0x00B8, 0x00B8}, propertyGeneralCategory{lbprAI, gcSk}},     //         CEDILLA
+	{runeRange{0x070F, 0x070F}, propertyGeneralCategory{lbprAL, gcCf}},     //         SYRIAC ABBREVIATION MARK
+	{runeRange{0x0ABE, 0x0AC0}, propertyGeneralCategory{lbprCM, gcMc}},     //     [3] GUJARATI VOWEL SIGN AA..GUJARATI VOWEL SIGN II
+	{runeRange{0x0D5F, 0x0D61}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] MALAYALAM LETTER ARCHAIC II..MALAYALAM LETTER VOCALIC LL
+	{runeRange{0x108F, 0x108F}, propertyGeneralCategory{lbprSA, gcMc}},     //         MYANMAR SIGN RUMAI PALAUNG TONE-5
+	{runeRange{0x1A1B, 0x1A1B}, propertyGeneralCategory{lbprCM, gcMn}},     //         BUGINESE VOWEL SIGN AE
+	{runeRange{0x1FED, 0x1FEF}, propertyGeneralCategory{lbprAL, gcSk}},     //     [3] GREEK DIALYTIKA AND VARIA..GREEK VARIA
+	{runeRange{0x2145, 0x2149}, propertyGeneralCategory{lbprAL, gcLC}},     //     [5] DOUBLE-STRUCK ITALIC CAPITAL D..DOUBLE-STRUCK ITALIC SMALL J
+	{runeRange{0x2500, 0x254B}, propertyGeneralCategory{lbprAI, gcSo}},     //    [76] BOX DRAWINGS LIGHT HORIZONTAL..BOX DRAWINGS HEAVY VERTICAL AND HORIZONTAL
+	{runeRange{0x27C7, 0x27E5}, propertyGeneralCategory{lbprAL, gcSm}},     //    [31] OR WITH DOT INSIDE..WHITE SQUARE WITH RIGHTWARDS TICK
+	{runeRange{0x2E40, 0x2E40}, propertyGeneralCategory{lbprBA, gcPd}},     //         DOUBLE HYPHEN
+	{runeRange{0x322A, 0x3247}, propertyGeneralCategory{lbprID, gcSo}},     //    [30] PARENTHESIZED IDEOGRAPH MOON..CIRCLED IDEOGRAPH KOTO
+	{runeRange{0xAA2F, 0xAA30}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] CHAM VOWEL SIGN O..CHAM VOWEL SIGN AI
+	{runeRange{0xAF64, 0xAF64}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGWAE
+	{runeRange{0xB664, 0xB664}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDOE
+	{runeRange{0xBD64, 0xBD64}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BYO
+	{runeRange{0xC464, 0xC464}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSU
+	{runeRange{0xCB64, 0xCB64}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJWEO
+	{runeRange{0xD264, 0xD264}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TWE
+	{runeRange{0xFDFC, 0xFDFC}, propertyGeneralCategory{lbprPO, gcSc}},     //         RIAL SIGN
+	{runeRange{0x10175, 0x10178}, propertyGeneralCategory{lbprAL, gcNo}},   //     [4] GREEK ONE HALF SIGN..GREEK THREE QUARTERS SIGN
+	{runeRange{0x10F46, 0x10F50}, propertyGeneralCategory{lbprCM, gcMn}},   //    [11] SOGDIAN COMBINING DOT BELOW..SOGDIAN COMBINING STROKE BELOW
+	{runeRange{0x1144F, 0x1144F}, propertyGeneralCategory{lbprAL, gcPo}},   //         NEWA ABBREVIATION SIGN
+	{runeRange{0x11A50, 0x11A50}, propertyGeneralCategory{lbprAL, gcLo}},   //         SOYOMBO LETTER A
+	{runeRange{0x11F04, 0x11F10}, propertyGeneralCategory{lbprAL, gcLo}},   //    [13] KAWI LETTER A..KAWI LETTER O
+	{runeRange{0x16B3A, 0x16B3B}, propertyGeneralCategory{lbprAL, gcPo}},   //     [2] PAHAWH HMONG SIGN VOS THIAB..PAHAWH HMONG SIGN VOS FEEM
+	{runeRange{0x1D242, 0x1D244}, propertyGeneralCategory{lbprCM, gcMn}},   //     [3] COMBINING GREEK MUSICAL TRISEME..COMBINING GREEK MUSICAL PENTASEME
+	{runeRange{0x1E000, 0x1E006}, propertyGeneralCategory{lbprCM, gcMn}},   //     [7] COMBINING GLAGOLITIC LETTER AZU..COMBINING GLAGOLITIC LETTER ZHIVETE
+	{runeRange{0x1EE61, 0x1EE62}, propertyGeneralCategory{lbprAL, gcLo}},   //     [2] ARABIC MATHEMATICAL STRETCHED BEH..ARABIC MATHEMATICAL STRETCHED JEEM
+	{runeRange{0x1F444, 0x1F445}, propertyGeneralCategory{lbprID, gcSo}},   //     [2] MOUTH..TONGUE
+	{runeRange{0x1F6ED, 0x1F6EF}, propertyGeneralCategory{lbprID, gcCn}},   //     [3] <reserved-1F6ED>..<reserved-1F6EF>
 	{runeRange{0x1FACE, 0x1FADB}, propertyGeneralCategory{lbprID, gcSo}},   //    [14] MOOSE..PEA POD
-	{runeRange{0x1FADC, 0x1FADF}, propertyGeneralCategory{lbprID, gcCn}},   //     [4] <reserved-1FADC>..<reserved-1FADF>
-	{runeRange{0x1FAE0, 0x1FAE8}, propertyGeneralCategory{lbprID, gcSo}},   //     [9] MELTING FACE..SHAKING FACE
-	{runeRange{0x1FAE9, 0x1FAEF}, propertyGeneralCategory{lbprID, gcCn}},   //     [7] <reserved-1FAE9>..<reserved-1FAEF>
-	{runeRange{0x1FAF0, 0x1FAF8}, propertyGeneralCategory{lbprEB, gcSo}},   //     [9] HAND WITH INDEX FINGER AND THUMB CROSSED..RIGHTWARDS PUSHING HAND
-	{runeRange{0x1FAF9, 0x1FAFF}, propertyGeneralCategory{lbprID, gcCn}},   //     [7] <reserved-1FAF9>..<reserved-1FAFF>
-	{runeRange{0x1FB00, 0x1FB92}, propertyGeneralCategory{lbprAL, gcSo}},   //   [147] BLOCK SEXTANT-1..UPPER HALF INVERSE MEDIUM SHADE AND LOWER HALF BLOCK
-	{runeRange{0x1FB94, 0x1FBCA}, propertyGeneralCategory{lbprAL, gcSo}},   //    [55] LEFT HALF INVERSE MEDIUM SHADE AND RIGHT HALF BLOCK..WHITE UP-POINTING CHEVRON
-	{runeRange{0x1FBF0, 0x1FBF9}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] SEGMENTED DIGIT ZERO..SEGMENTED DIGIT NINE
-	{runeRange{0x1FC00, 0x1FFFD}, propertyGeneralCategory{lbprID, gcCn}},   //  [1022] <reserved-1FC00>..<reserved-1FFFD>
-	{runeRange{0x20000, 0x2A6DF}, propertyGeneralCategory{lbprID, gcLo}},   // [42720] CJK UNIFIED IDEOGRAPH-20000..CJK UNIFIED IDEOGRAPH-2A6DF
-	{runeRange{0x2A6E0, 0x2A6FF}, propertyGeneralCategory{lbprID, gcCn}},   //    [32] <reserved-2A6E0>..<reserved-2A6FF>
-	{runeRange{0x2A700, 0x2B739}, propertyGeneralCategory{lbprID, gcLo}},   //  [4154] CJK UNIFIED IDEOGRAPH-2A700..CJK UNIFIED IDEOGRAPH-2B739
-	{runeRange{0x2B73A, 0x2B73F}, propertyGeneralCategory{lbprID, gcCn}},   //     [6] <reserved-2B73A>..<reserved-2B73F>
-	{runeRange{0x2B740, 0x2B81D}, propertyGeneralCategory{lbprID, gcLo}},   //   [222] CJK UNIFIED IDEOGRAPH-2B740..CJK UNIFIED IDEOGRAPH-2B81D
-	{runeRange{0x2B81E, 0x2B81F}, propertyGeneralCategory{lbprID, gcCn}},   //     [2] <reserved-2B81E>..<reserved-2B81F>
+	{runeRange{0x005E, 0x005E}, propertyGeneralCategory{lbprAL, gcSk}},     //         CIRCUMFLEX ACCENT
+	{runeRange{0x02D8, 0x02DB}, propertyGeneralCategory{lbprAI, gcSk}},     //     [4] BREVE..OGONEK
+	{runeRange{0x060E, 0x060F}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] ARABIC POETIC VERSE SIGN..ARABIC SIGN MISRA
+	{runeRange{0x085E, 0x085E}, propertyGeneralCategory{lbprAL, gcPo}},     //         MANDAIC PUNCTUATION
+	{runeRange{0x0A01, 0x0A02}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] GURMUKHI SIGN ADAK BINDI..GURMUKHI SIGN BINDI
+	{runeRange{0x0B57, 0x0B57}, propertyGeneralCategory{lbprCM, gcMc}},     //         ORIYA AU LENGTH MARK
+	{runeRange{0x0CBD, 0x0CBD}, propertyGeneralCategory{lbprAL, gcLo}},     //         KANNADA SIGN AVAGRAHA
+	{runeRange{0x0E81, 0x0E82}, propertyGeneralCategory{lbprSA, gcLo}},     //     [2] LAO LETTER KO..LAO LETTER KHO SUNG
+	{runeRange{0x0FD9, 0x0FDA}, propertyGeneralCategory{lbprGL, gcPo}},     //     [2] TIBETAN MARK LEADING MCHAN RTAGS..TIBETAN MARK TRAILING MCHAN RTAGS
+	{runeRange{0x1360, 0x1360}, propertyGeneralCategory{lbprAL, gcPo}},     //         ETHIOPIC SECTION MARK
+	{runeRange{0x1820, 0x1842}, propertyGeneralCategory{lbprAL, gcLo}},     //    [35] MONGOLIAN LETTER A..MONGOLIAN LETTER CHI
+	{runeRange{0x1B42, 0x1B42}, propertyGeneralCategory{lbprCM, gcMn}},     //         BALINESE VOWEL SIGN PEPET
+	{runeRange{0x1D6B, 0x1D77}, propertyGeneralCategory{lbprAL, gcLl}},     //    [13] LATIN SMALL LETTER UE..LATIN SMALL LETTER TURNED G
+	{runeRange{0x202A, 0x202E}, propertyGeneralCategory{lbprCM, gcCf}},     //     [5] LEFT-TO-RIGHT EMBEDDING..RIGHT-TO-LEFT OVERRIDE
+	{runeRange{0x2105, 0x2105}, propertyGeneralCategory{lbprAI, gcSo}},     //         CARE OF
+	{runeRange{0x21AF, 0x21CD}, propertyGeneralCategory{lbprAL, gcSo}},     //    [31] DOWNWARDS ZIGZAG ARROW..LEFTWARDS DOUBLE ARROW WITH STROKE
+	{runeRange{0x22C0, 0x22EE}, propertyGeneralCategory{lbprAL, gcSm}},     //    [47] N-ARY LOGICAL AND..VERTICAL ELLIPSIS
+	{runeRange{0x25F8, 0x25FF}, propertyGeneralCategory{lbprAL, gcSm}},     //     [8] UPPER LEFT TRIANGLE..LOWER RIGHT TRIANGLE
+	{runeRange{0x26FD, 0x26FF}, propertyGeneralCategory{lbprID, gcSo}},     //     [3] FUEL PUMP..WHITE FLAG WITH HORIZONTAL MIDDLE BLACK STRIPE
+	{runeRange{0x2994, 0x2994}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT ARC GREATER-THAN BRACKET
+	{runeRange{0x2E0C, 0x2E0C}, propertyGeneralCategory{lbprQU, gcPi}},     //         LEFT RAISED OMISSION BRACKET
+	{runeRange{0x3009, 0x3009}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT ANGLE BRACKET
+	{runeRange{0x30A5, 0x30A5}, propertyGeneralCategory{lbprCJ, gcLo}},     //         KATAKANA LETTER SMALL U
+	{runeRange{0xA673, 0xA673}, propertyGeneralCategory{lbprAL, gcPo}},     //         SLAVONIC ASTERISK
+	{runeRange{0xA900, 0xA909}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] KAYAH LI DIGIT ZERO..KAYAH LI DIGIT NINE
+	{runeRange{0xAADB, 0xAADC}, propertyGeneralCategory{lbprSA, gcLo}},     //     [2] TAI VIET SYMBOL KON..TAI VIET SYMBOL NUENG
+	{runeRange{0xADA4, 0xADA4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GWE
+	{runeRange{0xB124, 0xB124}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NE
+	{runeRange{0xB4A4, 0xB4A4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DWI
+	{runeRange{0xB824, 0xB824}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RYEO
+	{runeRange{0xBBA4, 0xBBA4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MYU
+	{runeRange{0xBF24, 0xBF24}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBYE
+	{runeRange{0xC2A4, 0xC2A4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SEU
+	{runeRange{0xC624, 0xC624}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE O
+	{runeRange{0xC9A4, 0xC9A4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JYI
+	{runeRange{0xCD24, 0xCD24}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CWA
+	{runeRange{0xD0A4, 0xD0A4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KI
+	{runeRange{0xD424, 0xD424}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PWAE
+	{runeRange{0xD7B0, 0xD7C6}, propertyGeneralCategory{lbprJV, gcLo}},     //    [23] HANGUL JUNGSEONG O-YEO..HANGUL JUNGSEONG ARAEA-E
+	{runeRange{0xFE48, 0xFE48}, propertyGeneralCategory{lbprCL, gcPe}},     //         PRESENTATION FORM FOR VERTICAL RIGHT SQUARE BRACKET
+	{runeRange{0xFF67, 0xFF6F}, propertyGeneralCategory{lbprCJ, gcLo}},     //     [9] HALFWIDTH KATAKANA LETTER SMALL A..HALFWIDTH KATAKANA LETTER SMALL TU
+	{runeRange{0x104D8, 0x104FB}, propertyGeneralCategory{lbprAL, gcLl}},   //    [36] OSAGE SMALL LETTER A..OSAGE SMALL LETTER ZHA
+	{runeRange{0x10AC8, 0x10AC8}, propertyGeneralCategory{lbprAL, gcSo}},   //         MANICHAEAN SIGN UD
+	{runeRange{0x110BE, 0x110C1}, propertyGeneralCategory{lbprBA, gcPo}},   //     [4] KAITHI SECTION MARK..KAITHI DOUBLE DANDA
+	{runeRange{0x112E3, 0x112EA}, propertyGeneralCategory{lbprCM, gcMn}},   //     [8] KHUDAWADI VOWEL SIGN U..KHUDAWADI SIGN VIRAMA
+	{runeRange{0x115DC, 0x115DD}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] SIDDHAM VOWEL SIGN ALTERNATE U..SIDDHAM VOWEL SIGN ALTERNATE UU
+	{runeRange{0x119D1, 0x119D3}, propertyGeneralCategory{lbprCM, gcMc}},   //     [3] NANDINAGARI VOWEL SIGN AA..NANDINAGARI VOWEL SIGN II
+	{runeRange{0x11C0A, 0x11C2E}, propertyGeneralCategory{lbprAL, gcLo}},   //    [37] BHAIKSUKI LETTER E..BHAIKSUKI LETTER HA
+	{runeRange{0x11D6A, 0x11D89}, propertyGeneralCategory{lbprAL, gcLo}},   //    [32] GUNJALA GONDI LETTER OO..GUNJALA GONDI LETTER SA
+	{runeRange{0x11FFF, 0x11FFF}, propertyGeneralCategory{lbprBA, gcPo}},   //         TAMIL PUNCTUATION END OF TEXT
+	{runeRange{0x14400, 0x145CD}, propertyGeneralCategory{lbprAL, gcLo}},   //   [462] ANATOLIAN HIEROGLYPH A001..ANATOLIAN HIEROGLYPH A409
+	{runeRange{0x16F51, 0x16F87}, propertyGeneralCategory{lbprCM, gcMc}},   //    [55] MIAO SIGN ASPIRATION..MIAO VOWEL SIGN UI
+	{runeRange{0x1CF50, 0x1CFC3}, propertyGeneralCategory{lbprAL, gcSo}},   //   [116] ZNAMENNY NEUME KRYUK..ZNAMENNY NEUME PAUK
+	{runeRange{0x1D507, 0x1D50A}, propertyGeneralCategory{lbprAL, gcLu}},   //     [4] MATHEMATICAL FRAKTUR CAPITAL D..MATHEMATICAL FRAKTUR CAPITAL G
+	{runeRange{0x1DA00, 0x1DA36}, propertyGeneralCategory{lbprCM, gcMn}},   //    [55] SIGNWRITING HEAD RIM..SIGNWRITING AIR SUCKING IN
+	{runeRange{0x1E2EC, 0x1E2EF}, propertyGeneralCategory{lbprCM, gcMn}},   //     [4] WANCHO TONE TUP..WANCHO TONE KOINI
+	{runeRange{0x1EE29, 0x1EE32}, propertyGeneralCategory{lbprAL, gcLo}},   //    [10] ARABIC MATHEMATICAL INITIAL YEH..ARABIC MATHEMATICAL INITIAL QAF
+	{runeRange{0x1F094, 0x1F09F}, propertyGeneralCategory{lbprID, gcCn}},   //    [12] <reserved-1F094>..<reserved-1F09F>
+	{runeRange{0x1F386, 0x1F39B}, propertyGeneralCategory{lbprID, gcSo}},   //    [22] FIREWORKS..CONTROL KNOBS
+	{runeRange{0x1F4A1, 0x1F4A1}, propertyGeneralCategory{lbprID, gcSo}},   //         ELECTRIC LIGHT BULB
+	{runeRange{0x1F64B, 0x1F64F}, propertyGeneralCategory{lbprEB, gcSo}},   //     [5] HAPPY PERSON RAISING ONE HAND..PERSON WITH FOLDED HANDS
+	{runeRange{0x1F810, 0x1F847}, propertyGeneralCategory{lbprAL, gcSo}},   //    [56] LEFTWARDS ARROW WITH SMALL EQUILATERAL ARROWHEAD..DOWNWARDS HEAVY ARROW
+	{runeRange{0x1F9D0, 0x1F9D0}, propertyGeneralCategory{lbprID, gcSo}},   //         FACE WITH MONOCLE
 	{runeRange{0x2B820, 0x2CEA1}, propertyGeneralCategory{lbprID, gcLo}},   //  [5762] CJK UNIFIED IDEOGRAPH-2B820..CJK UNIFIED IDEOGRAPH-2CEA1
-	{runeRange{0x2CEA2, 0x2CEAF}, propertyGeneralCategory{lbprID, gcCn}},   //    [14] <reserved-2CEA2>..<reserved-2CEAF>
-	{runeRange{0x2CEB0, 0x2EBE0}, propertyGeneralCategory{lbprID, gcLo}},   //  [7473] CJK UNIFIED IDEOGRAPH-2CEB0..CJK UNIFIED IDEOGRAPH-2EBE0
-	{runeRange{0x2EBE1, 0x2F7FF}, propertyGeneralCategory{lbprID, gcCn}},   //  [3103] <reserved-2EBE1>..<reserved-2F7FF>
-	{runeRange{0x2F800, 0x2FA1D}, propertyGeneralCategory{lbprID, gcLo}},   //   [542] CJK COMPATIBILITY IDEOGRAPH-2F800..CJK COMPATIBILITY IDEOGRAPH-2FA1D
-	{runeRange{0x2FA1E, 0x2FA1F}, propertyGeneralCategory{lbprID, gcCn}},   //     [2] <reserved-2FA1E>..<reserved-2FA1F>
-	{runeRange{0x2FA20, 0x2FFFD}, propertyGeneralCategory{lbprID, gcCn}},   //  [1502] <reserved-2FA20>..<reserved-2FFFD>
-	{runeRange{0x30000, 0x3134A}, propertyGeneralCategory{lbprID, gcLo}},   //  [4939] CJK UNIFIED IDEOGRAPH-30000..CJK UNIFIED IDEOGRAPH-3134A
+	{runeRange{0x0029, 0x0029}, propertyGeneralCategory{lbprCP, gcPe}},     //         RIGHT PARENTHESIS
+	{runeRange{0x00A6, 0x00A6}, propertyGeneralCategory{lbprAL, gcSo}},     //         BROKEN BAR
+	{runeRange{0x01C4, 0x024F}, propertyGeneralCategory{lbprAL, gcLC}},     //   [140] LATIN CAPITAL LETTER DZ WITH CARON..LATIN SMALL LETTER Y WITH STROKE
+	{runeRange{0x0370, 0x0373}, propertyGeneralCategory{lbprAL, gcLC}},     //     [4] GREEK CAPITAL LETTER HETA..GREEK SMALL LETTER ARCHAIC SAMPI
+	{runeRange{0x05BE, 0x05BE}, propertyGeneralCategory{lbprBA, gcPd}},     //         HEBREW PUNCTUATION MAQAF
+	{runeRange{0x06D4, 0x06D4}, propertyGeneralCategory{lbprEX, gcPo}},     //         ARABIC FULL STOP
+	{runeRange{0x07F8, 0x07F8}, propertyGeneralCategory{lbprIS, gcPo}},     //         NKO COMMA
+	{runeRange{0x093B, 0x093B}, propertyGeneralCategory{lbprCM, gcMc}},     //         DEVANAGARI VOWEL SIGN OOE
+	{runeRange{0x09CD, 0x09CD}, propertyGeneralCategory{lbprCM, gcMn}},     //         BENGALI SIGN VIRAMA
+	{runeRange{0x0A5E, 0x0A5E}, propertyGeneralCategory{lbprAL, gcLo}},     //         GURMUKHI LETTER FA
+	{runeRange{0x0B05, 0x0B0C}, propertyGeneralCategory{lbprAL, gcLo}},     //     [8] ORIYA LETTER A..ORIYA LETTER VOCALIC L
+	{runeRange{0x0BA3, 0x0BA4}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] TAMIL LETTER NNA..TAMIL LETTER TA
+	{runeRange{0x0C60, 0x0C61}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] TELUGU LETTER VOCALIC RR..TELUGU LETTER VOCALIC LL
+	{runeRange{0x0D02, 0x0D03}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] MALAYALAM SIGN ANUSVARA..MALAYALAM SIGN VISARGA
+	{runeRange{0x0DD6, 0x0DD6}, propertyGeneralCategory{lbprCM, gcMn}},     //         SINHALA VOWEL SIGN DIGA PAA-PILLA
+	{runeRange{0x0F01, 0x0F03}, propertyGeneralCategory{lbprBB, gcSo}},     //     [3] TIBETAN MARK GTER YIG MGO TRUNCATED A..TIBETAN MARK GTER YIG MGO -UM GTER TSHEG MA
+	{runeRange{0x0F80, 0x0F84}, propertyGeneralCategory{lbprCM, gcMn}},     //     [5] TIBETAN VOWEL SIGN REVERSED I..TIBETAN MARK HALANTA
+	{runeRange{0x1058, 0x1059}, propertyGeneralCategory{lbprSA, gcMn}},     //     [2] MYANMAR VOWEL SIGN VOCALIC L..MYANMAR VOWEL SIGN VOCALIC LL
+	{runeRange{0x124A, 0x124D}, propertyGeneralCategory{lbprAL, gcLo}},     //     [4] ETHIOPIC SYLLABLE QWI..ETHIOPIC SYLLABLE QWE
+	{runeRange{0x169C, 0x169C}, propertyGeneralCategory{lbprCL, gcPe}},     //         OGHAM REVERSED FEATHER MARK
+	{runeRange{0x17DB, 0x17DB}, propertyGeneralCategory{lbprPR, gcSc}},     //         KHMER CURRENCY SYMBOL RIEL
+	{runeRange{0x1933, 0x1938}, propertyGeneralCategory{lbprCM, gcMc}},     //     [6] LIMBU SMALL LETTER TA..LIMBU SMALL LETTER LA
+	{runeRange{0x1A90, 0x1A99}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] TAI THAM THAM DIGIT ZERO..TAI THAM THAM DIGIT NINE
+	{runeRange{0x1BA6, 0x1BA7}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] SUNDANESE VOWEL SIGN PANAELAENG..SUNDANESE VOWEL SIGN PANOLONG
+	{runeRange{0x1CC0, 0x1CC7}, propertyGeneralCategory{lbprAL, gcPo}},     //     [8] SUNDANESE PUNCTUATION BINDU SURYA..SUNDANESE PUNCTUATION BINDU BA SATANGA
+	{runeRange{0x1F59, 0x1F59}, propertyGeneralCategory{lbprAL, gcLu}},     //         GREEK CAPITAL LETTER UPSILON WITH DASIA
+	{runeRange{0x2015, 0x2015}, propertyGeneralCategory{lbprAI, gcPd}},     //         HORIZONTAL BAR
+	{runeRange{0x2052, 0x2052}, propertyGeneralCategory{lbprAL, gcSm}},     //         COMMERCIAL MINUS SIGN
+	{runeRange{0x20B7, 0x20BA}, propertyGeneralCategory{lbprPR, gcSc}},     //     [4] SPESMILO SIGN..TURKISH LIRA SIGN
+	{runeRange{0x2124, 0x2124}, propertyGeneralCategory{lbprAL, gcLu}},     //         DOUBLE-STRUCK CAPITAL Z
+	{runeRange{0x217A, 0x2182}, propertyGeneralCategory{lbprAL, gcNl}},     //     [9] SMALL ROMAN NUMERAL ELEVEN..ROMAN NUMERAL TEN THOUSAND
+	{runeRange{0x220F, 0x220F}, propertyGeneralCategory{lbprAI, gcSm}},     //         N-ARY PRODUCT
+	{runeRange{0x2268, 0x2269}, propertyGeneralCategory{lbprAL, gcSm}},     //     [2] LESS-THAN BUT NOT EQUAL TO..GREATER-THAN BUT NOT EQUAL TO
+	{runeRange{0x232A, 0x232A}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT-POINTING ANGLE BRACKET
+	{runeRange{0x25B8, 0x25BB}, propertyGeneralCategory{lbprAL, gcSo}},     //     [4] BLACK RIGHT-POINTING SMALL TRIANGLE..WHITE RIGHT-POINTING POINTER
+	{runeRange{0x2620, 0x2638}, propertyGeneralCategory{lbprAL, gcSo}},     //    [25] SKULL AND CROSSBONES..WHEEL OF DHARMA
+	{runeRange{0x26DA, 0x26DB}, propertyGeneralCategory{lbprAI, gcSo}},     //     [2] DRIVE SLOW SIGN..HEAVY WHITE DOWN-POINTING TRIANGLE
+	{runeRange{0x276B, 0x276B}, propertyGeneralCategory{lbprCL, gcPe}},     //         MEDIUM FLATTENED RIGHT PARENTHESIS ORNAMENT
+	{runeRange{0x2984, 0x2984}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT WHITE CURLY BRACKET
+	{runeRange{0x2B30, 0x2B44}, propertyGeneralCategory{lbprAL, gcSm}},     //    [21] LEFT ARROW WITH SMALL CIRCLE..RIGHTWARDS ARROW THROUGH SUPERSET
+	{runeRange{0x2DB0, 0x2DB6}, propertyGeneralCategory{lbprAL, gcLo}},     //     [7] ETHIOPIC SYLLABLE ZZA..ETHIOPIC SYLLABLE ZZO
+	{runeRange{0x2E24, 0x2E24}, propertyGeneralCategory{lbprOP, gcPs}},     //         BOTTOM LEFT HALF BRACKET
+	{runeRange{0x2E5A, 0x2E5A}, propertyGeneralCategory{lbprCL, gcPe}},     //         TOP HALF RIGHT PARENTHESIS
+	{runeRange{0x301A, 0x301A}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT WHITE SQUARE BRACKET
+	{runeRange{0x3085, 0x3085}, propertyGeneralCategory{lbprCJ, gcLo}},     //         HIRAGANA LETTER SMALL YU
+	{runeRange{0x30F5, 0x30F6}, propertyGeneralCategory{lbprCJ, gcLo}},     //     [2] KATAKANA LETTER SMALL KA..KATAKANA LETTER SMALL KE
+	{runeRange{0xA490, 0xA4C6}, propertyGeneralCategory{lbprID, gcSo}},     //    [55] YI RADICAL QOT..YI RADICAL KE
+	{runeRange{0xA770, 0xA770}, propertyGeneralCategory{lbprAL, gcLm}},     //         MODIFIER LETTER US
+	{runeRange{0xA840, 0xA873}, propertyGeneralCategory{lbprAL, gcLo}},     //    [52] PHAGS-PA LETTER KA..PHAGS-PA LETTER CANDRABINDU
+	{runeRange{0xA9BC, 0xA9BD}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] JAVANESE VOWEL SIGN PEPET..JAVANESE CONSONANT SIGN KERET
+	{runeRange{0xAA7A, 0xAA7A}, propertyGeneralCategory{lbprSA, gcLo}},     //         MYANMAR LETTER AITON RA
+	{runeRange{0xAB28, 0xAB2E}, propertyGeneralCategory{lbprAL, gcLo}},     //     [7] ETHIOPIC SYLLABLE BBA..ETHIOPIC SYLLABLE BBO
+	{runeRange{0xACC4, 0xACC4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GYE
+	{runeRange{0xAE84, 0xAE84}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGYA
+	{runeRange{0xB044, 0xB044}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGEU
+	{runeRange{0xB204, 0xB204}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NU
+	{runeRange{0xB3C4, 0xB3C4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DO
+	{runeRange{0xB584, 0xB584}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDYAE
+	{runeRange{0xB744, 0xB744}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDYI
+	{runeRange{0xB904, 0xB904}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RWEO
+	{runeRange{0xBAC4, 0xBAC4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MWA
+	{runeRange{0xBC84, 0xBC84}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BEO
+	{runeRange{0xBE44, 0xBE44}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BI
+	{runeRange{0xC004, 0xC004}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBWE
+	{runeRange{0xC1C4, 0xC1C4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SWAE
+	{runeRange{0xC384, 0xC384}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSE
+	{runeRange{0xC544, 0xC544}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE A
+	{runeRange{0xC704, 0xC704}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE WI
+	{runeRange{0xC8C4, 0xC8C4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JOE
+	{runeRange{0xCA84, 0xCA84}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJYEO
+	{runeRange{0xCC44, 0xCC44}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CAE
+	{runeRange{0xCE04, 0xCE04}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CYU
+	{runeRange{0xCFC4, 0xCFC4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KYO
+	{runeRange{0xD184, 0xD184}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TYE
+	{runeRange{0xD344, 0xD344}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PYA
+	{runeRange{0xD504, 0xD504}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PEU
+	{runeRange{0xD6C4, 0xD6C4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HU
+	{runeRange{0xFB2A, 0xFB36}, propertyGeneralCategory{lbprHL, gcLo}},     //    [13] HEBREW LETTER SHIN WITH SHIN DOT..HEBREW LETTER ZAYIN WITH DAGESH
+	{runeRange{0xFE37, 0xFE37}, propertyGeneralCategory{lbprOP, gcPs}},     //         PRESENTATION FORM FOR VERTICAL LEFT CURLY BRACKET
+	{runeRange{0xFE62, 0xFE62}, propertyGeneralCategory{lbprID, gcSm}},     //         SMALL PLUS SIGN
+	{runeRange{0xFF3E, 0xFF3E}, propertyGeneralCategory{lbprID, gcSk}},     //         FULLWIDTH CIRCUMFLEX ACCENT
+	{runeRange{0xFFE9, 0xFFEC}, propertyGeneralCategory{lbprAL, gcSm}},     //     [4] HALFWIDTH LEFTWARDS ARROW..HALFWIDTH DOWNWARDS ARROW
+	{runeRange{0x10341, 0x10341}, propertyGeneralCategory{lbprAL, gcNl}},   //         GOTHIC LETTER NINETY
+	{runeRange{0x10787, 0x107B0}, propertyGeneralCategory{lbprAL, gcLm}},   //    [42] MODIFIER LETTER SMALL DZ DIGRAPH..MODIFIER LETTER SMALL V WITH RIGHT HOOK
+	{runeRange{0x10A05, 0x10A06}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] KHAROSHTHI VOWEL SIGN E..KHAROSHTHI VOWEL SIGN O
+	{runeRange{0x10C80, 0x10CB2}, propertyGeneralCategory{lbprAL, gcLu}},   //    [51] OLD HUNGARIAN CAPITAL LETTER A..OLD HUNGARIAN CAPITAL LETTER US
+	{runeRange{0x11052, 0x11065}, propertyGeneralCategory{lbprAL, gcNo}},   //    [20] BRAHMI NUMBER ONE..BRAHMI NUMBER ONE THOUSAND
+	{runeRange{0x11173, 0x11173}, propertyGeneralCategory{lbprCM, gcMn}},   //         MAHAJANI SIGN NUKTA
+	{runeRange{0x11238, 0x11239}, propertyGeneralCategory{lbprBA, gcPo}},   //     [2] KHOJKI DANDA..KHOJKI DOUBLE DANDA
+	{runeRange{0x1134B, 0x1134D}, propertyGeneralCategory{lbprCM, gcMc}},   //     [3] GRANTHA VOWEL SIGN OO..GRANTHA SIGN VIRAMA
+	{runeRange{0x114C6, 0x114C6}, propertyGeneralCategory{lbprAL, gcPo}},   //         TIRHUTA ABBREVIATION SIGN
+	{runeRange{0x116AD, 0x116AD}, propertyGeneralCategory{lbprCM, gcMn}},   //         TAKRI VOWEL SIGN AA
+	{runeRange{0x11915, 0x11916}, propertyGeneralCategory{lbprAL, gcLo}},   //     [2] DIVES AKURU LETTER NYA..DIVES AKURU LETTER TTA
+	{runeRange{0x11A3A, 0x11A3A}, propertyGeneralCategory{lbprAL, gcLo}},   //         ZANABAZAR SQUARE CLUSTER-INITIAL LETTER RA
+	{runeRange{0x11A9A, 0x11A9C}, propertyGeneralCategory{lbprBA, gcPo}},   //     [3] SOYOMBO MARK TSHEG..SOYOMBO MARK DOUBLE SHAD
+	{runeRange{0x11C50, 0x11C59}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] BHAIKSUKI DIGIT ZERO..BHAIKSUKI DIGIT NINE
+	{runeRange{0x11D3A, 0x11D3A}, propertyGeneralCategory{lbprCM, gcMn}},   //         MASARAM GONDI VOWEL SIGN E
+	{runeRange{0x11DA0, 0x11DA9}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] GUNJALA GONDI DIGIT ZERO..GUNJALA GONDI DIGIT NINE
+	{runeRange{0x11F43, 0x11F44}, propertyGeneralCategory{lbprBA, gcPo}},   //     [2] KAWI DANDA..KAWI DOUBLE DANDA
+	{runeRange{0x13258, 0x1325A}, propertyGeneralCategory{lbprOP, gcLo}},   //     [3] EGYPTIAN HIEROGLYPH O006A..EGYPTIAN HIEROGLYPH O006C
+	{runeRange{0x13439, 0x1343B}, propertyGeneralCategory{lbprGL, gcCf}},   //     [3] EGYPTIAN HIEROGLYPH INSERT AT MIDDLE..EGYPTIAN HIEROGLYPH INSERT AT BOTTOM
+	{runeRange{0x16A70, 0x16ABE}, propertyGeneralCategory{lbprAL, gcLo}},   //    [79] TANGSA LETTER OZ..TANGSA LETTER ZA
+	{runeRange{0x16B7D, 0x16B8F}, propertyGeneralCategory{lbprAL, gcLo}},   //    [19] PAHAWH HMONG CLAN SIGN TSHEEJ..PAHAWH HMONG CLAN SIGN VWJ
+	{runeRange{0x17000, 0x187F7}, propertyGeneralCategory{lbprID, gcLo}},   //  [6136] TANGUT IDEOGRAPH-17000..TANGUT IDEOGRAPH-187F7
+	{runeRange{0x1BC80, 0x1BC88}, propertyGeneralCategory{lbprAL, gcLo}},   //     [9] DUPLOYAN AFFIX HIGH ACUTE..DUPLOYAN AFFIX HIGH VERTICAL
+	{runeRange{0x1D173, 0x1D17A}, propertyGeneralCategory{lbprCM, gcCf}},   //     [8] MUSICAL SYMBOL BEGIN BEAM..MUSICAL SYMBOL END PHRASE
+	{runeRange{0x1D49E, 0x1D49F}, propertyGeneralCategory{lbprAL, gcLu}},   //     [2] MATHEMATICAL SCRIPT CAPITAL C..MATHEMATICAL SCRIPT CAPITAL D
+	{runeRange{0x1D552, 0x1D6A5}, propertyGeneralCategory{lbprAL, gcLC}},   //   [340] MATHEMATICAL DOUBLE-STRUCK SMALL A..MATHEMATICAL ITALIC SMALL DOTLESS J
+	{runeRange{0x1D789, 0x1D789}, propertyGeneralCategory{lbprAL, gcSm}},   //         MATHEMATICAL SANS-SERIF BOLD PARTIAL DIFFERENTIAL
+	{runeRange{0x1DA87, 0x1DA8A}, propertyGeneralCategory{lbprBA, gcPo}},   //     [4] SIGNWRITING COMMA..SIGNWRITING COLON
+	{runeRange{0x1E130, 0x1E136}, propertyGeneralCategory{lbprCM, gcMn}},   //     [7] NYIAKENG PUACHUE HMONG TONE-B..NYIAKENG PUACHUE HMONG TONE-D
+	{runeRange{0x1E7E8, 0x1E7EB}, propertyGeneralCategory{lbprAL, gcLo}},   //     [4] ETHIOPIC SYLLABLE GURAGE HHWA..ETHIOPIC SYLLABLE HHWE
+	{runeRange{0x1ED01, 0x1ED2D}, propertyGeneralCategory{lbprAL, gcNo}},   //    [45] OTTOMAN SIYAQ NUMBER ONE..OTTOMAN SIYAQ NUMBER NINETY THOUSAND
+	{runeRange{0x1EE4D, 0x1EE4F}, propertyGeneralCategory{lbprAL, gcLo}},   //     [3] ARABIC MATHEMATICAL TAILED NOON..ARABIC MATHEMATICAL TAILED AIN
+	{runeRange{0x1EE8B, 0x1EE9B}, propertyGeneralCategory{lbprAL, gcLo}},   //    [17] ARABIC MATHEMATICAL LOOPED LAM..ARABIC MATHEMATICAL LOOPED GHAIN
+	{runeRange{0x1F0F6, 0x1F0FF}, propertyGeneralCategory{lbprID, gcCn}},   //    [10] <reserved-1F0F6>..<reserved-1F0FF>
+	{runeRange{0x1F240, 0x1F248}, propertyGeneralCategory{lbprID, gcSo}},   //     [9] TORTOISE SHELL BRACKETED CJK UNIFIED IDEOGRAPH-672C..TORTOISE SHELL BRACKETED CJK UNIFIED IDEOGRAPH-6557
+	{runeRange{0x1F3C5, 0x1F3C6}, propertyGeneralCategory{lbprID, gcSo}},   //     [2] SPORTS MEDAL..TROPHY
+	{runeRange{0x1F484, 0x1F484}, propertyGeneralCategory{lbprID, gcSo}},   //         LIPSTICK
+	{runeRange{0x1F4B0, 0x1F4B0}, propertyGeneralCategory{lbprID, gcSo}},   //         MONEY BAG
+	{runeRange{0x1F597, 0x1F5D3}, propertyGeneralCategory{lbprID, gcSo}},   //    [61] WHITE DOWN POINTING LEFT HAND INDEX..SPIRAL CALENDAR PAD
+	{runeRange{0x1F6B4, 0x1F6B6}, propertyGeneralCategory{lbprEB, gcSo}},   //     [3] BICYCLIST..PEDESTRIAN
+	{runeRange{0x1F7D5, 0x1F7D9}, propertyGeneralCategory{lbprID, gcSo}},   //     [5] CIRCLED TRIANGLE..NINE POINTED WHITE STAR
+	{runeRange{0x1F8B0, 0x1F8B1}, propertyGeneralCategory{lbprID, gcSo}},   //     [2] ARROW POINTING UPWARDS THEN NORTH WEST..ARROW POINTING RIGHTWARDS THEN CURVING SOUTH WEST
+	{runeRange{0x1F978, 0x1F9B4}, propertyGeneralCategory{lbprID, gcSo}},   //    [61] DISGUISED FACE..BONE
+	{runeRange{0x1FA7D, 0x1FA7F}, propertyGeneralCategory{lbprID, gcCn}},   //     [3] <reserved-1FA7D>..<reserved-1FA7F>
+	{runeRange{0x1FBF0, 0x1FBF9}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] SEGMENTED DIGIT ZERO..SEGMENTED DIGIT NINE
 	{runeRange{0x3134B, 0x3134F}, propertyGeneralCategory{lbprID, gcCn}},   //     [5] <reserved-3134B>..<reserved-3134F>
-	{runeRange{0x31350, 0x323AF}, propertyGeneralCategory{lbprID, gcLo}},   //  [4192] CJK UNIFIED IDEOGRAPH-31350..CJK UNIFIED IDEOGRAPH-323AF
-	{runeRange{0x323B0, 0x3FFFD}, propertyGeneralCategory{lbprID, gcCn}},   // [56398] <reserved-323B0>..<reserved-3FFFD>
-	{runeRange{0xE0001, 0xE0001}, propertyGeneralCategory{lbprCM, gcCf}},   //         LANGUAGE TAG
+	{runeRange{0x0021, 0x0021}, propertyGeneralCategory{lbprEX, gcPo}},     //         EXCLAMATION MARK
+	{runeRange{0x003A, 0x003B}, propertyGeneralCategory{lbprIS, gcPo}},     //     [2] COLON..SEMICOLON
+	{runeRange{0x007F, 0x007F}, propertyGeneralCategory{lbprCM, gcCc}},     //         <control-007F>
+	{runeRange{0x00AE, 0x00AE}, propertyGeneralCategory{lbprAL, gcSo}},     //         REGISTERED SIGN
+	{runeRange{0x00D8, 0x00F6}, propertyGeneralCategory{lbprAL, gcLC}},     //    [31] LATIN CAPITAL LETTER O WITH STROKE..LATIN SMALL LETTER O WITH DIAERESIS
+	{runeRange{0x02C8, 0x02C8}, propertyGeneralCategory{lbprBB, gcLm}},     //         MODIFIER LETTER VERTICAL LINE
+	{runeRange{0x02ED, 0x02ED}, propertyGeneralCategory{lbprAL, gcSk}},     //         MODIFIER LETTER UNASPIRATED
+	{runeRange{0x0384, 0x0385}, propertyGeneralCategory{lbprAL, gcSk}},     //     [2] GREEK TONOS..GREEK DIALYTIKA TONOS
+	{runeRange{0x0559, 0x0559}, propertyGeneralCategory{lbprAL, gcLm}},     //         ARMENIAN MODIFIER LETTER LEFT HALF RING
+	{runeRange{0x05D0, 0x05EA}, propertyGeneralCategory{lbprHL, gcLo}},     //    [27] HEBREW LETTER ALEF..HEBREW LETTER TAV
+	{runeRange{0x064B, 0x065F}, propertyGeneralCategory{lbprCM, gcMn}},     //    [21] ARABIC FATHATAN..ARABIC WAVY HAMZA BELOW
+	{runeRange{0x06E9, 0x06E9}, propertyGeneralCategory{lbprAL, gcSo}},     //         ARABIC PLACE OF SAJDAH
+	{runeRange{0x07A6, 0x07B0}, propertyGeneralCategory{lbprCM, gcMn}},     //    [11] THAANA ABAFILI..THAANA SUKUN
+	{runeRange{0x081B, 0x0823}, propertyGeneralCategory{lbprCM, gcMn}},     //     [9] SAMARITAN MARK EPENTHETIC YUT..SAMARITAN VOWEL SIGN A
+	{runeRange{0x08C9, 0x08C9}, propertyGeneralCategory{lbprAL, gcLm}},     //         ARABIC SMALL FARSI YEH
+	{runeRange{0x0950, 0x0950}, propertyGeneralCategory{lbprAL, gcLo}},     //         DEVANAGARI OM
+	{runeRange{0x09B2, 0x09B2}, propertyGeneralCategory{lbprAL, gcLo}},     //         BENGALI LETTER LA
+	{runeRange{0x09F2, 0x09F3}, propertyGeneralCategory{lbprPO, gcSc}},     //     [2] BENGALI RUPEE MARK..BENGALI RUPEE SIGN
+	{runeRange{0x0A38, 0x0A39}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] GURMUKHI LETTER SA..GURMUKHI LETTER HA
+	{runeRange{0x0A85, 0x0A8D}, propertyGeneralCategory{lbprAL, gcLo}},     //     [9] GUJARATI LETTER A..GUJARATI VOWEL CANDRA E
+	{runeRange{0x0AE2, 0x0AE3}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] GUJARATI VOWEL SIGN VOCALIC L..GUJARATI VOWEL SIGN VOCALIC LL
+	{runeRange{0x0B3E, 0x0B3E}, propertyGeneralCategory{lbprCM, gcMc}},     //         ORIYA VOWEL SIGN AA
+	{runeRange{0x0B82, 0x0B82}, propertyGeneralCategory{lbprCM, gcMn}},     //         TAMIL SIGN ANUSVARA
+	{runeRange{0x0BCD, 0x0BCD}, propertyGeneralCategory{lbprCM, gcMn}},     //         TAMIL SIGN VIRAMA
+	{runeRange{0x0C3D, 0x0C3D}, propertyGeneralCategory{lbprAL, gcLo}},     //         TELUGU SIGN AVAGRAHA
+	{runeRange{0x0C82, 0x0C83}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] KANNADA SIGN ANUSVARA..KANNADA SIGN VISARGA
+	{runeRange{0x0CD5, 0x0CD6}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] KANNADA LENGTH MARK..KANNADA AI LENGTH MARK
+	{runeRange{0x0D46, 0x0D48}, propertyGeneralCategory{lbprCM, gcMc}},     //     [3] MALAYALAM VOWEL SIGN E..MALAYALAM VOWEL SIGN AI
+	{runeRange{0x0D85, 0x0D96}, propertyGeneralCategory{lbprAL, gcLo}},     //    [18] SINHALA LETTER AYANNA..SINHALA LETTER AUYANNA
+	{runeRange{0x0E34, 0x0E3A}, propertyGeneralCategory{lbprSA, gcMn}},     //     [7] THAI CHARACTER SARA I..THAI CHARACTER PHINTHU
+	{runeRange{0x0EB4, 0x0EBC}, propertyGeneralCategory{lbprSA, gcMn}},     //     [9] LAO VOWEL SIGN I..LAO SEMIVOWEL SIGN LO
+	{runeRange{0x0F0D, 0x0F11}, propertyGeneralCategory{lbprEX, gcPo}},     //     [5] TIBETAN MARK SHAD..TIBETAN MARK RIN CHEN SPUNGS SHAD
+	{runeRange{0x0F3B, 0x0F3B}, propertyGeneralCategory{lbprCL, gcPe}},     //         TIBETAN MARK GUG RTAGS GYAS
+	{runeRange{0x0FC6, 0x0FC6}, propertyGeneralCategory{lbprCM, gcMn}},     //         TIBETAN SYMBOL PADMA GDAN
+	{runeRange{0x103B, 0x103C}, propertyGeneralCategory{lbprSA, gcMc}},     //     [2] MYANMAR CONSONANT SIGN MEDIAL YA..MYANMAR CONSONANT SIGN MEDIAL RA
+	{runeRange{0x1071, 0x1074}, propertyGeneralCategory{lbprSA, gcMn}},     //     [4] MYANMAR VOWEL SIGN GEBA KAREN I..MYANMAR VOWEL SIGN KAYAH EE
+	{runeRange{0x10D0, 0x10FA}, propertyGeneralCategory{lbprAL, gcLl}},     //    [43] GEORGIAN LETTER AN..GEORGIAN LETTER AIN
+	{runeRange{0x12B8, 0x12BE}, propertyGeneralCategory{lbprAL, gcLo}},     //     [7] ETHIOPIC SYLLABLE KXA..ETHIOPIC SYLLABLE KXO
+	{runeRange{0x1400, 0x1400}, propertyGeneralCategory{lbprBA, gcPd}},     //         CANADIAN SYLLABICS HYPHEN
+	{runeRange{0x171F, 0x171F}, propertyGeneralCategory{lbprAL, gcLo}},     //         TAGALOG LETTER ARCHAIC RA
+	{runeRange{0x17C7, 0x17C8}, propertyGeneralCategory{lbprSA, gcMc}},     //     [2] KHMER SIGN REAHMUK..KHMER SIGN YUUKALEAPINTU
+	{runeRange{0x1806, 0x1806}, propertyGeneralCategory{lbprBB, gcPd}},     //         MONGOLIAN TODO SOFT HYPHEN
+	{runeRange{0x18B0, 0x18F5}, propertyGeneralCategory{lbprAL, gcLo}},     //    [70] CANADIAN SYLLABICS OY..CANADIAN SYLLABICS CARRIER DENTAL S
+	{runeRange{0x19B0, 0x19C9}, propertyGeneralCategory{lbprSA, gcLo}},     //    [26] NEW TAI LUE VOWEL SIGN VOWEL SHORTENER..NEW TAI LUE TONE MARK-2
+	{runeRange{0x1A61, 0x1A61}, propertyGeneralCategory{lbprSA, gcMc}},     //         TAI THAM VOWEL SIGN A
+	{runeRange{0x1B04, 0x1B04}, propertyGeneralCategory{lbprCM, gcMc}},     //         BALINESE SIGN BISAH
+	{runeRange{0x1B6B, 0x1B73}, propertyGeneralCategory{lbprCM, gcMn}},     //     [9] BALINESE MUSICAL SYMBOL COMBINING TEGEH..BALINESE MUSICAL SYMBOL COMBINING GONG
+	{runeRange{0x1BE6, 0x1BE6}, propertyGeneralCategory{lbprCM, gcMn}},     //         BATAK SIGN TOMPI
+	{runeRange{0x1C4D, 0x1C4F}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] LEPCHA LETTER TTA..LEPCHA LETTER DDA
+	{runeRange{0x1CEE, 0x1CF3}, propertyGeneralCategory{lbprAL, gcLo}},     //     [6] VEDIC SIGN HEXIFORM LONG ANUSVARA..VEDIC SIGN ROTATED ARDHAVISARGA
+	{runeRange{0x1DFC, 0x1DFC}, propertyGeneralCategory{lbprGL, gcMn}},     //         COMBINING DOUBLE INVERTED BREVE BELOW
+	{runeRange{0x1FBF, 0x1FC1}, propertyGeneralCategory{lbprAL, gcSk}},     //     [3] GREEK PSILI..GREEK DIALYTIKA AND PERISPOMENI
+	{runeRange{0x200B, 0x200B}, propertyGeneralCategory{lbprZW, gcCf}},     //         ZERO WIDTH SPACE
+	{runeRange{0x201E, 0x201E}, propertyGeneralCategory{lbprOP, gcPs}},     //         DOUBLE LOW-9 QUOTATION MARK
+	{runeRange{0x203E, 0x203E}, propertyGeneralCategory{lbprAL, gcPo}},     //         OVERLINE
+	{runeRange{0x205D, 0x205E}, propertyGeneralCategory{lbprBA, gcPo}},     //     [2] TRICOLON..VERTICAL FOUR DOTS
+	{runeRange{0x208A, 0x208C}, propertyGeneralCategory{lbprAL, gcSm}},     //     [3] SUBSCRIPT PLUS SIGN..SUBSCRIPT EQUALS SIGN
+	{runeRange{0x20DD, 0x20E0}, propertyGeneralCategory{lbprCM, gcMe}},     //     [4] COMBINING ENCLOSING CIRCLE..COMBINING ENCLOSING CIRCLE BACKSLASH
+	{runeRange{0x2115, 0x2115}, propertyGeneralCategory{lbprAL, gcLu}},     //         DOUBLE-STRUCK CAPITAL N
+	{runeRange{0x212C, 0x212D}, propertyGeneralCategory{lbprAL, gcLu}},     //     [2] SCRIPT CAPITAL B..BLACK-LETTER CAPITAL C
+	{runeRange{0x2156, 0x215A}, propertyGeneralCategory{lbprAL, gcNo}},     //     [5] VULGAR FRACTION TWO FIFTHS..VULGAR FRACTION FIVE SIXTHS
+	{runeRange{0x219C, 0x219F}, propertyGeneralCategory{lbprAL, gcSo}},     //     [4] LEFTWARDS WAVE ARROW..UPWARDS TWO HEADED ARROW
+	{runeRange{0x2200, 0x2200}, propertyGeneralCategory{lbprAI, gcSm}},     //         FOR ALL
+	{runeRange{0x221B, 0x221C}, propertyGeneralCategory{lbprAL, gcSm}},     //     [2] CUBE ROOT..FOURTH ROOT
+	{runeRange{0x2249, 0x224B}, propertyGeneralCategory{lbprAL, gcSm}},     //     [3] NOT ALMOST EQUAL TO..TRIPLE TILDE
+	{runeRange{0x2288, 0x2294}, propertyGeneralCategory{lbprAL, gcSm}},     //    [13] NEITHER A SUBSET OF NOR EQUAL TO..SQUARE CUP
+	{runeRange{0x230C, 0x2311}, propertyGeneralCategory{lbprAL, gcSo}},     //     [6] BOTTOM RIGHT CROP..SQUARE LOZENGE
+	{runeRange{0x23F0, 0x23F3}, propertyGeneralCategory{lbprID, gcSo}},     //     [4] ALARM CLOCK..HOURGLASS WITH FLOWING SAND
+	{runeRange{0x25A0, 0x25A1}, propertyGeneralCategory{lbprAI, gcSo}},     //     [2] BLACK SQUARE..WHITE SQUARE
+	{runeRange{0x25CB, 0x25CB}, propertyGeneralCategory{lbprAI, gcSo}},     //         WHITE CIRCLE
+	{runeRange{0x2610, 0x2613}, propertyGeneralCategory{lbprAL, gcSo}},     //     [4] BALLOT BOX..SALTIRE
+	{runeRange{0x2662, 0x2662}, propertyGeneralCategory{lbprAL, gcSo}},     //         WHITE DIAMOND SUIT
+	{runeRange{0x26C9, 0x26CC}, propertyGeneralCategory{lbprAI, gcSo}},     //     [4] TURNED WHITE SHOGI PIECE..CROSSING LANES
+	{runeRange{0x26EA, 0x26EA}, propertyGeneralCategory{lbprID, gcSo}},     //         CHURCH
+	{runeRange{0x275B, 0x2760}, propertyGeneralCategory{lbprQU, gcSo}},     //     [6] HEAVY SINGLE TURNED COMMA QUOTATION MARK ORNAMENT..HEAVY LOW DOUBLE COMMA QUOTATION MARK ORNAMENT
+	{runeRange{0x2773, 0x2773}, propertyGeneralCategory{lbprCL, gcPe}},     //         LIGHT RIGHT TORTOISE SHELL BRACKET ORNAMENT
+	{runeRange{0x27ED, 0x27ED}, propertyGeneralCategory{lbprCL, gcPe}},     //         MATHEMATICAL RIGHT WHITE TORTOISE SHELL BRACKET
+	{runeRange{0x298C, 0x298C}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT SQUARE BRACKET WITH UNDERBAR
+	{runeRange{0x29DA, 0x29DA}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT DOUBLE WIGGLY FENCE
+	{runeRange{0x2C00, 0x2C5F}, propertyGeneralCategory{lbprAL, gcLC}},     //    [96] GLAGOLITIC CAPITAL LETTER AZU..GLAGOLITIC SMALL LETTER CAUDATE CHRIVI
+	{runeRange{0x2D2D, 0x2D2D}, propertyGeneralCategory{lbprAL, gcLl}},     //         GEORGIAN SMALL LETTER AEN
+	{runeRange{0x2E02, 0x2E02}, propertyGeneralCategory{lbprQU, gcPi}},     //         LEFT SUBSTITUTION BRACKET
+	{runeRange{0x2E1B, 0x2E1B}, propertyGeneralCategory{lbprAL, gcPo}},     //         TILDE WITH RING ABOVE
+	{runeRange{0x2E2F, 0x2E2F}, propertyGeneralCategory{lbprAL, gcLm}},     //         VERTICAL TILDE
+	{runeRange{0x2E50, 0x2E51}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] CROSS PATTY WITH RIGHT CROSSBAR..CROSS PATTY WITH LEFT CROSSBAR
+	{runeRange{0x3000, 0x3000}, propertyGeneralCategory{lbprBA, gcZs}},     //         IDEOGRAPHIC SPACE
+	{runeRange{0x3011, 0x3011}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT BLACK LENTICULAR BRACKET
+	{runeRange{0x302E, 0x302F}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] HANGUL SINGLE DOT TONE MARK..HANGUL DOUBLE DOT TONE MARK
+	{runeRange{0x3047, 0x3047}, propertyGeneralCategory{lbprCJ, gcLo}},     //         HIRAGANA LETTER SMALL E
+	{runeRange{0x309B, 0x309C}, propertyGeneralCategory{lbprNS, gcSk}},     //     [2] KATAKANA-HIRAGANA VOICED SOUND MARK..KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK
+	{runeRange{0x30E3, 0x30E3}, propertyGeneralCategory{lbprCJ, gcLo}},     //         KATAKANA LETTER SMALL YA
+	{runeRange{0x3190, 0x3191}, propertyGeneralCategory{lbprID, gcSo}},     //     [2] IDEOGRAPHIC ANNOTATION LINKING MARK..IDEOGRAPHIC ANNOTATION REVERSE MARK
+	{runeRange{0x32C0, 0x32FF}, propertyGeneralCategory{lbprID, gcSo}},     //    [64] IDEOGRAPHIC TELEGRAPH SYMBOL FOR JANUARY..SQUARE ERA NAME REIWA
+	{runeRange{0xA60F, 0xA60F}, propertyGeneralCategory{lbprBA, gcPo}},     //         VAI QUESTION MARK
+	{runeRange{0xA6E6, 0xA6EF}, propertyGeneralCategory{lbprAL, gcNl}},     //    [10] BAMUM LETTER MO..BAMUM LETTER KOGHOM
+	{runeRange{0xA7D3, 0xA7D3}, propertyGeneralCategory{lbprAL, gcLl}},     //         LATIN SMALL LETTER DOUBLE THORN
+	{runeRange{0xA825, 0xA826}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] SYLOTI NAGRI VOWEL SIGN U..SYLOTI NAGRI VOWEL SIGN E
+	{runeRange{0xA8D0, 0xA8D9}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] SAURASHTRA DIGIT ZERO..SAURASHTRA DIGIT NINE
+	{runeRange{0xA960, 0xA97C}, propertyGeneralCategory{lbprJL, gcLo}},     //    [29] HANGUL CHOSEONG TIKEUT-MIEUM..HANGUL CHOSEONG SSANGYEORINHIEUH
+	{runeRange{0xA9E0, 0xA9E4}, propertyGeneralCategory{lbprSA, gcLo}},     //     [5] MYANMAR LETTER SHAN GHA..MYANMAR LETTER SHAN BHA
+	{runeRange{0xAA4D, 0xAA4D}, propertyGeneralCategory{lbprCM, gcMc}},     //         CHAM CONSONANT SIGN FINAL H
+	{runeRange{0xAAB2, 0xAAB4}, propertyGeneralCategory{lbprSA, gcMn}},     //     [3] TAI VIET VOWEL I..TAI VIET VOWEL U
+	{runeRange{0xAAF2, 0xAAF2}, propertyGeneralCategory{lbprAL, gcLo}},     //         MEETEI MAYEK ANJI
+	{runeRange{0xABC0, 0xABE2}, propertyGeneralCategory{lbprAL, gcLo}},     //    [35] MEETEI MAYEK LETTER KOK..MEETEI MAYEK LETTER I LONSUM
+	{runeRange{0xAC54, 0xAC54}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GYAE
+	{runeRange{0xAD34, 0xAD34}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GOE
+	{runeRange{0xAE14, 0xAE14}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GYI
+	{runeRange{0xAEF4, 0xAEF4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGYEO
+	{runeRange{0xAFD4, 0xAFD4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGWEO
+	{runeRange{0xB0B4, 0xB0B4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NAE
+	{runeRange{0xB194, 0xB194}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NWA
+	{runeRange{0xB274, 0xB274}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NYU
+	{runeRange{0xB354, 0xB354}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DEO
+	{runeRange{0xB434, 0xB434}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DYO
+	{runeRange{0xB514, 0xB514}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DI
+	{runeRange{0xB5F4, 0xB5F4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDYE
+	{runeRange{0xB6D4, 0xB6D4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDWE
+	{runeRange{0xB7B4, 0xB7B4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RYA
+	{runeRange{0xB894, 0xB894}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RWAE
+	{runeRange{0xB974, 0xB974}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE REU
+	{runeRange{0xBA54, 0xBA54}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE ME
+	{runeRange{0xBB34, 0xBB34}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MU
+	{runeRange{0xBC14, 0xBC14}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BA
+	{runeRange{0xBCF4, 0xBCF4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BO
+	{runeRange{0xBDD4, 0xBDD4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BWI
+	{runeRange{0xBEB4, 0xBEB4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBYAE
+	{runeRange{0xBF94, 0xBF94}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBOE
+	{runeRange{0xC074, 0xC074}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBYI
+	{runeRange{0xC154, 0xC154}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SYEO
+	{runeRange{0xC234, 0xC234}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SWEO
+	{runeRange{0xC314, 0xC314}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSAE
+	{runeRange{0xC3F4, 0xC3F4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSWA
+	{runeRange{0xC4D4, 0xC4D4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSYU
+	{runeRange{0xC5B4, 0xC5B4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE EO
+	{runeRange{0xC694, 0xC694}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE YO
+	{runeRange{0xC774, 0xC774}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE I
+	{runeRange{0xC854, 0xC854}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JYE
+	{runeRange{0xC934, 0xC934}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JWE
+	{runeRange{0xCA14, 0xCA14}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJYA
+	{runeRange{0xCAF4, 0xCAF4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJWAE
+	{runeRange{0xCBD4, 0xCBD4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJEU
+	{runeRange{0xCCB4, 0xCCB4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CE
+	{runeRange{0xCD94, 0xCD94}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CU
+	{runeRange{0xCE74, 0xCE74}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KA
+	{runeRange{0xCF54, 0xCF54}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KO
+	{runeRange{0xD034, 0xD034}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KWI
+	{runeRange{0xD114, 0xD114}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TYAE
+	{runeRange{0xD1F4, 0xD1F4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TOE
+	{runeRange{0xD2D4, 0xD2D4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TYI
+	{runeRange{0xD3B4, 0xD3B4}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PYEO
+	{runeRange{0xD494, 0xD494}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PWEO
+	{runeRange{0xD574, 0xD574}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HAE
+	{runeRange{0xD654, 0xD654}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HWA
+	{runeRange{0xD734, 0xD734}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HYU
+	{runeRange{0xFA70, 0xFAD9}, propertyGeneralCategory{lbprID, gcLo}},     //   [106] CJK COMPATIBILITY IDEOGRAPH-FA70..CJK COMPATIBILITY IDEOGRAPH-FAD9
+	{runeRange{0xFBD3, 0xFD3D}, propertyGeneralCategory{lbprAL, gcLo}},     //   [363] ARABIC LETTER NG ISOLATED FORM..ARABIC LIGATURE ALEF WITH FATHATAN ISOLATED FORM
+	{runeRange{0xFE18, 0xFE18}, propertyGeneralCategory{lbprCL, gcPe}},     //         PRESENTATION FORM FOR VERTICAL RIGHT WHITE LENTICULAR BRAKCET
+	{runeRange{0xFE3F, 0xFE3F}, propertyGeneralCategory{lbprOP, gcPs}},     //         PRESENTATION FORM FOR VERTICAL LEFT ANGLE BRACKET
+	{runeRange{0xFE58, 0xFE58}, propertyGeneralCategory{lbprID, gcPd}},     //         SMALL EM DASH
+	{runeRange{0xFE76, 0xFEFC}, propertyGeneralCategory{lbprAL, gcLo}},     //   [135] ARABIC FATHA ISOLATED FORM..ARABIC LIGATURE LAM WITH ALEF FINAL FORM
+	{runeRange{0xFF1A, 0xFF1B}, propertyGeneralCategory{lbprNS, gcPo}},     //     [2] FULLWIDTH COLON..FULLWIDTH SEMICOLON
+	{runeRange{0xFF5F, 0xFF5F}, propertyGeneralCategory{lbprOP, gcPs}},     //         FULLWIDTH LEFT WHITE PARENTHESIS
+	{runeRange{0xFFDA, 0xFFDC}, propertyGeneralCategory{lbprID, gcLo}},     //     [3] HALFWIDTH HANGUL LETTER EU..HALFWIDTH HANGUL LETTER I
+	{runeRange{0x1003C, 0x1003D}, propertyGeneralCategory{lbprAL, gcLo}},   //     [2] LINEAR B SYLLABLE B017 ZA..LINEAR B SYLLABLE B074 ZE
+	{runeRange{0x10280, 0x1029C}, propertyGeneralCategory{lbprAL, gcLo}},   //    [29] LYCIAN LETTER A..LYCIAN LETTER X
+	{runeRange{0x103C8, 0x103CF}, propertyGeneralCategory{lbprAL, gcLo}},   //     [8] OLD PERSIAN SIGN AURAMAZDAA..OLD PERSIAN SIGN BUUMISH
+	{runeRange{0x10597, 0x105A1}, propertyGeneralCategory{lbprAL, gcLl}},   //    [11] VITHKUQI SMALL LETTER A..VITHKUQI SMALL LETTER GA
+	{runeRange{0x10840, 0x10855}, propertyGeneralCategory{lbprAL, gcLo}},   //    [22] IMPERIAL ARAMAIC LETTER ALEPH..IMPERIAL ARAMAIC LETTER TAW
+	{runeRange{0x10980, 0x1099F}, propertyGeneralCategory{lbprAL, gcLo}},   //    [32] MEROITIC HIEROGLYPHIC LETTER A..MEROITIC HIEROGLYPHIC SYMBOL VIDJ-2
+	{runeRange{0x10A50, 0x10A57}, propertyGeneralCategory{lbprBA, gcPo}},   //     [8] KHAROSHTHI PUNCTUATION DOT..KHAROSHTHI PUNCTUATION DOUBLE DANDA
+	{runeRange{0x10B40, 0x10B55}, propertyGeneralCategory{lbprAL, gcLo}},   //    [22] INSCRIPTIONAL PARTHIAN LETTER ALEPH..INSCRIPTIONAL PARTHIAN LETTER TAW
+	{runeRange{0x10EAB, 0x10EAC}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] YEZIDI COMBINING HAMZA MARK..YEZIDI COMBINING MADDA MARK
+	{runeRange{0x10FE0, 0x10FF6}, propertyGeneralCategory{lbprAL, gcLo}},   //    [23] ELYMAIC LETTER ALEPH..ELYMAIC LIGATURE ZAYIN-YODH
+	{runeRange{0x11082, 0x11082}, propertyGeneralCategory{lbprCM, gcMc}},   //         KAITHI SIGN VISARGA
+	{runeRange{0x1112C, 0x1112C}, propertyGeneralCategory{lbprCM, gcMc}},   //         CHAKMA VOWEL SIGN E
+	{runeRange{0x111B6, 0x111BE}, propertyGeneralCategory{lbprCM, gcMn}},   //     [9] SHARADA VOWEL SIGN U..SHARADA VOWEL SIGN O
+	{runeRange{0x11200, 0x11211}, propertyGeneralCategory{lbprAL, gcLo}},   //    [18] KHOJKI LETTER A..KHOJKI LETTER JJA
+	{runeRange{0x11288, 0x11288}, propertyGeneralCategory{lbprAL, gcLo}},   //         MULTANI LETTER GHA
+	{runeRange{0x11332, 0x11333}, propertyGeneralCategory{lbprAL, gcLo}},   //     [2] GRANTHA LETTER LA..GRANTHA LETTER LLA
+	{runeRange{0x11435, 0x11437}, propertyGeneralCategory{lbprCM, gcMc}},   //     [3] NEWA VOWEL SIGN AA..NEWA VOWEL SIGN II
+	{runeRange{0x114B3, 0x114B8}, propertyGeneralCategory{lbprCM, gcMn}},   //     [6] TIRHUTA VOWEL SIGN U..TIRHUTA VOWEL SIGN VOCALIC LL
+	{runeRange{0x115BE, 0x115BE}, propertyGeneralCategory{lbprCM, gcMc}},   //         SIDDHAM SIGN VISARGA
+	{runeRange{0x11641, 0x11642}, propertyGeneralCategory{lbprBA, gcPo}},   //     [2] MODI DANDA..MODI DOUBLE DANDA
+	{runeRange{0x11700, 0x1171A}, propertyGeneralCategory{lbprSA, gcLo}},   //    [27] AHOM LETTER KA..AHOM LETTER ALTERNATE BA
+	{runeRange{0x1183B, 0x1183B}, propertyGeneralCategory{lbprAL, gcPo}},   //         DOGRA ABBREVIATION SIGN
+	{runeRange{0x11940, 0x11940}, propertyGeneralCategory{lbprCM, gcMc}},   //         DIVES AKURU MEDIAL YA
+	{runeRange{0x119E4, 0x119E4}, propertyGeneralCategory{lbprCM, gcMc}},   //         NANDINAGARI VOWEL SIGN PRISHTHAMATRA E
+	{runeRange{0x11A41, 0x11A44}, propertyGeneralCategory{lbprBA, gcPo}},   //     [4] ZANABAZAR SQUARE MARK TSHEG..ZANABAZAR SQUARE MARK LONG TSHEG
+	{runeRange{0x11A5C, 0x11A89}, propertyGeneralCategory{lbprAL, gcLo}},   //    [46] SOYOMBO LETTER KA..SOYOMBO CLUSTER-INITIAL LETTER SA
+	{runeRange{0x11AB0, 0x11ABF}, propertyGeneralCategory{lbprAL, gcLo}},   //    [16] CANADIAN SYLLABICS NATTILIK HI..CANADIAN SYLLABICS SPA
+	{runeRange{0x11C3E, 0x11C3E}, propertyGeneralCategory{lbprCM, gcMc}},   //         BHAIKSUKI SIGN VISARGA
+	{runeRange{0x11C72, 0x11C8F}, propertyGeneralCategory{lbprAL, gcLo}},   //    [30] MARCHEN LETTER KA..MARCHEN LETTER A
+	{runeRange{0x11D00, 0x11D06}, propertyGeneralCategory{lbprAL, gcLo}},   //     [7] MASARAM GONDI LETTER A..MASARAM GONDI LETTER E
+	{runeRange{0x11D47, 0x11D47}, propertyGeneralCategory{lbprCM, gcMn}},   //         MASARAM GONDI RA-KARA
+	{runeRange{0x11D95, 0x11D95}, propertyGeneralCategory{lbprCM, gcMn}},   //         GUNJALA GONDI SIGN ANUSVARA
+	{runeRange{0x11EF7, 0x11EF8}, propertyGeneralCategory{lbprAL, gcPo}},   //     [2] MAKASAR PASSIMBANG..MAKASAR END OF SECTION
+	{runeRange{0x11F3E, 0x11F3F}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] KAWI VOWEL SIGN E..KAWI VOWEL SIGN AI
+	{runeRange{0x11FC0, 0x11FD4}, propertyGeneralCategory{lbprAL, gcNo}},   //    [21] TAMIL FRACTION ONE THREE-HUNDRED-AND-TWENTIETH..TAMIL FRACTION DOWNSCALING FACTOR KIIZH
+	{runeRange{0x12480, 0x12543}, propertyGeneralCategory{lbprAL, gcLo}},   //   [196] CUNEIFORM SIGN AB TIMES NUN TENU..CUNEIFORM SIGN ZU5 TIMES THREE DISH TENU
+	{runeRange{0x13283, 0x13285}, propertyGeneralCategory{lbprAL, gcLo}},   //     [3] EGYPTIAN HIEROGLYPH O034..EGYPTIAN HIEROGLYPH O036
+	{runeRange{0x1337C, 0x1342F}, propertyGeneralCategory{lbprAL, gcLo}},   //   [180] EGYPTIAN HIEROGLYPH V012..EGYPTIAN HIEROGLYPH V011D
+	{runeRange{0x1343F, 0x1343F}, propertyGeneralCategory{lbprCL, gcCf}},   //         EGYPTIAN HIEROGLYPH END WALLED ENCLOSURE
+	{runeRange{0x16800, 0x16A38}, propertyGeneralCategory{lbprAL, gcLo}},   //   [569] BAMUM LETTER PHASE-A NGKUE MFON..BAMUM LETTER PHASE-F VUEQ
+	{runeRange{0x16AF5, 0x16AF5}, propertyGeneralCategory{lbprBA, gcPo}},   //         BASSA VAH FULL STOP
+	{runeRange{0x16B45, 0x16B45}, propertyGeneralCategory{lbprAL, gcSo}},   //         PAHAWH HMONG SIGN CIM TSOV ROG
+	{runeRange{0x16E99, 0x16E9A}, propertyGeneralCategory{lbprAL, gcPo}},   //     [2] MEDEFAIDRIN SYMBOL AIVA..MEDEFAIDRIN EXCLAMATION OH
+	{runeRange{0x16FE2, 0x16FE2}, propertyGeneralCategory{lbprNS, gcPo}},   //         OLD CHINESE HOOK MARK
+	{runeRange{0x1AFF0, 0x1AFF3}, propertyGeneralCategory{lbprAL, gcLm}},   //     [4] KATAKANA LETTER MINNAN TONE-2..KATAKANA LETTER MINNAN TONE-5
+	{runeRange{0x1B164, 0x1B167}, propertyGeneralCategory{lbprCJ, gcLo}},   //     [4] KATAKANA LETTER SMALL WI..KATAKANA LETTER SMALL N
+	{runeRange{0x1BC9F, 0x1BC9F}, propertyGeneralCategory{lbprBA, gcPo}},   //         DUPLOYAN PUNCTUATION CHINOOK FULL STOP
+	{runeRange{0x1D165, 0x1D166}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] MUSICAL SYMBOL COMBINING STEM..MUSICAL SYMBOL COMBINING SPRECHGESANG STEM
+	{runeRange{0x1D18C, 0x1D1A9}, propertyGeneralCategory{lbprAL, gcSo}},   //    [30] MUSICAL SYMBOL RINFORZANDO..MUSICAL SYMBOL DEGREE SLASH
+	{runeRange{0x1D300, 0x1D356}, propertyGeneralCategory{lbprAL, gcSo}},   //    [87] MONOGRAM FOR EARTH..TETRAGRAM FOR FOSTERING
+	{runeRange{0x1D4AE, 0x1D4B9}, propertyGeneralCategory{lbprAL, gcLC}},   //    [12] MATHEMATICAL SCRIPT CAPITAL S..MATHEMATICAL SCRIPT SMALL D
+	{runeRange{0x1D53B, 0x1D53E}, propertyGeneralCategory{lbprAL, gcLu}},   //     [4] MATHEMATICAL DOUBLE-STRUCK CAPITAL D..MATHEMATICAL DOUBLE-STRUCK CAPITAL G
+	{runeRange{0x1D6DB, 0x1D6DB}, propertyGeneralCategory{lbprAL, gcSm}},   //         MATHEMATICAL BOLD PARTIAL DIFFERENTIAL
+	{runeRange{0x1D74F, 0x1D74F}, propertyGeneralCategory{lbprAL, gcSm}},   //         MATHEMATICAL BOLD ITALIC PARTIAL DIFFERENTIAL
+	{runeRange{0x1D7C3, 0x1D7C3}, propertyGeneralCategory{lbprAL, gcSm}},   //         MATHEMATICAL SANS-SERIF BOLD ITALIC PARTIAL DIFFERENTIAL
+	{runeRange{0x1DA75, 0x1DA75}, propertyGeneralCategory{lbprCM, gcMn}},   //         SIGNWRITING UPPER BODY TILTING FROM HIP JOINTS
+	{runeRange{0x1DF00, 0x1DF09}, propertyGeneralCategory{lbprAL, gcLl}},   //    [10] LATIN SMALL LETTER FENG DIGRAPH WITH TRILL..LATIN SMALL LETTER T WITH HOOK AND RETROFLEX HOOK
+	{runeRange{0x1E026, 0x1E02A}, propertyGeneralCategory{lbprCM, gcMn}},   //     [5] COMBINING GLAGOLITIC LETTER YO..COMBINING GLAGOLITIC LETTER FITA
+	{runeRange{0x1E14F, 0x1E14F}, propertyGeneralCategory{lbprAL, gcSo}},   //         NYIAKENG PUACHUE HMONG CIRCLED CA
+	{runeRange{0x1E4EB, 0x1E4EB}, propertyGeneralCategory{lbprAL, gcLm}},   //         NAG MUNDARI SIGN OJOD
+	{runeRange{0x1E8C7, 0x1E8CF}, propertyGeneralCategory{lbprAL, gcNo}},   //     [9] MENDE KIKAKUI DIGIT ONE..MENDE KIKAKUI DIGIT NINE
+	{runeRange{0x1ECAC, 0x1ECAC}, propertyGeneralCategory{lbprPO, gcSo}},   //         INDIC SIYAQ PLACEHOLDER
+	{runeRange{0x1EE05, 0x1EE1F}, propertyGeneralCategory{lbprAL, gcLo}},   //    [27] ARABIC MATHEMATICAL WAW..ARABIC MATHEMATICAL DOTLESS QAF
+	{runeRange{0x1EE42, 0x1EE42}, propertyGeneralCategory{lbprAL, gcLo}},   //         ARABIC MATHEMATICAL TAILED JEEM
+	{runeRange{0x1EE59, 0x1EE59}, propertyGeneralCategory{lbprAL, gcLo}},   //         ARABIC MATHEMATICAL TAILED DAD
+	{runeRange{0x1EE74, 0x1EE77}, propertyGeneralCategory{lbprAL, gcLo}},   //     [4] ARABIC MATHEMATICAL STRETCHED SHEEN..ARABIC MATHEMATICAL STRETCHED KHAH
+	{runeRange{0x1EEF0, 0x1EEF1}, propertyGeneralCategory{lbprAL, gcSm}},   //     [2] ARABIC MATHEMATICAL OPERATOR MEEM WITH HAH WITH TATWEEL..ARABIC MATHEMATICAL OPERATOR HAH WITH DAL
+	{runeRange{0x1F0C0, 0x1F0C0}, propertyGeneralCategory{lbprID, gcCn}},   //         <reserved-1F0C0>
+	{runeRange{0x1F12E, 0x1F12F}, propertyGeneralCategory{lbprAL, gcSo}},   //     [2] CIRCLED WZ..COPYLEFT SYMBOL
+	{runeRange{0x1F200, 0x1F202}, propertyGeneralCategory{lbprID, gcSo}},   //     [3] SQUARE HIRAGANA HOKA..SQUARED KATAKANA SA
+	{runeRange{0x1F260, 0x1F265}, propertyGeneralCategory{lbprID, gcSo}},   //     [6] ROUNDED SYMBOL FOR FU..ROUNDED SYMBOL FOR CAI
+	{runeRange{0x1F3B7, 0x1F3BB}, propertyGeneralCategory{lbprID, gcSo}},   //     [5] SAXOPHONE..VIOLIN
+	{runeRange{0x1F3CD, 0x1F3FA}, propertyGeneralCategory{lbprID, gcSo}},   //    [46] RACING MOTORCYCLE..AMPHORA
+	{runeRange{0x1F479, 0x1F47B}, propertyGeneralCategory{lbprID, gcSo}},   //     [3] JAPANESE OGRE..GHOST
+	{runeRange{0x1F490, 0x1F490}, propertyGeneralCategory{lbprID, gcSo}},   //         BOUQUET
+	{runeRange{0x1F4A5, 0x1F4A9}, propertyGeneralCategory{lbprID, gcSo}},   //     [5] COLLISION SYMBOL..PILE OF POO
+	{runeRange{0x1F507, 0x1F516}, propertyGeneralCategory{lbprID, gcSo}},   //    [16] SPEAKER WITH CANCELLATION STROKE..BOOKMARK
+	{runeRange{0x1F57B, 0x1F58F}, propertyGeneralCategory{lbprID, gcSo}},   //    [21] LEFT HAND TELEPHONE RECEIVER..TURNED OK HAND SIGN
+	{runeRange{0x1F5FA, 0x1F5FF}, propertyGeneralCategory{lbprID, gcSo}},   //     [6] WORLD MAP..MOYAI
+	{runeRange{0x1F67C, 0x1F67F}, propertyGeneralCategory{lbprAL, gcSo}},   //     [4] VERY HEAVY SOLIDUS..REVERSE CHECKER BOARD
+	{runeRange{0x1F6CC, 0x1F6CC}, propertyGeneralCategory{lbprEB, gcSo}},   //         SLEEPING ACCOMMODATION
+	{runeRange{0x1F774, 0x1F776}, propertyGeneralCategory{lbprID, gcSo}},   //     [3] LOT OF FORTUNE..LUNAR ECLIPSE
+	{runeRange{0x1F7F0, 0x1F7F0}, propertyGeneralCategory{lbprID, gcSo}},   //         HEAVY EQUALS SIGN
+	{runeRange{0x1F860, 0x1F887}, propertyGeneralCategory{lbprAL, gcSo}},   //    [40] WIDE-HEADED LEFTWARDS LIGHT BARB ARROW..WIDE-HEADED SOUTH WEST VERY HEAVY BARB ARROW
+	{runeRange{0x1F90D, 0x1F90E}, propertyGeneralCategory{lbprID, gcSo}},   //     [2] WHITE HEART..BROWN HEART
+	{runeRange{0x1F93A, 0x1F93B}, propertyGeneralCategory{lbprID, gcSo}},   //     [2] FENCER..MODERN PENTATHLON
+	{runeRange{0x1F9BA, 0x1F9BA}, propertyGeneralCategory{lbprID, gcSo}},   //         SAFETY VEST
+	{runeRange{0x1FA54, 0x1FA5F}, propertyGeneralCategory{lbprID, gcCn}},   //    [12] <reserved-1FA54>..<reserved-1FA5F>
+	{runeRange{0x1FABE, 0x1FABE}, propertyGeneralCategory{lbprID, gcCn}},   //         <reserved-1FABE>
+	{runeRange{0x1FAF0, 0x1FAF8}, propertyGeneralCategory{lbprEB, gcSo}},   //     [9] HAND WITH INDEX FINGER AND THUMB CROSSED..RIGHTWARDS PUSHING HAND
+	{runeRange{0x2A700, 0x2B739}, propertyGeneralCategory{lbprID, gcLo}},   //  [4154] CJK UNIFIED IDEOGRAPH-2A700..CJK UNIFIED IDEOGRAPH-2B739
+	{runeRange{0x2F800, 0x2FA1D}, propertyGeneralCategory{lbprID, gcLo}},   //   [542] CJK COMPATIBILITY IDEOGRAPH-2F800..CJK COMPATIBILITY IDEOGRAPH-2FA1D
 	{runeRange{0xE0020, 0xE007F}, propertyGeneralCategory{lbprCM, gcCf}},   //    [96] TAG SPACE..CANCEL TAG
-	{runeRange{0xE0100, 0xE01EF}, propertyGeneralCategory{lbprCM, gcMn}},   //   [240] VARIATION SELECTOR-17..VARIATION SELECTOR-256
+	{runeRange{0x000B, 0x000C}, propertyGeneralCategory{lbprBK, gcCc}},     //     [2] <control-000B>..<control-000C>
+	{runeRange{0x0025, 0x0025}, propertyGeneralCategory{lbprPO, gcPo}},     //         PERCENT SIGN
+	{runeRange{0x002D, 0x002D}, propertyGeneralCategory{lbprHY, gcPd}},     //         HYPHEN-MINUS
+	{runeRange{0x0041, 0x005A}, propertyGeneralCategory{lbprAL, gcLu}},     //    [26] LATIN CAPITAL LETTER A..LATIN CAPITAL LETTER Z
+	{runeRange{0x007B, 0x007B}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT CURLY BRACKET
+	{runeRange{0x00A0, 0x00A0}, propertyGeneralCategory{lbprGL, gcZs}},     //         NO-BREAK SPACE
+	{runeRange{0x00AA, 0x00AA}, propertyGeneralCategory{lbprAI, gcLo}},     //         FEMININE ORDINAL INDICATOR
+	{runeRange{0x00B2, 0x00B3}, propertyGeneralCategory{lbprAI, gcNo}},     //     [2] SUPERSCRIPT TWO..SUPERSCRIPT THREE
+	{runeRange{0x00BC, 0x00BE}, propertyGeneralCategory{lbprAI, gcNo}},     //     [3] VULGAR FRACTION ONE QUARTER..VULGAR FRACTION THREE QUARTERS
+	{runeRange{0x0180, 0x01BA}, propertyGeneralCategory{lbprAL, gcLC}},     //    [59] LATIN SMALL LETTER B WITH STROKE..LATIN SMALL LETTER EZH WITH TAIL
+	{runeRange{0x02B0, 0x02C1}, propertyGeneralCategory{lbprAL, gcLm}},     //    [18] MODIFIER LETTER SMALL H..MODIFIER LETTER REVERSED GLOTTAL STOP
+	{runeRange{0x02CE, 0x02CF}, propertyGeneralCategory{lbprAL, gcLm}},     //     [2] MODIFIER LETTER LOW GRAVE ACCENT..MODIFIER LETTER LOW ACUTE ACCENT
+	{runeRange{0x02DF, 0x02DF}, propertyGeneralCategory{lbprBB, gcSk}},     //         MODIFIER LETTER CROSS ACCENT
+	{runeRange{0x034F, 0x034F}, propertyGeneralCategory{lbprGL, gcMn}},     //         COMBINING GRAPHEME JOINER
+	{runeRange{0x037A, 0x037A}, propertyGeneralCategory{lbprAL, gcLm}},     //         GREEK YPOGEGRAMMENI
+	{runeRange{0x038C, 0x038C}, propertyGeneralCategory{lbprAL, gcLu}},     //         GREEK CAPITAL LETTER OMICRON WITH TONOS
+	{runeRange{0x0488, 0x0489}, propertyGeneralCategory{lbprCM, gcMe}},     //     [2] COMBINING CYRILLIC HUNDRED THOUSANDS SIGN..COMBINING CYRILLIC MILLIONS SIGN
+	{runeRange{0x058A, 0x058A}, propertyGeneralCategory{lbprBA, gcPd}},     //         ARMENIAN HYPHEN
+	{runeRange{0x05C3, 0x05C3}, propertyGeneralCategory{lbprAL, gcPo}},     //         HEBREW PUNCTUATION SOF PASUQ
+	{runeRange{0x0606, 0x0608}, propertyGeneralCategory{lbprAL, gcSm}},     //     [3] ARABIC-INDIC CUBE ROOT..ARABIC RAY
+	{runeRange{0x061D, 0x061F}, propertyGeneralCategory{lbprEX, gcPo}},     //     [3] ARABIC END OF TEXT MARK..ARABIC QUESTION MARK
+	{runeRange{0x066D, 0x066D}, propertyGeneralCategory{lbprAL, gcPo}},     //         ARABIC FIVE POINTED STAR
+	{runeRange{0x06DE, 0x06DE}, propertyGeneralCategory{lbprAL, gcSo}},     //         ARABIC START OF RUB EL HIZB
+	{runeRange{0x06FA, 0x06FC}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] ARABIC LETTER SHEEN WITH DOT BELOW..ARABIC LETTER GHAIN WITH DOT BELOW
+	{runeRange{0x0730, 0x074A}, propertyGeneralCategory{lbprCM, gcMn}},     //    [27] SYRIAC PTHAHA ABOVE..SYRIAC BARREKH
+	{runeRange{0x07EB, 0x07F3}, propertyGeneralCategory{lbprCM, gcMn}},     //     [9] NKO COMBINING SHORT HIGH TONE..NKO COMBINING DOUBLE DOT ABOVE
+	{runeRange{0x07FE, 0x07FF}, propertyGeneralCategory{lbprPR, gcSc}},     //     [2] NKO DOROME SIGN..NKO TAMAN SIGN
+	{runeRange{0x0829, 0x082D}, propertyGeneralCategory{lbprCM, gcMn}},     //     [5] SAMARITAN VOWEL SIGN LONG I..SAMARITAN MARK NEQUDAA
+	{runeRange{0x0889, 0x088E}, propertyGeneralCategory{lbprAL, gcLo}},     //     [6] ARABIC LETTER NOON WITH INVERTED SMALL V..ARABIC VERTICAL TAIL
+	{runeRange{0x0900, 0x0902}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] DEVANAGARI SIGN INVERTED CANDRABINDU..DEVANAGARI SIGN ANUSVARA
+	{runeRange{0x0941, 0x0948}, propertyGeneralCategory{lbprCM, gcMn}},     //     [8] DEVANAGARI VOWEL SIGN U..DEVANAGARI VOWEL SIGN AI
+	{runeRange{0x0964, 0x0965}, propertyGeneralCategory{lbprBA, gcPo}},     //     [2] DEVANAGARI DANDA..DEVANAGARI DOUBLE DANDA
+	{runeRange{0x0985, 0x098C}, propertyGeneralCategory{lbprAL, gcLo}},     //     [8] BENGALI LETTER A..BENGALI LETTER VOCALIC L
+	{runeRange{0x09BE, 0x09C0}, propertyGeneralCategory{lbprCM, gcMc}},     //     [3] BENGALI VOWEL SIGN AA..BENGALI VOWEL SIGN II
+	{runeRange{0x09DF, 0x09E1}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] BENGALI LETTER YYA..BENGALI LETTER VOCALIC LL
+	{runeRange{0x09FB, 0x09FB}, propertyGeneralCategory{lbprPR, gcSc}},     //         BENGALI GANDA MARK
+	{runeRange{0x0A13, 0x0A28}, propertyGeneralCategory{lbprAL, gcLo}},     //    [22] GURMUKHI LETTER OO..GURMUKHI LETTER NA
+	{runeRange{0x0A47, 0x0A48}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] GURMUKHI VOWEL SIGN EE..GURMUKHI VOWEL SIGN AI
+	{runeRange{0x0A75, 0x0A75}, propertyGeneralCategory{lbprCM, gcMn}},     //         GURMUKHI SIGN YAKASH
+	{runeRange{0x0AB2, 0x0AB3}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] GUJARATI LETTER LA..GUJARATI LETTER LLA
+	{runeRange{0x0ACB, 0x0ACC}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] GUJARATI VOWEL SIGN O..GUJARATI VOWEL SIGN AU
+	{runeRange{0x0AF9, 0x0AF9}, propertyGeneralCategory{lbprAL, gcLo}},     //         GUJARATI LETTER ZHA
+	{runeRange{0x0B32, 0x0B33}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] ORIYA LETTER LA..ORIYA LETTER LLA
+	{runeRange{0x0B47, 0x0B48}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] ORIYA VOWEL SIGN E..ORIYA VOWEL SIGN AI
+	{runeRange{0x0B66, 0x0B6F}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] ORIYA DIGIT ZERO..ORIYA DIGIT NINE
+	{runeRange{0x0B92, 0x0B95}, propertyGeneralCategory{lbprAL, gcLo}},     //     [4] TAMIL LETTER O..TAMIL LETTER KA
+	{runeRange{0x0BC0, 0x0BC0}, propertyGeneralCategory{lbprCM, gcMn}},     //         TAMIL VOWEL SIGN II
+	{runeRange{0x0BF0, 0x0BF2}, propertyGeneralCategory{lbprAL, gcNo}},     //     [3] TAMIL NUMBER TEN..TAMIL NUMBER ONE THOUSAND
+	{runeRange{0x0C0E, 0x0C10}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] TELUGU LETTER E..TELUGU LETTER AI
+	{runeRange{0x0C4A, 0x0C4D}, propertyGeneralCategory{lbprCM, gcMn}},     //     [4] TELUGU VOWEL SIGN O..TELUGU SIGN VIRAMA
+	{runeRange{0x0C78, 0x0C7E}, propertyGeneralCategory{lbprAL, gcNo}},     //     [7] TELUGU FRACTION DIGIT ZERO FOR ODD POWERS OF FOUR..TELUGU FRACTION DIGIT THREE FOR EVEN POWERS OF FOUR
+	{runeRange{0x0C92, 0x0CA8}, propertyGeneralCategory{lbprAL, gcLo}},     //    [23] KANNADA LETTER O..KANNADA LETTER NA
+	{runeRange{0x0CC6, 0x0CC6}, propertyGeneralCategory{lbprCM, gcMn}},     //         KANNADA VOWEL SIGN E
+	{runeRange{0x0CE6, 0x0CEF}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] KANNADA DIGIT ZERO..KANNADA DIGIT NINE
+	{runeRange{0x0D3B, 0x0D3C}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] MALAYALAM SIGN VERTICAL BAR VIRAMA..MALAYALAM SIGN CIRCULAR VIRAMA
+	{runeRange{0x0D4F, 0x0D4F}, propertyGeneralCategory{lbprAL, gcSo}},     //         MALAYALAM SIGN PARA
+	{runeRange{0x0D79, 0x0D79}, propertyGeneralCategory{lbprPO, gcSo}},     //         MALAYALAM DATE MARK
+	{runeRange{0x0DC0, 0x0DC6}, propertyGeneralCategory{lbprAL, gcLo}},     //     [7] SINHALA LETTER VAYANNA..SINHALA LETTER FAYANNA
+	{runeRange{0x0DF4, 0x0DF4}, propertyGeneralCategory{lbprAL, gcPo}},     //         SINHALA PUNCTUATION KUNDDALIYA
+	{runeRange{0x0E47, 0x0E4E}, propertyGeneralCategory{lbprSA, gcMn}},     //     [8] THAI CHARACTER MAITAIKHU..THAI CHARACTER YAMAKKAN
+	{runeRange{0x0EA5, 0x0EA5}, propertyGeneralCategory{lbprSA, gcLo}},     //         LAO LETTER LO LOOT
+	{runeRange{0x0EC8, 0x0ECE}, propertyGeneralCategory{lbprSA, gcMn}},     //     [7] LAO TONE MAI EK..LAO YAMAKKAN
+	{runeRange{0x0F08, 0x0F08}, propertyGeneralCategory{lbprGL, gcPo}},     //         TIBETAN MARK SBRUL SHAD
+	{runeRange{0x0F15, 0x0F17}, propertyGeneralCategory{lbprAL, gcSo}},     //     [3] TIBETAN LOGOTYPE SIGN CHAD RTAGS..TIBETAN ASTROLOGICAL SIGN SGRA GCAN -CHAR RTAGS
+	{runeRange{0x0F37, 0x0F37}, propertyGeneralCategory{lbprCM, gcMn}},     //         TIBETAN MARK NGAS BZUNG SGOR RTAGS
+	{runeRange{0x0F40, 0x0F47}, propertyGeneralCategory{lbprAL, gcLo}},     //     [8] TIBETAN LETTER KA..TIBETAN LETTER JA
+	{runeRange{0x0F8D, 0x0F97}, propertyGeneralCategory{lbprCM, gcMn}},     //    [11] TIBETAN SUBJOINED SIGN LCE TSA CAN..TIBETAN SUBJOINED LETTER JA
+	{runeRange{0x0FD2, 0x0FD2}, propertyGeneralCategory{lbprBA, gcPo}},     //         TIBETAN MARK NYIS TSHEG
+	{runeRange{0x1031, 0x1031}, propertyGeneralCategory{lbprSA, gcMc}},     //         MYANMAR VOWEL SIGN E
+	{runeRange{0x104A, 0x104B}, propertyGeneralCategory{lbprBA, gcPo}},     //     [2] MYANMAR SIGN LITTLE SECTION..MYANMAR SIGN SECTION
+	{runeRange{0x1062, 0x1064}, propertyGeneralCategory{lbprSA, gcMc}},     //     [3] MYANMAR VOWEL SIGN SGAW KAREN EU..MYANMAR TONE MARK SGAW KAREN KE PHO
+	{runeRange{0x1085, 0x1086}, propertyGeneralCategory{lbprSA, gcMn}},     //     [2] MYANMAR VOWEL SIGN SHAN E ABOVE..MYANMAR VOWEL SIGN SHAN FINAL Y
+	{runeRange{0x109E, 0x109F}, propertyGeneralCategory{lbprSA, gcSo}},     //     [2] MYANMAR SYMBOL SHAN ONE..MYANMAR SYMBOL SHAN EXCLAMATION
+	{runeRange{0x1100, 0x115F}, propertyGeneralCategory{lbprJL, gcLo}},     //    [96] HANGUL CHOSEONG KIYEOK..HANGUL CHOSEONG FILLER
+	{runeRange{0x1260, 0x1288}, propertyGeneralCategory{lbprAL, gcLo}},     //    [41] ETHIOPIC SYLLABLE BA..ETHIOPIC SYLLABLE XWA
+	{runeRange{0x12D8, 0x1310}, propertyGeneralCategory{lbprAL, gcLo}},     //    [57] ETHIOPIC SYLLABLE ZA..ETHIOPIC SYLLABLE GWA
+	{runeRange{0x1380, 0x138F}, propertyGeneralCategory{lbprAL, gcLo}},     //    [16] ETHIOPIC SYLLABLE SEBATBEIT MWA..ETHIOPIC SYLLABLE PWE
+	{runeRange{0x166F, 0x167F}, propertyGeneralCategory{lbprAL, gcLo}},     //    [17] CANADIAN SYLLABICS QAI..CANADIAN SYLLABICS BLACKFOOT W
+	{runeRange{0x16F1, 0x16F8}, propertyGeneralCategory{lbprAL, gcLo}},     //     [8] RUNIC LETTER K..RUNIC LETTER FRANKS CASKET AESC
+	{runeRange{0x1735, 0x1736}, propertyGeneralCategory{lbprBA, gcPo}},     //     [2] PHILIPPINE SINGLE PUNCTUATION..PHILIPPINE DOUBLE PUNCTUATION
+	{runeRange{0x17B6, 0x17B6}, propertyGeneralCategory{lbprSA, gcMc}},     //         KHMER VOWEL SIGN AA
+	{runeRange{0x17D7, 0x17D7}, propertyGeneralCategory{lbprSA, gcLm}},     //         KHMER SIGN LEK TOO
+	{runeRange{0x17F0, 0x17F9}, propertyGeneralCategory{lbprAL, gcNo}},     //    [10] KHMER SYMBOL LEK ATTAK SON..KHMER SYMBOL LEK ATTAK PRAM-BUON
+	{runeRange{0x180B, 0x180D}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] MONGOLIAN FREE VARIATION SELECTOR ONE..MONGOLIAN FREE VARIATION SELECTOR THREE
+	{runeRange{0x1885, 0x1886}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] MONGOLIAN LETTER ALI GALI BALUDA..MONGOLIAN LETTER ALI GALI THREE BALUDA
+	{runeRange{0x1927, 0x1928}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] LIMBU VOWEL SIGN E..LIMBU VOWEL SIGN O
+	{runeRange{0x1946, 0x194F}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] LIMBU DIGIT ZERO..LIMBU DIGIT NINE
+	{runeRange{0x19E0, 0x19FF}, propertyGeneralCategory{lbprAL, gcSo}},     //    [32] KHMER SYMBOL PATHAMASAT..KHMER SYMBOL DAP-PRAM ROC
+	{runeRange{0x1A56, 0x1A56}, propertyGeneralCategory{lbprSA, gcMn}},     //         TAI THAM CONSONANT SIGN MEDIAL LA
+	{runeRange{0x1A6D, 0x1A72}, propertyGeneralCategory{lbprSA, gcMc}},     //     [6] TAI THAM VOWEL SIGN OY..TAI THAM VOWEL SIGN THAM AI
+	{runeRange{0x1AB0, 0x1ABD}, propertyGeneralCategory{lbprCM, gcMn}},     //    [14] COMBINING DOUBLED CIRCUMFLEX ACCENT..COMBINING PARENTHESES BELOW
+	{runeRange{0x1B36, 0x1B3A}, propertyGeneralCategory{lbprCM, gcMn}},     //     [5] BALINESE VOWEL SIGN ULU..BALINESE VOWEL SIGN RA REPA
+	{runeRange{0x1B5A, 0x1B5B}, propertyGeneralCategory{lbprBA, gcPo}},     //     [2] BALINESE PANTI..BALINESE PAMADA
+	{runeRange{0x1B82, 0x1B82}, propertyGeneralCategory{lbprCM, gcMc}},     //         SUNDANESE SIGN PANGWISAD
+	{runeRange{0x1BAE, 0x1BAF}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] SUNDANESE LETTER KHA..SUNDANESE LETTER SYA
+	{runeRange{0x1BED, 0x1BED}, propertyGeneralCategory{lbprCM, gcMn}},     //         BATAK VOWEL SIGN KARO O
+	{runeRange{0x1C34, 0x1C35}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] LEPCHA CONSONANT SIGN NYIN-DO..LEPCHA CONSONANT SIGN KANG
+	{runeRange{0x1C7E, 0x1C7F}, propertyGeneralCategory{lbprBA, gcPo}},     //     [2] OL CHIKI PUNCTUATION MUCAAD..OL CHIKI PUNCTUATION DOUBLE MUCAAD
+	{runeRange{0x1CE1, 0x1CE1}, propertyGeneralCategory{lbprCM, gcMc}},     //         VEDIC TONE ATHARVAVEDIC INDEPENDENT SVARITA
+	{runeRange{0x1CF8, 0x1CF9}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] VEDIC TONE RING ABOVE..VEDIC TONE DOUBLE RING ABOVE
+	{runeRange{0x1D9B, 0x1DBF}, propertyGeneralCategory{lbprAL, gcLm}},     //    [37] MODIFIER LETTER SMALL TURNED ALPHA..MODIFIER LETTER SMALL THETA
+	{runeRange{0x1F18, 0x1F1D}, propertyGeneralCategory{lbprAL, gcLu}},     //     [6] GREEK CAPITAL LETTER EPSILON WITH PSILI..GREEK CAPITAL LETTER EPSILON WITH DASIA AND OXIA
+	{runeRange{0x1F80, 0x1FB4}, propertyGeneralCategory{lbprAL, gcLC}},     //    [53] GREEK SMALL LETTER ALPHA WITH PSILI AND YPOGEGRAMMENI..GREEK SMALL LETTER ALPHA WITH OXIA AND YPOGEGRAMMENI
+	{runeRange{0x1FD0, 0x1FD3}, propertyGeneralCategory{lbprAL, gcLl}},     //     [4] GREEK SMALL LETTER IOTA WITH VRACHY..GREEK SMALL LETTER IOTA WITH DIALYTIKA AND OXIA
+	{runeRange{0x1FFE, 0x1FFE}, propertyGeneralCategory{lbprAL, gcSk}},     //         GREEK DASIA
+	{runeRange{0x2010, 0x2010}, propertyGeneralCategory{lbprBA, gcPd}},     //         HYPHEN
+	{runeRange{0x2019, 0x2019}, propertyGeneralCategory{lbprQU, gcPf}},     //         RIGHT SINGLE QUOTATION MARK
+	{runeRange{0x2024, 0x2026}, propertyGeneralCategory{lbprIN, gcPo}},     //     [3] ONE DOT LEADER..HORIZONTAL ELLIPSIS
+	{runeRange{0x2039, 0x2039}, propertyGeneralCategory{lbprQU, gcPi}},     //         SINGLE LEFT-POINTING ANGLE QUOTATION MARK
+	{runeRange{0x2045, 0x2045}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT SQUARE BRACKET WITH QUILL
+	{runeRange{0x2056, 0x2056}, propertyGeneralCategory{lbprBA, gcPo}},     //         THREE DOT PUNCTUATION
+	{runeRange{0x2066, 0x206F}, propertyGeneralCategory{lbprCM, gcCf}},     //    [10] LEFT-TO-RIGHT ISOLATE..NOMINAL DIGIT SHAPES
+	{runeRange{0x207F, 0x207F}, propertyGeneralCategory{lbprAI, gcLm}},     //         SUPERSCRIPT LATIN SMALL LETTER N
+	{runeRange{0x20A0, 0x20A6}, propertyGeneralCategory{lbprPR, gcSc}},     //     [7] EURO-CURRENCY SIGN..NAIRA SIGN
+	{runeRange{0x20BF, 0x20BF}, propertyGeneralCategory{lbprPR, gcSc}},     //         BITCOIN SIGN
+	{runeRange{0x2100, 0x2101}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] ACCOUNT OF..ADDRESSED TO THE SUBJECT
+	{runeRange{0x2109, 0x2109}, propertyGeneralCategory{lbprPO, gcSo}},     //         DEGREE FAHRENHEIT
+	{runeRange{0x2119, 0x211D}, propertyGeneralCategory{lbprAL, gcLu}},     //     [5] DOUBLE-STRUCK CAPITAL P..DOUBLE-STRUCK CAPITAL R
+	{runeRange{0x2128, 0x2128}, propertyGeneralCategory{lbprAL, gcLu}},     //         BLACK-LETTER CAPITAL Z
+	{runeRange{0x2139, 0x2139}, propertyGeneralCategory{lbprAL, gcLl}},     //         INFORMATION SOURCE
+	{runeRange{0x214E, 0x214E}, propertyGeneralCategory{lbprAL, gcLl}},     //         TURNED SMALL F
+	{runeRange{0x215F, 0x215F}, propertyGeneralCategory{lbprAL, gcNo}},     //         FRACTION NUMERATOR ONE
+	{runeRange{0x218A, 0x218B}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] TURNED DIGIT TWO..TURNED DIGIT THREE
+	{runeRange{0x21A4, 0x21A5}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] LEFTWARDS ARROW FROM BAR..UPWARDS ARROW FROM BAR
+	{runeRange{0x21D3, 0x21D3}, propertyGeneralCategory{lbprAL, gcSo}},     //         DOWNWARDS DOUBLE ARROW
+	{runeRange{0x2207, 0x2208}, propertyGeneralCategory{lbprAI, gcSm}},     //     [2] NABLA..ELEMENT OF
+	{runeRange{0x2214, 0x2214}, propertyGeneralCategory{lbprAL, gcSm}},     //         DOT PLUS
+	{runeRange{0x2224, 0x2224}, propertyGeneralCategory{lbprAL, gcSm}},     //         DOES NOT DIVIDE
+	{runeRange{0x2238, 0x223B}, propertyGeneralCategory{lbprAL, gcSm}},     //     [4] DOT MINUS..HOMOTHETIC
+	{runeRange{0x2253, 0x225F}, propertyGeneralCategory{lbprAL, gcSm}},     //    [13] IMAGE OF OR APPROXIMATELY EQUAL TO..QUESTIONED EQUAL TO
+	{runeRange{0x2270, 0x2281}, propertyGeneralCategory{lbprAL, gcSm}},     //    [18] NEITHER LESS-THAN NOR EQUAL TO..DOES NOT SUCCEED
+	{runeRange{0x229A, 0x22A4}, propertyGeneralCategory{lbprAL, gcSm}},     //    [11] CIRCLED RING OPERATOR..DOWN TACK
+	{runeRange{0x2308, 0x2308}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT CEILING
+	{runeRange{0x231C, 0x231F}, propertyGeneralCategory{lbprAL, gcSo}},     //     [4] TOP LEFT CORNER..BOTTOM RIGHT CORNER
+	{runeRange{0x239B, 0x23B3}, propertyGeneralCategory{lbprAL, gcSm}},     //    [25] LEFT PARENTHESIS UPPER HOOK..SUMMATION BOTTOM
+	{runeRange{0x2460, 0x249B}, propertyGeneralCategory{lbprAI, gcNo}},     //    [60] CIRCLED DIGIT ONE..NUMBER TWENTY FULL STOP
+	{runeRange{0x2580, 0x258F}, propertyGeneralCategory{lbprAI, gcSo}},     //    [16] UPPER HALF BLOCK..LEFT ONE EIGHTH BLOCK
+	{runeRange{0x25B2, 0x25B3}, propertyGeneralCategory{lbprAI, gcSo}},     //     [2] BLACK UP-POINTING TRIANGLE..WHITE UP-POINTING TRIANGLE
+	{runeRange{0x25C1, 0x25C1}, propertyGeneralCategory{lbprAI, gcSm}},     //         WHITE LEFT-POINTING TRIANGLE
+	{runeRange{0x25E2, 0x25E5}, propertyGeneralCategory{lbprAI, gcSo}},     //     [4] BLACK LOWER RIGHT TRIANGLE..BLACK UPPER RIGHT TRIANGLE
+	{runeRange{0x2607, 0x2608}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] LIGHTNING..THUNDERSTORM
+	{runeRange{0x2619, 0x2619}, propertyGeneralCategory{lbprAL, gcSo}},     //         REVERSED ROTATED FLORAL HEART BULLET
+	{runeRange{0x2641, 0x2641}, propertyGeneralCategory{lbprAL, gcSo}},     //         EARTH
+	{runeRange{0x2668, 0x2668}, propertyGeneralCategory{lbprID, gcSo}},     //         HOT SPRINGS
+	{runeRange{0x2680, 0x269D}, propertyGeneralCategory{lbprAL, gcSo}},     //    [30] DIE FACE-1..OUTLINED WHITE STAR
+	{runeRange{0x26D2, 0x26D2}, propertyGeneralCategory{lbprAI, gcSo}},     //         CIRCLED CROSSING LANES
+	{runeRange{0x26E2, 0x26E2}, propertyGeneralCategory{lbprAL, gcSo}},     //         ASTRONOMICAL SYMBOL FOR URANUS
+	{runeRange{0x26F7, 0x26F8}, propertyGeneralCategory{lbprID, gcSo}},     //     [2] SKIER..ICE SKATE
+	{runeRange{0x270A, 0x270D}, propertyGeneralCategory{lbprEB, gcSo}},     //     [4] RAISED FIST..WRITING HAND
+	{runeRange{0x2765, 0x2767}, propertyGeneralCategory{lbprAL, gcSo}},     //     [3] ROTATED HEAVY BLACK HEART BULLET..ROTATED FLORAL HEART BULLET
+	{runeRange{0x276F, 0x276F}, propertyGeneralCategory{lbprCL, gcPe}},     //         HEAVY RIGHT-POINTING ANGLE QUOTATION MARK ORNAMENT
+	{runeRange{0x2794, 0x27BF}, propertyGeneralCategory{lbprAL, gcSo}},     //    [44] HEAVY WIDE-HEADED RIGHTWARDS ARROW..DOUBLE CURLY LOOP
+	{runeRange{0x27E9, 0x27E9}, propertyGeneralCategory{lbprCL, gcPe}},     //         MATHEMATICAL RIGHT ANGLE BRACKET
+	{runeRange{0x2800, 0x28FF}, propertyGeneralCategory{lbprAL, gcSo}},     //   [256] BRAILLE PATTERN BLANK..BRAILLE PATTERN DOTS-12345678
+	{runeRange{0x2988, 0x2988}, propertyGeneralCategory{lbprCL, gcPe}},     //         Z NOTATION RIGHT IMAGE BRACKET
+	{runeRange{0x2990, 0x2990}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT SQUARE BRACKET WITH TICK IN TOP CORNER
+	{runeRange{0x2998, 0x2998}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT BLACK TORTOISE SHELL BRACKET
+	{runeRange{0x29FD, 0x29FD}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT-POINTING CURVED ANGLE BRACKET
+	{runeRange{0x2B55, 0x2B59}, propertyGeneralCategory{lbprAI, gcSo}},     //     [5] HEAVY LARGE CIRCLE..HEAVY CIRCLED SALTIRE
+	{runeRange{0x2C80, 0x2CE4}, propertyGeneralCategory{lbprAL, gcLC}},     //   [101] COPTIC CAPITAL LETTER ALFA..COPTIC SYMBOL KAI
+	{runeRange{0x2CFE, 0x2CFE}, propertyGeneralCategory{lbprEX, gcPo}},     //         COPTIC FULL STOP
+	{runeRange{0x2D7F, 0x2D7F}, propertyGeneralCategory{lbprCM, gcMn}},     //         TIFINAGH CONSONANT JOINER
+	{runeRange{0x2DD0, 0x2DD6}, propertyGeneralCategory{lbprAL, gcLo}},     //     [7] ETHIOPIC SYLLABLE XYA..ETHIOPIC SYLLABLE XYO
+	{runeRange{0x2E06, 0x2E08}, propertyGeneralCategory{lbprQU, gcPo}},     //     [3] RAISED INTERPOLATION MARKER..DOTTED TRANSPOSITION MARKER
+	{runeRange{0x2E17, 0x2E17}, propertyGeneralCategory{lbprBA, gcPd}},     //         DOUBLE OBLIQUE HYPHEN
+	{runeRange{0x2E20, 0x2E20}, propertyGeneralCategory{lbprQU, gcPi}},     //         LEFT VERTICAL BAR WITH QUILL
+	{runeRange{0x2E28, 0x2E28}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT DOUBLE PARENTHESIS
+	{runeRange{0x2E35, 0x2E39}, propertyGeneralCategory{lbprAL, gcPo}},     //     [5] TURNED SEMICOLON..TOP HALF SECTION SIGN
+	{runeRange{0x2E4B, 0x2E4B}, propertyGeneralCategory{lbprAL, gcPo}},     //         TRIPLE DAGGER
+	{runeRange{0x2E56, 0x2E56}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT SQUARE BRACKET WITH STROKE
+	{runeRange{0x2E80, 0x2E99}, propertyGeneralCategory{lbprID, gcSo}},     //    [26] CJK RADICAL REPEAT..CJK RADICAL RAP
+	{runeRange{0x3005, 0x3005}, propertyGeneralCategory{lbprNS, gcLm}},     //         IDEOGRAPHIC ITERATION MARK
+	{runeRange{0x300D, 0x300D}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT CORNER BRACKET
+	{runeRange{0x3016, 0x3016}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT WHITE LENTICULAR BRACKET
+	{runeRange{0x301E, 0x301F}, propertyGeneralCategory{lbprCL, gcPe}},     //     [2] DOUBLE PRIME QUOTATION MARK..LOW DOUBLE PRIME QUOTATION MARK
+	{runeRange{0x3036, 0x3037}, propertyGeneralCategory{lbprID, gcSo}},     //     [2] CIRCLED POSTAL MARK..IDEOGRAPHIC TELEGRAPH LINE FEED SEPARATOR SYMBOL
+	{runeRange{0x3043, 0x3043}, propertyGeneralCategory{lbprCJ, gcLo}},     //         HIRAGANA LETTER SMALL I
+	{runeRange{0x3063, 0x3063}, propertyGeneralCategory{lbprCJ, gcLo}},     //         HIRAGANA LETTER SMALL TU
+	{runeRange{0x308E, 0x308E}, propertyGeneralCategory{lbprCJ, gcLo}},     //         HIRAGANA LETTER SMALL WA
+	{runeRange{0x30A1, 0x30A1}, propertyGeneralCategory{lbprCJ, gcLo}},     //         KATAKANA LETTER SMALL A
+	{runeRange{0x30A9, 0x30A9}, propertyGeneralCategory{lbprCJ, gcLo}},     //         KATAKANA LETTER SMALL O
+	{runeRange{0x30E7, 0x30E7}, propertyGeneralCategory{lbprCJ, gcLo}},     //         KATAKANA LETTER SMALL YO
+	{runeRange{0x30FD, 0x30FE}, propertyGeneralCategory{lbprNS, gcLm}},     //     [2] KATAKANA ITERATION MARK..KATAKANA VOICED ITERATION MARK
+	{runeRange{0x31C0, 0x31E3}, propertyGeneralCategory{lbprID, gcSo}},     //    [36] CJK STROKE T..CJK STROKE Q
+	{runeRange{0x3260, 0x327F}, propertyGeneralCategory{lbprID, gcSo}},     //    [32] CIRCLED HANGUL KIYEOK..KOREAN STANDARD SYMBOL
+	{runeRange{0x4E00, 0x9FFF}, propertyGeneralCategory{lbprID, gcLo}},     // [20992] CJK UNIFIED IDEOGRAPH-4E00..CJK UNIFIED IDEOGRAPH-9FFF
+	{runeRange{0xA500, 0xA60B}, propertyGeneralCategory{lbprAL, gcLo}},     //   [268] VAI SYLLABLE EE..VAI SYLLABLE NG
+	{runeRange{0xA640, 0xA66D}, propertyGeneralCategory{lbprAL, gcLC}},     //    [46] CYRILLIC CAPITAL LETTER ZEMLYA..CYRILLIC SMALL LETTER DOUBLE MONOCULAR O
+	{runeRange{0xA680, 0xA69B}, propertyGeneralCategory{lbprAL, gcLC}},     //    [28] CYRILLIC CAPITAL LETTER DWE..CYRILLIC SMALL LETTER CROSSED O
+	{runeRange{0xA700, 0xA716}, propertyGeneralCategory{lbprAL, gcSk}},     //    [23] MODIFIER LETTER CHINESE TONE YIN PING..MODIFIER LETTER EXTRA-LOW LEFT-STEM TONE BAR
+	{runeRange{0xA78B, 0xA78E}, propertyGeneralCategory{lbprAL, gcLC}},     //     [4] LATIN CAPITAL LETTER SALTILLO..LATIN SMALL LETTER L WITH RETROFLEX HOOK AND BELT
+	{runeRange{0xA7F7, 0xA7F7}, propertyGeneralCategory{lbprAL, gcLo}},     //         LATIN EPIGRAPHIC LETTER SIDEWAYS I
+	{runeRange{0xA807, 0xA80A}, propertyGeneralCategory{lbprAL, gcLo}},     //     [4] SYLOTI NAGRI LETTER KO..SYLOTI NAGRI LETTER GHO
+	{runeRange{0xA830, 0xA835}, propertyGeneralCategory{lbprAL, gcNo}},     //     [6] NORTH INDIC FRACTION ONE QUARTER..NORTH INDIC FRACTION THREE SIXTEENTHS
+	{runeRange{0xA882, 0xA8B3}, propertyGeneralCategory{lbprAL, gcLo}},     //    [50] SAURASHTRA LETTER A..SAURASHTRA LETTER LLA
+	{runeRange{0xA8FB, 0xA8FB}, propertyGeneralCategory{lbprAL, gcLo}},     //         DEVANAGARI HEADSTROKE
+	{runeRange{0xA930, 0xA946}, propertyGeneralCategory{lbprAL, gcLo}},     //    [23] REJANG LETTER KA..REJANG LETTER A
+	{runeRange{0xA9B3, 0xA9B3}, propertyGeneralCategory{lbprCM, gcMn}},     //         JAVANESE SIGN CECAK TELU
+	{runeRange{0xA9CA, 0xA9CD}, propertyGeneralCategory{lbprAL, gcPo}},     //     [4] JAVANESE PADA ADEG..JAVANESE TURNED PADA PISELEH
+	{runeRange{0xA9F0, 0xA9F9}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] MYANMAR TAI LAING DIGIT ZERO..MYANMAR TAI LAING DIGIT NINE
+	{runeRange{0xAA40, 0xAA42}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] CHAM LETTER FINAL K..CHAM LETTER FINAL NG
+	{runeRange{0xAA60, 0xAA6F}, propertyGeneralCategory{lbprSA, gcLo}},     //    [16] MYANMAR LETTER KHAMTI GA..MYANMAR LETTER KHAMTI FA
+	{runeRange{0xAA7E, 0xAA7F}, propertyGeneralCategory{lbprSA, gcLo}},     //     [2] MYANMAR LETTER SHWE PALAUNG CHA..MYANMAR LETTER SHWE PALAUNG SHA
+	{runeRange{0xAABE, 0xAABF}, propertyGeneralCategory{lbprSA, gcMn}},     //     [2] TAI VIET VOWEL AM..TAI VIET TONE MAI EK
+	{runeRange{0xAAEB, 0xAAEB}, propertyGeneralCategory{lbprCM, gcMc}},     //         MEETEI MAYEK VOWEL SIGN II
+	{runeRange{0xAB01, 0xAB06}, propertyGeneralCategory{lbprAL, gcLo}},     //     [6] ETHIOPIC SYLLABLE TTHU..ETHIOPIC SYLLABLE TTHO
+	{runeRange{0xAB60, 0xAB68}, propertyGeneralCategory{lbprAL, gcLl}},     //     [9] LATIN SMALL LETTER SAKHA YAT..LATIN SMALL LETTER TURNED R WITH MIDDLE TILDE
+	{runeRange{0xABE8, 0xABE8}, propertyGeneralCategory{lbprCM, gcMn}},     //         MEETEI MAYEK VOWEL SIGN UNAP
+	{runeRange{0xAC1C, 0xAC1C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GAE
+	{runeRange{0xAC8C, 0xAC8C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GE
+	{runeRange{0xACFC, 0xACFC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GWA
+	{runeRange{0xAD6C, 0xAD6C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GU
+	{runeRange{0xADDC, 0xADDC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GYU
+	{runeRange{0xAE4C, 0xAE4C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGA
+	{runeRange{0xAEBC, 0xAEBC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGEO
+	{runeRange{0xAF2C, 0xAF2C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGO
+	{runeRange{0xAF9C, 0xAF9C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGYO
+	{runeRange{0xB00C, 0xB00C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGWI
+	{runeRange{0xB07C, 0xB07C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGI
+	{runeRange{0xB0EC, 0xB0EC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NYAE
+	{runeRange{0xB15C, 0xB15C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NYE
+	{runeRange{0xB1CC, 0xB1CC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NOE
+	{runeRange{0xB23C, 0xB23C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NWE
+	{runeRange{0xB2AC, 0xB2AC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NYI
+	{runeRange{0xB31C, 0xB31C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DYA
+	{runeRange{0xB38C, 0xB38C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DYEO
+	{runeRange{0xB3FC, 0xB3FC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DWAE
+	{runeRange{0xB46C, 0xB46C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DWEO
+	{runeRange{0xB4DC, 0xB4DC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DEU
+	{runeRange{0xB54C, 0xB54C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDAE
+	{runeRange{0xB5BC, 0xB5BC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDE
+	{runeRange{0xB62C, 0xB62C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDWA
+	{runeRange{0xB69C, 0xB69C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDU
+	{runeRange{0xB70C, 0xB70C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDYU
+	{runeRange{0xB77C, 0xB77C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RA
+	{runeRange{0xB7EC, 0xB7EC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE REO
+	{runeRange{0xB85C, 0xB85C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RO
+	{runeRange{0xB8CC, 0xB8CC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RYO
+	{runeRange{0xB93C, 0xB93C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RWI
+	{runeRange{0xB9AC, 0xB9AC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RI
+	{runeRange{0xBA1C, 0xBA1C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MYAE
+	{runeRange{0xBA8C, 0xBA8C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MYE
+	{runeRange{0xBAFC, 0xBAFC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MOE
+	{runeRange{0xBB6C, 0xBB6C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MWE
+	{runeRange{0xBBDC, 0xBBDC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MYI
+	{runeRange{0xBC4C, 0xBC4C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BYA
+	{runeRange{0xBCBC, 0xBCBC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BYEO
+	{runeRange{0xBD2C, 0xBD2C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BWAE
+	{runeRange{0xBD9C, 0xBD9C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BWEO
+	{runeRange{0xBE0C, 0xBE0C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BEU
+	{runeRange{0xBE7C, 0xBE7C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBAE
+	{runeRange{0xBEEC, 0xBEEC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBE
+	{runeRange{0xBF5C, 0xBF5C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBWA
+	{runeRange{0xBFCC, 0xBFCC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBU
+	{runeRange{0xC03C, 0xC03C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBYU
+	{runeRange{0xC0AC, 0xC0AC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SA
+	{runeRange{0xC11C, 0xC11C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SEO
+	{runeRange{0xC18C, 0xC18C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SO
+	{runeRange{0xC1FC, 0xC1FC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SYO
+	{runeRange{0xC26C, 0xC26C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SWI
+	{runeRange{0xC2DC, 0xC2DC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SI
+	{runeRange{0xC34C, 0xC34C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSYAE
+	{runeRange{0xC3BC, 0xC3BC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSYE
+	{runeRange{0xC42C, 0xC42C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSOE
+	{runeRange{0xC49C, 0xC49C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSWE
+	{runeRange{0xC50C, 0xC50C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSYI
+	{runeRange{0xC57C, 0xC57C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE YA
+	{runeRange{0xC5EC, 0xC5EC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE YEO
+	{runeRange{0xC65C, 0xC65C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE WAE
+	{runeRange{0xC6CC, 0xC6CC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE WEO
+	{runeRange{0xC73C, 0xC73C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE EU
+	{runeRange{0xC7AC, 0xC7AC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JAE
+	{runeRange{0xC81C, 0xC81C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JE
+	{runeRange{0xC88C, 0xC88C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JWA
+	{runeRange{0xC8FC, 0xC8FC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JU
+	{runeRange{0xC96C, 0xC96C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JYU
+	{runeRange{0xC9DC, 0xC9DC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJA
+	{runeRange{0xCA4C, 0xCA4C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJEO
+	{runeRange{0xCABC, 0xCABC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJO
+	{runeRange{0xCB2C, 0xCB2C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJYO
+	{runeRange{0xCB9C, 0xCB9C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJWI
+	{runeRange{0xCC0C, 0xCC0C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJI
+	{runeRange{0xCC7C, 0xCC7C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CYAE
+	{runeRange{0xCCEC, 0xCCEC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CYE
+	{runeRange{0xCD5C, 0xCD5C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE COE
+	{runeRange{0xCDCC, 0xCDCC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CWE
+	{runeRange{0xCE3C, 0xCE3C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CYI
+	{runeRange{0xCEAC, 0xCEAC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KYA
+	{runeRange{0xCF1C, 0xCF1C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KYEO
+	{runeRange{0xCF8C, 0xCF8C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KWAE
+	{runeRange{0xCFFC, 0xCFFC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KWEO
+	{runeRange{0xD06C, 0xD06C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KEU
+	{runeRange{0xD0DC, 0xD0DC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TAE
+	{runeRange{0xD14C, 0xD14C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TE
+	{runeRange{0xD1BC, 0xD1BC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TWA
+	{runeRange{0xD22C, 0xD22C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TU
+	{runeRange{0xD29C, 0xD29C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TYU
+	{runeRange{0xD30C, 0xD30C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PA
+	{runeRange{0xD37C, 0xD37C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PEO
+	{runeRange{0xD3EC, 0xD3EC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PO
+	{runeRange{0xD45C, 0xD45C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PYO
+	{runeRange{0xD4CC, 0xD4CC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PWI
+	{runeRange{0xD53C, 0xD53C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PI
+	{runeRange{0xD5AC, 0xD5AC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HYAE
+	{runeRange{0xD61C, 0xD61C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HYE
+	{runeRange{0xD68C, 0xD68C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HOE
+	{runeRange{0xD6FC, 0xD6FC}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HWE
+	{runeRange{0xD76C, 0xD76C}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HYI
+	{runeRange{0xDC00, 0xDFFF}, propertyGeneralCategory{lbprSG, gcCs}},     //  [1024] <surrogate-DC00>..<surrogate-DFFF>
+	{runeRange{0xFB1D, 0xFB1D}, propertyGeneralCategory{lbprHL, gcLo}},     //         HEBREW LETTER YOD WITH HIRIQ
+	{runeRange{0xFB43, 0xFB44}, propertyGeneralCategory{lbprHL, gcLo}},     //     [2] HEBREW LETTER FINAL PE WITH DAGESH..HEBREW LETTER PE WITH DAGESH
+	{runeRange{0xFD50, 0xFD8F}, propertyGeneralCategory{lbprAL, gcLo}},     //    [64] ARABIC LIGATURE TEH WITH JEEM WITH MEEM INITIAL FORM..ARABIC LIGATURE MEEM WITH KHAH WITH MEEM INITIAL FORM
+	{runeRange{0xFE11, 0xFE12}, propertyGeneralCategory{lbprCL, gcPo}},     //     [2] PRESENTATION FORM FOR VERTICAL IDEOGRAPHIC COMMA..PRESENTATION FORM FOR VERTICAL IDEOGRAPHIC FULL STOP
+	{runeRange{0xFE31, 0xFE32}, propertyGeneralCategory{lbprID, gcPd}},     //     [2] PRESENTATION FORM FOR VERTICAL EM DASH..PRESENTATION FORM FOR VERTICAL EN DASH
+	{runeRange{0xFE3B, 0xFE3B}, propertyGeneralCategory{lbprOP, gcPs}},     //         PRESENTATION FORM FOR VERTICAL LEFT BLACK LENTICULAR BRACKET
+	{runeRange{0xFE43, 0xFE43}, propertyGeneralCategory{lbprOP, gcPs}},     //         PRESENTATION FORM FOR VERTICAL LEFT WHITE CORNER BRACKET
+	{runeRange{0xFE51, 0xFE51}, propertyGeneralCategory{lbprID, gcPo}},     //         SMALL IDEOGRAPHIC COMMA
+	{runeRange{0xFE5C, 0xFE5C}, propertyGeneralCategory{lbprCL, gcPe}},     //         SMALL RIGHT CURLY BRACKET
+	{runeRange{0xFE69, 0xFE69}, propertyGeneralCategory{lbprPR, gcSc}},     //         SMALL DOLLAR SIGN
+	{runeRange{0xFF04, 0xFF04}, propertyGeneralCategory{lbprPR, gcSc}},     //         FULLWIDTH DOLLAR SIGN
+	{runeRange{0xFF0D, 0xFF0D}, propertyGeneralCategory{lbprID, gcPd}},     //         FULLWIDTH HYPHEN-MINUS
+	{runeRange{0xFF21, 0xFF3A}, propertyGeneralCategory{lbprID, gcLu}},     //    [26] FULLWIDTH LATIN CAPITAL LETTER A..FULLWIDTH LATIN CAPITAL LETTER Z
+	{runeRange{0xFF5B, 0xFF5B}, propertyGeneralCategory{lbprOP, gcPs}},     //         FULLWIDTH LEFT CURLY BRACKET
+	{runeRange{0xFF63, 0xFF63}, propertyGeneralCategory{lbprCL, gcPe}},     //         HALFWIDTH RIGHT CORNER BRACKET
+	{runeRange{0xFFA0, 0xFFBE}, propertyGeneralCategory{lbprID, gcLo}},     //    [31] HALFWIDTH HANGUL FILLER..HALFWIDTH HANGUL LETTER HIEUH
+	{runeRange{0xFFE3, 0xFFE3}, propertyGeneralCategory{lbprID, gcSk}},     //         FULLWIDTH MACRON
+	{runeRange{0xFFFD, 0xFFFD}, propertyGeneralCategory{lbprAI, gcSo}},     //         REPLACEMENT CHARACTER
+	{runeRange{0x10100, 0x10102}, propertyGeneralCategory{lbprBA, gcPo}},   //     [3] AEGEAN WORD SEPARATOR LINE..AEGEAN CHECK MARK
+	{runeRange{0x10190, 0x1019C}, propertyGeneralCategory{lbprAL, gcSo}},   //    [13] ROMAN SEXTANS SIGN..ASCIA SYMBOL
+	{runeRange{0x10300, 0x1031F}, propertyGeneralCategory{lbprAL, gcLo}},   //    [32] OLD ITALIC LETTER A..OLD ITALIC LETTER ESS
+	{runeRange{0x10376, 0x1037A}, propertyGeneralCategory{lbprCM, gcMn}},   //     [5] COMBINING OLD PERMIC LETTER AN..COMBINING OLD PERMIC LETTER SII
+	{runeRange{0x10450, 0x1047F}, propertyGeneralCategory{lbprAL, gcLo}},   //    [48] SHAVIAN LETTER PEEP..SHAVIAN LETTER YEW
+	{runeRange{0x10570, 0x1057A}, propertyGeneralCategory{lbprAL, gcLu}},   //    [11] VITHKUQI CAPITAL LETTER A..VITHKUQI CAPITAL LETTER GA
+	{runeRange{0x10600, 0x10736}, propertyGeneralCategory{lbprAL, gcLo}},   //   [311] LINEAR A SIGN AB001..LINEAR A SIGN A664
+	{runeRange{0x1080A, 0x10835}, propertyGeneralCategory{lbprAL, gcLo}},   //    [44] CYPRIOT SYLLABLE KA..CYPRIOT SYLLABLE WO
+	{runeRange{0x10877, 0x10878}, propertyGeneralCategory{lbprAL, gcSo}},   //     [2] PALMYRENE LEFT-POINTING FLEURON..PALMYRENE RIGHT-POINTING FLEURON
+	{runeRange{0x10916, 0x1091B}, propertyGeneralCategory{lbprAL, gcNo}},   //     [6] PHOENICIAN NUMBER ONE..PHOENICIAN NUMBER THREE
+	{runeRange{0x109C0, 0x109CF}, propertyGeneralCategory{lbprAL, gcNo}},   //    [16] MEROITIC CURSIVE NUMBER ONE..MEROITIC CURSIVE NUMBER SEVENTY
+	{runeRange{0x10A19, 0x10A35}, propertyGeneralCategory{lbprAL, gcLo}},   //    [29] KHAROSHTHI LETTER NYA..KHAROSHTHI LETTER VHA
+	{runeRange{0x10A7F, 0x10A7F}, propertyGeneralCategory{lbprAL, gcPo}},   //         OLD SOUTH ARABIAN NUMERIC INDICATOR
+	{runeRange{0x10AF0, 0x10AF5}, propertyGeneralCategory{lbprBA, gcPo}},   //     [6] MANICHAEAN PUNCTUATION STAR..MANICHAEAN PUNCTUATION TWO DOTS
+	{runeRange{0x10B80, 0x10B91}, propertyGeneralCategory{lbprAL, gcLo}},   //    [18] PSALTER PAHLAVI LETTER ALEPH..PSALTER PAHLAVI LETTER TAW
+	{runeRange{0x10D24, 0x10D27}, propertyGeneralCategory{lbprCM, gcMn}},   //     [4] HANIFI ROHINGYA SIGN HARBAHAY..HANIFI ROHINGYA SIGN TASSI
+	{runeRange{0x10F00, 0x10F1C}, propertyGeneralCategory{lbprAL, gcLo}},   //    [29] OLD SOGDIAN LETTER ALEPH..OLD SOGDIAN LETTER FINAL TAW WITH VERTICAL TAIL
+	{runeRange{0x10F82, 0x10F85}, propertyGeneralCategory{lbprCM, gcMn}},   //     [4] OLD UYGHUR COMBINING DOT ABOVE..OLD UYGHUR COMBINING TWO DOTS BELOW
+	{runeRange{0x11003, 0x11037}, propertyGeneralCategory{lbprAL, gcLo}},   //    [53] BRAHMI SIGN JIHVAMULIYA..BRAHMI LETTER OLD TAMIL NNNA
+	{runeRange{0x11073, 0x11074}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] BRAHMI VOWEL SIGN OLD TAMIL SHORT E..BRAHMI VOWEL SIGN OLD TAMIL SHORT O
+	{runeRange{0x110B7, 0x110B8}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] KAITHI VOWEL SIGN O..KAITHI VOWEL SIGN AU
+	{runeRange{0x110F0, 0x110F9}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] SORA SOMPENG DIGIT ZERO..SORA SOMPENG DIGIT NINE
+	{runeRange{0x11144, 0x11144}, propertyGeneralCategory{lbprAL, gcLo}},   //         CHAKMA LETTER LHAA
+	{runeRange{0x11180, 0x11181}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] SHARADA SIGN CANDRABINDU..SHARADA SIGN ANUSVARA
+	{runeRange{0x111C7, 0x111C7}, propertyGeneralCategory{lbprAL, gcPo}},   //         SHARADA ABBREVIATION SIGN
+	{runeRange{0x111DB, 0x111DB}, propertyGeneralCategory{lbprBB, gcPo}},   //         SHARADA SIGN SIDDHAM
+	{runeRange{0x11232, 0x11233}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] KHOJKI VOWEL SIGN O..KHOJKI VOWEL SIGN AU
+	{runeRange{0x1123E, 0x1123E}, propertyGeneralCategory{lbprCM, gcMn}},   //         KHOJKI SIGN SUKUN
+	{runeRange{0x112A9, 0x112A9}, propertyGeneralCategory{lbprBA, gcPo}},   //         MULTANI SECTION MARK
+	{runeRange{0x11305, 0x1130C}, propertyGeneralCategory{lbprAL, gcLo}},   //     [8] GRANTHA LETTER A..GRANTHA LETTER VOCALIC L
+	{runeRange{0x1133E, 0x1133F}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] GRANTHA VOWEL SIGN AA..GRANTHA VOWEL SIGN I
+	{runeRange{0x11362, 0x11363}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] GRANTHA VOWEL SIGN VOCALIC L..GRANTHA VOWEL SIGN VOCALIC LL
+	{runeRange{0x11445, 0x11445}, propertyGeneralCategory{lbprCM, gcMc}},   //         NEWA SIGN VISARGA
+	{runeRange{0x1145E, 0x1145E}, propertyGeneralCategory{lbprCM, gcMn}},   //         NEWA SANDHI MARK
+	{runeRange{0x114BF, 0x114C0}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] TIRHUTA SIGN CANDRABINDU..TIRHUTA SIGN ANUSVARA
+	{runeRange{0x115AF, 0x115B1}, propertyGeneralCategory{lbprCM, gcMc}},   //     [3] SIDDHAM VOWEL SIGN AA..SIDDHAM VOWEL SIGN II
+	{runeRange{0x115C4, 0x115C5}, propertyGeneralCategory{lbprEX, gcPo}},   //     [2] SIDDHAM SEPARATOR DOT..SIDDHAM SEPARATOR BAR
+	{runeRange{0x1163B, 0x1163C}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] MODI VOWEL SIGN O..MODI VOWEL SIGN AU
+	{runeRange{0x11660, 0x1166C}, propertyGeneralCategory{lbprBB, gcPo}},   //    [13] MONGOLIAN BIRGA WITH ORNAMENT..MONGOLIAN TURNED SWIRL BIRGA WITH DOUBLE ORNAMENT
+	{runeRange{0x116B7, 0x116B7}, propertyGeneralCategory{lbprCM, gcMn}},   //         TAKRI SIGN NUKTA
+	{runeRange{0x11726, 0x11726}, propertyGeneralCategory{lbprSA, gcMc}},   //         AHOM VOWEL SIGN E
+	{runeRange{0x1182C, 0x1182E}, propertyGeneralCategory{lbprCM, gcMc}},   //     [3] DOGRA VOWEL SIGN AA..DOGRA VOWEL SIGN II
+	{runeRange{0x118FF, 0x118FF}, propertyGeneralCategory{lbprAL, gcLo}},   //         WARANG CITI OM
+	{runeRange{0x1193B, 0x1193C}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] DIVES AKURU SIGN ANUSVARA..DIVES AKURU SIGN CANDRABINDU
+	{runeRange{0x11944, 0x11946}, propertyGeneralCategory{lbprBA, gcPo}},   //     [3] DIVES AKURU DOUBLE DANDA..DIVES AKURU END OF TEXT MARK
+	{runeRange{0x119E0, 0x119E0}, propertyGeneralCategory{lbprCM, gcMn}},   //         NANDINAGARI SIGN VIRAMA
+	{runeRange{0x11A33, 0x11A38}, propertyGeneralCategory{lbprCM, gcMn}},   //     [6] ZANABAZAR SQUARE FINAL CONSONANT MARK..ZANABAZAR SQUARE SIGN ANUSVARA
+	{runeRange{0x11A3F, 0x11A3F}, propertyGeneralCategory{lbprBB, gcPo}},   //         ZANABAZAR SQUARE INITIAL HEAD MARK
+	{runeRange{0x11A46, 0x11A46}, propertyGeneralCategory{lbprAL, gcPo}},   //         ZANABAZAR SQUARE CLOSING DOUBLE-LINED HEAD MARK
+	{runeRange{0x11A57, 0x11A58}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] SOYOMBO VOWEL SIGN AI..SOYOMBO VOWEL SIGN AU
+	{runeRange{0x11A97, 0x11A97}, propertyGeneralCategory{lbprCM, gcMc}},   //         SOYOMBO SIGN VISARGA
+	{runeRange{0x11A9E, 0x11AA0}, propertyGeneralCategory{lbprBB, gcPo}},   //     [3] SOYOMBO HEAD MARK WITH MOON AND SUN AND TRIPLE FLAME..SOYOMBO HEAD MARK WITH MOON AND SUN
+	{runeRange{0x11B00, 0x11B09}, propertyGeneralCategory{lbprBB, gcPo}},   //    [10] DEVANAGARI HEAD MARK..DEVANAGARI SIGN MINDU
+	{runeRange{0x11C30, 0x11C36}, propertyGeneralCategory{lbprCM, gcMn}},   //     [7] BHAIKSUKI VOWEL SIGN I..BHAIKSUKI VOWEL SIGN VOCALIC L
+	{runeRange{0x11C40, 0x11C40}, propertyGeneralCategory{lbprAL, gcLo}},   //         BHAIKSUKI SIGN AVAGRAHA
+	{runeRange{0x11C70, 0x11C70}, propertyGeneralCategory{lbprBB, gcPo}},   //         MARCHEN HEAD MARK
+	{runeRange{0x11CA9, 0x11CA9}, propertyGeneralCategory{lbprCM, gcMc}},   //         MARCHEN SUBJOINED LETTER YA
+	{runeRange{0x11CB4, 0x11CB4}, propertyGeneralCategory{lbprCM, gcMc}},   //         MARCHEN VOWEL SIGN O
+	{runeRange{0x11D0B, 0x11D30}, propertyGeneralCategory{lbprAL, gcLo}},   //    [38] MASARAM GONDI LETTER AU..MASARAM GONDI LETTER TRA
+	{runeRange{0x11D3F, 0x11D45}, propertyGeneralCategory{lbprCM, gcMn}},   //     [7] MASARAM GONDI VOWEL SIGN AU..MASARAM GONDI VIRAMA
+	{runeRange{0x11D60, 0x11D65}, propertyGeneralCategory{lbprAL, gcLo}},   //     [6] GUNJALA GONDI LETTER A..GUNJALA GONDI LETTER UU
+	{runeRange{0x11D90, 0x11D91}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] GUNJALA GONDI VOWEL SIGN EE..GUNJALA GONDI VOWEL SIGN AI
+	{runeRange{0x11D97, 0x11D97}, propertyGeneralCategory{lbprCM, gcMn}},   //         GUNJALA GONDI VIRAMA
+	{runeRange{0x11EF3, 0x11EF4}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] MAKASAR VOWEL SIGN I..MAKASAR VOWEL SIGN U
+	{runeRange{0x11F02, 0x11F02}, propertyGeneralCategory{lbprAL, gcLo}},   //         KAWI SIGN REPHA
+	{runeRange{0x11F34, 0x11F35}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] KAWI VOWEL SIGN AA..KAWI VOWEL SIGN ALTERNATE AA
+	{runeRange{0x11F41, 0x11F41}, propertyGeneralCategory{lbprCM, gcMc}},   //         KAWI SIGN KILLER
+	{runeRange{0x11F50, 0x11F59}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] KAWI DIGIT ZERO..KAWI DIGIT NINE
+	{runeRange{0x11FDD, 0x11FE0}, propertyGeneralCategory{lbprPO, gcSc}},   //     [4] TAMIL SIGN KAACU..TAMIL SIGN VARAAKAN
+	{runeRange{0x12400, 0x1246E}, propertyGeneralCategory{lbprAL, gcNl}},   //   [111] CUNEIFORM NUMERIC SIGN TWO ASH..CUNEIFORM NUMERIC SIGN NINE U VARIANT FORM
+	{runeRange{0x12FF1, 0x12FF2}, propertyGeneralCategory{lbprAL, gcPo}},   //     [2] CYPRO-MINOAN SIGN CM301..CYPRO-MINOAN SIGN CM302
+	{runeRange{0x1325E, 0x13281}, propertyGeneralCategory{lbprAL, gcLo}},   //    [36] EGYPTIAN HIEROGLYPH O007..EGYPTIAN HIEROGLYPH O033
+	{runeRange{0x13287, 0x13287}, propertyGeneralCategory{lbprCL, gcLo}},   //         EGYPTIAN HIEROGLYPH O036B
+	{runeRange{0x13379, 0x13379}, propertyGeneralCategory{lbprOP, gcLo}},   //         EGYPTIAN HIEROGLYPH V011A
+	{runeRange{0x13437, 0x13437}, propertyGeneralCategory{lbprOP, gcCf}},   //         EGYPTIAN HIEROGLYPH BEGIN SEGMENT
+	{runeRange{0x1343D, 0x1343D}, propertyGeneralCategory{lbprCL, gcCf}},   //         EGYPTIAN HIEROGLYPH END ENCLOSURE
+	{runeRange{0x13441, 0x13446}, propertyGeneralCategory{lbprAL, gcLo}},   //     [6] EGYPTIAN HIEROGLYPH FULL BLANK..EGYPTIAN HIEROGLYPH WIDE LOST SIGN
+	{runeRange{0x145CF, 0x145CF}, propertyGeneralCategory{lbprCL, gcLo}},   //         ANATOLIAN HIEROGLYPH A410A END LOGOGRAM MARK
+	{runeRange{0x16A60, 0x16A69}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] MRO DIGIT ZERO..MRO DIGIT NINE
+	{runeRange{0x16AD0, 0x16AED}, propertyGeneralCategory{lbprAL, gcLo}},   //    [30] BASSA VAH LETTER ENNI..BASSA VAH LETTER I
+	{runeRange{0x16B30, 0x16B36}, propertyGeneralCategory{lbprCM, gcMn}},   //     [7] PAHAWH HMONG MARK CIM TUB..PAHAWH HMONG MARK CIM TAUM
+	{runeRange{0x16B40, 0x16B43}, propertyGeneralCategory{lbprAL, gcLm}},   //     [4] PAHAWH HMONG SIGN VOS SEEV..PAHAWH HMONG SIGN IB YAM
+	{runeRange{0x16B5B, 0x16B61}, propertyGeneralCategory{lbprAL, gcNo}},   //     [7] PAHAWH HMONG NUMBER TENS..PAHAWH HMONG NUMBER TRILLIONS
+	{runeRange{0x16E80, 0x16E96}, propertyGeneralCategory{lbprAL, gcNo}},   //    [23] MEDEFAIDRIN DIGIT ZERO..MEDEFAIDRIN DIGIT THREE ALTERNATE FORM
+	{runeRange{0x16F4F, 0x16F4F}, propertyGeneralCategory{lbprCM, gcMn}},   //         MIAO SIGN CONSONANT MODIFIER BAR
+	{runeRange{0x16F93, 0x16F9F}, propertyGeneralCategory{lbprAL, gcLm}},   //    [13] MIAO LETTER TONE-2..MIAO LETTER REFORMED TONE-8
+	{runeRange{0x16FE4, 0x16FE4}, propertyGeneralCategory{lbprGL, gcMn}},   //         KHITAN SMALL SCRIPT FILLER
+	{runeRange{0x18B00, 0x18CD5}, propertyGeneralCategory{lbprAL, gcLo}},   //   [470] KHITAN SMALL SCRIPT CHARACTER-18B00..KHITAN SMALL SCRIPT CHARACTER-18CD5
+	{runeRange{0x1AFFD, 0x1AFFE}, propertyGeneralCategory{lbprAL, gcLm}},   //     [2] KATAKANA LETTER MINNAN NASALIZED TONE-7..KATAKANA LETTER MINNAN NASALIZED TONE-8
+	{runeRange{0x1B150, 0x1B152}, propertyGeneralCategory{lbprCJ, gcLo}},   //     [3] HIRAGANA LETTER SMALL WI..HIRAGANA LETTER SMALL WO
+	{runeRange{0x1BC00, 0x1BC6A}, propertyGeneralCategory{lbprAL, gcLo}},   //   [107] DUPLOYAN LETTER H..DUPLOYAN LETTER VOCALIC M
+	{runeRange{0x1BC9C, 0x1BC9C}, propertyGeneralCategory{lbprAL, gcSo}},   //         DUPLOYAN SIGN O WITH CROSS
+	{runeRange{0x1CF00, 0x1CF2D}, propertyGeneralCategory{lbprCM, gcMn}},   //    [46] ZNAMENNY COMBINING MARK GORAZDO NIZKO S KRYZHEM ON LEFT..ZNAMENNY COMBINING MARK KRYZH ON LEFT
+	{runeRange{0x1D100, 0x1D126}, propertyGeneralCategory{lbprAL, gcSo}},   //    [39] MUSICAL SYMBOL SINGLE BARLINE..MUSICAL SYMBOL DRUM CLEF-2
+	{runeRange{0x1D16A, 0x1D16C}, propertyGeneralCategory{lbprAL, gcSo}},   //     [3] MUSICAL SYMBOL FINGERED TREMOLO-1..MUSICAL SYMBOL FINGERED TREMOLO-3
+	{runeRange{0x1D183, 0x1D184}, propertyGeneralCategory{lbprAL, gcSo}},   //     [2] MUSICAL SYMBOL ARPEGGIATO UP..MUSICAL SYMBOL ARPEGGIATO DOWN
+	{runeRange{0x1D1AE, 0x1D1EA}, propertyGeneralCategory{lbprAL, gcSo}},   //    [61] MUSICAL SYMBOL PEDAL MARK..MUSICAL SYMBOL KORON
+	{runeRange{0x1D2C0, 0x1D2D3}, propertyGeneralCategory{lbprAL, gcNo}},   //    [20] KAKTOVIK NUMERAL ZERO..KAKTOVIK NUMERAL NINETEEN
+	{runeRange{0x1D400, 0x1D454}, propertyGeneralCategory{lbprAL, gcLC}},   //    [85] MATHEMATICAL BOLD CAPITAL A..MATHEMATICAL ITALIC SMALL G
+	{runeRange{0x1D4A5, 0x1D4A6}, propertyGeneralCategory{lbprAL, gcLu}},   //     [2] MATHEMATICAL SCRIPT CAPITAL J..MATHEMATICAL SCRIPT CAPITAL K
+	{runeRange{0x1D4BD, 0x1D4C3}, propertyGeneralCategory{lbprAL, gcLl}},   //     [7] MATHEMATICAL SCRIPT SMALL H..MATHEMATICAL SCRIPT SMALL N
+	{runeRange{0x1D516, 0x1D51C}, propertyGeneralCategory{lbprAL, gcLu}},   //     [7] MATHEMATICAL FRAKTUR CAPITAL S..MATHEMATICAL FRAKTUR CAPITAL Y
+	{runeRange{0x1D546, 0x1D546}, propertyGeneralCategory{lbprAL, gcLu}},   //         MATHEMATICAL DOUBLE-STRUCK CAPITAL O
+	{runeRange{0x1D6C1, 0x1D6C1}, propertyGeneralCategory{lbprAL, gcSm}},   //         MATHEMATICAL BOLD NABLA
+	{runeRange{0x1D6FB, 0x1D6FB}, propertyGeneralCategory{lbprAL, gcSm}},   //         MATHEMATICAL ITALIC NABLA
+	{runeRange{0x1D735, 0x1D735}, propertyGeneralCategory{lbprAL, gcSm}},   //         MATHEMATICAL BOLD ITALIC NABLA
+	{runeRange{0x1D76F, 0x1D76F}, propertyGeneralCategory{lbprAL, gcSm}},   //         MATHEMATICAL SANS-SERIF BOLD NABLA
+	{runeRange{0x1D7A9, 0x1D7A9}, propertyGeneralCategory{lbprAL, gcSm}},   //         MATHEMATICAL SANS-SERIF BOLD ITALIC NABLA
+	{runeRange{0x1D7CE, 0x1D7FF}, propertyGeneralCategory{lbprNU, gcNd}},   //    [50] MATHEMATICAL BOLD DIGIT ZERO..MATHEMATICAL MONOSPACE DIGIT NINE
+	{runeRange{0x1DA3B, 0x1DA6C}, propertyGeneralCategory{lbprCM, gcMn}},   //    [50] SIGNWRITING MOUTH CLOSED NEUTRAL..SIGNWRITING EXCITEMENT
+	{runeRange{0x1DA84, 0x1DA84}, propertyGeneralCategory{lbprCM, gcMn}},   //         SIGNWRITING LOCATION HEAD NECK
+	{runeRange{0x1DA9B, 0x1DA9F}, propertyGeneralCategory{lbprCM, gcMn}},   //     [5] SIGNWRITING FILL MODIFIER-2..SIGNWRITING FILL MODIFIER-6
+	{runeRange{0x1DF0B, 0x1DF1E}, propertyGeneralCategory{lbprAL, gcLl}},   //    [20] LATIN SMALL LETTER ESH WITH DOUBLE BAR..LATIN SMALL LETTER S WITH CURL
+	{runeRange{0x1E01B, 0x1E021}, propertyGeneralCategory{lbprCM, gcMn}},   //     [7] COMBINING GLAGOLITIC LETTER SHTA..COMBINING GLAGOLITIC LETTER YATI
+	{runeRange{0x1E08F, 0x1E08F}, propertyGeneralCategory{lbprCM, gcMn}},   //         COMBINING CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I
+	{runeRange{0x1E140, 0x1E149}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] NYIAKENG PUACHUE HMONG DIGIT ZERO..NYIAKENG PUACHUE HMONG DIGIT NINE
+	{runeRange{0x1E2AE, 0x1E2AE}, propertyGeneralCategory{lbprCM, gcMn}},   //         TOTO SIGN RISING TONE
+	{runeRange{0x1E2FF, 0x1E2FF}, propertyGeneralCategory{lbprPR, gcSc}},   //         WANCHO NGUN SIGN
+	{runeRange{0x1E4F0, 0x1E4F9}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] NAG MUNDARI DIGIT ZERO..NAG MUNDARI DIGIT NINE
+	{runeRange{0x1E7F0, 0x1E7FE}, propertyGeneralCategory{lbprAL, gcLo}},   //    [15] ETHIOPIC SYLLABLE GURAGE QWI..ETHIOPIC SYLLABLE GURAGE PWEE
+	{runeRange{0x1E900, 0x1E943}, propertyGeneralCategory{lbprAL, gcLC}},   //    [68] ADLAM CAPITAL LETTER ALIF..ADLAM SMALL LETTER SHA
+	{runeRange{0x1E95E, 0x1E95F}, propertyGeneralCategory{lbprOP, gcPo}},   //     [2] ADLAM INITIAL EXCLAMATION MARK..ADLAM INITIAL QUESTION MARK
+	{runeRange{0x1ECB0, 0x1ECB0}, propertyGeneralCategory{lbprPO, gcSc}},   //         INDIC SIYAQ RUPEE MARK
+	{runeRange{0x1ED2F, 0x1ED3D}, propertyGeneralCategory{lbprAL, gcNo}},   //    [15] OTTOMAN SIYAQ ALTERNATE NUMBER TWO..OTTOMAN SIYAQ FRACTION ONE SIXTH
+	{runeRange{0x1EE24, 0x1EE24}, propertyGeneralCategory{lbprAL, gcLo}},   //         ARABIC MATHEMATICAL INITIAL HEH
+	{runeRange{0x1EE39, 0x1EE39}, propertyGeneralCategory{lbprAL, gcLo}},   //         ARABIC MATHEMATICAL INITIAL DAD
+	{runeRange{0x1EE49, 0x1EE49}, propertyGeneralCategory{lbprAL, gcLo}},   //         ARABIC MATHEMATICAL TAILED YEH
+	{runeRange{0x1EE54, 0x1EE54}, propertyGeneralCategory{lbprAL, gcLo}},   //         ARABIC MATHEMATICAL TAILED SHEEN
+	{runeRange{0x1EE5D, 0x1EE5D}, propertyGeneralCategory{lbprAL, gcLo}},   //         ARABIC MATHEMATICAL TAILED DOTLESS NOON
+	{runeRange{0x1EE67, 0x1EE6A}, propertyGeneralCategory{lbprAL, gcLo}},   //     [4] ARABIC MATHEMATICAL STRETCHED HAH..ARABIC MATHEMATICAL STRETCHED KAF
+	{runeRange{0x1EE7E, 0x1EE7E}, propertyGeneralCategory{lbprAL, gcLo}},   //         ARABIC MATHEMATICAL STRETCHED DOTLESS FEH
+	{runeRange{0x1EEA5, 0x1EEA9}, propertyGeneralCategory{lbprAL, gcLo}},   //     [5] ARABIC MATHEMATICAL DOUBLE-STRUCK WAW..ARABIC MATHEMATICAL DOUBLE-STRUCK YEH
+	{runeRange{0x1F02C, 0x1F02F}, propertyGeneralCategory{lbprID, gcCn}},   //     [4] <reserved-1F02C>..<reserved-1F02F>
+	{runeRange{0x1F0AF, 0x1F0B0}, propertyGeneralCategory{lbprID, gcCn}},   //     [2] <reserved-1F0AF>..<reserved-1F0B0>
+	{runeRange{0x1F0D0, 0x1F0D0}, propertyGeneralCategory{lbprID, gcCn}},   //         <reserved-1F0D0>
+	{runeRange{0x1F10D, 0x1F10F}, propertyGeneralCategory{lbprID, gcSo}},   //     [3] CIRCLED ZERO WITH SLASH..CIRCLED DOLLAR SIGN WITH OVERLAID BACKSLASH
+	{runeRange{0x1F16A, 0x1F16C}, propertyGeneralCategory{lbprAL, gcSo}},   //     [3] RAISED MC SIGN..RAISED MR SIGN
+	{runeRange{0x1F1AE, 0x1F1E5}, propertyGeneralCategory{lbprID, gcCn}},   //    [56] <reserved-1F1AE>..<reserved-1F1E5>
+	{runeRange{0x1F210, 0x1F23B}, propertyGeneralCategory{lbprID, gcSo}},   //    [44] SQUARED CJK UNIFIED IDEOGRAPH-624B..SQUARED CJK UNIFIED IDEOGRAPH-914D
+	{runeRange{0x1F250, 0x1F251}, propertyGeneralCategory{lbprID, gcSo}},   //     [2] CIRCLED IDEOGRAPH ADVANTAGE..CIRCLED IDEOGRAPH ACCEPT
+	{runeRange{0x1F300, 0x1F384}, propertyGeneralCategory{lbprID, gcSo}},   //   [133] CYCLONE..CHRISTMAS TREE
+	{runeRange{0x1F39E, 0x1F3B4}, propertyGeneralCategory{lbprID, gcSo}},   //    [23] FILM FRAMES..FLOWER PLAYING CARDS
+	{runeRange{0x1F3BD, 0x1F3C1}, propertyGeneralCategory{lbprID, gcSo}},   //     [5] RUNNING SHIRT WITH SASH..CHEQUERED FLAG
+	{runeRange{0x1F3C8, 0x1F3C9}, propertyGeneralCategory{lbprID, gcSo}},   //     [2] AMERICAN FOOTBALL..RUGBY FOOTBALL
+	{runeRange{0x1F400, 0x1F441}, propertyGeneralCategory{lbprID, gcSo}},   //    [66] RAT..EYE
+	{runeRange{0x1F451, 0x1F465}, propertyGeneralCategory{lbprID, gcSo}},   //    [21] CROWN..BUSTS IN SILHOUETTE
+	{runeRange{0x1F47D, 0x1F480}, propertyGeneralCategory{lbprID, gcSo}},   //     [4] EXTRATERRESTRIAL ALIEN..SKULL
+	{runeRange{0x1F488, 0x1F48E}, propertyGeneralCategory{lbprID, gcSo}},   //     [7] BARBER POLE..GEM STONE
+	{runeRange{0x1F492, 0x1F49F}, propertyGeneralCategory{lbprID, gcSo}},   //    [14] WEDDING..HEART DECORATION
+	{runeRange{0x1F4A3, 0x1F4A3}, propertyGeneralCategory{lbprID, gcSo}},   //         BOMB
+	{runeRange{0x1F4AB, 0x1F4AE}, propertyGeneralCategory{lbprID, gcSo}},   //     [4] DIZZY SYMBOL..WHITE FLOWER
+	{runeRange{0x1F4B3, 0x1F4FF}, propertyGeneralCategory{lbprID, gcSo}},   //    [77] CREDIT CARD..PRAYER BEADS
+	{runeRange{0x1F525, 0x1F531}, propertyGeneralCategory{lbprID, gcSo}},   //    [13] FIRE..TRIDENT EMBLEM
+	{runeRange{0x1F576, 0x1F579}, propertyGeneralCategory{lbprID, gcSo}},   //     [4] DARK SUNGLASSES..JOYSTICK
+	{runeRange{0x1F591, 0x1F594}, propertyGeneralCategory{lbprID, gcSo}},   //     [4] REVERSED RAISED HAND WITH FINGERS SPLAYED..REVERSED VICTORY HAND
+	{runeRange{0x1F5DC, 0x1F5F3}, propertyGeneralCategory{lbprID, gcSo}},   //    [24] COMPRESSION..BALLOT BOX WITH BALLOT
+	{runeRange{0x1F645, 0x1F647}, propertyGeneralCategory{lbprEB, gcSo}},   //     [3] FACE WITH NO GOOD GESTURE..PERSON BOWING DEEPLY
+	{runeRange{0x1F676, 0x1F678}, propertyGeneralCategory{lbprQU, gcSo}},   //     [3] SANS-SERIF HEAVY DOUBLE TURNED COMMA QUOTATION MARK ORNAMENT..SANS-SERIF HEAVY LOW DOUBLE COMMA QUOTATION MARK ORNAMENT
+	{runeRange{0x1F6A3, 0x1F6A3}, propertyGeneralCategory{lbprEB, gcSo}},   //         ROWBOAT
+	{runeRange{0x1F6C0, 0x1F6C0}, propertyGeneralCategory{lbprEB, gcSo}},   //         BATH
+	{runeRange{0x1F6D8, 0x1F6DB}, propertyGeneralCategory{lbprID, gcCn}},   //     [4] <reserved-1F6D8>..<reserved-1F6DB>
+	{runeRange{0x1F6FD, 0x1F6FF}, propertyGeneralCategory{lbprID, gcCn}},   //     [3] <reserved-1F6FD>..<reserved-1F6FF>
+	{runeRange{0x1F77B, 0x1F77F}, propertyGeneralCategory{lbprID, gcSo}},   //     [5] HAUMEA..ORCUS
+	{runeRange{0x1F7E0, 0x1F7EB}, propertyGeneralCategory{lbprID, gcSo}},   //    [12] LARGE ORANGE CIRCLE..LARGE BROWN SQUARE
+	{runeRange{0x1F800, 0x1F80B}, propertyGeneralCategory{lbprAL, gcSo}},   //    [12] LEFTWARDS ARROW WITH SMALL TRIANGLE ARROWHEAD..DOWNWARDS ARROW WITH LARGE TRIANGLE ARROWHEAD
+	{runeRange{0x1F850, 0x1F859}, propertyGeneralCategory{lbprAL, gcSo}},   //    [10] LEFTWARDS SANS-SERIF ARROW..UP DOWN SANS-SERIF ARROW
+	{runeRange{0x1F890, 0x1F8AD}, propertyGeneralCategory{lbprAL, gcSo}},   //    [30] LEFTWARDS TRIANGLE ARROWHEAD..WHITE ARROW SHAFT WIDTH TWO THIRDS
+	{runeRange{0x1F900, 0x1F90B}, propertyGeneralCategory{lbprAL, gcSo}},   //    [12] CIRCLED CROSS FORMEE WITH FOUR DOTS..DOWNWARD FACING NOTCHED HOOK WITH DOT
+	{runeRange{0x1F910, 0x1F917}, propertyGeneralCategory{lbprID, gcSo}},   //     [8] ZIPPER-MOUTH FACE..HUGGING FACE
+	{runeRange{0x1F927, 0x1F92F}, propertyGeneralCategory{lbprID, gcSo}},   //     [9] SNEEZING FACE..SHOCKED FACE WITH EXPLODING HEAD
+	{runeRange{0x1F93F, 0x1F976}, propertyGeneralCategory{lbprID, gcSo}},   //    [56] DIVING MASK..FREEZING FACE
+	{runeRange{0x1F9B7, 0x1F9B7}, propertyGeneralCategory{lbprID, gcSo}},   //         TOOTH
+	{runeRange{0x1F9BC, 0x1F9CC}, propertyGeneralCategory{lbprID, gcSo}},   //    [17] MOTORIZED WHEELCHAIR..TROLL
+	{runeRange{0x1F9DE, 0x1F9FF}, propertyGeneralCategory{lbprID, gcSo}},   //    [34] GENIE..NAZAR AMULET
+	{runeRange{0x1FA6E, 0x1FA6F}, propertyGeneralCategory{lbprID, gcCn}},   //     [2] <reserved-1FA6E>..<reserved-1FA6F>
+	{runeRange{0x1FA89, 0x1FA8F}, propertyGeneralCategory{lbprID, gcCn}},   //     [7] <reserved-1FA89>..<reserved-1FA8F>
+	{runeRange{0x1FAC3, 0x1FAC5}, propertyGeneralCategory{lbprEB, gcSo}},   //     [3] PREGNANT MAN..PERSON WITH CROWN
+	{runeRange{0x1FAE0, 0x1FAE8}, propertyGeneralCategory{lbprID, gcSo}},   //     [9] MELTING FACE..SHAKING FACE
+	{runeRange{0x1FB00, 0x1FB92}, propertyGeneralCategory{lbprAL, gcSo}},   //   [147] BLOCK SEXTANT-1..UPPER HALF INVERSE MEDIUM SHADE AND LOWER HALF BLOCK
+	{runeRange{0x20000, 0x2A6DF}, propertyGeneralCategory{lbprID, gcLo}},   // [42720] CJK UNIFIED IDEOGRAPH-20000..CJK UNIFIED IDEOGRAPH-2A6DF
+	{runeRange{0x2B740, 0x2B81D}, propertyGeneralCategory{lbprID, gcLo}},   //   [222] CJK UNIFIED IDEOGRAPH-2B740..CJK UNIFIED IDEOGRAPH-2B81D
+	{runeRange{0x2CEB0, 0x2EBE0}, propertyGeneralCategory{lbprID, gcLo}},   //  [7473] CJK UNIFIED IDEOGRAPH-2CEB0..CJK UNIFIED IDEOGRAPH-2EBE0
+	{runeRange{0x2FA20, 0x2FFFD}, propertyGeneralCategory{lbprID, gcCn}},   //  [1502] <reserved-2FA20>..<reserved-2FFFD>
+	{runeRange{0x323B0, 0x3FFFD}, propertyGeneralCategory{lbprID, gcCn}},   // [56398] <reserved-323B0>..<reserved-3FFFD>
 	{runeRange{0xF0000, 0xFFFFD}, propertyGeneralCategory{lbprXX, gcCo}},   // [65534] <private-use-F0000>..<private-use-FFFFD>
+	{runeRange{0x0009, 0x0009}, propertyGeneralCategory{lbprBA, gcCc}},     //         <control-0009>
+	{runeRange{0x000E, 0x001F}, propertyGeneralCategory{lbprCM, gcCc}},     //    [18] <control-000E>..<control-001F>
+	{runeRange{0x0023, 0x0023}, propertyGeneralCategory{lbprAL, gcPo}},     //         NUMBER SIGN
+	{runeRange{0x0027, 0x0027}, propertyGeneralCategory{lbprQU, gcPo}},     //         APOSTROPHE
+	{runeRange{0x002B, 0x002B}, propertyGeneralCategory{lbprPR, gcSm}},     //         PLUS SIGN
+	{runeRange{0x002F, 0x002F}, propertyGeneralCategory{lbprSY, gcPo}},     //         SOLIDUS
+	{runeRange{0x003F, 0x003F}, propertyGeneralCategory{lbprEX, gcPo}},     //         QUESTION MARK
+	{runeRange{0x005C, 0x005C}, propertyGeneralCategory{lbprPR, gcPo}},     //         REVERSE SOLIDUS
+	{runeRange{0x0060, 0x0060}, propertyGeneralCategory{lbprAL, gcSk}},     //         GRAVE ACCENT
+	{runeRange{0x007D, 0x007D}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT CURLY BRACKET
+	{runeRange{0x0085, 0x0085}, propertyGeneralCategory{lbprNL, gcCc}},     //         <control-0085>
+	{runeRange{0x00A2, 0x00A2}, propertyGeneralCategory{lbprPO, gcSc}},     //         CENT SIGN
+	{runeRange{0x00A8, 0x00A8}, propertyGeneralCategory{lbprAI, gcSk}},     //         DIAERESIS
+	{runeRange{0x00AC, 0x00AC}, propertyGeneralCategory{lbprAL, gcSm}},     //         NOT SIGN
+	{runeRange{0x00B0, 0x00B0}, propertyGeneralCategory{lbprPO, gcSo}},     //         DEGREE SIGN
+	{runeRange{0x00B5, 0x00B5}, propertyGeneralCategory{lbprAL, gcLl}},     //         MICRO SIGN
+	{runeRange{0x00BA, 0x00BA}, propertyGeneralCategory{lbprAI, gcLo}},     //         MASCULINE ORDINAL INDICATOR
+	{runeRange{0x00C0, 0x00D6}, propertyGeneralCategory{lbprAL, gcLu}},     //    [23] LATIN CAPITAL LETTER A WITH GRAVE..LATIN CAPITAL LETTER O WITH DIAERESIS
+	{runeRange{0x00F8, 0x00FF}, propertyGeneralCategory{lbprAL, gcLl}},     //     [8] LATIN SMALL LETTER O WITH STROKE..LATIN SMALL LETTER Y WITH DIAERESIS
+	{runeRange{0x01BC, 0x01BF}, propertyGeneralCategory{lbprAL, gcLC}},     //     [4] LATIN CAPITAL LETTER TONE FIVE..LATIN LETTER WYNN
+	{runeRange{0x0294, 0x0294}, propertyGeneralCategory{lbprAL, gcLo}},     //         LATIN LETTER GLOTTAL STOP
+	{runeRange{0x02C6, 0x02C6}, propertyGeneralCategory{lbprAL, gcLm}},     //         MODIFIER LETTER CIRCUMFLEX ACCENT
+	{runeRange{0x02CC, 0x02CC}, propertyGeneralCategory{lbprBB, gcLm}},     //         MODIFIER LETTER LOW VERTICAL LINE
+	{runeRange{0x02D1, 0x02D1}, propertyGeneralCategory{lbprAL, gcLm}},     //         MODIFIER LETTER HALF TRIANGULAR COLON
+	{runeRange{0x02DD, 0x02DD}, propertyGeneralCategory{lbprAI, gcSk}},     //         DOUBLE ACUTE ACCENT
+	{runeRange{0x02E5, 0x02EB}, propertyGeneralCategory{lbprAL, gcSk}},     //     [7] MODIFIER LETTER EXTRA-HIGH TONE BAR..MODIFIER LETTER YANG DEPARTING TONE MARK
+	{runeRange{0x02EF, 0x02FF}, propertyGeneralCategory{lbprAL, gcSk}},     //    [17] MODIFIER LETTER LOW DOWN ARROWHEAD..MODIFIER LETTER LOW LEFT ARROW
+	{runeRange{0x035C, 0x0362}, propertyGeneralCategory{lbprGL, gcMn}},     //     [7] COMBINING DOUBLE BREVE BELOW..COMBINING DOUBLE RIGHTWARDS ARROW BELOW
+	{runeRange{0x0375, 0x0375}, propertyGeneralCategory{lbprAL, gcSk}},     //         GREEK LOWER NUMERAL SIGN
+	{runeRange{0x037E, 0x037E}, propertyGeneralCategory{lbprIS, gcPo}},     //         GREEK QUESTION MARK
+	{runeRange{0x0387, 0x0387}, propertyGeneralCategory{lbprAL, gcPo}},     //         GREEK ANO TELEIA
+	{runeRange{0x03A3, 0x03F5}, propertyGeneralCategory{lbprAL, gcLC}},     //    [83] GREEK CAPITAL LETTER SIGMA..GREEK LUNATE EPSILON SYMBOL
+	{runeRange{0x0482, 0x0482}, propertyGeneralCategory{lbprAL, gcSo}},     //         CYRILLIC THOUSANDS SIGN
+	{runeRange{0x0500, 0x052F}, propertyGeneralCategory{lbprAL, gcLC}},     //    [48] CYRILLIC CAPITAL LETTER KOMI DE..CYRILLIC SMALL LETTER EL WITH DESCENDER
+	{runeRange{0x0560, 0x0588}, propertyGeneralCategory{lbprAL, gcLl}},     //    [41] ARMENIAN SMALL LETTER TURNED AYB..ARMENIAN SMALL LETTER YI WITH STROKE
+	{runeRange{0x058F, 0x058F}, propertyGeneralCategory{lbprPR, gcSc}},     //         ARMENIAN DRAM SIGN
+	{runeRange{0x05C0, 0x05C0}, propertyGeneralCategory{lbprAL, gcPo}},     //         HEBREW PUNCTUATION PASEQ
+	{runeRange{0x05C6, 0x05C6}, propertyGeneralCategory{lbprEX, gcPo}},     //         HEBREW PUNCTUATION NUN HAFUKHA
+	{runeRange{0x05F3, 0x05F4}, propertyGeneralCategory{lbprAL, gcPo}},     //     [2] HEBREW PUNCTUATION GERESH..HEBREW PUNCTUATION GERSHAYIM
+	{runeRange{0x060B, 0x060B}, propertyGeneralCategory{lbprPO, gcSc}},     //         AFGHANI SIGN
+	{runeRange{0x061B, 0x061B}, propertyGeneralCategory{lbprEX, gcPo}},     //         ARABIC SEMICOLON
+	{runeRange{0x0640, 0x0640}, propertyGeneralCategory{lbprAL, gcLm}},     //         ARABIC TATWEEL
+	{runeRange{0x066A, 0x066A}, propertyGeneralCategory{lbprPO, gcPo}},     //         ARABIC PERCENT SIGN
+	{runeRange{0x0670, 0x0670}, propertyGeneralCategory{lbprCM, gcMn}},     //         ARABIC LETTER SUPERSCRIPT ALEF
+	{runeRange{0x06D6, 0x06DC}, propertyGeneralCategory{lbprCM, gcMn}},     //     [7] ARABIC SMALL HIGH LIGATURE SAD WITH LAM WITH ALEF MAKSURA..ARABIC SMALL HIGH SEEN
+	{runeRange{0x06E5, 0x06E6}, propertyGeneralCategory{lbprAL, gcLm}},     //     [2] ARABIC SMALL WAW..ARABIC SMALL YEH
+	{runeRange{0x06EE, 0x06EF}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] ARABIC LETTER DAL WITH INVERTED V..ARABIC LETTER REH WITH INVERTED V
+	{runeRange{0x06FF, 0x06FF}, propertyGeneralCategory{lbprAL, gcLo}},     //         ARABIC LETTER HEH WITH INVERTED V
+	{runeRange{0x0711, 0x0711}, propertyGeneralCategory{lbprCM, gcMn}},     //         SYRIAC LETTER SUPERSCRIPT ALAPH
+	{runeRange{0x0750, 0x077F}, propertyGeneralCategory{lbprAL, gcLo}},     //    [48] ARABIC LETTER BEH WITH THREE DOTS HORIZONTALLY BELOW..ARABIC LETTER KAF WITH TWO DOTS ABOVE
+	{runeRange{0x07C0, 0x07C9}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] NKO DIGIT ZERO..NKO DIGIT NINE
+	{runeRange{0x07F6, 0x07F6}, propertyGeneralCategory{lbprAL, gcSo}},     //         NKO SYMBOL OO DENNEN
+	{runeRange{0x07FA, 0x07FA}, propertyGeneralCategory{lbprAL, gcLm}},     //         NKO LAJANYALAN
+	{runeRange{0x0816, 0x0819}, propertyGeneralCategory{lbprCM, gcMn}},     //     [4] SAMARITAN MARK IN..SAMARITAN MARK DAGESH
+	{runeRange{0x0825, 0x0827}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] SAMARITAN VOWEL SIGN SHORT A..SAMARITAN VOWEL SIGN U
+	{runeRange{0x0840, 0x0858}, propertyGeneralCategory{lbprAL, gcLo}},     //    [25] MANDAIC LETTER HALQA..MANDAIC LETTER AIN
+	{runeRange{0x0870, 0x0887}, propertyGeneralCategory{lbprAL, gcLo}},     //    [24] ARABIC LETTER ALEF WITH ATTACHED FATHA..ARABIC BASELINE ROUND DOT
+	{runeRange{0x0898, 0x089F}, propertyGeneralCategory{lbprCM, gcMn}},     //     [8] ARABIC SMALL HIGH WORD AL-JUZ..ARABIC HALF MADDA OVER MADDA
+	{runeRange{0x08E2, 0x08E2}, propertyGeneralCategory{lbprAL, gcCf}},     //         ARABIC DISPUTED END OF AYAH
+	{runeRange{0x0904, 0x0939}, propertyGeneralCategory{lbprAL, gcLo}},     //    [54] DEVANAGARI LETTER SHORT A..DEVANAGARI LETTER HA
+	{runeRange{0x093D, 0x093D}, propertyGeneralCategory{lbprAL, gcLo}},     //         DEVANAGARI SIGN AVAGRAHA
+	{runeRange{0x094D, 0x094D}, propertyGeneralCategory{lbprCM, gcMn}},     //         DEVANAGARI SIGN VIRAMA
+	{runeRange{0x0958, 0x0961}, propertyGeneralCategory{lbprAL, gcLo}},     //    [10] DEVANAGARI LETTER QA..DEVANAGARI LETTER VOCALIC LL
+	{runeRange{0x0970, 0x0970}, propertyGeneralCategory{lbprAL, gcPo}},     //         DEVANAGARI ABBREVIATION SIGN
+	{runeRange{0x0981, 0x0981}, propertyGeneralCategory{lbprCM, gcMn}},     //         BENGALI SIGN CANDRABINDU
+	{runeRange{0x0993, 0x09A8}, propertyGeneralCategory{lbprAL, gcLo}},     //    [22] BENGALI LETTER O..BENGALI LETTER NA
+	{runeRange{0x09BC, 0x09BC}, propertyGeneralCategory{lbprCM, gcMn}},     //         BENGALI SIGN NUKTA
+	{runeRange{0x09C7, 0x09C8}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] BENGALI VOWEL SIGN E..BENGALI VOWEL SIGN AI
+	{runeRange{0x09D7, 0x09D7}, propertyGeneralCategory{lbprCM, gcMc}},     //         BENGALI AU LENGTH MARK
+	{runeRange{0x09E6, 0x09EF}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] BENGALI DIGIT ZERO..BENGALI DIGIT NINE
+	{runeRange{0x09F9, 0x09F9}, propertyGeneralCategory{lbprPO, gcNo}},     //         BENGALI CURRENCY DENOMINATOR SIXTEEN
+	{runeRange{0x09FD, 0x09FD}, propertyGeneralCategory{lbprAL, gcPo}},     //         BENGALI ABBREVIATION SIGN
+	{runeRange{0x0A05, 0x0A0A}, propertyGeneralCategory{lbprAL, gcLo}},     //     [6] GURMUKHI LETTER A..GURMUKHI LETTER UU
+	{runeRange{0x0A32, 0x0A33}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] GURMUKHI LETTER LA..GURMUKHI LETTER LLA
+	{runeRange{0x0A3E, 0x0A40}, propertyGeneralCategory{lbprCM, gcMc}},     //     [3] GURMUKHI VOWEL SIGN AA..GURMUKHI VOWEL SIGN II
+	{runeRange{0x0A51, 0x0A51}, propertyGeneralCategory{lbprCM, gcMn}},     //         GURMUKHI SIGN UDAAT
+	{runeRange{0x0A70, 0x0A71}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] GURMUKHI TIPPI..GURMUKHI ADDAK
+	{runeRange{0x0A81, 0x0A82}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] GUJARATI SIGN CANDRABINDU..GUJARATI SIGN ANUSVARA
+	{runeRange{0x0A93, 0x0AA8}, propertyGeneralCategory{lbprAL, gcLo}},     //    [22] GUJARATI LETTER O..GUJARATI LETTER NA
+	{runeRange{0x0ABC, 0x0ABC}, propertyGeneralCategory{lbprCM, gcMn}},     //         GUJARATI SIGN NUKTA
+	{runeRange{0x0AC7, 0x0AC8}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] GUJARATI VOWEL SIGN E..GUJARATI VOWEL SIGN AI
+	{runeRange{0x0AD0, 0x0AD0}, propertyGeneralCategory{lbprAL, gcLo}},     //         GUJARATI OM
+	{runeRange{0x0AF0, 0x0AF0}, propertyGeneralCategory{lbprAL, gcPo}},     //         GUJARATI ABBREVIATION SIGN
+	{runeRange{0x0B01, 0x0B01}, propertyGeneralCategory{lbprCM, gcMn}},     //         ORIYA SIGN CANDRABINDU
+	{runeRange{0x0B13, 0x0B28}, propertyGeneralCategory{lbprAL, gcLo}},     //    [22] ORIYA LETTER O..ORIYA LETTER NA
+	{runeRange{0x0B3C, 0x0B3C}, propertyGeneralCategory{lbprCM, gcMn}},     //         ORIYA SIGN NUKTA
+	{runeRange{0x0B40, 0x0B40}, propertyGeneralCategory{lbprCM, gcMc}},     //         ORIYA VOWEL SIGN II
+	{runeRange{0x0B4D, 0x0B4D}, propertyGeneralCategory{lbprCM, gcMn}},     //         ORIYA SIGN VIRAMA
+	{runeRange{0x0B5F, 0x0B61}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] ORIYA LETTER YYA..ORIYA LETTER VOCALIC LL
+	{runeRange{0x0B71, 0x0B71}, propertyGeneralCategory{lbprAL, gcLo}},     //         ORIYA LETTER WA
+	{runeRange{0x0B85, 0x0B8A}, propertyGeneralCategory{lbprAL, gcLo}},     //     [6] TAMIL LETTER A..TAMIL LETTER UU
+	{runeRange{0x0B9C, 0x0B9C}, propertyGeneralCategory{lbprAL, gcLo}},     //         TAMIL LETTER JA
+	{runeRange{0x0BAE, 0x0BB9}, propertyGeneralCategory{lbprAL, gcLo}},     //    [12] TAMIL LETTER MA..TAMIL LETTER HA
+	{runeRange{0x0BC6, 0x0BC8}, propertyGeneralCategory{lbprCM, gcMc}},     //     [3] TAMIL VOWEL SIGN E..TAMIL VOWEL SIGN AI
+	{runeRange{0x0BD7, 0x0BD7}, propertyGeneralCategory{lbprCM, gcMc}},     //         TAMIL AU LENGTH MARK
+	{runeRange{0x0BF9, 0x0BF9}, propertyGeneralCategory{lbprPR, gcSc}},     //         TAMIL RUPEE SIGN
+	{runeRange{0x0C04, 0x0C04}, propertyGeneralCategory{lbprCM, gcMn}},     //         TELUGU SIGN COMBINING ANUSVARA ABOVE
+	{runeRange{0x0C2A, 0x0C39}, propertyGeneralCategory{lbprAL, gcLo}},     //    [16] TELUGU LETTER PA..TELUGU LETTER HA
+	{runeRange{0x0C41, 0x0C44}, propertyGeneralCategory{lbprCM, gcMc}},     //     [4] TELUGU VOWEL SIGN U..TELUGU VOWEL SIGN VOCALIC RR
+	{runeRange{0x0C58, 0x0C5A}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] TELUGU LETTER TSA..TELUGU LETTER RRRA
+	{runeRange{0x0C66, 0x0C6F}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] TELUGU DIGIT ZERO..TELUGU DIGIT NINE
+	{runeRange{0x0C80, 0x0C80}, propertyGeneralCategory{lbprAL, gcLo}},     //         KANNADA SIGN SPACING CANDRABINDU
+	{runeRange{0x0C85, 0x0C8C}, propertyGeneralCategory{lbprAL, gcLo}},     //     [8] KANNADA LETTER A..KANNADA LETTER VOCALIC L
+	{runeRange{0x0CB5, 0x0CB9}, propertyGeneralCategory{lbprAL, gcLo}},     //     [5] KANNADA LETTER VA..KANNADA LETTER HA
+	{runeRange{0x0CBF, 0x0CBF}, propertyGeneralCategory{lbprCM, gcMn}},     //         KANNADA VOWEL SIGN I
+	{runeRange{0x0CCA, 0x0CCB}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] KANNADA VOWEL SIGN O..KANNADA VOWEL SIGN OO
+	{runeRange{0x0CE0, 0x0CE1}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] KANNADA LETTER VOCALIC RR..KANNADA LETTER VOCALIC LL
+	{runeRange{0x0CF3, 0x0CF3}, propertyGeneralCategory{lbprCM, gcMc}},     //         KANNADA SIGN COMBINING ANUSVARA ABOVE RIGHT
+	{runeRange{0x0D0E, 0x0D10}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] MALAYALAM LETTER E..MALAYALAM LETTER AI
+	{runeRange{0x0D3E, 0x0D40}, propertyGeneralCategory{lbprCM, gcMc}},     //     [3] MALAYALAM VOWEL SIGN AA..MALAYALAM VOWEL SIGN II
+	{runeRange{0x0D4D, 0x0D4D}, propertyGeneralCategory{lbprCM, gcMn}},     //         MALAYALAM SIGN VIRAMA
+	{runeRange{0x0D57, 0x0D57}, propertyGeneralCategory{lbprCM, gcMc}},     //         MALAYALAM AU LENGTH MARK
+	{runeRange{0x0D66, 0x0D6F}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] MALAYALAM DIGIT ZERO..MALAYALAM DIGIT NINE
+	{runeRange{0x0D81, 0x0D81}, propertyGeneralCategory{lbprCM, gcMn}},     //         SINHALA SIGN CANDRABINDU
+	{runeRange{0x0DB3, 0x0DBB}, propertyGeneralCategory{lbprAL, gcLo}},     //     [9] SINHALA LETTER SANYAKA DAYANNA..SINHALA LETTER RAYANNA
+	{runeRange{0x0DCF, 0x0DD1}, propertyGeneralCategory{lbprCM, gcMc}},     //     [3] SINHALA VOWEL SIGN AELA-PILLA..SINHALA VOWEL SIGN DIGA AEDA-PILLA
+	{runeRange{0x0DE6, 0x0DEF}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] SINHALA LITH DIGIT ZERO..SINHALA LITH DIGIT NINE
+	{runeRange{0x0E31, 0x0E31}, propertyGeneralCategory{lbprSA, gcMn}},     //         THAI CHARACTER MAI HAN-AKAT
+	{runeRange{0x0E40, 0x0E45}, propertyGeneralCategory{lbprSA, gcLo}},     //     [6] THAI CHARACTER SARA E..THAI CHARACTER LAKKHANGYAO
+	{runeRange{0x0E50, 0x0E59}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] THAI DIGIT ZERO..THAI DIGIT NINE
+	{runeRange{0x0E86, 0x0E8A}, propertyGeneralCategory{lbprSA, gcLo}},     //     [5] LAO LETTER PALI GHA..LAO LETTER SO TAM
+	{runeRange{0x0EB1, 0x0EB1}, propertyGeneralCategory{lbprSA, gcMn}},     //         LAO VOWEL SIGN MAI KAN
+	{runeRange{0x0EC0, 0x0EC4}, propertyGeneralCategory{lbprSA, gcLo}},     //     [5] LAO VOWEL SIGN E..LAO VOWEL SIGN AI
+	{runeRange{0x0EDC, 0x0EDF}, propertyGeneralCategory{lbprSA, gcLo}},     //     [4] LAO HO NO..LAO LETTER KHMU NYO
+	{runeRange{0x0F05, 0x0F05}, propertyGeneralCategory{lbprAL, gcPo}},     //         TIBETAN MARK CLOSING YIG MGO SGAB MA
+	{runeRange{0x0F0B, 0x0F0B}, propertyGeneralCategory{lbprBA, gcPo}},     //         TIBETAN MARK INTERSYLLABIC TSHEG
+	{runeRange{0x0F13, 0x0F13}, propertyGeneralCategory{lbprAL, gcSo}},     //         TIBETAN MARK CARET -DZUD RTAGS ME LONG CAN
+	{runeRange{0x0F1A, 0x0F1F}, propertyGeneralCategory{lbprAL, gcSo}},     //     [6] TIBETAN SIGN RDEL DKAR GCIG..TIBETAN SIGN RDEL DKAR RDEL NAG
+	{runeRange{0x0F35, 0x0F35}, propertyGeneralCategory{lbprCM, gcMn}},     //         TIBETAN MARK NGAS BZUNG NYI ZLA
+	{runeRange{0x0F39, 0x0F39}, propertyGeneralCategory{lbprCM, gcMn}},     //         TIBETAN MARK TSA -PHRU
+	{runeRange{0x0F3D, 0x0F3D}, propertyGeneralCategory{lbprCL, gcPe}},     //         TIBETAN MARK ANG KHANG GYAS
+	{runeRange{0x0F71, 0x0F7E}, propertyGeneralCategory{lbprCM, gcMn}},     //    [14] TIBETAN VOWEL SIGN AA..TIBETAN SIGN RJES SU NGA RO
+	{runeRange{0x0F86, 0x0F87}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] TIBETAN SIGN LCI RTAGS..TIBETAN SIGN YANG RTAGS
+	{runeRange{0x0FBE, 0x0FBF}, propertyGeneralCategory{lbprBA, gcSo}},     //     [2] TIBETAN KU RU KHA..TIBETAN KU RU KHA BZHI MIG CAN
+	{runeRange{0x0FCE, 0x0FCF}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] TIBETAN SIGN RDEL NAG RDEL DKAR..TIBETAN SIGN RDEL NAG GSUM
+	{runeRange{0x0FD4, 0x0FD4}, propertyGeneralCategory{lbprAL, gcPo}},     //         TIBETAN MARK CLOSING BRDA RNYING YIG MGO SGAB MA
+	{runeRange{0x102B, 0x102C}, propertyGeneralCategory{lbprSA, gcMc}},     //     [2] MYANMAR VOWEL SIGN TALL AA..MYANMAR VOWEL SIGN AA
+	{runeRange{0x1038, 0x1038}, propertyGeneralCategory{lbprSA, gcMc}},     //         MYANMAR SIGN VISARGA
+	{runeRange{0x103F, 0x103F}, propertyGeneralCategory{lbprSA, gcLo}},     //         MYANMAR LETTER GREAT SA
+	{runeRange{0x1050, 0x1055}, propertyGeneralCategory{lbprSA, gcLo}},     //     [6] MYANMAR LETTER SHA..MYANMAR LETTER VOCALIC LL
+	{runeRange{0x105E, 0x1060}, propertyGeneralCategory{lbprSA, gcMn}},     //     [3] MYANMAR CONSONANT SIGN MON MEDIAL NA..MYANMAR CONSONANT SIGN MON MEDIAL LA
+	{runeRange{0x1067, 0x106D}, propertyGeneralCategory{lbprSA, gcMc}},     //     [7] MYANMAR VOWEL SIGN WESTERN PWO KAREN EU..MYANMAR SIGN WESTERN PWO KAREN TONE-5
+	{runeRange{0x1082, 0x1082}, propertyGeneralCategory{lbprSA, gcMn}},     //         MYANMAR CONSONANT SIGN SHAN MEDIAL WA
+	{runeRange{0x108D, 0x108D}, propertyGeneralCategory{lbprSA, gcMn}},     //         MYANMAR SIGN SHAN COUNCIL EMPHATIC TONE
+	{runeRange{0x109A, 0x109C}, propertyGeneralCategory{lbprSA, gcMc}},     //     [3] MYANMAR SIGN KHAMTI TONE-1..MYANMAR VOWEL SIGN AITON A
+	{runeRange{0x10C7, 0x10C7}, propertyGeneralCategory{lbprAL, gcLu}},     //         GEORGIAN CAPITAL LETTER YN
+	{runeRange{0x10FC, 0x10FC}, propertyGeneralCategory{lbprAL, gcLm}},     //         MODIFIER LETTER GEORGIAN NAR
+	{runeRange{0x11A8, 0x11FF}, propertyGeneralCategory{lbprJT, gcLo}},     //    [88] HANGUL JONGSEONG KIYEOK..HANGUL JONGSEONG SSANGNIEUN
+	{runeRange{0x1258, 0x1258}, propertyGeneralCategory{lbprAL, gcLo}},     //         ETHIOPIC SYLLABLE QHWA
+	{runeRange{0x1290, 0x12B0}, propertyGeneralCategory{lbprAL, gcLo}},     //    [33] ETHIOPIC SYLLABLE NA..ETHIOPIC SYLLABLE KWA
+	{runeRange{0x12C2, 0x12C5}, propertyGeneralCategory{lbprAL, gcLo}},     //     [4] ETHIOPIC SYLLABLE KXWI..ETHIOPIC SYLLABLE KXWE
+	{runeRange{0x1318, 0x135A}, propertyGeneralCategory{lbprAL, gcLo}},     //    [67] ETHIOPIC SYLLABLE GGA..ETHIOPIC SYLLABLE FYA
+	{runeRange{0x1362, 0x1368}, propertyGeneralCategory{lbprAL, gcPo}},     //     [7] ETHIOPIC FULL STOP..ETHIOPIC PARAGRAPH SEPARATOR
+	{runeRange{0x13A0, 0x13F5}, propertyGeneralCategory{lbprAL, gcLu}},     //    [86] CHEROKEE LETTER A..CHEROKEE LETTER MV
+	{runeRange{0x166D, 0x166D}, propertyGeneralCategory{lbprAL, gcSo}},     //         CANADIAN SYLLABICS CHI SIGN
+	{runeRange{0x1681, 0x169A}, propertyGeneralCategory{lbprAL, gcLo}},     //    [26] OGHAM LETTER BEITH..OGHAM LETTER PEITH
+	{runeRange{0x16EB, 0x16ED}, propertyGeneralCategory{lbprBA, gcPo}},     //     [3] RUNIC SINGLE PUNCTUATION..RUNIC CROSS PUNCTUATION
+	{runeRange{0x1712, 0x1714}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] TAGALOG VOWEL SIGN I..TAGALOG SIGN VIRAMA
+	{runeRange{0x1732, 0x1733}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] HANUNOO VOWEL SIGN I..HANUNOO VOWEL SIGN U
+	{runeRange{0x1752, 0x1753}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] BUHID VOWEL SIGN I..BUHID VOWEL SIGN U
+	{runeRange{0x1780, 0x17B3}, propertyGeneralCategory{lbprSA, gcLo}},     //    [52] KHMER LETTER KA..KHMER INDEPENDENT VOWEL QAU
+	{runeRange{0x17BE, 0x17C5}, propertyGeneralCategory{lbprSA, gcMc}},     //     [8] KHMER VOWEL SIGN OE..KHMER VOWEL SIGN AU
+	{runeRange{0x17D4, 0x17D5}, propertyGeneralCategory{lbprBA, gcPo}},     //     [2] KHMER SIGN KHAN..KHMER SIGN BARIYOOSAN
+	{runeRange{0x17D9, 0x17D9}, propertyGeneralCategory{lbprAL, gcPo}},     //         KHMER SIGN PHNAEK MUAN
+	{runeRange{0x17DD, 0x17DD}, propertyGeneralCategory{lbprSA, gcMn}},     //         KHMER SIGN ATTHACAN
+	{runeRange{0x1802, 0x1803}, propertyGeneralCategory{lbprEX, gcPo}},     //     [2] MONGOLIAN COMMA..MONGOLIAN FULL STOP
+	{runeRange{0x1808, 0x1809}, propertyGeneralCategory{lbprEX, gcPo}},     //     [2] MONGOLIAN MANCHU COMMA..MONGOLIAN MANCHU FULL STOP
+	{runeRange{0x180F, 0x180F}, propertyGeneralCategory{lbprCM, gcMn}},     //         MONGOLIAN FREE VARIATION SELECTOR FOUR
+	{runeRange{0x1844, 0x1878}, propertyGeneralCategory{lbprAL, gcLo}},     //    [53] MONGOLIAN LETTER TODO E..MONGOLIAN LETTER CHA WITH TWO DOTS
+	{runeRange{0x18A9, 0x18A9}, propertyGeneralCategory{lbprCM, gcMn}},     //         MONGOLIAN LETTER ALI GALI DAGALGA
+	{runeRange{0x1920, 0x1922}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] LIMBU VOWEL SIGN A..LIMBU VOWEL SIGN U
+	{runeRange{0x1930, 0x1931}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] LIMBU SMALL LETTER KA..LIMBU SMALL LETTER NGA
+	{runeRange{0x1940, 0x1940}, propertyGeneralCategory{lbprAL, gcSo}},     //         LIMBU SIGN LOO
+	{runeRange{0x1970, 0x1974}, propertyGeneralCategory{lbprSA, gcLo}},     //     [5] TAI LE LETTER TONE-2..TAI LE LETTER TONE-6
+	{runeRange{0x19DA, 0x19DA}, propertyGeneralCategory{lbprSA, gcNo}},     //         NEW TAI LUE THAM DIGIT ONE
+	{runeRange{0x1A17, 0x1A18}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] BUGINESE VOWEL SIGN I..BUGINESE VOWEL SIGN U
+	{runeRange{0x1A20, 0x1A54}, propertyGeneralCategory{lbprSA, gcLo}},     //    [53] TAI THAM LETTER HIGH KA..TAI THAM LETTER GREAT SA
+	{runeRange{0x1A58, 0x1A5E}, propertyGeneralCategory{lbprSA, gcMn}},     //     [7] TAI THAM SIGN MAI KANG LAI..TAI THAM CONSONANT SIGN SA
+	{runeRange{0x1A63, 0x1A64}, propertyGeneralCategory{lbprSA, gcMc}},     //     [2] TAI THAM VOWEL SIGN AA..TAI THAM VOWEL SIGN TALL AA
+	{runeRange{0x1A7F, 0x1A7F}, propertyGeneralCategory{lbprCM, gcMn}},     //         TAI THAM COMBINING CRYPTOGRAMMIC DOT
+	{runeRange{0x1AA7, 0x1AA7}, propertyGeneralCategory{lbprSA, gcLm}},     //         TAI THAM SIGN MAI YAMOK
+	{runeRange{0x1ABF, 0x1ACE}, propertyGeneralCategory{lbprCM, gcMn}},     //    [16] COMBINING LATIN SMALL LETTER W BELOW..COMBINING LATIN SMALL LETTER INSULAR T
+	{runeRange{0x1B34, 0x1B34}, propertyGeneralCategory{lbprCM, gcMn}},     //         BALINESE SIGN REREKAN
+	{runeRange{0x1B3C, 0x1B3C}, propertyGeneralCategory{lbprCM, gcMn}},     //         BALINESE VOWEL SIGN LA LENGA
+	{runeRange{0x1B45, 0x1B4C}, propertyGeneralCategory{lbprAL, gcLo}},     //     [8] BALINESE LETTER KAF SASAK..BALINESE LETTER ARCHAIC JNYA
+	{runeRange{0x1B5D, 0x1B60}, propertyGeneralCategory{lbprBA, gcPo}},     //     [4] BALINESE CARIK PAMUNGKAH..BALINESE PAMENENG
+	{runeRange{0x1B7D, 0x1B7E}, propertyGeneralCategory{lbprBA, gcPo}},     //     [2] BALINESE PANTI LANTANG..BALINESE PAMADA LANTANG
+	{runeRange{0x1BA1, 0x1BA1}, propertyGeneralCategory{lbprCM, gcMc}},     //         SUNDANESE CONSONANT SIGN PAMINGKAL
+	{runeRange{0x1BAA, 0x1BAA}, propertyGeneralCategory{lbprCM, gcMc}},     //         SUNDANESE SIGN PAMAAEH
+	{runeRange{0x1BBA, 0x1BBF}, propertyGeneralCategory{lbprAL, gcLo}},     //     [6] SUNDANESE AVAGRAHA..SUNDANESE LETTER FINAL M
+	{runeRange{0x1BE8, 0x1BE9}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] BATAK VOWEL SIGN PAKPAK E..BATAK VOWEL SIGN EE
+	{runeRange{0x1BEF, 0x1BF1}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] BATAK VOWEL SIGN U FOR SIMALUNGUN SA..BATAK CONSONANT SIGN H
+	{runeRange{0x1C24, 0x1C2B}, propertyGeneralCategory{lbprCM, gcMc}},     //     [8] LEPCHA SUBJOINED LETTER YA..LEPCHA VOWEL SIGN UU
+	{runeRange{0x1C3B, 0x1C3F}, propertyGeneralCategory{lbprBA, gcPo}},     //     [5] LEPCHA PUNCTUATION TA-ROL..LEPCHA PUNCTUATION TSHOOK
+	{runeRange{0x1C5A, 0x1C77}, propertyGeneralCategory{lbprAL, gcLo}},     //    [30] OL CHIKI LETTER LA..OL CHIKI LETTER OH
+	{runeRange{0x1C90, 0x1CBA}, propertyGeneralCategory{lbprAL, gcLu}},     //    [43] GEORGIAN MTAVRULI CAPITAL LETTER AN..GEORGIAN MTAVRULI CAPITAL LETTER AIN
+	{runeRange{0x1CD3, 0x1CD3}, propertyGeneralCategory{lbprAL, gcPo}},     //         VEDIC SIGN NIHSHVASA
+	{runeRange{0x1CE9, 0x1CEC}, propertyGeneralCategory{lbprAL, gcLo}},     //     [4] VEDIC SIGN ANUSVARA ANTARGOMUKHA..VEDIC SIGN ANUSVARA VAMAGOMUKHA WITH TAIL
+	{runeRange{0x1CF5, 0x1CF6}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] VEDIC SIGN JIHVAMULIYA..VEDIC SIGN UPADHMANIYA
+	{runeRange{0x1D00, 0x1D2B}, propertyGeneralCategory{lbprAL, gcLl}},     //    [44] LATIN LETTER SMALL CAPITAL A..CYRILLIC LETTER SMALL CAPITAL EL
+	{runeRange{0x1D79, 0x1D7F}, propertyGeneralCategory{lbprAL, gcLl}},     //     [7] LATIN SMALL LETTER INSULAR G..LATIN SMALL LETTER UPSILON WITH STROKE
+	{runeRange{0x1DCD, 0x1DCD}, propertyGeneralCategory{lbprGL, gcMn}},     //         COMBINING DOUBLE CIRCUMFLEX ABOVE
+	{runeRange{0x1E00, 0x1EFF}, propertyGeneralCategory{lbprAL, gcLC}},     //   [256] LATIN CAPITAL LETTER A WITH RING BELOW..LATIN SMALL LETTER Y WITH LOOP
+	{runeRange{0x1F48, 0x1F4D}, propertyGeneralCategory{lbprAL, gcLu}},     //     [6] GREEK CAPITAL LETTER OMICRON WITH PSILI..GREEK CAPITAL LETTER OMICRON WITH DASIA AND OXIA
+	{runeRange{0x1F5D, 0x1F5D}, propertyGeneralCategory{lbprAL, gcLu}},     //         GREEK CAPITAL LETTER UPSILON WITH DASIA AND OXIA
+	{runeRange{0x1FBD, 0x1FBD}, propertyGeneralCategory{lbprAL, gcSk}},     //         GREEK KORONIS
+	{runeRange{0x1FC6, 0x1FCC}, propertyGeneralCategory{lbprAL, gcLC}},     //     [7] GREEK SMALL LETTER ETA WITH PERISPOMENI..GREEK CAPITAL LETTER ETA WITH PROSGEGRAMMENI
+	{runeRange{0x1FDD, 0x1FDF}, propertyGeneralCategory{lbprAL, gcSk}},     //     [3] GREEK DASIA AND VARIA..GREEK DASIA AND PERISPOMENI
+	{runeRange{0x1FF6, 0x1FFC}, propertyGeneralCategory{lbprAL, gcLC}},     //     [7] GREEK SMALL LETTER OMEGA WITH PERISPOMENI..GREEK CAPITAL LETTER OMEGA WITH PROSGEGRAMMENI
+	{runeRange{0x2007, 0x2007}, propertyGeneralCategory{lbprGL, gcZs}},     //         FIGURE SPACE
+	{runeRange{0x200D, 0x200D}, propertyGeneralCategory{lbprZWJ, gcCf}},    //         ZERO WIDTH JOINER
+	{runeRange{0x2012, 0x2013}, propertyGeneralCategory{lbprBA, gcPd}},     //     [2] FIGURE DASH..EN DASH
+	{runeRange{0x2017, 0x2017}, propertyGeneralCategory{lbprAL, gcPo}},     //         DOUBLE LOW LINE
+	{runeRange{0x201B, 0x201C}, propertyGeneralCategory{lbprQU, gcPi}},     //     [2] SINGLE HIGH-REVERSED-9 QUOTATION MARK..LEFT DOUBLE QUOTATION MARK
+	{runeRange{0x2020, 0x2021}, propertyGeneralCategory{lbprAI, gcPo}},     //     [2] DAGGER..DOUBLE DAGGER
+	{runeRange{0x2028, 0x2028}, propertyGeneralCategory{lbprBK, gcZl}},     //         LINE SEPARATOR
+	{runeRange{0x2030, 0x2037}, propertyGeneralCategory{lbprPO, gcPo}},     //     [8] PER MILLE SIGN..REVERSED TRIPLE PRIME
+	{runeRange{0x203B, 0x203B}, propertyGeneralCategory{lbprAI, gcPo}},     //         REFERENCE MARK
+	{runeRange{0x2041, 0x2043}, propertyGeneralCategory{lbprAL, gcPo}},     //     [3] CARET INSERTION POINT..HYPHEN BULLET
+	{runeRange{0x2047, 0x2049}, propertyGeneralCategory{lbprNS, gcPo}},     //     [3] DOUBLE QUESTION MARK..EXCLAMATION QUESTION MARK
+	{runeRange{0x2054, 0x2054}, propertyGeneralCategory{lbprAL, gcPc}},     //         INVERTED UNDERTIE
+	{runeRange{0x2058, 0x205B}, propertyGeneralCategory{lbprBA, gcPo}},     //     [4] FOUR DOT PUNCTUATION..FOUR DOT MARK
+	{runeRange{0x2060, 0x2060}, propertyGeneralCategory{lbprWJ, gcCf}},     //         WORD JOINER
+	{runeRange{0x2071, 0x2071}, propertyGeneralCategory{lbprAL, gcLm}},     //         SUPERSCRIPT LATIN SMALL LETTER I
+	{runeRange{0x207D, 0x207D}, propertyGeneralCategory{lbprOP, gcPs}},     //         SUPERSCRIPT LEFT PARENTHESIS
+	{runeRange{0x2081, 0x2084}, propertyGeneralCategory{lbprAI, gcNo}},     //     [4] SUBSCRIPT ONE..SUBSCRIPT FOUR
+	{runeRange{0x208E, 0x208E}, propertyGeneralCategory{lbprCL, gcPe}},     //         SUBSCRIPT RIGHT PARENTHESIS
+	{runeRange{0x20A8, 0x20B5}, propertyGeneralCategory{lbprPR, gcSc}},     //    [14] RUPEE SIGN..CEDI SIGN
+	{runeRange{0x20BC, 0x20BD}, propertyGeneralCategory{lbprPR, gcSc}},     //     [2] MANAT SIGN..RUBLE SIGN
+	{runeRange{0x20C1, 0x20CF}, propertyGeneralCategory{lbprPR, gcCn}},     //    [15] <reserved-20C1>..<reserved-20CF>
+	{runeRange{0x20E2, 0x20E4}, propertyGeneralCategory{lbprCM, gcMe}},     //     [3] COMBINING ENCLOSING SCREEN..COMBINING ENCLOSING UPWARD POINTING TRIANGLE
+	{runeRange{0x2103, 0x2103}, propertyGeneralCategory{lbprPO, gcSo}},     //         DEGREE CELSIUS
+	{runeRange{0x2107, 0x2107}, propertyGeneralCategory{lbprAL, gcLu}},     //         EULER CONSTANT
+	{runeRange{0x2113, 0x2113}, propertyGeneralCategory{lbprAI, gcLl}},     //         SCRIPT SMALL L
+	{runeRange{0x2117, 0x2117}, propertyGeneralCategory{lbprAL, gcSo}},     //         SOUND RECORDING COPYRIGHT
+	{runeRange{0x2121, 0x2122}, propertyGeneralCategory{lbprAI, gcSo}},     //     [2] TELEPHONE SIGN..TRADE MARK SIGN
+	{runeRange{0x2126, 0x2126}, propertyGeneralCategory{lbprAL, gcLu}},     //         OHM SIGN
+	{runeRange{0x212A, 0x212A}, propertyGeneralCategory{lbprAL, gcLu}},     //         KELVIN SIGN
+	{runeRange{0x212F, 0x2134}, propertyGeneralCategory{lbprAL, gcLC}},     //     [6] SCRIPT SMALL E..SCRIPT SMALL O
+	{runeRange{0x213C, 0x213F}, propertyGeneralCategory{lbprAL, gcLC}},     //     [4] DOUBLE-STRUCK SMALL PI..DOUBLE-STRUCK CAPITAL PI
+	{runeRange{0x214B, 0x214B}, propertyGeneralCategory{lbprAL, gcSm}},     //         TURNED AMPERSAND
+	{runeRange{0x2150, 0x2153}, propertyGeneralCategory{lbprAL, gcNo}},     //     [4] VULGAR FRACTION ONE SEVENTH..VULGAR FRACTION ONE THIRD
+	{runeRange{0x215C, 0x215D}, propertyGeneralCategory{lbprAL, gcNo}},     //     [2] VULGAR FRACTION THREE EIGHTHS..VULGAR FRACTION FIVE EIGHTHS
+	{runeRange{0x216C, 0x216F}, propertyGeneralCategory{lbprAL, gcNl}},     //     [4] ROMAN NUMERAL FIFTY..ROMAN NUMERAL ONE THOUSAND
+	{runeRange{0x2185, 0x2188}, propertyGeneralCategory{lbprAL, gcNl}},     //     [4] ROMAN NUMERAL SIX LATE FORM..ROMAN NUMERAL ONE HUNDRED THOUSAND
+	{runeRange{0x2195, 0x2199}, propertyGeneralCategory{lbprAI, gcSo}},     //     [5] UP DOWN ARROW..SOUTH WEST ARROW
+	{runeRange{0x21A1, 0x21A2}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] DOWNWARDS TWO HEADED ARROW..LEFTWARDS ARROW WITH TAIL
+	{runeRange{0x21A7, 0x21AD}, propertyGeneralCategory{lbprAL, gcSo}},     //     [7] DOWNWARDS ARROW FROM BAR..LEFT RIGHT WAVE ARROW
+	{runeRange{0x21D0, 0x21D1}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] LEFTWARDS DOUBLE ARROW..UPWARDS DOUBLE ARROW
+	{runeRange{0x21D5, 0x21F3}, propertyGeneralCategory{lbprAL, gcSo}},     //    [31] UP DOWN DOUBLE ARROW..UP DOWN WHITE ARROW
+	{runeRange{0x2202, 0x2203}, propertyGeneralCategory{lbprAI, gcSm}},     //     [2] PARTIAL DIFFERENTIAL..THERE EXISTS
+	{runeRange{0x220B, 0x220B}, propertyGeneralCategory{lbprAI, gcSm}},     //         CONTAINS AS MEMBER
+	{runeRange{0x2211, 0x2211}, propertyGeneralCategory{lbprAI, gcSm}},     //         N-ARY SUMMATION
+	{runeRange{0x2216, 0x2219}, propertyGeneralCategory{lbprAL, gcSm}},     //     [4] SET MINUS..BULLET OPERATOR
+	{runeRange{0x2221, 0x2222}, propertyGeneralCategory{lbprAL, gcSm}},     //     [2] MEASURED ANGLE..SPHERICAL ANGLE
+	{runeRange{0x2226, 0x2226}, propertyGeneralCategory{lbprAL, gcSm}},     //         NOT PARALLEL TO
+	{runeRange{0x222F, 0x2233}, propertyGeneralCategory{lbprAL, gcSm}},     //     [5] SURFACE INTEGRAL..ANTICLOCKWISE CONTOUR INTEGRAL
+	{runeRange{0x223E, 0x2247}, propertyGeneralCategory{lbprAL, gcSm}},     //    [10] INVERTED LAZY S..NEITHER APPROXIMATELY NOR ACTUALLY EQUAL TO
+	{runeRange{0x224D, 0x2251}, propertyGeneralCategory{lbprAL, gcSm}},     //     [5] EQUIVALENT TO..GEOMETRICALLY EQUAL TO
+	{runeRange{0x2262, 0x2263}, propertyGeneralCategory{lbprAL, gcSm}},     //     [2] NOT IDENTICAL TO..STRICTLY EQUIVALENT TO
+	{runeRange{0x226C, 0x226D}, propertyGeneralCategory{lbprAL, gcSm}},     //     [2] BETWEEN..NOT EQUIVALENT TO
+	{runeRange{0x2284, 0x2285}, propertyGeneralCategory{lbprAL, gcSm}},     //     [2] NOT A SUBSET OF..NOT A SUPERSET OF
+	{runeRange{0x2296, 0x2298}, propertyGeneralCategory{lbprAL, gcSm}},     //     [3] CIRCLED MINUS..CIRCLED DIVISION SLASH
+	{runeRange{0x22A6, 0x22BE}, propertyGeneralCategory{lbprAL, gcSm}},     //    [25] ASSERTION..RIGHT ANGLE WITH ARC
+	{runeRange{0x22F0, 0x22FF}, propertyGeneralCategory{lbprAL, gcSm}},     //    [16] UP RIGHT DIAGONAL ELLIPSIS..Z NOTATION BAG MEMBERSHIP
+	{runeRange{0x230A, 0x230A}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT FLOOR
+	{runeRange{0x2313, 0x2319}, propertyGeneralCategory{lbprAL, gcSo}},     //     [7] SEGMENT..TURNED NOT SIGN
+	{runeRange{0x2322, 0x2328}, propertyGeneralCategory{lbprAL, gcSo}},     //     [7] FROWN..KEYBOARD
+	{runeRange{0x237C, 0x237C}, propertyGeneralCategory{lbprAL, gcSm}},     //         RIGHT ANGLE WITH DOWNWARDS ZIGZAG ARROW
+	{runeRange{0x23DC, 0x23E1}, propertyGeneralCategory{lbprAL, gcSm}},     //     [6] TOP PARENTHESIS..BOTTOM TORTOISE SHELL BRACKET
+	{runeRange{0x2400, 0x2426}, propertyGeneralCategory{lbprAL, gcSo}},     //    [39] SYMBOL FOR NULL..SYMBOL FOR SUBSTITUTE FORM TWO
+	{runeRange{0x24EA, 0x24FE}, propertyGeneralCategory{lbprAI, gcNo}},     //    [21] CIRCLED DIGIT ZERO..DOUBLE CIRCLED NUMBER TEN
+	{runeRange{0x2550, 0x2574}, propertyGeneralCategory{lbprAI, gcSo}},     //    [37] BOX DRAWINGS DOUBLE HORIZONTAL..BOX DRAWINGS LIGHT LEFT
+	{runeRange{0x2592, 0x2595}, propertyGeneralCategory{lbprAI, gcSo}},     //     [4] MEDIUM SHADE..RIGHT ONE EIGHTH BLOCK
+	{runeRange{0x25A3, 0x25A9}, propertyGeneralCategory{lbprAI, gcSo}},     //     [7] WHITE SQUARE CONTAINING BLACK SMALL SQUARE..SQUARE WITH DIAGONAL CROSSHATCH FILL
+	{runeRange{0x25B6, 0x25B6}, propertyGeneralCategory{lbprAI, gcSo}},     //         BLACK RIGHT-POINTING TRIANGLE
+	{runeRange{0x25BE, 0x25BF}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] BLACK DOWN-POINTING SMALL TRIANGLE..WHITE DOWN-POINTING SMALL TRIANGLE
+	{runeRange{0x25C6, 0x25C8}, propertyGeneralCategory{lbprAI, gcSo}},     //     [3] BLACK DIAMOND..WHITE DIAMOND CONTAINING BLACK SMALL DIAMOND
+	{runeRange{0x25CE, 0x25D1}, propertyGeneralCategory{lbprAI, gcSo}},     //     [4] BULLSEYE..CIRCLE WITH RIGHT HALF BLACK
+	{runeRange{0x25EF, 0x25EF}, propertyGeneralCategory{lbprAI, gcSo}},     //         LARGE CIRCLE
+	{runeRange{0x2604, 0x2604}, propertyGeneralCategory{lbprAL, gcSo}},     //         COMET
+	{runeRange{0x260A, 0x260D}, propertyGeneralCategory{lbprAL, gcSo}},     //     [4] ASCENDING NODE..OPPOSITION
+	{runeRange{0x2616, 0x2617}, propertyGeneralCategory{lbprAI, gcSo}},     //     [2] WHITE SHOGI PIECE..BLACK SHOGI PIECE
+	{runeRange{0x261D, 0x261D}, propertyGeneralCategory{lbprEB, gcSo}},     //         WHITE UP POINTING INDEX
+	{runeRange{0x263C, 0x263F}, propertyGeneralCategory{lbprAL, gcSo}},     //     [4] WHITE SUN WITH RAYS..MERCURY
+	{runeRange{0x2643, 0x265F}, propertyGeneralCategory{lbprAL, gcSo}},     //    [29] JUPITER..BLACK CHESS PAWN
+	{runeRange{0x2666, 0x2666}, propertyGeneralCategory{lbprAL, gcSo}},     //         BLACK DIAMOND SUIT
+	{runeRange{0x266B, 0x266B}, propertyGeneralCategory{lbprAL, gcSo}},     //         BEAMED EIGHTH NOTES
+	{runeRange{0x2670, 0x267E}, propertyGeneralCategory{lbprAL, gcSo}},     //    [15] WEST SYRIAC CROSS..PERMANENT PAPER SIGN
+	{runeRange{0x26A0, 0x26BC}, propertyGeneralCategory{lbprAL, gcSo}},     //    [29] WARNING SIGN..SESQUIQUADRATE
+	{runeRange{0x26CE, 0x26CE}, propertyGeneralCategory{lbprAL, gcSo}},     //         OPHIUCHUS
+	{runeRange{0x26D5, 0x26D7}, propertyGeneralCategory{lbprAI, gcSo}},     //     [3] ALTERNATE ONE-WAY LEFT WAY TRAFFIC..WHITE TWO-WAY LEFT WAY TRAFFIC
+	{runeRange{0x26DD, 0x26DE}, propertyGeneralCategory{lbprAI, gcSo}},     //     [2] SQUARED SALTIRE..FALLING DIAGONAL IN WHITE CIRCLE IN BLACK SQUARE
+	{runeRange{0x26E4, 0x26E7}, propertyGeneralCategory{lbprAL, gcSo}},     //     [4] PENTAGRAM..INVERTED PENTAGRAM
+	{runeRange{0x26F1, 0x26F5}, propertyGeneralCategory{lbprID, gcSo}},     //     [5] UMBRELLA ON GROUND..SAILBOAT
+	{runeRange{0x26FA, 0x26FA}, propertyGeneralCategory{lbprID, gcSo}},     //         TENT
+	{runeRange{0x2705, 0x2707}, propertyGeneralCategory{lbprAL, gcSo}},     //     [3] WHITE HEAVY CHECK MARK..TAPE DRIVE
+	{runeRange{0x2757, 0x2757}, propertyGeneralCategory{lbprAI, gcSo}},     //         HEAVY EXCLAMATION MARK SYMBOL
+	{runeRange{0x2762, 0x2763}, propertyGeneralCategory{lbprEX, gcSo}},     //     [2] HEAVY EXCLAMATION MARK ORNAMENT..HEAVY HEART EXCLAMATION MARK ORNAMENT
+	{runeRange{0x2769, 0x2769}, propertyGeneralCategory{lbprCL, gcPe}},     //         MEDIUM RIGHT PARENTHESIS ORNAMENT
+	{runeRange{0x276D, 0x276D}, propertyGeneralCategory{lbprCL, gcPe}},     //         MEDIUM RIGHT-POINTING ANGLE BRACKET ORNAMENT
+	{runeRange{0x2771, 0x2771}, propertyGeneralCategory{lbprCL, gcPe}},     //         HEAVY RIGHT-POINTING ANGLE BRACKET ORNAMENT
+	{runeRange{0x2775, 0x2775}, propertyGeneralCategory{lbprCL, gcPe}},     //         MEDIUM RIGHT CURLY BRACKET ORNAMENT
+	{runeRange{0x27C5, 0x27C5}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT S-SHAPED BAG DELIMITER
+	{runeRange{0x27E7, 0x27E7}, propertyGeneralCategory{lbprCL, gcPe}},     //         MATHEMATICAL RIGHT WHITE SQUARE BRACKET
+	{runeRange{0x27EB, 0x27EB}, propertyGeneralCategory{lbprCL, gcPe}},     //         MATHEMATICAL RIGHT DOUBLE ANGLE BRACKET
+	{runeRange{0x27EF, 0x27EF}, propertyGeneralCategory{lbprCL, gcPe}},     //         MATHEMATICAL RIGHT FLATTENED PARENTHESIS
+	{runeRange{0x2980, 0x2982}, propertyGeneralCategory{lbprAL, gcSm}},     //     [3] TRIPLE VERTICAL BAR DELIMITER..Z NOTATION TYPE COLON
+	{runeRange{0x2986, 0x2986}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT WHITE PARENTHESIS
+	{runeRange{0x298A, 0x298A}, propertyGeneralCategory{lbprCL, gcPe}},     //         Z NOTATION RIGHT BINDING BRACKET
+	{runeRange{0x298E, 0x298E}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT SQUARE BRACKET WITH TICK IN BOTTOM CORNER
+	{runeRange{0x2992, 0x2992}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT ANGLE BRACKET WITH DOT
+	{runeRange{0x2996, 0x2996}, propertyGeneralCategory{lbprCL, gcPe}},     //         DOUBLE RIGHT ARC LESS-THAN BRACKET
+	{runeRange{0x29D8, 0x29D8}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT WIGGLY FENCE
+	{runeRange{0x29DC, 0x29FB}, propertyGeneralCategory{lbprAL, gcSm}},     //    [32] INCOMPLETE INFINITY..TRIPLE PLUS
+	{runeRange{0x2A00, 0x2AFF}, propertyGeneralCategory{lbprAL, gcSm}},     //   [256] N-ARY CIRCLED DOT OPERATOR..N-ARY WHITE VERTICAL BAR
+	{runeRange{0x2B47, 0x2B4C}, propertyGeneralCategory{lbprAL, gcSm}},     //     [6] REVERSE TILDE OPERATOR ABOVE RIGHTWARDS ARROW..RIGHTWARDS ARROW ABOVE REVERSE TILDE OPERATOR
+	{runeRange{0x2B76, 0x2B95}, propertyGeneralCategory{lbprAL, gcSo}},     //    [32] NORTH WEST TRIANGLE-HEADED ARROW TO BAR..RIGHTWARDS BLACK ARROW
+	{runeRange{0x2C7C, 0x2C7D}, propertyGeneralCategory{lbprAL, gcLm}},     //     [2] LATIN SUBSCRIPT SMALL LETTER J..MODIFIER LETTER CAPITAL V
+	{runeRange{0x2CEB, 0x2CEE}, propertyGeneralCategory{lbprAL, gcLC}},     //     [4] COPTIC CAPITAL LETTER CRYPTOGRAMMIC SHEI..COPTIC SMALL LETTER CRYPTOGRAMMIC GANGIA
+	{runeRange{0x2CFA, 0x2CFC}, propertyGeneralCategory{lbprBA, gcPo}},     //     [3] COPTIC OLD NUBIAN DIRECT QUESTION MARK..COPTIC OLD NUBIAN VERSE DIVIDER
+	{runeRange{0x2D00, 0x2D25}, propertyGeneralCategory{lbprAL, gcLl}},     //    [38] GEORGIAN SMALL LETTER AN..GEORGIAN SMALL LETTER HOE
+	{runeRange{0x2D6F, 0x2D6F}, propertyGeneralCategory{lbprAL, gcLm}},     //         TIFINAGH MODIFIER LETTER LABIALIZATION MARK
+	{runeRange{0x2DA0, 0x2DA6}, propertyGeneralCategory{lbprAL, gcLo}},     //     [7] ETHIOPIC SYLLABLE SSA..ETHIOPIC SYLLABLE SSO
+	{runeRange{0x2DC0, 0x2DC6}, propertyGeneralCategory{lbprAL, gcLo}},     //     [7] ETHIOPIC SYLLABLE QYA..ETHIOPIC SYLLABLE QYO
+	{runeRange{0x2DE0, 0x2DFF}, propertyGeneralCategory{lbprCM, gcMn}},     //    [32] COMBINING CYRILLIC LETTER BE..COMBINING CYRILLIC LETTER IOTIFIED BIG YUS
+	{runeRange{0x2E04, 0x2E04}, propertyGeneralCategory{lbprQU, gcPi}},     //         LEFT DOTTED SUBSTITUTION BRACKET
+	{runeRange{0x2E0A, 0x2E0A}, propertyGeneralCategory{lbprQU, gcPf}},     //         RIGHT TRANSPOSITION BRACKET
+	{runeRange{0x2E0E, 0x2E15}, propertyGeneralCategory{lbprBA, gcPo}},     //     [8] EDITORIAL CORONIS..UPWARDS ANCORA
+	{runeRange{0x2E19, 0x2E19}, propertyGeneralCategory{lbprBA, gcPo}},     //         PALM BRANCH
+	{runeRange{0x2E1D, 0x2E1D}, propertyGeneralCategory{lbprQU, gcPf}},     //         RIGHT LOW PARAPHRASE BRACKET
+	{runeRange{0x2E22, 0x2E22}, propertyGeneralCategory{lbprOP, gcPs}},     //         TOP LEFT HALF BRACKET
+	{runeRange{0x2E26, 0x2E26}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT SIDEWAYS U BRACKET
+	{runeRange{0x2E2A, 0x2E2D}, propertyGeneralCategory{lbprBA, gcPo}},     //     [4] TWO DOTS OVER ONE DOT PUNCTUATION..FIVE DOT MARK
+	{runeRange{0x2E32, 0x2E32}, propertyGeneralCategory{lbprAL, gcPo}},     //         TURNED COMMA
+	{runeRange{0x2E3C, 0x2E3E}, propertyGeneralCategory{lbprBA, gcPo}},     //     [3] STENOGRAPHIC FULL STOP..WIGGLY VERTICAL LINE
+	{runeRange{0x2E42, 0x2E42}, propertyGeneralCategory{lbprOP, gcPs}},     //         DOUBLE LOW-REVERSED-9 QUOTATION MARK
+	{runeRange{0x2E4D, 0x2E4D}, propertyGeneralCategory{lbprAL, gcPo}},     //         PARAGRAPHUS MARK
+	{runeRange{0x2E53, 0x2E54}, propertyGeneralCategory{lbprEX, gcPo}},     //     [2] MEDIEVAL EXCLAMATION MARK..MEDIEVAL QUESTION MARK
+	{runeRange{0x2E58, 0x2E58}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT SQUARE BRACKET WITH DOUBLE STROKE
+	{runeRange{0x2E5C, 0x2E5C}, propertyGeneralCategory{lbprCL, gcPe}},     //         BOTTOM HALF RIGHT PARENTHESIS
+	{runeRange{0x2F00, 0x2FD5}, propertyGeneralCategory{lbprID, gcSo}},     //   [214] KANGXI RADICAL ONE..KANGXI RADICAL FLUTE
+	{runeRange{0x3003, 0x3003}, propertyGeneralCategory{lbprID, gcPo}},     //         DITTO MARK
+	{runeRange{0x3007, 0x3007}, propertyGeneralCategory{lbprID, gcNl}},     //         IDEOGRAPHIC NUMBER ZERO
+	{runeRange{0x300B, 0x300B}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT DOUBLE ANGLE BRACKET
+	{runeRange{0x300F, 0x300F}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT WHITE CORNER BRACKET
+	{runeRange{0x3014, 0x3014}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT TORTOISE SHELL BRACKET
+	{runeRange{0x3018, 0x3018}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT WHITE TORTOISE SHELL BRACKET
+	{runeRange{0x301C, 0x301C}, propertyGeneralCategory{lbprNS, gcPd}},     //         WAVE DASH
+	{runeRange{0x3021, 0x3029}, propertyGeneralCategory{lbprID, gcNl}},     //     [9] HANGZHOU NUMERAL ONE..HANGZHOU NUMERAL NINE
+	{runeRange{0x3031, 0x3034}, propertyGeneralCategory{lbprID, gcLm}},     //     [4] VERTICAL KANA REPEAT MARK..VERTICAL KANA REPEAT WITH VOICED SOUND MARK UPPER HALF
+	{runeRange{0x303B, 0x303B}, propertyGeneralCategory{lbprNS, gcLm}},     //         VERTICAL IDEOGRAPHIC ITERATION MARK
+	{runeRange{0x3041, 0x3041}, propertyGeneralCategory{lbprCJ, gcLo}},     //         HIRAGANA LETTER SMALL A
+	{runeRange{0x3045, 0x3045}, propertyGeneralCategory{lbprCJ, gcLo}},     //         HIRAGANA LETTER SMALL U
+	{runeRange{0x3049, 0x3049}, propertyGeneralCategory{lbprCJ, gcLo}},     //         HIRAGANA LETTER SMALL O
+	{runeRange{0x3083, 0x3083}, propertyGeneralCategory{lbprCJ, gcLo}},     //         HIRAGANA LETTER SMALL YA
+	{runeRange{0x3087, 0x3087}, propertyGeneralCategory{lbprCJ, gcLo}},     //         HIRAGANA LETTER SMALL YO
+	{runeRange{0x3095, 0x3096}, propertyGeneralCategory{lbprCJ, gcLo}},     //     [2] HIRAGANA LETTER SMALL KA..HIRAGANA LETTER SMALL KE
+	{runeRange{0x309F, 0x309F}, propertyGeneralCategory{lbprID, gcLo}},     //         HIRAGANA DIGRAPH YORI
+	{runeRange{0x30A3, 0x30A3}, propertyGeneralCategory{lbprCJ, gcLo}},     //         KATAKANA LETTER SMALL I
+	{runeRange{0x30A7, 0x30A7}, propertyGeneralCategory{lbprCJ, gcLo}},     //         KATAKANA LETTER SMALL E
+	{runeRange{0x30C3, 0x30C3}, propertyGeneralCategory{lbprCJ, gcLo}},     //         KATAKANA LETTER SMALL TU
+	{runeRange{0x30E5, 0x30E5}, propertyGeneralCategory{lbprCJ, gcLo}},     //         KATAKANA LETTER SMALL YU
+	{runeRange{0x30EE, 0x30EE}, propertyGeneralCategory{lbprCJ, gcLo}},     //         KATAKANA LETTER SMALL WA
+	{runeRange{0x30FB, 0x30FB}, propertyGeneralCategory{lbprNS, gcPo}},     //         KATAKANA MIDDLE DOT
+	{runeRange{0x3105, 0x312F}, propertyGeneralCategory{lbprID, gcLo}},     //    [43] BOPOMOFO LETTER B..BOPOMOFO LETTER NN
+	{runeRange{0x3196, 0x319F}, propertyGeneralCategory{lbprID, gcSo}},     //    [10] IDEOGRAPHIC ANNOTATION TOP MARK..IDEOGRAPHIC ANNOTATION MAN MARK
+	{runeRange{0x3200, 0x321E}, propertyGeneralCategory{lbprID, gcSo}},     //    [31] PARENTHESIZED HANGUL KIYEOK..PARENTHESIZED KOREAN CHARACTER O HU
+	{runeRange{0x3250, 0x3250}, propertyGeneralCategory{lbprID, gcSo}},     //         PARTNERSHIP SIGN
+	{runeRange{0x328A, 0x32B0}, propertyGeneralCategory{lbprID, gcSo}},     //    [39] CIRCLED IDEOGRAPH MOON..CIRCLED IDEOGRAPH NIGHT
+	{runeRange{0x3400, 0x4DBF}, propertyGeneralCategory{lbprID, gcLo}},     //  [6592] CJK UNIFIED IDEOGRAPH-3400..CJK UNIFIED IDEOGRAPH-4DBF
+	{runeRange{0xA015, 0xA015}, propertyGeneralCategory{lbprNS, gcLm}},     //         YI SYLLABLE WU
+	{runeRange{0xA4F8, 0xA4FD}, propertyGeneralCategory{lbprAL, gcLm}},     //     [6] LISU LETTER TONE MYA TI..LISU LETTER TONE MYA JEU
+	{runeRange{0xA60D, 0xA60D}, propertyGeneralCategory{lbprBA, gcPo}},     //         VAI COMMA
+	{runeRange{0xA620, 0xA629}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] VAI DIGIT ZERO..VAI DIGIT NINE
+	{runeRange{0xA66F, 0xA66F}, propertyGeneralCategory{lbprCM, gcMn}},     //         COMBINING CYRILLIC VZMET
+	{runeRange{0xA67E, 0xA67E}, propertyGeneralCategory{lbprAL, gcPo}},     //         CYRILLIC KAVYKA
+	{runeRange{0xA69E, 0xA69F}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] COMBINING CYRILLIC LETTER EF..COMBINING CYRILLIC LETTER IOTIFIED E
+	{runeRange{0xA6F2, 0xA6F2}, propertyGeneralCategory{lbprAL, gcPo}},     //         BAMUM NJAEMLI
+	{runeRange{0xA720, 0xA721}, propertyGeneralCategory{lbprAL, gcSk}},     //     [2] MODIFIER LETTER STRESS AND HIGH TONE..MODIFIER LETTER STRESS AND LOW TONE
+	{runeRange{0xA788, 0xA788}, propertyGeneralCategory{lbprAL, gcLm}},     //         MODIFIER LETTER LOW CIRCUMFLEX ACCENT
+	{runeRange{0xA790, 0xA7CA}, propertyGeneralCategory{lbprAL, gcLC}},     //    [59] LATIN CAPITAL LETTER N WITH DESCENDER..LATIN SMALL LETTER S WITH SHORT STROKE OVERLAY
+	{runeRange{0xA7F2, 0xA7F4}, propertyGeneralCategory{lbprAL, gcLm}},     //     [3] MODIFIER LETTER CAPITAL C..MODIFIER LETTER CAPITAL Q
+	{runeRange{0xA7FA, 0xA7FA}, propertyGeneralCategory{lbprAL, gcLl}},     //         LATIN LETTER SMALL CAPITAL TURNED M
+	{runeRange{0xA803, 0xA805}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] SYLOTI NAGRI LETTER U..SYLOTI NAGRI LETTER O
+	{runeRange{0xA80C, 0xA822}, propertyGeneralCategory{lbprAL, gcLo}},     //    [23] SYLOTI NAGRI LETTER CO..SYLOTI NAGRI LETTER HO
+	{runeRange{0xA828, 0xA82B}, propertyGeneralCategory{lbprAL, gcSo}},     //     [4] SYLOTI NAGRI POETRY MARK-1..SYLOTI NAGRI POETRY MARK-4
+	{runeRange{0xA838, 0xA838}, propertyGeneralCategory{lbprPO, gcSc}},     //         NORTH INDIC RUPEE MARK
+	{runeRange{0xA876, 0xA877}, propertyGeneralCategory{lbprEX, gcPo}},     //     [2] PHAGS-PA MARK SHAD..PHAGS-PA MARK DOUBLE SHAD
+	{runeRange{0xA8C4, 0xA8C5}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] SAURASHTRA SIGN VIRAMA..SAURASHTRA SIGN CANDRABINDU
+	{runeRange{0xA8F2, 0xA8F7}, propertyGeneralCategory{lbprAL, gcLo}},     //     [6] DEVANAGARI SIGN SPACING CANDRABINDU..DEVANAGARI SIGN CANDRABINDU AVAGRAHA
+	{runeRange{0xA8FD, 0xA8FE}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] DEVANAGARI JAIN OM..DEVANAGARI LETTER AY
+	{runeRange{0xA926, 0xA92D}, propertyGeneralCategory{lbprCM, gcMn}},     //     [8] KAYAH LI VOWEL UE..KAYAH LI TONE CALYA PLOPHU
+	{runeRange{0xA952, 0xA953}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] REJANG CONSONANT SIGN H..REJANG VIRAMA
+	{runeRange{0xA983, 0xA983}, propertyGeneralCategory{lbprCM, gcMc}},     //         JAVANESE SIGN WIGNYAN
+	{runeRange{0xA9B6, 0xA9B9}, propertyGeneralCategory{lbprCM, gcMn}},     //     [4] JAVANESE VOWEL SIGN WULU..JAVANESE VOWEL SIGN SUKU MENDUT
+	{runeRange{0xA9C1, 0xA9C6}, propertyGeneralCategory{lbprAL, gcPo}},     //     [6] JAVANESE LEFT RERENGGAN..JAVANESE PADA WINDU
+	{runeRange{0xA9D0, 0xA9D9}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] JAVANESE DIGIT ZERO..JAVANESE DIGIT NINE
+	{runeRange{0xA9E6, 0xA9E6}, propertyGeneralCategory{lbprSA, gcLm}},     //         MYANMAR MODIFIER LETTER SHAN REDUPLICATION
+	{runeRange{0xAA00, 0xAA28}, propertyGeneralCategory{lbprAL, gcLo}},     //    [41] CHAM LETTER A..CHAM LETTER HA
+	{runeRange{0xAA33, 0xAA34}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] CHAM CONSONANT SIGN YA..CHAM CONSONANT SIGN RA
+	{runeRange{0xAA44, 0xAA4B}, propertyGeneralCategory{lbprAL, gcLo}},     //     [8] CHAM LETTER FINAL CH..CHAM LETTER FINAL SS
+	{runeRange{0xAA5C, 0xAA5C}, propertyGeneralCategory{lbprAL, gcPo}},     //         CHAM PUNCTUATION SPIRAL
+	{runeRange{0xAA71, 0xAA76}, propertyGeneralCategory{lbprSA, gcLo}},     //     [6] MYANMAR LETTER KHAMTI XA..MYANMAR LOGOGRAM KHAMTI HM
+	{runeRange{0xAA7C, 0xAA7C}, propertyGeneralCategory{lbprSA, gcMn}},     //         MYANMAR SIGN TAI LAING TONE-2
+	{runeRange{0xAAB0, 0xAAB0}, propertyGeneralCategory{lbprSA, gcMn}},     //         TAI VIET MAI KANG
+	{runeRange{0xAAB7, 0xAAB8}, propertyGeneralCategory{lbprSA, gcMn}},     //     [2] TAI VIET MAI KHIT..TAI VIET VOWEL IA
+	{runeRange{0xAAC1, 0xAAC1}, propertyGeneralCategory{lbprSA, gcMn}},     //         TAI VIET TONE MAI THO
+	{runeRange{0xAADE, 0xAADF}, propertyGeneralCategory{lbprSA, gcPo}},     //     [2] TAI VIET SYMBOL HO HOI..TAI VIET SYMBOL KOI KOI
+	{runeRange{0xAAEE, 0xAAEF}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] MEETEI MAYEK VOWEL SIGN AU..MEETEI MAYEK VOWEL SIGN AAU
+	{runeRange{0xAAF5, 0xAAF5}, propertyGeneralCategory{lbprCM, gcMc}},     //         MEETEI MAYEK VOWEL SIGN VISARGA
+	{runeRange{0xAB11, 0xAB16}, propertyGeneralCategory{lbprAL, gcLo}},     //     [6] ETHIOPIC SYLLABLE DZU..ETHIOPIC SYLLABLE DZO
+	{runeRange{0xAB5B, 0xAB5B}, propertyGeneralCategory{lbprAL, gcSk}},     //         MODIFIER BREVE WITH INVERTED BREVE
+	{runeRange{0xAB6A, 0xAB6B}, propertyGeneralCategory{lbprAL, gcSk}},     //     [2] MODIFIER LETTER LEFT TACK..MODIFIER LETTER RIGHT TACK
+	{runeRange{0xABE5, 0xABE5}, propertyGeneralCategory{lbprCM, gcMn}},     //         MEETEI MAYEK VOWEL SIGN ANAP
+	{runeRange{0xABEB, 0xABEB}, propertyGeneralCategory{lbprBA, gcPo}},     //         MEETEI MAYEK CHEIKHEI
+	{runeRange{0xAC00, 0xAC00}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GA
+	{runeRange{0xAC38, 0xAC38}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GYA
+	{runeRange{0xAC70, 0xAC70}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GEO
+	{runeRange{0xACA8, 0xACA8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GYEO
+	{runeRange{0xACE0, 0xACE0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GO
+	{runeRange{0xAD18, 0xAD18}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GWAE
+	{runeRange{0xAD50, 0xAD50}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GYO
+	{runeRange{0xAD88, 0xAD88}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GWEO
+	{runeRange{0xADC0, 0xADC0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GWI
+	{runeRange{0xADF8, 0xADF8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GEU
+	{runeRange{0xAE30, 0xAE30}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GI
+	{runeRange{0xAE68, 0xAE68}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGAE
+	{runeRange{0xAEA0, 0xAEA0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGYAE
+	{runeRange{0xAED8, 0xAED8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGE
+	{runeRange{0xAF10, 0xAF10}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGYE
+	{runeRange{0xAF48, 0xAF48}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGWA
+	{runeRange{0xAF80, 0xAF80}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGOE
+	{runeRange{0xAFB8, 0xAFB8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGU
+	{runeRange{0xAFF0, 0xAFF0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGWE
+	{runeRange{0xB028, 0xB028}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGYU
+	{runeRange{0xB060, 0xB060}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE GGYI
+	{runeRange{0xB098, 0xB098}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NA
+	{runeRange{0xB0D0, 0xB0D0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NYA
+	{runeRange{0xB108, 0xB108}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NEO
+	{runeRange{0xB140, 0xB140}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NYEO
+	{runeRange{0xB178, 0xB178}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NO
+	{runeRange{0xB1B0, 0xB1B0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NWAE
+	{runeRange{0xB1E8, 0xB1E8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NYO
+	{runeRange{0xB220, 0xB220}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NWEO
+	{runeRange{0xB258, 0xB258}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NWI
+	{runeRange{0xB290, 0xB290}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NEU
+	{runeRange{0xB2C8, 0xB2C8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE NI
+	{runeRange{0xB300, 0xB300}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DAE
+	{runeRange{0xB338, 0xB338}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DYAE
+	{runeRange{0xB370, 0xB370}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DE
+	{runeRange{0xB3A8, 0xB3A8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DYE
+	{runeRange{0xB3E0, 0xB3E0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DWA
+	{runeRange{0xB418, 0xB418}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DOE
+	{runeRange{0xB450, 0xB450}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DU
+	{runeRange{0xB488, 0xB488}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DWE
+	{runeRange{0xB4C0, 0xB4C0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DYU
+	{runeRange{0xB4F8, 0xB4F8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DYI
+	{runeRange{0xB530, 0xB530}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDA
+	{runeRange{0xB568, 0xB568}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDYA
+	{runeRange{0xB5A0, 0xB5A0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDEO
+	{runeRange{0xB5D8, 0xB5D8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDYEO
+	{runeRange{0xB610, 0xB610}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDO
+	{runeRange{0xB648, 0xB648}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDWAE
+	{runeRange{0xB680, 0xB680}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDYO
+	{runeRange{0xB6B8, 0xB6B8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDWEO
+	{runeRange{0xB6F0, 0xB6F0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDWI
+	{runeRange{0xB728, 0xB728}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDEU
+	{runeRange{0xB760, 0xB760}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE DDI
+	{runeRange{0xB798, 0xB798}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RAE
+	{runeRange{0xB7D0, 0xB7D0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RYAE
+	{runeRange{0xB808, 0xB808}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RE
+	{runeRange{0xB840, 0xB840}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RYE
+	{runeRange{0xB878, 0xB878}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RWA
+	{runeRange{0xB8B0, 0xB8B0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE ROE
+	{runeRange{0xB8E8, 0xB8E8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RU
+	{runeRange{0xB920, 0xB920}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RWE
+	{runeRange{0xB958, 0xB958}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RYU
+	{runeRange{0xB990, 0xB990}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE RYI
+	{runeRange{0xB9C8, 0xB9C8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MA
+	{runeRange{0xBA00, 0xBA00}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MYA
+	{runeRange{0xBA38, 0xBA38}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MEO
+	{runeRange{0xBA70, 0xBA70}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MYEO
+	{runeRange{0xBAA8, 0xBAA8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MO
+	{runeRange{0xBAE0, 0xBAE0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MWAE
+	{runeRange{0xBB18, 0xBB18}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MYO
+	{runeRange{0xBB50, 0xBB50}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MWEO
+	{runeRange{0xBB88, 0xBB88}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MWI
+	{runeRange{0xBBC0, 0xBBC0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MEU
+	{runeRange{0xBBF8, 0xBBF8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE MI
+	{runeRange{0xBC30, 0xBC30}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BAE
+	{runeRange{0xBC68, 0xBC68}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BYAE
+	{runeRange{0xBCA0, 0xBCA0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BE
+	{runeRange{0xBCD8, 0xBCD8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BYE
+	{runeRange{0xBD10, 0xBD10}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BWA
+	{runeRange{0xBD48, 0xBD48}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BOE
+	{runeRange{0xBD80, 0xBD80}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BU
+	{runeRange{0xBDB8, 0xBDB8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BWE
+	{runeRange{0xBDF0, 0xBDF0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BYU
+	{runeRange{0xBE28, 0xBE28}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BYI
+	{runeRange{0xBE60, 0xBE60}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBA
+	{runeRange{0xBE98, 0xBE98}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBYA
+	{runeRange{0xBED0, 0xBED0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBEO
+	{runeRange{0xBF08, 0xBF08}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBYEO
+	{runeRange{0xBF40, 0xBF40}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBO
+	{runeRange{0xBF78, 0xBF78}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBWAE
+	{runeRange{0xBFB0, 0xBFB0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBYO
+	{runeRange{0xBFE8, 0xBFE8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBWEO
+	{runeRange{0xC020, 0xC020}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBWI
+	{runeRange{0xC058, 0xC058}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBEU
+	{runeRange{0xC090, 0xC090}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE BBI
+	{runeRange{0xC0C8, 0xC0C8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SAE
+	{runeRange{0xC100, 0xC100}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SYAE
+	{runeRange{0xC138, 0xC138}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SE
+	{runeRange{0xC170, 0xC170}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SYE
+	{runeRange{0xC1A8, 0xC1A8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SWA
+	{runeRange{0xC1E0, 0xC1E0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SOE
+	{runeRange{0xC218, 0xC218}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SU
+	{runeRange{0xC250, 0xC250}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SWE
+	{runeRange{0xC288, 0xC288}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SYU
+	{runeRange{0xC2C0, 0xC2C0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SYI
+	{runeRange{0xC2F8, 0xC2F8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSA
+	{runeRange{0xC330, 0xC330}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSYA
+	{runeRange{0xC368, 0xC368}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSEO
+	{runeRange{0xC3A0, 0xC3A0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSYEO
+	{runeRange{0xC3D8, 0xC3D8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSO
+	{runeRange{0xC410, 0xC410}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSWAE
+	{runeRange{0xC448, 0xC448}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSYO
+	{runeRange{0xC480, 0xC480}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSWEO
+	{runeRange{0xC4B8, 0xC4B8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSWI
+	{runeRange{0xC4F0, 0xC4F0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSEU
+	{runeRange{0xC528, 0xC528}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE SSI
+	{runeRange{0xC560, 0xC560}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE AE
+	{runeRange{0xC598, 0xC598}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE YAE
+	{runeRange{0xC5D0, 0xC5D0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE E
+	{runeRange{0xC608, 0xC608}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE YE
+	{runeRange{0xC640, 0xC640}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE WA
+	{runeRange{0xC678, 0xC678}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE OE
+	{runeRange{0xC6B0, 0xC6B0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE U
+	{runeRange{0xC6E8, 0xC6E8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE WE
+	{runeRange{0xC720, 0xC720}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE YU
+	{runeRange{0xC758, 0xC758}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE YI
+	{runeRange{0xC790, 0xC790}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JA
+	{runeRange{0xC7C8, 0xC7C8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JYA
+	{runeRange{0xC800, 0xC800}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JEO
+	{runeRange{0xC838, 0xC838}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JYEO
+	{runeRange{0xC870, 0xC870}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JO
+	{runeRange{0xC8A8, 0xC8A8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JWAE
+	{runeRange{0xC8E0, 0xC8E0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JYO
+	{runeRange{0xC918, 0xC918}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JWEO
+	{runeRange{0xC950, 0xC950}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JWI
+	{runeRange{0xC988, 0xC988}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JEU
+	{runeRange{0xC9C0, 0xC9C0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JI
+	{runeRange{0xC9F8, 0xC9F8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJAE
+	{runeRange{0xCA30, 0xCA30}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJYAE
+	{runeRange{0xCA68, 0xCA68}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJE
+	{runeRange{0xCAA0, 0xCAA0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJYE
+	{runeRange{0xCAD8, 0xCAD8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJWA
+	{runeRange{0xCB10, 0xCB10}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJOE
+	{runeRange{0xCB48, 0xCB48}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJU
+	{runeRange{0xCB80, 0xCB80}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJWE
+	{runeRange{0xCBB8, 0xCBB8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJYU
+	{runeRange{0xCBF0, 0xCBF0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE JJYI
+	{runeRange{0xCC28, 0xCC28}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CA
+	{runeRange{0xCC60, 0xCC60}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CYA
+	{runeRange{0xCC98, 0xCC98}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CEO
+	{runeRange{0xCCD0, 0xCCD0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CYEO
+	{runeRange{0xCD08, 0xCD08}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CO
+	{runeRange{0xCD40, 0xCD40}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CWAE
+	{runeRange{0xCD78, 0xCD78}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CYO
+	{runeRange{0xCDB0, 0xCDB0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CWEO
+	{runeRange{0xCDE8, 0xCDE8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CWI
+	{runeRange{0xCE20, 0xCE20}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CEU
+	{runeRange{0xCE58, 0xCE58}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE CI
+	{runeRange{0xCE90, 0xCE90}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KAE
+	{runeRange{0xCEC8, 0xCEC8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KYAE
+	{runeRange{0xCF00, 0xCF00}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KE
+	{runeRange{0xCF38, 0xCF38}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KYE
+	{runeRange{0xCF70, 0xCF70}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KWA
+	{runeRange{0xCFA8, 0xCFA8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KOE
+	{runeRange{0xCFE0, 0xCFE0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KU
+	{runeRange{0xD018, 0xD018}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KWE
+	{runeRange{0xD050, 0xD050}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KYU
+	{runeRange{0xD088, 0xD088}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE KYI
+	{runeRange{0xD0C0, 0xD0C0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TA
+	{runeRange{0xD0F8, 0xD0F8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TYA
+	{runeRange{0xD130, 0xD130}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TEO
+	{runeRange{0xD168, 0xD168}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TYEO
+	{runeRange{0xD1A0, 0xD1A0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TO
+	{runeRange{0xD1D8, 0xD1D8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TWAE
+	{runeRange{0xD210, 0xD210}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TYO
+	{runeRange{0xD248, 0xD248}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TWEO
+	{runeRange{0xD280, 0xD280}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TWI
+	{runeRange{0xD2B8, 0xD2B8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TEU
+	{runeRange{0xD2F0, 0xD2F0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE TI
+	{runeRange{0xD328, 0xD328}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PAE
+	{runeRange{0xD360, 0xD360}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PYAE
+	{runeRange{0xD398, 0xD398}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PE
+	{runeRange{0xD3D0, 0xD3D0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PYE
+	{runeRange{0xD408, 0xD408}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PWA
+	{runeRange{0xD440, 0xD440}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE POE
+	{runeRange{0xD478, 0xD478}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PU
+	{runeRange{0xD4B0, 0xD4B0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PWE
+	{runeRange{0xD4E8, 0xD4E8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PYU
+	{runeRange{0xD520, 0xD520}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE PYI
+	{runeRange{0xD558, 0xD558}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HA
+	{runeRange{0xD590, 0xD590}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HYA
+	{runeRange{0xD5C8, 0xD5C8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HEO
+	{runeRange{0xD600, 0xD600}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HYEO
+	{runeRange{0xD638, 0xD638}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HO
+	{runeRange{0xD670, 0xD670}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HWAE
+	{runeRange{0xD6A8, 0xD6A8}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HYO
+	{runeRange{0xD6E0, 0xD6E0}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HWEO
+	{runeRange{0xD718, 0xD718}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HWI
+	{runeRange{0xD750, 0xD750}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HEU
+	{runeRange{0xD788, 0xD788}, propertyGeneralCategory{lbprH2, gcLo}},     //         HANGUL SYLLABLE HI
+	{runeRange{0xD800, 0xDB7F}, propertyGeneralCategory{lbprSG, gcCs}},     //   [896] <surrogate-D800>..<surrogate-DB7F>
+	{runeRange{0xF900, 0xFA6D}, propertyGeneralCategory{lbprID, gcLo}},     //   [366] CJK COMPATIBILITY IDEOGRAPH-F900..CJK COMPATIBILITY IDEOGRAPH-FA6D
+	{runeRange{0xFB00, 0xFB06}, propertyGeneralCategory{lbprAL, gcLl}},     //     [7] LATIN SMALL LIGATURE FF..LATIN SMALL LIGATURE ST
+	{runeRange{0xFB1F, 0xFB28}, propertyGeneralCategory{lbprHL, gcLo}},     //    [10] HEBREW LIGATURE YIDDISH YOD YOD PATAH..HEBREW LETTER WIDE TAV
+	{runeRange{0xFB3E, 0xFB3E}, propertyGeneralCategory{lbprHL, gcLo}},     //         HEBREW LETTER MEM WITH DAGESH
+	{runeRange{0xFB50, 0xFBB1}, propertyGeneralCategory{lbprAL, gcLo}},     //    [98] ARABIC LETTER ALEF WASLA ISOLATED FORM..ARABIC LETTER YEH BARREE WITH HAMZA ABOVE FINAL FORM
+	{runeRange{0xFD3F, 0xFD3F}, propertyGeneralCategory{lbprOP, gcPs}},     //         ORNATE RIGHT PARENTHESIS
+	{runeRange{0xFDCF, 0xFDCF}, propertyGeneralCategory{lbprAL, gcSo}},     //         ARABIC LIGATURE SALAAMUHU ALAYNAA
+	{runeRange{0xFE00, 0xFE0F}, propertyGeneralCategory{lbprCM, gcMn}},     //    [16] VARIATION SELECTOR-1..VARIATION SELECTOR-16
+	{runeRange{0xFE15, 0xFE16}, propertyGeneralCategory{lbprEX, gcPo}},     //     [2] PRESENTATION FORM FOR VERTICAL EXCLAMATION MARK..PRESENTATION FORM FOR VERTICAL QUESTION MARK
+	{runeRange{0xFE20, 0xFE2F}, propertyGeneralCategory{lbprCM, gcMn}},     //    [16] COMBINING LIGATURE LEFT HALF..COMBINING CYRILLIC TITLO RIGHT HALF
+	{runeRange{0xFE35, 0xFE35}, propertyGeneralCategory{lbprOP, gcPs}},     //         PRESENTATION FORM FOR VERTICAL LEFT PARENTHESIS
+	{runeRange{0xFE39, 0xFE39}, propertyGeneralCategory{lbprOP, gcPs}},     //         PRESENTATION FORM FOR VERTICAL LEFT TORTOISE SHELL BRACKET
+	{runeRange{0xFE3D, 0xFE3D}, propertyGeneralCategory{lbprOP, gcPs}},     //         PRESENTATION FORM FOR VERTICAL LEFT DOUBLE ANGLE BRACKET
+	{runeRange{0xFE41, 0xFE41}, propertyGeneralCategory{lbprOP, gcPs}},     //         PRESENTATION FORM FOR VERTICAL LEFT CORNER BRACKET
+	{runeRange{0xFE45, 0xFE46}, propertyGeneralCategory{lbprID, gcPo}},     //     [2] SESAME DOT..WHITE SESAME DOT
+	{runeRange{0xFE4D, 0xFE4F}, propertyGeneralCategory{lbprID, gcPc}},     //     [3] DASHED LOW LINE..WAVY LOW LINE
+	{runeRange{0xFE54, 0xFE55}, propertyGeneralCategory{lbprNS, gcPo}},     //     [2] SMALL SEMICOLON..SMALL COLON
+	{runeRange{0xFE5A, 0xFE5A}, propertyGeneralCategory{lbprCL, gcPe}},     //         SMALL RIGHT PARENTHESIS
+	{runeRange{0xFE5E, 0xFE5E}, propertyGeneralCategory{lbprCL, gcPe}},     //         SMALL RIGHT TORTOISE SHELL BRACKET
+	{runeRange{0xFE64, 0xFE66}, propertyGeneralCategory{lbprID, gcSm}},     //     [3] SMALL LESS-THAN SIGN..SMALL EQUALS SIGN
+	{runeRange{0xFE6B, 0xFE6B}, propertyGeneralCategory{lbprID, gcPo}},     //         SMALL COMMERCIAL AT
+	{runeRange{0xFF01, 0xFF01}, propertyGeneralCategory{lbprEX, gcPo}},     //         FULLWIDTH EXCLAMATION MARK
+	{runeRange{0xFF06, 0xFF07}, propertyGeneralCategory{lbprID, gcPo}},     //     [2] FULLWIDTH AMPERSAND..FULLWIDTH APOSTROPHE
+	{runeRange{0xFF0B, 0xFF0B}, propertyGeneralCategory{lbprID, gcSm}},     //         FULLWIDTH PLUS SIGN
+	{runeRange{0xFF0F, 0xFF0F}, propertyGeneralCategory{lbprID, gcPo}},     //         FULLWIDTH SOLIDUS
+	{runeRange{0xFF1F, 0xFF1F}, propertyGeneralCategory{lbprEX, gcPo}},     //         FULLWIDTH QUESTION MARK
+	{runeRange{0xFF3C, 0xFF3C}, propertyGeneralCategory{lbprID, gcPo}},     //         FULLWIDTH REVERSE SOLIDUS
+	{runeRange{0xFF40, 0xFF40}, propertyGeneralCategory{lbprID, gcSk}},     //         FULLWIDTH GRAVE ACCENT
+	{runeRange{0xFF5D, 0xFF5D}, propertyGeneralCategory{lbprCL, gcPe}},     //         FULLWIDTH RIGHT CURLY BRACKET
+	{runeRange{0xFF61, 0xFF61}, propertyGeneralCategory{lbprCL, gcPo}},     //         HALFWIDTH IDEOGRAPHIC FULL STOP
+	{runeRange{0xFF65, 0xFF65}, propertyGeneralCategory{lbprNS, gcPo}},     //         HALFWIDTH KATAKANA MIDDLE DOT
+	{runeRange{0xFF71, 0xFF9D}, propertyGeneralCategory{lbprID, gcLo}},     //    [45] HALFWIDTH KATAKANA LETTER A..HALFWIDTH KATAKANA LETTER N
+	{runeRange{0xFFCA, 0xFFCF}, propertyGeneralCategory{lbprID, gcLo}},     //     [6] HALFWIDTH HANGUL LETTER YEO..HALFWIDTH HANGUL LETTER OE
+	{runeRange{0xFFE1, 0xFFE1}, propertyGeneralCategory{lbprPR, gcSc}},     //         FULLWIDTH POUND SIGN
+	{runeRange{0xFFE5, 0xFFE6}, propertyGeneralCategory{lbprPR, gcSc}},     //     [2] FULLWIDTH YEN SIGN..FULLWIDTH WON SIGN
+	{runeRange{0xFFF9, 0xFFFB}, propertyGeneralCategory{lbprCM, gcCf}},     //     [3] INTERLINEAR ANNOTATION ANCHOR..INTERLINEAR ANNOTATION TERMINATOR
+	{runeRange{0x1000D, 0x10026}, propertyGeneralCategory{lbprAL, gcLo}},   //    [26] LINEAR B SYLLABLE B036 JO..LINEAR B SYLLABLE B032 QO
+	{runeRange{0x10050, 0x1005D}, propertyGeneralCategory{lbprAL, gcLo}},   //    [14] LINEAR B SYMBOL B018..LINEAR B SYMBOL B089
+	{runeRange{0x10137, 0x1013F}, propertyGeneralCategory{lbprAL, gcSo}},   //     [9] AEGEAN WEIGHT BASE UNIT..AEGEAN MEASURE THIRD SUBUNIT
+	{runeRange{0x1018A, 0x1018B}, propertyGeneralCategory{lbprAL, gcNo}},   //     [2] GREEK ZERO SIGN..GREEK ONE QUARTER SIGN
+	{runeRange{0x101D0, 0x101FC}, propertyGeneralCategory{lbprAL, gcSo}},   //    [45] PHAISTOS DISC SIGN PEDESTRIAN..PHAISTOS DISC SIGN WAVY BAND
+	{runeRange{0x102E0, 0x102E0}, propertyGeneralCategory{lbprCM, gcMn}},   //         COPTIC EPACT THOUSANDS MARK
+	{runeRange{0x1032D, 0x1032F}, propertyGeneralCategory{lbprAL, gcLo}},   //     [3] OLD ITALIC LETTER YE..OLD ITALIC LETTER SOUTHERN TSE
+	{runeRange{0x1034A, 0x1034A}, propertyGeneralCategory{lbprAL, gcNl}},   //         GOTHIC LETTER NINE HUNDRED
+	{runeRange{0x1039F, 0x1039F}, propertyGeneralCategory{lbprBA, gcPo}},   //         UGARITIC WORD DIVIDER
+	{runeRange{0x103D1, 0x103D5}, propertyGeneralCategory{lbprAL, gcNl}},   //     [5] OLD PERSIAN NUMBER ONE..OLD PERSIAN NUMBER HUNDRED
+	{runeRange{0x104A0, 0x104A9}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] OSMANYA DIGIT ZERO..OSMANYA DIGIT NINE
+	{runeRange{0x10530, 0x10563}, propertyGeneralCategory{lbprAL, gcLo}},   //    [52] CAUCASIAN ALBANIAN LETTER ALT..CAUCASIAN ALBANIAN LETTER KIW
+	{runeRange{0x1058C, 0x10592}, propertyGeneralCategory{lbprAL, gcLu}},   //     [7] VITHKUQI CAPITAL LETTER SE..VITHKUQI CAPITAL LETTER XE
+	{runeRange{0x105B3, 0x105B9}, propertyGeneralCategory{lbprAL, gcLl}},   //     [7] VITHKUQI SMALL LETTER SE..VITHKUQI SMALL LETTER XE
+	{runeRange{0x10760, 0x10767}, propertyGeneralCategory{lbprAL, gcLo}},   //     [8] LINEAR A SIGN A800..LINEAR A SIGN A807
+	{runeRange{0x10800, 0x10805}, propertyGeneralCategory{lbprAL, gcLo}},   //     [6] CYPRIOT SYLLABLE A..CYPRIOT SYLLABLE JA
+	{runeRange{0x1083C, 0x1083C}, propertyGeneralCategory{lbprAL, gcLo}},   //         CYPRIOT SYLLABLE ZA
+	{runeRange{0x10858, 0x1085F}, propertyGeneralCategory{lbprAL, gcNo}},   //     [8] IMPERIAL ARAMAIC NUMBER ONE..IMPERIAL ARAMAIC NUMBER TEN THOUSAND
+	{runeRange{0x10880, 0x1089E}, propertyGeneralCategory{lbprAL, gcLo}},   //    [31] NABATAEAN LETTER FINAL ALEPH..NABATAEAN LETTER TAW
+	{runeRange{0x108FB, 0x108FF}, propertyGeneralCategory{lbprAL, gcNo}},   //     [5] HATRAN NUMBER ONE..HATRAN NUMBER ONE HUNDRED
+	{runeRange{0x10920, 0x10939}, propertyGeneralCategory{lbprAL, gcLo}},   //    [26] LYDIAN LETTER A..LYDIAN LETTER C
+	{runeRange{0x109BC, 0x109BD}, propertyGeneralCategory{lbprAL, gcNo}},   //     [2] MEROITIC CURSIVE FRACTION ELEVEN TWELFTHS..MEROITIC CURSIVE FRACTION ONE HALF
+	{runeRange{0x10A00, 0x10A00}, propertyGeneralCategory{lbprAL, gcLo}},   //         KHAROSHTHI LETTER A
+	{runeRange{0x10A10, 0x10A13}, propertyGeneralCategory{lbprAL, gcLo}},   //     [4] KHAROSHTHI LETTER KA..KHAROSHTHI LETTER GHA
+	{runeRange{0x10A3F, 0x10A3F}, propertyGeneralCategory{lbprCM, gcMn}},   //         KHAROSHTHI VIRAMA
+	{runeRange{0x10A60, 0x10A7C}, propertyGeneralCategory{lbprAL, gcLo}},   //    [29] OLD SOUTH ARABIAN LETTER HE..OLD SOUTH ARABIAN LETTER THETH
+	{runeRange{0x10A9D, 0x10A9F}, propertyGeneralCategory{lbprAL, gcNo}},   //     [3] OLD NORTH ARABIAN NUMBER ONE..OLD NORTH ARABIAN NUMBER TWENTY
+	{runeRange{0x10AE5, 0x10AE6}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] MANICHAEAN ABBREVIATION MARK ABOVE..MANICHAEAN ABBREVIATION MARK BELOW
+	{runeRange{0x10B00, 0x10B35}, propertyGeneralCategory{lbprAL, gcLo}},   //    [54] AVESTAN LETTER A..AVESTAN LETTER HE
+	{runeRange{0x10B60, 0x10B72}, propertyGeneralCategory{lbprAL, gcLo}},   //    [19] INSCRIPTIONAL PAHLAVI LETTER ALEPH..INSCRIPTIONAL PAHLAVI LETTER TAW
+	{runeRange{0x10BA9, 0x10BAF}, propertyGeneralCategory{lbprAL, gcNo}},   //     [7] PSALTER PAHLAVI NUMBER ONE..PSALTER PAHLAVI NUMBER ONE HUNDRED
+	{runeRange{0x10CFA, 0x10CFF}, propertyGeneralCategory{lbprAL, gcNo}},   //     [6] OLD HUNGARIAN NUMBER ONE..OLD HUNGARIAN NUMBER ONE THOUSAND
+	{runeRange{0x10E60, 0x10E7E}, propertyGeneralCategory{lbprAL, gcNo}},   //    [31] RUMI DIGIT ONE..RUMI FRACTION TWO THIRDS
+	{runeRange{0x10EB0, 0x10EB1}, propertyGeneralCategory{lbprAL, gcLo}},   //     [2] YEZIDI LETTER LAM WITH DOT ABOVE..YEZIDI LETTER YOT WITH CIRCUMFLEX ABOVE
+	{runeRange{0x10F27, 0x10F27}, propertyGeneralCategory{lbprAL, gcLo}},   //         OLD SOGDIAN LIGATURE AYIN-DALETH
+	{runeRange{0x10F55, 0x10F59}, propertyGeneralCategory{lbprAL, gcPo}},   //     [5] SOGDIAN PUNCTUATION TWO VERTICAL BARS..SOGDIAN PUNCTUATION HALF CIRCLE WITH DOT
+	{runeRange{0x10FB0, 0x10FC4}, propertyGeneralCategory{lbprAL, gcLo}},   //    [21] CHORASMIAN LETTER ALEPH..CHORASMIAN LETTER TAW
+	{runeRange{0x11001, 0x11001}, propertyGeneralCategory{lbprCM, gcMn}},   //         BRAHMI SIGN ANUSVARA
+	{runeRange{0x11047, 0x11048}, propertyGeneralCategory{lbprBA, gcPo}},   //     [2] BRAHMI DANDA..BRAHMI DOUBLE DANDA
+	{runeRange{0x11070, 0x11070}, propertyGeneralCategory{lbprCM, gcMn}},   //         BRAHMI SIGN OLD TAMIL VIRAMA
+	{runeRange{0x1107F, 0x1107F}, propertyGeneralCategory{lbprCM, gcMn}},   //         BRAHMI NUMBER JOINER
+	{runeRange{0x110B0, 0x110B2}, propertyGeneralCategory{lbprCM, gcMc}},   //     [3] KAITHI VOWEL SIGN AA..KAITHI VOWEL SIGN II
+	{runeRange{0x110BB, 0x110BC}, propertyGeneralCategory{lbprAL, gcPo}},   //     [2] KAITHI ABBREVIATION SIGN..KAITHI ENUMERATION SIGN
+	{runeRange{0x110CD, 0x110CD}, propertyGeneralCategory{lbprAL, gcCf}},   //         KAITHI NUMBER SIGN ABOVE
+	{runeRange{0x11103, 0x11126}, propertyGeneralCategory{lbprAL, gcLo}},   //    [36] CHAKMA LETTER AA..CHAKMA LETTER HAA
+	{runeRange{0x11136, 0x1113F}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] CHAKMA DIGIT ZERO..CHAKMA DIGIT NINE
+	{runeRange{0x11147, 0x11147}, propertyGeneralCategory{lbprAL, gcLo}},   //         CHAKMA LETTER VAA
+	{runeRange{0x11175, 0x11175}, propertyGeneralCategory{lbprBB, gcPo}},   //         MAHAJANI SECTION MARK
+	{runeRange{0x11183, 0x111B2}, propertyGeneralCategory{lbprAL, gcLo}},   //    [48] SHARADA LETTER A..SHARADA LETTER HA
+	{runeRange{0x111C1, 0x111C4}, propertyGeneralCategory{lbprAL, gcLo}},   //     [4] SHARADA SIGN AVAGRAHA..SHARADA OM
+	{runeRange{0x111C9, 0x111CC}, propertyGeneralCategory{lbprCM, gcMn}},   //     [4] SHARADA SANDHI MARK..SHARADA EXTRA SHORT VOWEL MARK
+	{runeRange{0x111D0, 0x111D9}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] SHARADA DIGIT ZERO..SHARADA DIGIT NINE
+	{runeRange{0x111DD, 0x111DF}, propertyGeneralCategory{lbprBA, gcPo}},   //     [3] SHARADA CONTINUATION SIGN..SHARADA SECTION MARK-2
+	{runeRange{0x1122C, 0x1122E}, propertyGeneralCategory{lbprCM, gcMc}},   //     [3] KHOJKI VOWEL SIGN AA..KHOJKI VOWEL SIGN II
+	{runeRange{0x11235, 0x11235}, propertyGeneralCategory{lbprCM, gcMc}},   //         KHOJKI SIGN VIRAMA
+	{runeRange{0x1123B, 0x1123C}, propertyGeneralCategory{lbprBA, gcPo}},   //     [2] KHOJKI SECTION MARK..KHOJKI DOUBLE SECTION MARK
+	{runeRange{0x11241, 0x11241}, propertyGeneralCategory{lbprCM, gcMn}},   //         KHOJKI VOWEL SIGN VOCALIC R
+	{runeRange{0x1128F, 0x1129D}, propertyGeneralCategory{lbprAL, gcLo}},   //    [15] MULTANI LETTER NYA..MULTANI LETTER BA
+	{runeRange{0x112DF, 0x112DF}, propertyGeneralCategory{lbprCM, gcMn}},   //         KHUDAWADI SIGN ANUSVARA
+	{runeRange{0x11300, 0x11301}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] GRANTHA SIGN COMBINING ANUSVARA ABOVE..GRANTHA SIGN CANDRABINDU
+	{runeRange{0x11313, 0x11328}, propertyGeneralCategory{lbprAL, gcLo}},   //    [22] GRANTHA LETTER OO..GRANTHA LETTER NA
+	{runeRange{0x1133B, 0x1133C}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] COMBINING BINDU BELOW..GRANTHA SIGN NUKTA
+	{runeRange{0x11341, 0x11344}, propertyGeneralCategory{lbprCM, gcMc}},   //     [4] GRANTHA VOWEL SIGN U..GRANTHA VOWEL SIGN VOCALIC RR
+	{runeRange{0x11357, 0x11357}, propertyGeneralCategory{lbprCM, gcMc}},   //         GRANTHA AU LENGTH MARK
+	{runeRange{0x11370, 0x11374}, propertyGeneralCategory{lbprCM, gcMn}},   //     [5] COMBINING GRANTHA LETTER A..COMBINING GRANTHA LETTER PA
+	{runeRange{0x11440, 0x11441}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] NEWA VOWEL SIGN O..NEWA VOWEL SIGN AU
+	{runeRange{0x11447, 0x1144A}, propertyGeneralCategory{lbprAL, gcLo}},   //     [4] NEWA SIGN AVAGRAHA..NEWA SIDDHI
+	{runeRange{0x1145A, 0x1145B}, propertyGeneralCategory{lbprBA, gcPo}},   //     [2] NEWA DOUBLE COMMA..NEWA PLACEHOLDER MARK
+	{runeRange{0x11480, 0x114AF}, propertyGeneralCategory{lbprAL, gcLo}},   //    [48] TIRHUTA ANJI..TIRHUTA LETTER HA
+	{runeRange{0x114BA, 0x114BA}, propertyGeneralCategory{lbprCM, gcMn}},   //         TIRHUTA VOWEL SIGN SHORT E
+	{runeRange{0x114C2, 0x114C3}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] TIRHUTA SIGN VIRAMA..TIRHUTA SIGN NUKTA
+	{runeRange{0x114D0, 0x114D9}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] TIRHUTA DIGIT ZERO..TIRHUTA DIGIT NINE
+	{runeRange{0x115B8, 0x115BB}, propertyGeneralCategory{lbprCM, gcMc}},   //     [4] SIDDHAM VOWEL SIGN E..SIDDHAM VOWEL SIGN AU
+	{runeRange{0x115C1, 0x115C1}, propertyGeneralCategory{lbprBB, gcPo}},   //         SIDDHAM SIGN SIDDHAM
+	{runeRange{0x115C9, 0x115D7}, propertyGeneralCategory{lbprBA, gcPo}},   //    [15] SIDDHAM END OF TEXT MARK..SIDDHAM SECTION MARK WITH CIRCLES AND FOUR ENCLOSURES
+	{runeRange{0x11630, 0x11632}, propertyGeneralCategory{lbprCM, gcMc}},   //     [3] MODI VOWEL SIGN AA..MODI VOWEL SIGN II
+	{runeRange{0x1163E, 0x1163E}, propertyGeneralCategory{lbprCM, gcMc}},   //         MODI SIGN VISARGA
+	{runeRange{0x11644, 0x11644}, propertyGeneralCategory{lbprAL, gcLo}},   //         MODI SIGN HUVA
+	{runeRange{0x116AB, 0x116AB}, propertyGeneralCategory{lbprCM, gcMn}},   //         TAKRI SIGN ANUSVARA
+	{runeRange{0x116B0, 0x116B5}, propertyGeneralCategory{lbprCM, gcMn}},   //     [6] TAKRI VOWEL SIGN U..TAKRI VOWEL SIGN AU
+	{runeRange{0x116B9, 0x116B9}, propertyGeneralCategory{lbprAL, gcPo}},   //         TAKRI ABBREVIATION SIGN
+	{runeRange{0x11720, 0x11721}, propertyGeneralCategory{lbprSA, gcMc}},   //     [2] AHOM VOWEL SIGN A..AHOM VOWEL SIGN AA
+	{runeRange{0x11730, 0x11739}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] AHOM DIGIT ZERO..AHOM DIGIT NINE
+	{runeRange{0x11740, 0x11746}, propertyGeneralCategory{lbprSA, gcLo}},   //     [7] AHOM LETTER CA..AHOM LETTER LLA
+	{runeRange{0x11838, 0x11838}, propertyGeneralCategory{lbprCM, gcMc}},   //         DOGRA SIGN VISARGA
+	{runeRange{0x118E0, 0x118E9}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] WARANG CITI DIGIT ZERO..WARANG CITI DIGIT NINE
+	{runeRange{0x11909, 0x11909}, propertyGeneralCategory{lbprAL, gcLo}},   //         DIVES AKURU LETTER O
+	{runeRange{0x11930, 0x11935}, propertyGeneralCategory{lbprCM, gcMc}},   //     [6] DIVES AKURU VOWEL SIGN AA..DIVES AKURU VOWEL SIGN E
+	{runeRange{0x1193E, 0x1193E}, propertyGeneralCategory{lbprCM, gcMn}},   //         DIVES AKURU VIRAMA
+	{runeRange{0x11942, 0x11942}, propertyGeneralCategory{lbprCM, gcMc}},   //         DIVES AKURU MEDIAL RA
+	{runeRange{0x119A0, 0x119A7}, propertyGeneralCategory{lbprAL, gcLo}},   //     [8] NANDINAGARI LETTER A..NANDINAGARI LETTER VOCALIC RR
+	{runeRange{0x119DA, 0x119DB}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] NANDINAGARI VOWEL SIGN E..NANDINAGARI VOWEL SIGN AI
+	{runeRange{0x119E2, 0x119E2}, propertyGeneralCategory{lbprBB, gcPo}},   //         NANDINAGARI SIGN SIDDHAM
+	{runeRange{0x11A01, 0x11A0A}, propertyGeneralCategory{lbprCM, gcMn}},   //    [10] ZANABAZAR SQUARE VOWEL SIGN I..ZANABAZAR SQUARE VOWEL LENGTH MARK
+	{runeRange{0x11A39, 0x11A39}, propertyGeneralCategory{lbprCM, gcMc}},   //         ZANABAZAR SQUARE SIGN VISARGA
+	{runeRange{0x11A3B, 0x11A3E}, propertyGeneralCategory{lbprCM, gcMn}},   //     [4] ZANABAZAR SQUARE CLUSTER-FINAL LETTER YA..ZANABAZAR SQUARE CLUSTER-FINAL LETTER VA
+	{runeRange{0x11A40, 0x11A40}, propertyGeneralCategory{lbprAL, gcPo}},   //         ZANABAZAR SQUARE CLOSING HEAD MARK
+	{runeRange{0x11A45, 0x11A45}, propertyGeneralCategory{lbprBB, gcPo}},   //         ZANABAZAR SQUARE INITIAL DOUBLE-LINED HEAD MARK
+	{runeRange{0x11A47, 0x11A47}, propertyGeneralCategory{lbprCM, gcMn}},   //         ZANABAZAR SQUARE SUBJOINER
+	{runeRange{0x11A51, 0x11A56}, propertyGeneralCategory{lbprCM, gcMn}},   //     [6] SOYOMBO VOWEL SIGN I..SOYOMBO VOWEL SIGN OE
+	{runeRange{0x11A59, 0x11A5B}, propertyGeneralCategory{lbprCM, gcMn}},   //     [3] SOYOMBO VOWEL SIGN VOCALIC R..SOYOMBO VOWEL LENGTH MARK
+	{runeRange{0x11A8A, 0x11A96}, propertyGeneralCategory{lbprCM, gcMn}},   //    [13] SOYOMBO FINAL CONSONANT SIGN G..SOYOMBO SIGN ANUSVARA
+	{runeRange{0x11A98, 0x11A99}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] SOYOMBO GEMINATION MARK..SOYOMBO SUBJOINER
+	{runeRange{0x11A9D, 0x11A9D}, propertyGeneralCategory{lbprAL, gcLo}},   //         SOYOMBO MARK PLUTA
+	{runeRange{0x11AA1, 0x11AA2}, propertyGeneralCategory{lbprBA, gcPo}},   //     [2] SOYOMBO TERMINAL MARK-1..SOYOMBO TERMINAL MARK-2
+	{runeRange{0x11AC0, 0x11AF8}, propertyGeneralCategory{lbprAL, gcLo}},   //    [57] PAU CIN HAU LETTER PA..PAU CIN HAU GLOTTAL STOP FINAL
+	{runeRange{0x11C00, 0x11C08}, propertyGeneralCategory{lbprAL, gcLo}},   //     [9] BHAIKSUKI LETTER A..BHAIKSUKI LETTER VOCALIC L
+	{runeRange{0x11C2F, 0x11C2F}, propertyGeneralCategory{lbprCM, gcMc}},   //         BHAIKSUKI VOWEL SIGN AA
+	{runeRange{0x11C38, 0x11C3D}, propertyGeneralCategory{lbprCM, gcMn}},   //     [6] BHAIKSUKI VOWEL SIGN E..BHAIKSUKI SIGN ANUSVARA
+	{runeRange{0x11C3F, 0x11C3F}, propertyGeneralCategory{lbprCM, gcMn}},   //         BHAIKSUKI SIGN VIRAMA
+	{runeRange{0x11C41, 0x11C45}, propertyGeneralCategory{lbprBA, gcPo}},   //     [5] BHAIKSUKI DANDA..BHAIKSUKI GAP FILLER-2
+	{runeRange{0x11C5A, 0x11C6C}, propertyGeneralCategory{lbprAL, gcNo}},   //    [19] BHAIKSUKI NUMBER ONE..BHAIKSUKI HUNDREDS UNIT MARK
+	{runeRange{0x11C71, 0x11C71}, propertyGeneralCategory{lbprEX, gcPo}},   //         MARCHEN MARK SHAD
+	{runeRange{0x11C92, 0x11CA7}, propertyGeneralCategory{lbprCM, gcMn}},   //    [22] MARCHEN SUBJOINED LETTER KA..MARCHEN SUBJOINED LETTER ZA
+	{runeRange{0x11CAA, 0x11CB0}, propertyGeneralCategory{lbprCM, gcMn}},   //     [7] MARCHEN SUBJOINED LETTER RA..MARCHEN VOWEL SIGN AA
+	{runeRange{0x11CB2, 0x11CB3}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] MARCHEN VOWEL SIGN U..MARCHEN VOWEL SIGN E
+	{runeRange{0x11CB5, 0x11CB6}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] MARCHEN SIGN ANUSVARA..MARCHEN SIGN CANDRABINDU
+	{runeRange{0x11D08, 0x11D09}, propertyGeneralCategory{lbprAL, gcLo}},   //     [2] MASARAM GONDI LETTER AI..MASARAM GONDI LETTER O
+	{runeRange{0x11D31, 0x11D36}, propertyGeneralCategory{lbprCM, gcMn}},   //     [6] MASARAM GONDI VOWEL SIGN AA..MASARAM GONDI VOWEL SIGN VOCALIC R
+	{runeRange{0x11D3C, 0x11D3D}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] MASARAM GONDI VOWEL SIGN AI..MASARAM GONDI VOWEL SIGN O
+	{runeRange{0x11D46, 0x11D46}, propertyGeneralCategory{lbprAL, gcLo}},   //         MASARAM GONDI REPHA
+	{runeRange{0x11D50, 0x11D59}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] MASARAM GONDI DIGIT ZERO..MASARAM GONDI DIGIT NINE
+	{runeRange{0x11D67, 0x11D68}, propertyGeneralCategory{lbprAL, gcLo}},   //     [2] GUNJALA GONDI LETTER EE..GUNJALA GONDI LETTER AI
+	{runeRange{0x11D8A, 0x11D8E}, propertyGeneralCategory{lbprCM, gcMc}},   //     [5] GUNJALA GONDI VOWEL SIGN AA..GUNJALA GONDI VOWEL SIGN UU
+	{runeRange{0x11D93, 0x11D94}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] GUNJALA GONDI VOWEL SIGN OO..GUNJALA GONDI VOWEL SIGN AU
+	{runeRange{0x11D96, 0x11D96}, propertyGeneralCategory{lbprCM, gcMc}},   //         GUNJALA GONDI SIGN VISARGA
+	{runeRange{0x11D98, 0x11D98}, propertyGeneralCategory{lbprAL, gcLo}},   //         GUNJALA GONDI OM
+	{runeRange{0x11EE0, 0x11EF2}, propertyGeneralCategory{lbprAL, gcLo}},   //    [19] MAKASAR LETTER KA..MAKASAR ANGKA
+	{runeRange{0x11EF5, 0x11EF6}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] MAKASAR VOWEL SIGN E..MAKASAR VOWEL SIGN O
+	{runeRange{0x11F00, 0x11F01}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] KAWI SIGN CANDRABINDU..KAWI SIGN ANUSVARA
+	{runeRange{0x11F03, 0x11F03}, propertyGeneralCategory{lbprCM, gcMc}},   //         KAWI SIGN VISARGA
+	{runeRange{0x11F12, 0x11F33}, propertyGeneralCategory{lbprAL, gcLo}},   //    [34] KAWI LETTER KA..KAWI LETTER JNYA
+	{runeRange{0x11F36, 0x11F3A}, propertyGeneralCategory{lbprCM, gcMn}},   //     [5] KAWI VOWEL SIGN I..KAWI VOWEL SIGN VOCALIC R
+	{runeRange{0x11F40, 0x11F40}, propertyGeneralCategory{lbprCM, gcMn}},   //         KAWI VOWEL SIGN EU
+	{runeRange{0x11F42, 0x11F42}, propertyGeneralCategory{lbprCM, gcMn}},   //         KAWI CONJOINER
+	{runeRange{0x11F45, 0x11F4F}, propertyGeneralCategory{lbprID, gcPo}},   //    [11] KAWI PUNCTUATION SECTION MARKER..KAWI PUNCTUATION CLOSING SPIRAL
+	{runeRange{0x11FB0, 0x11FB0}, propertyGeneralCategory{lbprAL, gcLo}},   //         LISU LETTER YHA
+	{runeRange{0x11FD5, 0x11FDC}, propertyGeneralCategory{lbprAL, gcSo}},   //     [8] TAMIL SIGN NEL..TAMIL SIGN MUKKURUNI
+	{runeRange{0x11FE1, 0x11FF1}, propertyGeneralCategory{lbprAL, gcSo}},   //    [17] TAMIL SIGN PAARAM..TAMIL SIGN VAKAIYARAA
+	{runeRange{0x12000, 0x12399}, propertyGeneralCategory{lbprAL, gcLo}},   //   [922] CUNEIFORM SIGN A..CUNEIFORM SIGN U U
+	{runeRange{0x12470, 0x12474}, propertyGeneralCategory{lbprBA, gcPo}},   //     [5] CUNEIFORM PUNCTUATION SIGN OLD ASSYRIAN WORD DIVIDER..CUNEIFORM PUNCTUATION SIGN DIAGONAL QUADCOLON
+	{runeRange{0x12F90, 0x12FF0}, propertyGeneralCategory{lbprAL, gcLo}},   //    [97] CYPRO-MINOAN SIGN CM001..CYPRO-MINOAN SIGN CM114
+	{runeRange{0x13000, 0x13257}, propertyGeneralCategory{lbprAL, gcLo}},   //   [600] EGYPTIAN HIEROGLYPH A001..EGYPTIAN HIEROGLYPH O006
+	{runeRange{0x1325B, 0x1325D}, propertyGeneralCategory{lbprCL, gcLo}},   //     [3] EGYPTIAN HIEROGLYPH O006D..EGYPTIAN HIEROGLYPH O006F
+	{runeRange{0x13282, 0x13282}, propertyGeneralCategory{lbprCL, gcLo}},   //         EGYPTIAN HIEROGLYPH O033A
+	{runeRange{0x13286, 0x13286}, propertyGeneralCategory{lbprOP, gcLo}},   //         EGYPTIAN HIEROGLYPH O036A
+	{runeRange{0x13288, 0x13288}, propertyGeneralCategory{lbprOP, gcLo}},   //         EGYPTIAN HIEROGLYPH O036C
+	{runeRange{0x1328A, 0x13378}, propertyGeneralCategory{lbprAL, gcLo}},   //   [239] EGYPTIAN HIEROGLYPH O037..EGYPTIAN HIEROGLYPH V011
+	{runeRange{0x1337A, 0x1337B}, propertyGeneralCategory{lbprCL, gcLo}},   //     [2] EGYPTIAN HIEROGLYPH V011B..EGYPTIAN HIEROGLYPH V011C
+	{runeRange{0x13430, 0x13436}, propertyGeneralCategory{lbprGL, gcCf}},   //     [7] EGYPTIAN HIEROGLYPH VERTICAL JOINER..EGYPTIAN HIEROGLYPH OVERLAY MIDDLE
+	{runeRange{0x13438, 0x13438}, propertyGeneralCategory{lbprCL, gcCf}},   //         EGYPTIAN HIEROGLYPH END SEGMENT
+	{runeRange{0x1343C, 0x1343C}, propertyGeneralCategory{lbprOP, gcCf}},   //         EGYPTIAN HIEROGLYPH BEGIN ENCLOSURE
+	{runeRange{0x1343E, 0x1343E}, propertyGeneralCategory{lbprOP, gcCf}},   //         EGYPTIAN HIEROGLYPH BEGIN WALLED ENCLOSURE
+	{runeRange{0x13440, 0x13440}, propertyGeneralCategory{lbprCM, gcMn}},   //         EGYPTIAN HIEROGLYPH MIRROR HORIZONTALLY
+	{runeRange{0x13447, 0x13455}, propertyGeneralCategory{lbprCM, gcMn}},   //    [15] EGYPTIAN HIEROGLYPH MODIFIER DAMAGED AT TOP START..EGYPTIAN HIEROGLYPH MODIFIER DAMAGED
+	{runeRange{0x145CE, 0x145CE}, propertyGeneralCategory{lbprOP, gcLo}},   //         ANATOLIAN HIEROGLYPH A410 BEGIN LOGOGRAM MARK
+	{runeRange{0x145D0, 0x14646}, propertyGeneralCategory{lbprAL, gcLo}},   //   [119] ANATOLIAN HIEROGLYPH A411..ANATOLIAN HIEROGLYPH A530
+	{runeRange{0x16A40, 0x16A5E}, propertyGeneralCategory{lbprAL, gcLo}},   //    [31] MRO LETTER TA..MRO LETTER TEK
+	{runeRange{0x16A6E, 0x16A6F}, propertyGeneralCategory{lbprBA, gcPo}},   //     [2] MRO DANDA..MRO DOUBLE DANDA
+	{runeRange{0x16AC0, 0x16AC9}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] TANGSA DIGIT ZERO..TANGSA DIGIT NINE
+	{runeRange{0x16AF0, 0x16AF4}, propertyGeneralCategory{lbprCM, gcMn}},   //     [5] BASSA VAH COMBINING HIGH TONE..BASSA VAH COMBINING HIGH-LOW TONE
+	{runeRange{0x16B00, 0x16B2F}, propertyGeneralCategory{lbprAL, gcLo}},   //    [48] PAHAWH HMONG VOWEL KEEB..PAHAWH HMONG CONSONANT CAU
+	{runeRange{0x16B37, 0x16B39}, propertyGeneralCategory{lbprBA, gcPo}},   //     [3] PAHAWH HMONG SIGN VOS THOM..PAHAWH HMONG SIGN CIM CHEEM
+	{runeRange{0x16B3C, 0x16B3F}, propertyGeneralCategory{lbprAL, gcSo}},   //     [4] PAHAWH HMONG SIGN XYEEM NTXIV..PAHAWH HMONG SIGN XYEEM FAIB
+	{runeRange{0x16B44, 0x16B44}, propertyGeneralCategory{lbprBA, gcPo}},   //         PAHAWH HMONG SIGN XAUS
+	{runeRange{0x16B50, 0x16B59}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] PAHAWH HMONG DIGIT ZERO..PAHAWH HMONG DIGIT NINE
+	{runeRange{0x16B63, 0x16B77}, propertyGeneralCategory{lbprAL, gcLo}},   //    [21] PAHAWH HMONG SIGN VOS LUB..PAHAWH HMONG SIGN CIM NRES TOS
+	{runeRange{0x16E40, 0x16E7F}, propertyGeneralCategory{lbprAL, gcLC}},   //    [64] MEDEFAIDRIN CAPITAL LETTER M..MEDEFAIDRIN SMALL LETTER Y
+	{runeRange{0x16E97, 0x16E98}, propertyGeneralCategory{lbprBA, gcPo}},   //     [2] MEDEFAIDRIN COMMA..MEDEFAIDRIN FULL STOP
+	{runeRange{0x16F00, 0x16F4A}, propertyGeneralCategory{lbprAL, gcLo}},   //    [75] MIAO LETTER PA..MIAO LETTER RTE
+	{runeRange{0x16F50, 0x16F50}, propertyGeneralCategory{lbprAL, gcLo}},   //         MIAO LETTER NASALIZATION
+	{runeRange{0x16F8F, 0x16F92}, propertyGeneralCategory{lbprCM, gcMn}},   //     [4] MIAO TONE RIGHT..MIAO TONE BELOW
+	{runeRange{0x16FE0, 0x16FE1}, propertyGeneralCategory{lbprNS, gcLm}},   //     [2] TANGUT ITERATION MARK..NUSHU ITERATION MARK
+	{runeRange{0x16FE3, 0x16FE3}, propertyGeneralCategory{lbprNS, gcLm}},   //         OLD CHINESE ITERATION MARK
+	{runeRange{0x16FF0, 0x16FF1}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] VIETNAMESE ALTERNATE READING MARK CA..VIETNAMESE ALTERNATE READING MARK NHAY
+	{runeRange{0x18800, 0x18AFF}, propertyGeneralCategory{lbprID, gcLo}},   //   [768] TANGUT COMPONENT-001..TANGUT COMPONENT-768
+	{runeRange{0x18D00, 0x18D08}, propertyGeneralCategory{lbprID, gcLo}},   //     [9] TANGUT IDEOGRAPH-18D00..TANGUT IDEOGRAPH-18D08
+	{runeRange{0x1AFF5, 0x1AFFB}, propertyGeneralCategory{lbprAL, gcLm}},   //     [7] KATAKANA LETTER MINNAN TONE-7..KATAKANA LETTER MINNAN NASALIZED TONE-5
+	{runeRange{0x1B000, 0x1B0FF}, propertyGeneralCategory{lbprID, gcLo}},   //   [256] KATAKANA LETTER ARCHAIC E..HENTAIGANA LETTER RE-2
+	{runeRange{0x1B132, 0x1B132}, propertyGeneralCategory{lbprCJ, gcLo}},   //         HIRAGANA LETTER SMALL KO
+	{runeRange{0x1B155, 0x1B155}, propertyGeneralCategory{lbprCJ, gcLo}},   //         KATAKANA LETTER SMALL KO
+	{runeRange{0x1B170, 0x1B2FB}, propertyGeneralCategory{lbprID, gcLo}},   //   [396] NUSHU CHARACTER-1B170..NUSHU CHARACTER-1B2FB
+	{runeRange{0x1BC70, 0x1BC7C}, propertyGeneralCategory{lbprAL, gcLo}},   //    [13] DUPLOYAN AFFIX LEFT HORIZONTAL SECANT..DUPLOYAN AFFIX ATTACHED TANGENT HOOK
+	{runeRange{0x1BC90, 0x1BC99}, propertyGeneralCategory{lbprAL, gcLo}},   //    [10] DUPLOYAN AFFIX LOW ACUTE..DUPLOYAN AFFIX LOW ARROW
+	{runeRange{0x1BC9D, 0x1BC9E}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] DUPLOYAN THICK LETTER SELECTOR..DUPLOYAN DOUBLE MARK
+	{runeRange{0x1BCA0, 0x1BCA3}, propertyGeneralCategory{lbprCM, gcCf}},   //     [4] SHORTHAND FORMAT LETTER OVERLAP..SHORTHAND FORMAT UP STEP
+	{runeRange{0x1CF30, 0x1CF46}, propertyGeneralCategory{lbprCM, gcMn}},   //    [23] ZNAMENNY COMBINING TONAL RANGE MARK MRACHNO..ZNAMENNY PRIZNAK MODIFIER ROG
+	{runeRange{0x1D000, 0x1D0F5}, propertyGeneralCategory{lbprAL, gcSo}},   //   [246] BYZANTINE MUSICAL SYMBOL PSILI..BYZANTINE MUSICAL SYMBOL GORGON NEO KATO
+	{runeRange{0x1D129, 0x1D164}, propertyGeneralCategory{lbprAL, gcSo}},   //    [60] MUSICAL SYMBOL MULTIPLE MEASURE REST..MUSICAL SYMBOL ONE HUNDRED TWENTY-EIGHTH NOTE
+	{runeRange{0x1D167, 0x1D169}, propertyGeneralCategory{lbprCM, gcMn}},   //     [3] MUSICAL SYMBOL COMBINING TREMOLO-1..MUSICAL SYMBOL COMBINING TREMOLO-3
+	{runeRange{0x1D16D, 0x1D172}, propertyGeneralCategory{lbprCM, gcMc}},   //     [6] MUSICAL SYMBOL COMBINING AUGMENTATION DOT..MUSICAL SYMBOL COMBINING FLAG-5
+	{runeRange{0x1D17B, 0x1D182}, propertyGeneralCategory{lbprCM, gcMn}},   //     [8] MUSICAL SYMBOL COMBINING ACCENT..MUSICAL SYMBOL COMBINING LOURE
+	{runeRange{0x1D185, 0x1D18B}, propertyGeneralCategory{lbprCM, gcMn}},   //     [7] MUSICAL SYMBOL COMBINING DOIT..MUSICAL SYMBOL COMBINING TRIPLE TONGUE
+	{runeRange{0x1D1AA, 0x1D1AD}, propertyGeneralCategory{lbprCM, gcMn}},   //     [4] MUSICAL SYMBOL COMBINING DOWN BOW..MUSICAL SYMBOL COMBINING SNAP PIZZICATO
+	{runeRange{0x1D200, 0x1D241}, propertyGeneralCategory{lbprAL, gcSo}},   //    [66] GREEK VOCAL NOTATION SYMBOL-1..GREEK INSTRUMENTAL NOTATION SYMBOL-54
+	{runeRange{0x1D245, 0x1D245}, propertyGeneralCategory{lbprAL, gcSo}},   //         GREEK MUSICAL LEIMMA
+	{runeRange{0x1D2E0, 0x1D2F3}, propertyGeneralCategory{lbprAL, gcNo}},   //    [20] MAYAN NUMERAL ZERO..MAYAN NUMERAL NINETEEN
+	{runeRange{0x1D360, 0x1D378}, propertyGeneralCategory{lbprAL, gcNo}},   //    [25] COUNTING ROD UNIT DIGIT ONE..TALLY MARK FIVE
+	{runeRange{0x1D456, 0x1D49C}, propertyGeneralCategory{lbprAL, gcLC}},   //    [71] MATHEMATICAL ITALIC SMALL I..MATHEMATICAL SCRIPT CAPITAL A
+	{runeRange{0x1D4A2, 0x1D4A2}, propertyGeneralCategory{lbprAL, gcLu}},   //         MATHEMATICAL SCRIPT CAPITAL G
+	{runeRange{0x1D4A9, 0x1D4AC}, propertyGeneralCategory{lbprAL, gcLu}},   //     [4] MATHEMATICAL SCRIPT CAPITAL N..MATHEMATICAL SCRIPT CAPITAL Q
+	{runeRange{0x1D4BB, 0x1D4BB}, propertyGeneralCategory{lbprAL, gcLl}},   //         MATHEMATICAL SCRIPT SMALL F
+	{runeRange{0x1D4C5, 0x1D505}, propertyGeneralCategory{lbprAL, gcLC}},   //    [65] MATHEMATICAL SCRIPT SMALL P..MATHEMATICAL FRAKTUR CAPITAL B
+	{runeRange{0x1D50D, 0x1D514}, propertyGeneralCategory{lbprAL, gcLu}},   //     [8] MATHEMATICAL FRAKTUR CAPITAL J..MATHEMATICAL FRAKTUR CAPITAL Q
+	{runeRange{0x1D51E, 0x1D539}, propertyGeneralCategory{lbprAL, gcLC}},   //    [28] MATHEMATICAL FRAKTUR SMALL A..MATHEMATICAL DOUBLE-STRUCK CAPITAL B
+	{runeRange{0x1D540, 0x1D544}, propertyGeneralCategory{lbprAL, gcLu}},   //     [5] MATHEMATICAL DOUBLE-STRUCK CAPITAL I..MATHEMATICAL DOUBLE-STRUCK CAPITAL M
+	{runeRange{0x1D54A, 0x1D550}, propertyGeneralCategory{lbprAL, gcLu}},   //     [7] MATHEMATICAL DOUBLE-STRUCK CAPITAL S..MATHEMATICAL DOUBLE-STRUCK CAPITAL Y
+	{runeRange{0x1D6A8, 0x1D6C0}, propertyGeneralCategory{lbprAL, gcLu}},   //    [25] MATHEMATICAL BOLD CAPITAL ALPHA..MATHEMATICAL BOLD CAPITAL OMEGA
+	{runeRange{0x1D6C2, 0x1D6DA}, propertyGeneralCategory{lbprAL, gcLl}},   //    [25] MATHEMATICAL BOLD SMALL ALPHA..MATHEMATICAL BOLD SMALL OMEGA
+	{runeRange{0x1D6DC, 0x1D6FA}, propertyGeneralCategory{lbprAL, gcLC}},   //    [31] MATHEMATICAL BOLD EPSILON SYMBOL..MATHEMATICAL ITALIC CAPITAL OMEGA
+	{runeRange{0x1D6FC, 0x1D714}, propertyGeneralCategory{lbprAL, gcLl}},   //    [25] MATHEMATICAL ITALIC SMALL ALPHA..MATHEMATICAL ITALIC SMALL OMEGA
+	{runeRange{0x1D716, 0x1D734}, propertyGeneralCategory{lbprAL, gcLC}},   //    [31] MATHEMATICAL ITALIC EPSILON SYMBOL..MATHEMATICAL BOLD ITALIC CAPITAL OMEGA
+	{runeRange{0x1D736, 0x1D74E}, propertyGeneralCategory{lbprAL, gcLl}},   //    [25] MATHEMATICAL BOLD ITALIC SMALL ALPHA..MATHEMATICAL BOLD ITALIC SMALL OMEGA
+	{runeRange{0x1D750, 0x1D76E}, propertyGeneralCategory{lbprAL, gcLC}},   //    [31] MATHEMATICAL BOLD ITALIC EPSILON SYMBOL..MATHEMATICAL SANS-SERIF BOLD CAPITAL OMEGA
+	{runeRange{0x1D770, 0x1D788}, propertyGeneralCategory{lbprAL, gcLl}},   //    [25] MATHEMATICAL SANS-SERIF BOLD SMALL ALPHA..MATHEMATICAL SANS-SERIF BOLD SMALL OMEGA
+	{runeRange{0x1D78A, 0x1D7A8}, propertyGeneralCategory{lbprAL, gcLC}},   //    [31] MATHEMATICAL SANS-SERIF BOLD EPSILON SYMBOL..MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL OMEGA
+	{runeRange{0x1D7AA, 0x1D7C2}, propertyGeneralCategory{lbprAL, gcLl}},   //    [25] MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL ALPHA..MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL OMEGA
+	{runeRange{0x1D7C4, 0x1D7CB}, propertyGeneralCategory{lbprAL, gcLC}},   //     [8] MATHEMATICAL SANS-SERIF BOLD ITALIC EPSILON SYMBOL..MATHEMATICAL BOLD SMALL DIGAMMA
+	{runeRange{0x1D800, 0x1D9FF}, propertyGeneralCategory{lbprAL, gcSo}},   //   [512] SIGNWRITING HAND-FIST INDEX..SIGNWRITING HEAD
+	{runeRange{0x1DA37, 0x1DA3A}, propertyGeneralCategory{lbprAL, gcSo}},   //     [4] SIGNWRITING AIR BLOW SMALL ROTATIONS..SIGNWRITING BREATH EXHALE
+	{runeRange{0x1DA6D, 0x1DA74}, propertyGeneralCategory{lbprAL, gcSo}},   //     [8] SIGNWRITING SHOULDER HIP SPINE..SIGNWRITING TORSO-FLOORPLANE TWISTING
+	{runeRange{0x1DA76, 0x1DA83}, propertyGeneralCategory{lbprAL, gcSo}},   //    [14] SIGNWRITING LIMB COMBINATION..SIGNWRITING LOCATION DEPTH
+	{runeRange{0x1DA85, 0x1DA86}, propertyGeneralCategory{lbprAL, gcSo}},   //     [2] SIGNWRITING LOCATION TORSO..SIGNWRITING LOCATION LIMBS DIGITS
+	{runeRange{0x1DA8B, 0x1DA8B}, propertyGeneralCategory{lbprAL, gcPo}},   //         SIGNWRITING PARENTHESIS
+	{runeRange{0x1DAA1, 0x1DAAF}, propertyGeneralCategory{lbprCM, gcMn}},   //    [15] SIGNWRITING ROTATION MODIFIER-2..SIGNWRITING ROTATION MODIFIER-16
+	{runeRange{0x1DF0A, 0x1DF0A}, propertyGeneralCategory{lbprAL, gcLo}},   //         LATIN LETTER RETROFLEX CLICK WITH RETROFLEX HOOK
+	{runeRange{0x1DF25, 0x1DF2A}, propertyGeneralCategory{lbprAL, gcLl}},   //     [6] LATIN SMALL LETTER D WITH MID-HEIGHT LEFT HOOK..LATIN SMALL LETTER T WITH MID-HEIGHT LEFT HOOK
+	{runeRange{0x1E008, 0x1E018}, propertyGeneralCategory{lbprCM, gcMn}},   //    [17] COMBINING GLAGOLITIC LETTER ZEMLJA..COMBINING GLAGOLITIC LETTER HERU
+	{runeRange{0x1E023, 0x1E024}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] COMBINING GLAGOLITIC LETTER YU..COMBINING GLAGOLITIC LETTER SMALL YUS
+	{runeRange{0x1E030, 0x1E06D}, propertyGeneralCategory{lbprAL, gcLm}},   //    [62] MODIFIER LETTER CYRILLIC SMALL A..MODIFIER LETTER CYRILLIC SMALL STRAIGHT U WITH STROKE
+	{runeRange{0x1E100, 0x1E12C}, propertyGeneralCategory{lbprAL, gcLo}},   //    [45] NYIAKENG PUACHUE HMONG LETTER MA..NYIAKENG PUACHUE HMONG LETTER W
+	{runeRange{0x1E137, 0x1E13D}, propertyGeneralCategory{lbprAL, gcLm}},   //     [7] NYIAKENG PUACHUE HMONG SIGN FOR PERSON..NYIAKENG PUACHUE HMONG SYLLABLE LENGTHENER
+	{runeRange{0x1E14E, 0x1E14E}, propertyGeneralCategory{lbprAL, gcLo}},   //         NYIAKENG PUACHUE HMONG LOGOGRAM NYAJ
+	{runeRange{0x1E290, 0x1E2AD}, propertyGeneralCategory{lbprAL, gcLo}},   //    [30] TOTO LETTER PA..TOTO LETTER A
+	{runeRange{0x1E2C0, 0x1E2EB}, propertyGeneralCategory{lbprAL, gcLo}},   //    [44] WANCHO LETTER AA..WANCHO LETTER YIH
+	{runeRange{0x1E2F0, 0x1E2F9}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] WANCHO DIGIT ZERO..WANCHO DIGIT NINE
+	{runeRange{0x1E4D0, 0x1E4EA}, propertyGeneralCategory{lbprAL, gcLo}},   //    [27] NAG MUNDARI LETTER O..NAG MUNDARI LETTER ELL
+	{runeRange{0x1E4EC, 0x1E4EF}, propertyGeneralCategory{lbprCM, gcMn}},   //     [4] NAG MUNDARI SIGN MUHOR..NAG MUNDARI SIGN SUTUH
+	{runeRange{0x1E7E0, 0x1E7E6}, propertyGeneralCategory{lbprAL, gcLo}},   //     [7] ETHIOPIC SYLLABLE HHYA..ETHIOPIC SYLLABLE HHYO
+	{runeRange{0x1E7ED, 0x1E7EE}, propertyGeneralCategory{lbprAL, gcLo}},   //     [2] ETHIOPIC SYLLABLE GURAGE MWI..ETHIOPIC SYLLABLE GURAGE MWEE
+	{runeRange{0x1E800, 0x1E8C4}, propertyGeneralCategory{lbprAL, gcLo}},   //   [197] MENDE KIKAKUI SYLLABLE M001 KI..MENDE KIKAKUI SYLLABLE M060 NYON
+	{runeRange{0x1E8D0, 0x1E8D6}, propertyGeneralCategory{lbprCM, gcMn}},   //     [7] MENDE KIKAKUI COMBINING NUMBER TEENS..MENDE KIKAKUI COMBINING NUMBER MILLIONS
+	{runeRange{0x1E944, 0x1E94A}, propertyGeneralCategory{lbprCM, gcMn}},   //     [7] ADLAM ALIF LENGTHENER..ADLAM NUKTA
+	{runeRange{0x1E950, 0x1E959}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] ADLAM DIGIT ZERO..ADLAM DIGIT NINE
+	{runeRange{0x1EC71, 0x1ECAB}, propertyGeneralCategory{lbprAL, gcNo}},   //    [59] INDIC SIYAQ NUMBER ONE..INDIC SIYAQ NUMBER PREFIXED NINE
+	{runeRange{0x1ECAD, 0x1ECAF}, propertyGeneralCategory{lbprAL, gcNo}},   //     [3] INDIC SIYAQ FRACTION ONE QUARTER..INDIC SIYAQ FRACTION THREE QUARTERS
+	{runeRange{0x1ECB1, 0x1ECB4}, propertyGeneralCategory{lbprAL, gcNo}},   //     [4] INDIC SIYAQ NUMBER ALTERNATE ONE..INDIC SIYAQ ALTERNATE LAKH MARK
+	{runeRange{0x1ED2E, 0x1ED2E}, propertyGeneralCategory{lbprAL, gcSo}},   //         OTTOMAN SIYAQ MARRATAN
+	{runeRange{0x1EE00, 0x1EE03}, propertyGeneralCategory{lbprAL, gcLo}},   //     [4] ARABIC MATHEMATICAL ALEF..ARABIC MATHEMATICAL DAL
+	{runeRange{0x1EE21, 0x1EE22}, propertyGeneralCategory{lbprAL, gcLo}},   //     [2] ARABIC MATHEMATICAL INITIAL BEH..ARABIC MATHEMATICAL INITIAL JEEM
+	{runeRange{0x1EE27, 0x1EE27}, propertyGeneralCategory{lbprAL, gcLo}},   //         ARABIC MATHEMATICAL INITIAL HAH
+	{runeRange{0x1EE34, 0x1EE37}, propertyGeneralCategory{lbprAL, gcLo}},   //     [4] ARABIC MATHEMATICAL INITIAL SHEEN..ARABIC MATHEMATICAL INITIAL KHAH
+	{runeRange{0x1EE3B, 0x1EE3B}, propertyGeneralCategory{lbprAL, gcLo}},   //         ARABIC MATHEMATICAL INITIAL GHAIN
+	{runeRange{0x1EE47, 0x1EE47}, propertyGeneralCategory{lbprAL, gcLo}},   //         ARABIC MATHEMATICAL TAILED HAH
+	{runeRange{0x1EE4B, 0x1EE4B}, propertyGeneralCategory{lbprAL, gcLo}},   //         ARABIC MATHEMATICAL TAILED LAM
+	{runeRange{0x1EE51, 0x1EE52}, propertyGeneralCategory{lbprAL, gcLo}},   //     [2] ARABIC MATHEMATICAL TAILED SAD..ARABIC MATHEMATICAL TAILED QAF
+	{runeRange{0x1EE57, 0x1EE57}, propertyGeneralCategory{lbprAL, gcLo}},   //         ARABIC MATHEMATICAL TAILED KHAH
+	{runeRange{0x1EE5B, 0x1EE5B}, propertyGeneralCategory{lbprAL, gcLo}},   //         ARABIC MATHEMATICAL TAILED GHAIN
+	{runeRange{0x1EE5F, 0x1EE5F}, propertyGeneralCategory{lbprAL, gcLo}},   //         ARABIC MATHEMATICAL TAILED DOTLESS QAF
+	{runeRange{0x1EE64, 0x1EE64}, propertyGeneralCategory{lbprAL, gcLo}},   //         ARABIC MATHEMATICAL STRETCHED HEH
+	{runeRange{0x1EE6C, 0x1EE72}, propertyGeneralCategory{lbprAL, gcLo}},   //     [7] ARABIC MATHEMATICAL STRETCHED MEEM..ARABIC MATHEMATICAL STRETCHED QAF
+	{runeRange{0x1EE79, 0x1EE7C}, propertyGeneralCategory{lbprAL, gcLo}},   //     [4] ARABIC MATHEMATICAL STRETCHED DAD..ARABIC MATHEMATICAL STRETCHED DOTLESS BEH
+	{runeRange{0x1EE80, 0x1EE89}, propertyGeneralCategory{lbprAL, gcLo}},   //    [10] ARABIC MATHEMATICAL LOOPED ALEF..ARABIC MATHEMATICAL LOOPED YEH
+	{runeRange{0x1EEA1, 0x1EEA3}, propertyGeneralCategory{lbprAL, gcLo}},   //     [3] ARABIC MATHEMATICAL DOUBLE-STRUCK BEH..ARABIC MATHEMATICAL DOUBLE-STRUCK DAL
+	{runeRange{0x1EEAB, 0x1EEBB}, propertyGeneralCategory{lbprAL, gcLo}},   //    [17] ARABIC MATHEMATICAL DOUBLE-STRUCK LAM..ARABIC MATHEMATICAL DOUBLE-STRUCK GHAIN
+	{runeRange{0x1F000, 0x1F02B}, propertyGeneralCategory{lbprID, gcSo}},   //    [44] MAHJONG TILE EAST WIND..MAHJONG TILE BACK
+	{runeRange{0x1F030, 0x1F093}, propertyGeneralCategory{lbprID, gcSo}},   //   [100] DOMINO TILE HORIZONTAL BACK..DOMINO TILE VERTICAL-06-06
+	{runeRange{0x1F0A0, 0x1F0AE}, propertyGeneralCategory{lbprID, gcSo}},   //    [15] PLAYING CARD BACK..PLAYING CARD KING OF SPADES
+	{runeRange{0x1F0B1, 0x1F0BF}, propertyGeneralCategory{lbprID, gcSo}},   //    [15] PLAYING CARD ACE OF HEARTS..PLAYING CARD RED JOKER
+	{runeRange{0x1F0C1, 0x1F0CF}, propertyGeneralCategory{lbprID, gcSo}},   //    [15] PLAYING CARD ACE OF DIAMONDS..PLAYING CARD BLACK JOKER
+	{runeRange{0x1F0D1, 0x1F0F5}, propertyGeneralCategory{lbprID, gcSo}},   //    [37] PLAYING CARD ACE OF CLUBS..PLAYING CARD TRUMP-21
+	{runeRange{0x1F100, 0x1F10C}, propertyGeneralCategory{lbprAI, gcNo}},   //    [13] DIGIT ZERO FULL STOP..DINGBAT NEGATIVE CIRCLED SANS-SERIF DIGIT ZERO
+	{runeRange{0x1F110, 0x1F12D}, propertyGeneralCategory{lbprAI, gcSo}},   //    [30] PARENTHESIZED LATIN CAPITAL LETTER A..CIRCLED CD
+	{runeRange{0x1F130, 0x1F169}, propertyGeneralCategory{lbprAI, gcSo}},   //    [58] SQUARED LATIN CAPITAL LETTER A..NEGATIVE CIRCLED LATIN CAPITAL LETTER Z
+	{runeRange{0x1F16D, 0x1F16F}, propertyGeneralCategory{lbprID, gcSo}},   //     [3] CIRCLED CC..CIRCLED HUMAN FIGURE
+	{runeRange{0x1F1AD, 0x1F1AD}, propertyGeneralCategory{lbprID, gcSo}},   //         MASK WORK SYMBOL
+	{runeRange{0x1F1E6, 0x1F1FF}, propertyGeneralCategory{lbprRI, gcSo}},   //    [26] REGIONAL INDICATOR SYMBOL LETTER A..REGIONAL INDICATOR SYMBOL LETTER Z
+	{runeRange{0x1F203, 0x1F20F}, propertyGeneralCategory{lbprID, gcCn}},   //    [13] <reserved-1F203>..<reserved-1F20F>
+	{runeRange{0x1F23C, 0x1F23F}, propertyGeneralCategory{lbprID, gcCn}},   //     [4] <reserved-1F23C>..<reserved-1F23F>
+	{runeRange{0x1F249, 0x1F24F}, propertyGeneralCategory{lbprID, gcCn}},   //     [7] <reserved-1F249>..<reserved-1F24F>
+	{runeRange{0x1F252, 0x1F25F}, propertyGeneralCategory{lbprID, gcCn}},   //    [14] <reserved-1F252>..<reserved-1F25F>
+	{runeRange{0x1F266, 0x1F2FF}, propertyGeneralCategory{lbprID, gcCn}},   //   [154] <reserved-1F266>..<reserved-1F2FF>
+	{runeRange{0x1F385, 0x1F385}, propertyGeneralCategory{lbprEB, gcSo}},   //         FATHER CHRISTMAS
+	{runeRange{0x1F39C, 0x1F39D}, propertyGeneralCategory{lbprAL, gcSo}},   //     [2] BEAMED ASCENDING MUSICAL NOTES..BEAMED DESCENDING MUSICAL NOTES
+	{runeRange{0x1F3B5, 0x1F3B6}, propertyGeneralCategory{lbprAL, gcSo}},   //     [2] MUSICAL NOTE..MULTIPLE MUSICAL NOTES
+	{runeRange{0x1F3BC, 0x1F3BC}, propertyGeneralCategory{lbprAL, gcSo}},   //         MUSICAL SCORE
+	{runeRange{0x1F3C2, 0x1F3C4}, propertyGeneralCategory{lbprEB, gcSo}},   //     [3] SNOWBOARDER..SURFER
+	{runeRange{0x1F3C7, 0x1F3C7}, propertyGeneralCategory{lbprEB, gcSo}},   //         HORSE RACING
+	{runeRange{0x1F3CA, 0x1F3CC}, propertyGeneralCategory{lbprEB, gcSo}},   //     [3] SWIMMER..GOLFER
+	{runeRange{0x1F3FB, 0x1F3FF}, propertyGeneralCategory{lbprEM, gcSk}},   //     [5] EMOJI MODIFIER FITZPATRICK TYPE-1-2..EMOJI MODIFIER FITZPATRICK TYPE-6
+	{runeRange{0x1F442, 0x1F443}, propertyGeneralCategory{lbprEB, gcSo}},   //     [2] EAR..NOSE
+	{runeRange{0x1F446, 0x1F450}, propertyGeneralCategory{lbprEB, gcSo}},   //    [11] WHITE UP POINTING BACKHAND INDEX..OPEN HANDS SIGN
+	{runeRange{0x1F466, 0x1F478}, propertyGeneralCategory{lbprEB, gcSo}},   //    [19] BOY..PRINCESS
+	{runeRange{0x1F47C, 0x1F47C}, propertyGeneralCategory{lbprEB, gcSo}},   //         BABY ANGEL
+	{runeRange{0x1F481, 0x1F483}, propertyGeneralCategory{lbprEB, gcSo}},   //     [3] INFORMATION DESK PERSON..DANCER
+	{runeRange{0x1F485, 0x1F487}, propertyGeneralCategory{lbprEB, gcSo}},   //     [3] NAIL POLISH..HAIRCUT
+	{runeRange{0x1F48F, 0x1F48F}, propertyGeneralCategory{lbprEB, gcSo}},   //         KISS
+	{runeRange{0x1F491, 0x1F491}, propertyGeneralCategory{lbprEB, gcSo}},   //         COUPLE WITH HEART
+	{runeRange{0x1F4A0, 0x1F4A0}, propertyGeneralCategory{lbprAL, gcSo}},   //         DIAMOND SHAPE WITH A DOT INSIDE
+	{runeRange{0x1F4A2, 0x1F4A2}, propertyGeneralCategory{lbprAL, gcSo}},   //         ANGER SYMBOL
+	{runeRange{0x1F4A4, 0x1F4A4}, propertyGeneralCategory{lbprAL, gcSo}},   //         SLEEPING SYMBOL
+	{runeRange{0x1F4AA, 0x1F4AA}, propertyGeneralCategory{lbprEB, gcSo}},   //         FLEXED BICEPS
+	{runeRange{0x1F4AF, 0x1F4AF}, propertyGeneralCategory{lbprAL, gcSo}},   //         HUNDRED POINTS SYMBOL
+	{runeRange{0x1F4B1, 0x1F4B2}, propertyGeneralCategory{lbprAL, gcSo}},   //     [2] CURRENCY EXCHANGE..HEAVY DOLLAR SIGN
+	{runeRange{0x1F500, 0x1F506}, propertyGeneralCategory{lbprAL, gcSo}},   //     [7] TWISTED RIGHTWARDS ARROWS..HIGH BRIGHTNESS SYMBOL
+	{runeRange{0x1F517, 0x1F524}, propertyGeneralCategory{lbprAL, gcSo}},   //    [14] LINK SYMBOL..INPUT SYMBOL FOR LATIN LETTERS
+	{runeRange{0x1F532, 0x1F549}, propertyGeneralCategory{lbprAL, gcSo}},   //    [24] BLACK SQUARE BUTTON..OM SYMBOL
+	{runeRange{0x1F574, 0x1F575}, propertyGeneralCategory{lbprEB, gcSo}},   //     [2] MAN IN BUSINESS SUIT LEVITATING..SLEUTH OR SPY
+	{runeRange{0x1F57A, 0x1F57A}, propertyGeneralCategory{lbprEB, gcSo}},   //         MAN DANCING
+	{runeRange{0x1F590, 0x1F590}, propertyGeneralCategory{lbprEB, gcSo}},   //         RAISED HAND WITH FINGERS SPLAYED
+	{runeRange{0x1F595, 0x1F596}, propertyGeneralCategory{lbprEB, gcSo}},   //     [2] REVERSED HAND WITH MIDDLE FINGER EXTENDED..RAISED HAND WITH PART BETWEEN MIDDLE AND RING FINGERS
+	{runeRange{0x1F5D4, 0x1F5DB}, propertyGeneralCategory{lbprAL, gcSo}},   //     [8] DESKTOP WINDOW..DECREASE FONT SIZE SYMBOL
+	{runeRange{0x1F5F4, 0x1F5F9}, propertyGeneralCategory{lbprAL, gcSo}},   //     [6] BALLOT SCRIPT X..BALLOT BOX WITH BOLD CHECK
+	{runeRange{0x1F600, 0x1F644}, propertyGeneralCategory{lbprID, gcSo}},   //    [69] GRINNING FACE..FACE WITH ROLLING EYES
+	{runeRange{0x1F648, 0x1F64A}, propertyGeneralCategory{lbprID, gcSo}},   //     [3] SEE-NO-EVIL MONKEY..SPEAK-NO-EVIL MONKEY
+	{runeRange{0x1F650, 0x1F675}, propertyGeneralCategory{lbprAL, gcSo}},   //    [38] NORTH WEST POINTING LEAF..SWASH AMPERSAND ORNAMENT
+	{runeRange{0x1F679, 0x1F67B}, propertyGeneralCategory{lbprNS, gcSo}},   //     [3] HEAVY INTERROBANG ORNAMENT..HEAVY SANS-SERIF INTERROBANG ORNAMENT
+	{runeRange{0x1F680, 0x1F6A2}, propertyGeneralCategory{lbprID, gcSo}},   //    [35] ROCKET..SHIP
+	{runeRange{0x1F6A4, 0x1F6B3}, propertyGeneralCategory{lbprID, gcSo}},   //    [16] SPEEDBOAT..NO BICYCLES
+	{runeRange{0x1F6B7, 0x1F6BF}, propertyGeneralCategory{lbprID, gcSo}},   //     [9] NO PEDESTRIANS..SHOWER
+	{runeRange{0x1F6C1, 0x1F6CB}, propertyGeneralCategory{lbprID, gcSo}},   //    [11] BATHTUB..COUCH AND LAMP
+	{runeRange{0x1F6CD, 0x1F6D7}, propertyGeneralCategory{lbprID, gcSo}},   //    [11] SHOPPING BAGS..ELEVATOR
+	{runeRange{0x1F6DC, 0x1F6EC}, propertyGeneralCategory{lbprID, gcSo}},   //    [17] WIRELESS..AIRPLANE ARRIVING
+	{runeRange{0x1F6F0, 0x1F6FC}, propertyGeneralCategory{lbprID, gcSo}},   //    [13] SATELLITE..ROLLER SKATE
+	{runeRange{0x1F700, 0x1F773}, propertyGeneralCategory{lbprAL, gcSo}},   //   [116] ALCHEMICAL SYMBOL FOR QUINTESSENCE..ALCHEMICAL SYMBOL FOR HALF OUNCE
+	{runeRange{0x1F777, 0x1F77A}, propertyGeneralCategory{lbprID, gcCn}},   //     [4] <reserved-1F777>..<reserved-1F77A>
+	{runeRange{0x1F780, 0x1F7D4}, propertyGeneralCategory{lbprAL, gcSo}},   //    [85] BLACK LEFT-POINTING ISOSCELES RIGHT TRIANGLE..HEAVY TWELVE POINTED PINWHEEL STAR
+	{runeRange{0x1F7DA, 0x1F7DF}, propertyGeneralCategory{lbprID, gcCn}},   //     [6] <reserved-1F7DA>..<reserved-1F7DF>
+	{runeRange{0x1F7EC, 0x1F7EF}, propertyGeneralCategory{lbprID, gcCn}},   //     [4] <reserved-1F7EC>..<reserved-1F7EF>
+	{runeRange{0x1F7F1, 0x1F7FF}, propertyGeneralCategory{lbprID, gcCn}},   //    [15] <reserved-1F7F1>..<reserved-1F7FF>
+	{runeRange{0x1F80C, 0x1F80F}, propertyGeneralCategory{lbprID, gcCn}},   //     [4] <reserved-1F80C>..<reserved-1F80F>
+	{runeRange{0x1F848, 0x1F84F}, propertyGeneralCategory{lbprID, gcCn}},   //     [8] <reserved-1F848>..<reserved-1F84F>
+	{runeRange{0x1F85A, 0x1F85F}, propertyGeneralCategory{lbprID, gcCn}},   //     [6] <reserved-1F85A>..<reserved-1F85F>
+	{runeRange{0x1F888, 0x1F88F}, propertyGeneralCategory{lbprID, gcCn}},   //     [8] <reserved-1F888>..<reserved-1F88F>
+	{runeRange{0x1F8AE, 0x1F8AF}, propertyGeneralCategory{lbprID, gcCn}},   //     [2] <reserved-1F8AE>..<reserved-1F8AF>
+	{runeRange{0x1F8B2, 0x1F8FF}, propertyGeneralCategory{lbprID, gcCn}},   //    [78] <reserved-1F8B2>..<reserved-1F8FF>
+	{runeRange{0x1F90C, 0x1F90C}, propertyGeneralCategory{lbprEB, gcSo}},   //         PINCHED FINGERS
+	{runeRange{0x1F90F, 0x1F90F}, propertyGeneralCategory{lbprEB, gcSo}},   //         PINCHING HAND
+	{runeRange{0x1F918, 0x1F91F}, propertyGeneralCategory{lbprEB, gcSo}},   //     [8] SIGN OF THE HORNS..I LOVE YOU HAND SIGN
+	{runeRange{0x1F926, 0x1F926}, propertyGeneralCategory{lbprEB, gcSo}},   //         FACE PALM
+	{runeRange{0x1F930, 0x1F939}, propertyGeneralCategory{lbprEB, gcSo}},   //    [10] PREGNANT WOMAN..JUGGLING
+	{runeRange{0x1F93C, 0x1F93E}, propertyGeneralCategory{lbprEB, gcSo}},   //     [3] WRESTLERS..HANDBALL
+	{runeRange{0x1F977, 0x1F977}, propertyGeneralCategory{lbprEB, gcSo}},   //         NINJA
+	{runeRange{0x1F9B5, 0x1F9B6}, propertyGeneralCategory{lbprEB, gcSo}},   //     [2] LEG..FOOT
+	{runeRange{0x1F9B8, 0x1F9B9}, propertyGeneralCategory{lbprEB, gcSo}},   //     [2] SUPERHERO..SUPERVILLAIN
+	{runeRange{0x1F9BB, 0x1F9BB}, propertyGeneralCategory{lbprEB, gcSo}},   //         EAR WITH HEARING AID
+	{runeRange{0x1F9CD, 0x1F9CF}, propertyGeneralCategory{lbprEB, gcSo}},   //     [3] STANDING PERSON..DEAF PERSON
+	{runeRange{0x1F9D1, 0x1F9DD}, propertyGeneralCategory{lbprEB, gcSo}},   //    [13] ADULT..ELF
+	{runeRange{0x1FA00, 0x1FA53}, propertyGeneralCategory{lbprAL, gcSo}},   //    [84] NEUTRAL CHESS KING..BLACK CHESS KNIGHT-BISHOP
+	{runeRange{0x1FA60, 0x1FA6D}, propertyGeneralCategory{lbprID, gcSo}},   //    [14] XIANGQI RED GENERAL..XIANGQI BLACK SOLDIER
+	{runeRange{0x1FA70, 0x1FA7C}, propertyGeneralCategory{lbprID, gcSo}},   //    [13] BALLET SHOES..CRUTCH
+	{runeRange{0x1FA80, 0x1FA88}, propertyGeneralCategory{lbprID, gcSo}},   //     [9] YO-YO..FLUTE
+	{runeRange{0x1FA90, 0x1FABD}, propertyGeneralCategory{lbprID, gcSo}},   //    [46] RINGED PLANET..WING
+	{runeRange{0x1FABF, 0x1FAC2}, propertyGeneralCategory{lbprID, gcSo}},   //     [4] GOOSE..PEOPLE HUGGING
+	{runeRange{0x1FAC6, 0x1FACD}, propertyGeneralCategory{lbprID, gcCn}},   //     [8] <reserved-1FAC6>..<reserved-1FACD>
+	{runeRange{0x1FADC, 0x1FADF}, propertyGeneralCategory{lbprID, gcCn}},   //     [4] <reserved-1FADC>..<reserved-1FADF>
+	{runeRange{0x1FAE9, 0x1FAEF}, propertyGeneralCategory{lbprID, gcCn}},   //     [7] <reserved-1FAE9>..<reserved-1FAEF>
+	{runeRange{0x1FAF9, 0x1FAFF}, propertyGeneralCategory{lbprID, gcCn}},   //     [7] <reserved-1FAF9>..<reserved-1FAFF>
+	{runeRange{0x1FB94, 0x1FBCA}, propertyGeneralCategory{lbprAL, gcSo}},   //    [55] LEFT HALF INVERSE MEDIUM SHADE AND RIGHT HALF BLOCK..WHITE UP-POINTING CHEVRON
+	{runeRange{0x1FC00, 0x1FFFD}, propertyGeneralCategory{lbprID, gcCn}},   //  [1022] <reserved-1FC00>..<reserved-1FFFD>
+	{runeRange{0x2A6E0, 0x2A6FF}, propertyGeneralCategory{lbprID, gcCn}},   //    [32] <reserved-2A6E0>..<reserved-2A6FF>
+	{runeRange{0x2B73A, 0x2B73F}, propertyGeneralCategory{lbprID, gcCn}},   //     [6] <reserved-2B73A>..<reserved-2B73F>
+	{runeRange{0x2B81E, 0x2B81F}, propertyGeneralCategory{lbprID, gcCn}},   //     [2] <reserved-2B81E>..<reserved-2B81F>
+	{runeRange{0x2CEA2, 0x2CEAF}, propertyGeneralCategory{lbprID, gcCn}},   //    [14] <reserved-2CEA2>..<reserved-2CEAF>
+	{runeRange{0x2EBE1, 0x2F7FF}, propertyGeneralCategory{lbprID, gcCn}},   //  [3103] <reserved-2EBE1>..<reserved-2F7FF>
+	{runeRange{0x2FA1E, 0x2FA1F}, propertyGeneralCategory{lbprID, gcCn}},   //     [2] <reserved-2FA1E>..<reserved-2FA1F>
+	{runeRange{0x30000, 0x3134A}, propertyGeneralCategory{lbprID, gcLo}},   //  [4939] CJK UNIFIED IDEOGRAPH-30000..CJK UNIFIED IDEOGRAPH-3134A
+	{runeRange{0x31350, 0x323AF}, propertyGeneralCategory{lbprID, gcLo}},   //  [4192] CJK UNIFIED IDEOGRAPH-31350..CJK UNIFIED IDEOGRAPH-323AF
+	{runeRange{0xE0001, 0xE0001}, propertyGeneralCategory{lbprCM, gcCf}},   //         LANGUAGE TAG
+	{runeRange{0xE0100, 0xE01EF}, propertyGeneralCategory{lbprCM, gcMn}},   //   [240] VARIATION SELECTOR-17..VARIATION SELECTOR-256
 	{runeRange{0x100000, 0x10FFFD}, propertyGeneralCategory{lbprXX, gcCo}}, // [65534] <private-use-100000>..<private-use-10FFFD>
+	{runeRange{0x0000, 0x0008}, propertyGeneralCategory{lbprCM, gcCc}},     //     [9] <control-0000>..<control-0008>
+	{runeRange{0x000A, 0x000A}, propertyGeneralCategory{lbprLF, gcCc}},     //         <control-000A>
+	{runeRange{0x000D, 0x000D}, propertyGeneralCategory{lbprCR, gcCc}},     //         <control-000D>
+	{runeRange{0x0020, 0x0020}, propertyGeneralCategory{lbprSP, gcZs}},     //         SPACE
+	{runeRange{0x0022, 0x0022}, propertyGeneralCategory{lbprQU, gcPo}},     //         QUOTATION MARK
+	{runeRange{0x0024, 0x0024}, propertyGeneralCategory{lbprPR, gcSc}},     //         DOLLAR SIGN
+	{runeRange{0x0026, 0x0026}, propertyGeneralCategory{lbprAL, gcPo}},     //         AMPERSAND
+	{runeRange{0x0028, 0x0028}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT PARENTHESIS
+	{runeRange{0x002A, 0x002A}, propertyGeneralCategory{lbprAL, gcPo}},     //         ASTERISK
+	{runeRange{0x002C, 0x002C}, propertyGeneralCategory{lbprIS, gcPo}},     //         COMMA
+	{runeRange{0x002E, 0x002E}, propertyGeneralCategory{lbprIS, gcPo}},     //         FULL STOP
+	{runeRange{0x0030, 0x0039}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] DIGIT ZERO..DIGIT NINE
+	{runeRange{0x003C, 0x003E}, propertyGeneralCategory{lbprAL, gcSm}},     //     [3] LESS-THAN SIGN..GREATER-THAN SIGN
+	{runeRange{0x0040, 0x0040}, propertyGeneralCategory{lbprAL, gcPo}},     //         COMMERCIAL AT
+	{runeRange{0x005B, 0x005B}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT SQUARE BRACKET
+	{runeRange{0x005D, 0x005D}, propertyGeneralCategory{lbprCP, gcPe}},     //         RIGHT SQUARE BRACKET
+	{runeRange{0x005F, 0x005F}, propertyGeneralCategory{lbprAL, gcPc}},     //         LOW LINE
+	{runeRange{0x0061, 0x007A}, propertyGeneralCategory{lbprAL, gcLl}},     //    [26] LATIN SMALL LETTER A..LATIN SMALL LETTER Z
+	{runeRange{0x007C, 0x007C}, propertyGeneralCategory{lbprBA, gcSm}},     //         VERTICAL LINE
+	{runeRange{0x007E, 0x007E}, propertyGeneralCategory{lbprAL, gcSm}},     //         TILDE
+	{runeRange{0x0080, 0x0084}, propertyGeneralCategory{lbprCM, gcCc}},     //     [5] <control-0080>..<control-0084>
+	{runeRange{0x0086, 0x009F}, propertyGeneralCategory{lbprCM, gcCc}},     //    [26] <control-0086>..<control-009F>
+	{runeRange{0x00A1, 0x00A1}, propertyGeneralCategory{lbprOP, gcPo}},     //         INVERTED EXCLAMATION MARK
+	{runeRange{0x00A3, 0x00A5}, propertyGeneralCategory{lbprPR, gcSc}},     //     [3] POUND SIGN..YEN SIGN
+	{runeRange{0x00A7, 0x00A7}, propertyGeneralCategory{lbprAI, gcPo}},     //         SECTION SIGN
+	{runeRange{0x00A9, 0x00A9}, propertyGeneralCategory{lbprAL, gcSo}},     //         COPYRIGHT SIGN
+	{runeRange{0x00AB, 0x00AB}, propertyGeneralCategory{lbprQU, gcPi}},     //         LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
+	{runeRange{0x00AD, 0x00AD}, propertyGeneralCategory{lbprBA, gcCf}},     //         SOFT HYPHEN
+	{runeRange{0x00AF, 0x00AF}, propertyGeneralCategory{lbprAL, gcSk}},     //         MACRON
+	{runeRange{0x00B1, 0x00B1}, propertyGeneralCategory{lbprPR, gcSm}},     //         PLUS-MINUS SIGN
+	{runeRange{0x00B4, 0x00B4}, propertyGeneralCategory{lbprBB, gcSk}},     //         ACUTE ACCENT
+	{runeRange{0x00B6, 0x00B7}, propertyGeneralCategory{lbprAI, gcPo}},     //     [2] PILCROW SIGN..MIDDLE DOT
+	{runeRange{0x00B9, 0x00B9}, propertyGeneralCategory{lbprAI, gcNo}},     //         SUPERSCRIPT ONE
+	{runeRange{0x00BB, 0x00BB}, propertyGeneralCategory{lbprQU, gcPf}},     //         RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
+	{runeRange{0x00BF, 0x00BF}, propertyGeneralCategory{lbprOP, gcPo}},     //         INVERTED QUESTION MARK
+	{runeRange{0x00D7, 0x00D7}, propertyGeneralCategory{lbprAI, gcSm}},     //         MULTIPLICATION SIGN
+	{runeRange{0x00F7, 0x00F7}, propertyGeneralCategory{lbprAI, gcSm}},     //         DIVISION SIGN
+	{runeRange{0x0100, 0x017F}, propertyGeneralCategory{lbprAL, gcLC}},     //   [128] LATIN CAPITAL LETTER A WITH MACRON..LATIN SMALL LETTER LONG S
+	{runeRange{0x01BB, 0x01BB}, propertyGeneralCategory{lbprAL, gcLo}},     //         LATIN LETTER TWO WITH STROKE
+	{runeRange{0x01C0, 0x01C3}, propertyGeneralCategory{lbprAL, gcLo}},     //     [4] LATIN LETTER DENTAL CLICK..LATIN LETTER RETROFLEX CLICK
+	{runeRange{0x0250, 0x0293}, propertyGeneralCategory{lbprAL, gcLl}},     //    [68] LATIN SMALL LETTER TURNED A..LATIN SMALL LETTER EZH WITH CURL
+	{runeRange{0x0295, 0x02AF}, propertyGeneralCategory{lbprAL, gcLl}},     //    [27] LATIN LETTER PHARYNGEAL VOICED FRICATIVE..LATIN SMALL LETTER TURNED H WITH FISHHOOK AND TAIL
+	{runeRange{0x02C2, 0x02C5}, propertyGeneralCategory{lbprAL, gcSk}},     //     [4] MODIFIER LETTER LEFT ARROWHEAD..MODIFIER LETTER DOWN ARROWHEAD
+	{runeRange{0x02C7, 0x02C7}, propertyGeneralCategory{lbprAI, gcLm}},     //         CARON
+	{runeRange{0x02C9, 0x02CB}, propertyGeneralCategory{lbprAI, gcLm}},     //     [3] MODIFIER LETTER MACRON..MODIFIER LETTER GRAVE ACCENT
+	{runeRange{0x02CD, 0x02CD}, propertyGeneralCategory{lbprAI, gcLm}},     //         MODIFIER LETTER LOW MACRON
+	{runeRange{0x02D0, 0x02D0}, propertyGeneralCategory{lbprAI, gcLm}},     //         MODIFIER LETTER TRIANGULAR COLON
+	{runeRange{0x02D2, 0x02D7}, propertyGeneralCategory{lbprAL, gcSk}},     //     [6] MODIFIER LETTER CENTRED RIGHT HALF RING..MODIFIER LETTER MINUS SIGN
+	{runeRange{0x02DC, 0x02DC}, propertyGeneralCategory{lbprAL, gcSk}},     //         SMALL TILDE
+	{runeRange{0x02DE, 0x02DE}, propertyGeneralCategory{lbprAL, gcSk}},     //         MODIFIER LETTER RHOTIC HOOK
+	{runeRange{0x02E0, 0x02E4}, propertyGeneralCategory{lbprAL, gcLm}},     //     [5] MODIFIER LETTER SMALL GAMMA..MODIFIER LETTER SMALL REVERSED GLOTTAL STOP
+	{runeRange{0x02EC, 0x02EC}, propertyGeneralCategory{lbprAL, gcLm}},     //         MODIFIER LETTER VOICING
+	{runeRange{0x02EE, 0x02EE}, propertyGeneralCategory{lbprAL, gcLm}},     //         MODIFIER LETTER DOUBLE APOSTROPHE
+	{runeRange{0x0300, 0x034E}, propertyGeneralCategory{lbprCM, gcMn}},     //    [79] COMBINING GRAVE ACCENT..COMBINING UPWARDS ARROW BELOW
+	{runeRange{0x0350, 0x035B}, propertyGeneralCategory{lbprCM, gcMn}},     //    [12] COMBINING RIGHT ARROWHEAD ABOVE..COMBINING ZIGZAG ABOVE
+	{runeRange{0x0363, 0x036F}, propertyGeneralCategory{lbprCM, gcMn}},     //    [13] COMBINING LATIN SMALL LETTER A..COMBINING LATIN SMALL LETTER X
+	{runeRange{0x0374, 0x0374}, propertyGeneralCategory{lbprAL, gcLm}},     //         GREEK NUMERAL SIGN
+	{runeRange{0x0376, 0x0377}, propertyGeneralCategory{lbprAL, gcLC}},     //     [2] GREEK CAPITAL LETTER PAMPHYLIAN DIGAMMA..GREEK SMALL LETTER PAMPHYLIAN DIGAMMA
+	{runeRange{0x037B, 0x037D}, propertyGeneralCategory{lbprAL, gcLl}},     //     [3] GREEK SMALL REVERSED LUNATE SIGMA SYMBOL..GREEK SMALL REVERSED DOTTED LUNATE SIGMA SYMBOL
+	{runeRange{0x037F, 0x037F}, propertyGeneralCategory{lbprAL, gcLu}},     //         GREEK CAPITAL LETTER YOT
+	{runeRange{0x0386, 0x0386}, propertyGeneralCategory{lbprAL, gcLu}},     //         GREEK CAPITAL LETTER ALPHA WITH TONOS
+	{runeRange{0x0388, 0x038A}, propertyGeneralCategory{lbprAL, gcLu}},     //     [3] GREEK CAPITAL LETTER EPSILON WITH TONOS..GREEK CAPITAL LETTER IOTA WITH TONOS
+	{runeRange{0x038E, 0x03A1}, propertyGeneralCategory{lbprAL, gcLC}},     //    [20] GREEK CAPITAL LETTER UPSILON WITH TONOS..GREEK CAPITAL LETTER RHO
+	{runeRange{0x03F6, 0x03F6}, propertyGeneralCategory{lbprAL, gcSm}},     //         GREEK REVERSED LUNATE EPSILON SYMBOL
+	{runeRange{0x0400, 0x0481}, propertyGeneralCategory{lbprAL, gcLC}},     //   [130] CYRILLIC CAPITAL LETTER IE WITH GRAVE..CYRILLIC SMALL LETTER KOPPA
+	{runeRange{0x0483, 0x0487}, propertyGeneralCategory{lbprCM, gcMn}},     //     [5] COMBINING CYRILLIC TITLO..COMBINING CYRILLIC POKRYTIE
+	{runeRange{0x048A, 0x04FF}, propertyGeneralCategory{lbprAL, gcLC}},     //   [118] CYRILLIC CAPITAL LETTER SHORT I WITH TAIL..CYRILLIC SMALL LETTER HA WITH STROKE
+	{runeRange{0x0531, 0x0556}, propertyGeneralCategory{lbprAL, gcLu}},     //    [38] ARMENIAN CAPITAL LETTER AYB..ARMENIAN CAPITAL LETTER FEH
+	{runeRange{0x055A, 0x055F}, propertyGeneralCategory{lbprAL, gcPo}},     //     [6] ARMENIAN APOSTROPHE..ARMENIAN ABBREVIATION MARK
+	{runeRange{0x0589, 0x0589}, propertyGeneralCategory{lbprIS, gcPo}},     //         ARMENIAN FULL STOP
+	{runeRange{0x058D, 0x058E}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] RIGHT-FACING ARMENIAN ETERNITY SIGN..LEFT-FACING ARMENIAN ETERNITY SIGN
+	{runeRange{0x0591, 0x05BD}, propertyGeneralCategory{lbprCM, gcMn}},     //    [45] HEBREW ACCENT ETNAHTA..HEBREW POINT METEG
+	{runeRange{0x05BF, 0x05BF}, propertyGeneralCategory{lbprCM, gcMn}},     //         HEBREW POINT RAFE
+	{runeRange{0x05C1, 0x05C2}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] HEBREW POINT SHIN DOT..HEBREW POINT SIN DOT
+	{runeRange{0x05C4, 0x05C5}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] HEBREW MARK UPPER DOT..HEBREW MARK LOWER DOT
+	{runeRange{0x05C7, 0x05C7}, propertyGeneralCategory{lbprCM, gcMn}},     //         HEBREW POINT QAMATS QATAN
+	{runeRange{0x05EF, 0x05F2}, propertyGeneralCategory{lbprHL, gcLo}},     //     [4] HEBREW YOD TRIANGLE..HEBREW LIGATURE YIDDISH DOUBLE YOD
+	{runeRange{0x0600, 0x0605}, propertyGeneralCategory{lbprAL, gcCf}},     //     [6] ARABIC NUMBER SIGN..ARABIC NUMBER MARK ABOVE
+	{runeRange{0x0609, 0x060A}, propertyGeneralCategory{lbprPO, gcPo}},     //     [2] ARABIC-INDIC PER MILLE SIGN..ARABIC-INDIC PER TEN THOUSAND SIGN
+	{runeRange{0x060C, 0x060D}, propertyGeneralCategory{lbprIS, gcPo}},     //     [2] ARABIC COMMA..ARABIC DATE SEPARATOR
+	{runeRange{0x0610, 0x061A}, propertyGeneralCategory{lbprCM, gcMn}},     //    [11] ARABIC SIGN SALLALLAHOU ALAYHE WASSALLAM..ARABIC SMALL KASRA
+	{runeRange{0x061C, 0x061C}, propertyGeneralCategory{lbprCM, gcCf}},     //         ARABIC LETTER MARK
+	{runeRange{0x0620, 0x063F}, propertyGeneralCategory{lbprAL, gcLo}},     //    [32] ARABIC LETTER KASHMIRI YEH..ARABIC LETTER FARSI YEH WITH THREE DOTS ABOVE
+	{runeRange{0x0641, 0x064A}, propertyGeneralCategory{lbprAL, gcLo}},     //    [10] ARABIC LETTER FEH..ARABIC LETTER YEH
+	{runeRange{0x0660, 0x0669}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] ARABIC-INDIC DIGIT ZERO..ARABIC-INDIC DIGIT NINE
+	{runeRange{0x066B, 0x066C}, propertyGeneralCategory{lbprNU, gcPo}},     //     [2] ARABIC DECIMAL SEPARATOR..ARABIC THOUSANDS SEPARATOR
+	{runeRange{0x066E, 0x066F}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] ARABIC LETTER DOTLESS BEH..ARABIC LETTER DOTLESS QAF
+	{runeRange{0x0671, 0x06D3}, propertyGeneralCategory{lbprAL, gcLo}},     //    [99] ARABIC LETTER ALEF WASLA..ARABIC LETTER YEH BARREE WITH HAMZA ABOVE
+	{runeRange{0x06D5, 0x06D5}, propertyGeneralCategory{lbprAL, gcLo}},     //         ARABIC LETTER AE
+	{runeRange{0x06DD, 0x06DD}, propertyGeneralCategory{lbprAL, gcCf}},     //         ARABIC END OF AYAH
+	{runeRange{0x06DF, 0x06E4}, propertyGeneralCategory{lbprCM, gcMn}},     //     [6] ARABIC SMALL HIGH ROUNDED ZERO..ARABIC SMALL HIGH MADDA
+	{runeRange{0x06E7, 0x06E8}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] ARABIC SMALL HIGH YEH..ARABIC SMALL HIGH NOON
+	{runeRange{0x06EA, 0x06ED}, propertyGeneralCategory{lbprCM, gcMn}},     //     [4] ARABIC EMPTY CENTRE LOW STOP..ARABIC SMALL LOW MEEM
+	{runeRange{0x06F0, 0x06F9}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] EXTENDED ARABIC-INDIC DIGIT ZERO..EXTENDED ARABIC-INDIC DIGIT NINE
+	{runeRange{0x06FD, 0x06FE}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] ARABIC SIGN SINDHI AMPERSAND..ARABIC SIGN SINDHI POSTPOSITION MEN
+	{runeRange{0x0700, 0x070D}, propertyGeneralCategory{lbprAL, gcPo}},     //    [14] SYRIAC END OF PARAGRAPH..SYRIAC HARKLEAN ASTERISCUS
+	{runeRange{0x0710, 0x0710}, propertyGeneralCategory{lbprAL, gcLo}},     //         SYRIAC LETTER ALAPH
+	{runeRange{0x0712, 0x072F}, propertyGeneralCategory{lbprAL, gcLo}},     //    [30] SYRIAC LETTER BETH..SYRIAC LETTER PERSIAN DHALATH
+	{runeRange{0x074D, 0x074F}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] SYRIAC LETTER SOGDIAN ZHAIN..SYRIAC LETTER SOGDIAN FE
+	{runeRange{0x0780, 0x07A5}, propertyGeneralCategory{lbprAL, gcLo}},     //    [38] THAANA LETTER HAA..THAANA LETTER WAAVU
+	{runeRange{0x07B1, 0x07B1}, propertyGeneralCategory{lbprAL, gcLo}},     //         THAANA LETTER NAA
+	{runeRange{0x07CA, 0x07EA}, propertyGeneralCategory{lbprAL, gcLo}},     //    [33] NKO LETTER A..NKO LETTER JONA RA
+	{runeRange{0x07F4, 0x07F5}, propertyGeneralCategory{lbprAL, gcLm}},     //     [2] NKO HIGH TONE APOSTROPHE..NKO LOW TONE APOSTROPHE
+	{runeRange{0x07F7, 0x07F7}, propertyGeneralCategory{lbprAL, gcPo}},     //         NKO SYMBOL GBAKURUNEN
+	{runeRange{0x07F9, 0x07F9}, propertyGeneralCategory{lbprEX, gcPo}},     //         NKO EXCLAMATION MARK
+	{runeRange{0x07FD, 0x07FD}, propertyGeneralCategory{lbprCM, gcMn}},     //         NKO DANTAYALAN
+	{runeRange{0x0800, 0x0815}, propertyGeneralCategory{lbprAL, gcLo}},     //    [22] SAMARITAN LETTER ALAF..SAMARITAN LETTER TAAF
+	{runeRange{0x081A, 0x081A}, propertyGeneralCategory{lbprAL, gcLm}},     //         SAMARITAN MODIFIER LETTER EPENTHETIC YUT
+	{runeRange{0x0824, 0x0824}, propertyGeneralCategory{lbprAL, gcLm}},     //         SAMARITAN MODIFIER LETTER SHORT A
+	{runeRange{0x0828, 0x0828}, propertyGeneralCategory{lbprAL, gcLm}},     //         SAMARITAN MODIFIER LETTER I
+	{runeRange{0x0830, 0x083E}, propertyGeneralCategory{lbprAL, gcPo}},     //    [15] SAMARITAN PUNCTUATION NEQUDAA..SAMARITAN PUNCTUATION ANNAAU
+	{runeRange{0x0859, 0x085B}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] MANDAIC AFFRICATION MARK..MANDAIC GEMINATION MARK
+	{runeRange{0x0860, 0x086A}, propertyGeneralCategory{lbprAL, gcLo}},     //    [11] SYRIAC LETTER MALAYALAM NGA..SYRIAC LETTER MALAYALAM SSA
+	{runeRange{0x0888, 0x0888}, propertyGeneralCategory{lbprAL, gcSk}},     //         ARABIC RAISED ROUND DOT
+	{runeRange{0x0890, 0x0891}, propertyGeneralCategory{lbprAL, gcCf}},     //     [2] ARABIC POUND MARK ABOVE..ARABIC PIASTRE MARK ABOVE
+	{runeRange{0x08A0, 0x08C8}, propertyGeneralCategory{lbprAL, gcLo}},     //    [41] ARABIC LETTER BEH WITH SMALL V BELOW..ARABIC LETTER GRAF
+	{runeRange{0x08CA, 0x08E1}, propertyGeneralCategory{lbprCM, gcMn}},     //    [24] ARABIC SMALL HIGH FARSI YEH..ARABIC SMALL HIGH SIGN SAFHA
+	{runeRange{0x08E3, 0x08FF}, propertyGeneralCategory{lbprCM, gcMn}},     //    [29] ARABIC TURNED DAMMA BELOW..ARABIC MARK SIDEWAYS NOON GHUNNA
+	{runeRange{0x0903, 0x0903}, propertyGeneralCategory{lbprCM, gcMc}},     //         DEVANAGARI SIGN VISARGA
+	{runeRange{0x093A, 0x093A}, propertyGeneralCategory{lbprCM, gcMn}},     //         DEVANAGARI VOWEL SIGN OE
+	{runeRange{0x093C, 0x093C}, propertyGeneralCategory{lbprCM, gcMn}},     //         DEVANAGARI SIGN NUKTA
+	{runeRange{0x093E, 0x0940}, propertyGeneralCategory{lbprCM, gcMc}},     //     [3] DEVANAGARI VOWEL SIGN AA..DEVANAGARI VOWEL SIGN II
+	{runeRange{0x0949, 0x094C}, propertyGeneralCategory{lbprCM, gcMc}},     //     [4] DEVANAGARI VOWEL SIGN CANDRA O..DEVANAGARI VOWEL SIGN AU
+	{runeRange{0x094E, 0x094F}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] DEVANAGARI VOWEL SIGN PRISHTHAMATRA E..DEVANAGARI VOWEL SIGN AW
+	{runeRange{0x0951, 0x0957}, propertyGeneralCategory{lbprCM, gcMn}},     //     [7] DEVANAGARI STRESS SIGN UDATTA..DEVANAGARI VOWEL SIGN UUE
+	{runeRange{0x0962, 0x0963}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] DEVANAGARI VOWEL SIGN VOCALIC L..DEVANAGARI VOWEL SIGN VOCALIC LL
+	{runeRange{0x0966, 0x096F}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] DEVANAGARI DIGIT ZERO..DEVANAGARI DIGIT NINE
+	{runeRange{0x0971, 0x0971}, propertyGeneralCategory{lbprAL, gcLm}},     //         DEVANAGARI SIGN HIGH SPACING DOT
+	{runeRange{0x0980, 0x0980}, propertyGeneralCategory{lbprAL, gcLo}},     //         BENGALI ANJI
+	{runeRange{0x0982, 0x0983}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] BENGALI SIGN ANUSVARA..BENGALI SIGN VISARGA
+	{runeRange{0x098F, 0x0990}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] BENGALI LETTER E..BENGALI LETTER AI
+	{runeRange{0x09AA, 0x09B0}, propertyGeneralCategory{lbprAL, gcLo}},     //     [7] BENGALI LETTER PA..BENGALI LETTER RA
+	{runeRange{0x09B6, 0x09B9}, propertyGeneralCategory{lbprAL, gcLo}},     //     [4] BENGALI LETTER SHA..BENGALI LETTER HA
+	{runeRange{0x09BD, 0x09BD}, propertyGeneralCategory{lbprAL, gcLo}},     //         BENGALI SIGN AVAGRAHA
+	{runeRange{0x09C1, 0x09C4}, propertyGeneralCategory{lbprCM, gcMn}},     //     [4] BENGALI VOWEL SIGN U..BENGALI VOWEL SIGN VOCALIC RR
+	{runeRange{0x09CB, 0x09CC}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] BENGALI VOWEL SIGN O..BENGALI VOWEL SIGN AU
+	{runeRange{0x09CE, 0x09CE}, propertyGeneralCategory{lbprAL, gcLo}},     //         BENGALI LETTER KHANDA TA
+	{runeRange{0x09DC, 0x09DD}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] BENGALI LETTER RRA..BENGALI LETTER RHA
+	{runeRange{0x09E2, 0x09E3}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] BENGALI VOWEL SIGN VOCALIC L..BENGALI VOWEL SIGN VOCALIC LL
+	{runeRange{0x09F0, 0x09F1}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] BENGALI LETTER RA WITH MIDDLE DIAGONAL..BENGALI LETTER RA WITH LOWER DIAGONAL
+	{runeRange{0x09F4, 0x09F8}, propertyGeneralCategory{lbprAL, gcNo}},     //     [5] BENGALI CURRENCY NUMERATOR ONE..BENGALI CURRENCY NUMERATOR ONE LESS THAN THE DENOMINATOR
+	{runeRange{0x09FA, 0x09FA}, propertyGeneralCategory{lbprAL, gcSo}},     //         BENGALI ISSHAR
+	{runeRange{0x09FC, 0x09FC}, propertyGeneralCategory{lbprAL, gcLo}},     //         BENGALI LETTER VEDIC ANUSVARA
+	{runeRange{0x09FE, 0x09FE}, propertyGeneralCategory{lbprCM, gcMn}},     //         BENGALI SANDHI MARK
+	{runeRange{0x0A03, 0x0A03}, propertyGeneralCategory{lbprCM, gcMc}},     //         GURMUKHI SIGN VISARGA
+	{runeRange{0x0A0F, 0x0A10}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] GURMUKHI LETTER EE..GURMUKHI LETTER AI
+	{runeRange{0x0A2A, 0x0A30}, propertyGeneralCategory{lbprAL, gcLo}},     //     [7] GURMUKHI LETTER PA..GURMUKHI LETTER RA
+	{runeRange{0x0A35, 0x0A36}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] GURMUKHI LETTER VA..GURMUKHI LETTER SHA
+	{runeRange{0x0A3C, 0x0A3C}, propertyGeneralCategory{lbprCM, gcMn}},     //         GURMUKHI SIGN NUKTA
+	{runeRange{0x0A41, 0x0A42}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] GURMUKHI VOWEL SIGN U..GURMUKHI VOWEL SIGN UU
+	{runeRange{0x0A4B, 0x0A4D}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] GURMUKHI VOWEL SIGN OO..GURMUKHI SIGN VIRAMA
+	{runeRange{0x0A59, 0x0A5C}, propertyGeneralCategory{lbprAL, gcLo}},     //     [4] GURMUKHI LETTER KHHA..GURMUKHI LETTER RRA
+	{runeRange{0x0A66, 0x0A6F}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] GURMUKHI DIGIT ZERO..GURMUKHI DIGIT NINE
+	{runeRange{0x0A72, 0x0A74}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] GURMUKHI IRI..GURMUKHI EK ONKAR
+	{runeRange{0x0A76, 0x0A76}, propertyGeneralCategory{lbprAL, gcPo}},     //         GURMUKHI ABBREVIATION SIGN
+	{runeRange{0x0A83, 0x0A83}, propertyGeneralCategory{lbprCM, gcMc}},     //         GUJARATI SIGN VISARGA
+	{runeRange{0x0A8F, 0x0A91}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] GUJARATI LETTER E..GUJARATI VOWEL CANDRA O
+	{runeRange{0x0AAA, 0x0AB0}, propertyGeneralCategory{lbprAL, gcLo}},     //     [7] GUJARATI LETTER PA..GUJARATI LETTER RA
+	{runeRange{0x0AB5, 0x0AB9}, propertyGeneralCategory{lbprAL, gcLo}},     //     [5] GUJARATI LETTER VA..GUJARATI LETTER HA
+	{runeRange{0x0ABD, 0x0ABD}, propertyGeneralCategory{lbprAL, gcLo}},     //         GUJARATI SIGN AVAGRAHA
+	{runeRange{0x0AC1, 0x0AC5}, propertyGeneralCategory{lbprCM, gcMn}},     //     [5] GUJARATI VOWEL SIGN U..GUJARATI VOWEL SIGN CANDRA E
+	{runeRange{0x0AC9, 0x0AC9}, propertyGeneralCategory{lbprCM, gcMc}},     //         GUJARATI VOWEL SIGN CANDRA O
+	{runeRange{0x0ACD, 0x0ACD}, propertyGeneralCategory{lbprCM, gcMn}},     //         GUJARATI SIGN VIRAMA
+	{runeRange{0x0AE0, 0x0AE1}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] GUJARATI LETTER VOCALIC RR..GUJARATI LETTER VOCALIC LL
+	{runeRange{0x0AE6, 0x0AEF}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] GUJARATI DIGIT ZERO..GUJARATI DIGIT NINE
+	{runeRange{0x0AF1, 0x0AF1}, propertyGeneralCategory{lbprPR, gcSc}},     //         GUJARATI RUPEE SIGN
+	{runeRange{0x0AFA, 0x0AFF}, propertyGeneralCategory{lbprCM, gcMn}},     //     [6] GUJARATI SIGN SUKUN..GUJARATI SIGN TWO-CIRCLE NUKTA ABOVE
+	{runeRange{0x0B02, 0x0B03}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] ORIYA SIGN ANUSVARA..ORIYA SIGN VISARGA
+	{runeRange{0x0B0F, 0x0B10}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] ORIYA LETTER E..ORIYA LETTER AI
+	{runeRange{0x0B2A, 0x0B30}, propertyGeneralCategory{lbprAL, gcLo}},     //     [7] ORIYA LETTER PA..ORIYA LETTER RA
+	{runeRange{0x0B35, 0x0B39}, propertyGeneralCategory{lbprAL, gcLo}},     //     [5] ORIYA LETTER VA..ORIYA LETTER HA
+	{runeRange{0x0B3D, 0x0B3D}, propertyGeneralCategory{lbprAL, gcLo}},     //         ORIYA SIGN AVAGRAHA
+	{runeRange{0x0B3F, 0x0B3F}, propertyGeneralCategory{lbprCM, gcMn}},     //         ORIYA VOWEL SIGN I
+	{runeRange{0x0B41, 0x0B44}, propertyGeneralCategory{lbprCM, gcMn}},     //     [4] ORIYA VOWEL SIGN U..ORIYA VOWEL SIGN VOCALIC RR
+	{runeRange{0x0B4B, 0x0B4C}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] ORIYA VOWEL SIGN O..ORIYA VOWEL SIGN AU
+	{runeRange{0x0B55, 0x0B56}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] ORIYA SIGN OVERLINE..ORIYA AI LENGTH MARK
+	{runeRange{0x0B5C, 0x0B5D}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] ORIYA LETTER RRA..ORIYA LETTER RHA
+	{runeRange{0x0B62, 0x0B63}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] ORIYA VOWEL SIGN VOCALIC L..ORIYA VOWEL SIGN VOCALIC LL
+	{runeRange{0x0B70, 0x0B70}, propertyGeneralCategory{lbprAL, gcSo}},     //         ORIYA ISSHAR
+	{runeRange{0x0B72, 0x0B77}, propertyGeneralCategory{lbprAL, gcNo}},     //     [6] ORIYA FRACTION ONE QUARTER..ORIYA FRACTION THREE SIXTEENTHS
+	{runeRange{0x0B83, 0x0B83}, propertyGeneralCategory{lbprAL, gcLo}},     //         TAMIL SIGN VISARGA
+	{runeRange{0x0B8E, 0x0B90}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] TAMIL LETTER E..TAMIL LETTER AI
+	{runeRange{0x0B99, 0x0B9A}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] TAMIL LETTER NGA..TAMIL LETTER CA
+	{runeRange{0x0B9E, 0x0B9F}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] TAMIL LETTER NYA..TAMIL LETTER TTA
+	{runeRange{0x0BA8, 0x0BAA}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] TAMIL LETTER NA..TAMIL LETTER PA
+	{runeRange{0x0BBE, 0x0BBF}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] TAMIL VOWEL SIGN AA..TAMIL VOWEL SIGN I
+	{runeRange{0x0BC1, 0x0BC2}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] TAMIL VOWEL SIGN U..TAMIL VOWEL SIGN UU
+	{runeRange{0x0BCA, 0x0BCC}, propertyGeneralCategory{lbprCM, gcMc}},     //     [3] TAMIL VOWEL SIGN O..TAMIL VOWEL SIGN AU
+	{runeRange{0x0BD0, 0x0BD0}, propertyGeneralCategory{lbprAL, gcLo}},     //         TAMIL OM
+	{runeRange{0x0BE6, 0x0BEF}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] TAMIL DIGIT ZERO..TAMIL DIGIT NINE
+	{runeRange{0x0BF3, 0x0BF8}, propertyGeneralCategory{lbprAL, gcSo}},     //     [6] TAMIL DAY SIGN..TAMIL AS ABOVE SIGN
+	{runeRange{0x0BFA, 0x0BFA}, propertyGeneralCategory{lbprAL, gcSo}},     //         TAMIL NUMBER SIGN
+	{runeRange{0x0C01, 0x0C03}, propertyGeneralCategory{lbprCM, gcMc}},     //     [3] TELUGU SIGN CANDRABINDU..TELUGU SIGN VISARGA
+	{runeRange{0x0C05, 0x0C0C}, propertyGeneralCategory{lbprAL, gcLo}},     //     [8] TELUGU LETTER A..TELUGU LETTER VOCALIC L
+	{runeRange{0x0C12, 0x0C28}, propertyGeneralCategory{lbprAL, gcLo}},     //    [23] TELUGU LETTER O..TELUGU LETTER NA
+	{runeRange{0x0C3C, 0x0C3C}, propertyGeneralCategory{lbprCM, gcMn}},     //         TELUGU SIGN NUKTA
+	{runeRange{0x0C3E, 0x0C40}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] TELUGU VOWEL SIGN AA..TELUGU VOWEL SIGN II
+	{runeRange{0x0C46, 0x0C48}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] TELUGU VOWEL SIGN E..TELUGU VOWEL SIGN AI
+	{runeRange{0x0C55, 0x0C56}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] TELUGU LENGTH MARK..TELUGU AI LENGTH MARK
+	{runeRange{0x0C5D, 0x0C5D}, propertyGeneralCategory{lbprAL, gcLo}},     //         TELUGU LETTER NAKAARA POLLU
+	{runeRange{0x0C62, 0x0C63}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] TELUGU VOWEL SIGN VOCALIC L..TELUGU VOWEL SIGN VOCALIC LL
+	{runeRange{0x0C77, 0x0C77}, propertyGeneralCategory{lbprBB, gcPo}},     //         TELUGU SIGN SIDDHAM
+	{runeRange{0x0C7F, 0x0C7F}, propertyGeneralCategory{lbprAL, gcSo}},     //         TELUGU SIGN TUUMU
+	{runeRange{0x0C81, 0x0C81}, propertyGeneralCategory{lbprCM, gcMn}},     //         KANNADA SIGN CANDRABINDU
+	{runeRange{0x0C84, 0x0C84}, propertyGeneralCategory{lbprBB, gcPo}},     //         KANNADA SIGN SIDDHAM
+	{runeRange{0x0C8E, 0x0C90}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] KANNADA LETTER E..KANNADA LETTER AI
+	{runeRange{0x0CAA, 0x0CB3}, propertyGeneralCategory{lbprAL, gcLo}},     //    [10] KANNADA LETTER PA..KANNADA LETTER LLA
+	{runeRange{0x0CBC, 0x0CBC}, propertyGeneralCategory{lbprCM, gcMn}},     //         KANNADA SIGN NUKTA
+	{runeRange{0x0CBE, 0x0CBE}, propertyGeneralCategory{lbprCM, gcMc}},     //         KANNADA VOWEL SIGN AA
+	{runeRange{0x0CC0, 0x0CC4}, propertyGeneralCategory{lbprCM, gcMc}},     //     [5] KANNADA VOWEL SIGN II..KANNADA VOWEL SIGN VOCALIC RR
+	{runeRange{0x0CC7, 0x0CC8}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] KANNADA VOWEL SIGN EE..KANNADA VOWEL SIGN AI
+	{runeRange{0x0CCC, 0x0CCD}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] KANNADA VOWEL SIGN AU..KANNADA SIGN VIRAMA
+	{runeRange{0x0CDD, 0x0CDE}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] KANNADA LETTER NAKAARA POLLU..KANNADA LETTER FA
+	{runeRange{0x0CE2, 0x0CE3}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] KANNADA VOWEL SIGN VOCALIC L..KANNADA VOWEL SIGN VOCALIC LL
+	{runeRange{0x0CF1, 0x0CF2}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] KANNADA SIGN JIHVAMULIYA..KANNADA SIGN UPADHMANIYA
+	{runeRange{0x0D00, 0x0D01}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] MALAYALAM SIGN COMBINING ANUSVARA ABOVE..MALAYALAM SIGN CANDRABINDU
+	{runeRange{0x0D04, 0x0D0C}, propertyGeneralCategory{lbprAL, gcLo}},     //     [9] MALAYALAM LETTER VEDIC ANUSVARA..MALAYALAM LETTER VOCALIC L
+	{runeRange{0x0D12, 0x0D3A}, propertyGeneralCategory{lbprAL, gcLo}},     //    [41] MALAYALAM LETTER O..MALAYALAM LETTER TTTA
+	{runeRange{0x0D3D, 0x0D3D}, propertyGeneralCategory{lbprAL, gcLo}},     //         MALAYALAM SIGN AVAGRAHA
+	{runeRange{0x0D41, 0x0D44}, propertyGeneralCategory{lbprCM, gcMn}},     //     [4] MALAYALAM VOWEL SIGN U..MALAYALAM VOWEL SIGN VOCALIC RR
+	{runeRange{0x0D4A, 0x0D4C}, propertyGeneralCategory{lbprCM, gcMc}},     //     [3] MALAYALAM VOWEL SIGN O..MALAYALAM VOWEL SIGN AU
+	{runeRange{0x0D4E, 0x0D4E}, propertyGeneralCategory{lbprAL, gcLo}},     //         MALAYALAM LETTER DOT REPH
+	{runeRange{0x0D54, 0x0D56}, propertyGeneralCategory{lbprAL, gcLo}},     //     [3] MALAYALAM LETTER CHILLU M..MALAYALAM LETTER CHILLU LLL
+	{runeRange{0x0D58, 0x0D5E}, propertyGeneralCategory{lbprAL, gcNo}},     //     [7] MALAYALAM FRACTION ONE ONE-HUNDRED-AND-SIXTIETH..MALAYALAM FRACTION ONE FIFTH
+	{runeRange{0x0D62, 0x0D63}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] MALAYALAM VOWEL SIGN VOCALIC L..MALAYALAM VOWEL SIGN VOCALIC LL
+	{runeRange{0x0D70, 0x0D78}, propertyGeneralCategory{lbprAL, gcNo}},     //     [9] MALAYALAM NUMBER TEN..MALAYALAM FRACTION THREE SIXTEENTHS
+	{runeRange{0x0D7A, 0x0D7F}, propertyGeneralCategory{lbprAL, gcLo}},     //     [6] MALAYALAM LETTER CHILLU NN..MALAYALAM LETTER CHILLU K
+	{runeRange{0x0D82, 0x0D83}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] SINHALA SIGN ANUSVARAYA..SINHALA SIGN VISARGAYA
+	{runeRange{0x0D9A, 0x0DB1}, propertyGeneralCategory{lbprAL, gcLo}},     //    [24] SINHALA LETTER ALPAPRAANA KAYANNA..SINHALA LETTER DANTAJA NAYANNA
+	{runeRange{0x0DBD, 0x0DBD}, propertyGeneralCategory{lbprAL, gcLo}},     //         SINHALA LETTER DANTAJA LAYANNA
+	{runeRange{0x0DCA, 0x0DCA}, propertyGeneralCategory{lbprCM, gcMn}},     //         SINHALA SIGN AL-LAKUNA
+	{runeRange{0x0DD2, 0x0DD4}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] SINHALA VOWEL SIGN KETTI IS-PILLA..SINHALA VOWEL SIGN KETTI PAA-PILLA
+	{runeRange{0x0DD8, 0x0DDF}, propertyGeneralCategory{lbprCM, gcMc}},     //     [8] SINHALA VOWEL SIGN GAETTA-PILLA..SINHALA VOWEL SIGN GAYANUKITTA
+	{runeRange{0x0DF2, 0x0DF3}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] SINHALA VOWEL SIGN DIGA GAETTA-PILLA..SINHALA VOWEL SIGN DIGA GAYANUKITTA
+	{runeRange{0x0E01, 0x0E30}, propertyGeneralCategory{lbprSA, gcLo}},     //    [48] THAI CHARACTER KO KAI..THAI CHARACTER SARA A
+	{runeRange{0x0E32, 0x0E33}, propertyGeneralCategory{lbprSA, gcLo}},     //     [2] THAI CHARACTER SARA AA..THAI CHARACTER SARA AM
+	{runeRange{0x0E3F, 0x0E3F}, propertyGeneralCategory{lbprPR, gcSc}},     //         THAI CURRENCY SYMBOL BAHT
+	{runeRange{0x0E46, 0x0E46}, propertyGeneralCategory{lbprSA, gcLm}},     //         THAI CHARACTER MAIYAMOK
+	{runeRange{0x0E4F, 0x0E4F}, propertyGeneralCategory{lbprAL, gcPo}},     //         THAI CHARACTER FONGMAN
+	{runeRange{0x0E5A, 0x0E5B}, propertyGeneralCategory{lbprBA, gcPo}},     //     [2] THAI CHARACTER ANGKHANKHU..THAI CHARACTER KHOMUT
+	{runeRange{0x0E84, 0x0E84}, propertyGeneralCategory{lbprSA, gcLo}},     //         LAO LETTER KHO TAM
+	{runeRange{0x0E8C, 0x0EA3}, propertyGeneralCategory{lbprSA, gcLo}},     //    [24] LAO LETTER PALI JHA..LAO LETTER LO LING
+	{runeRange{0x0EA7, 0x0EB0}, propertyGeneralCategory{lbprSA, gcLo}},     //    [10] LAO LETTER WO..LAO VOWEL SIGN A
+	{runeRange{0x0EB2, 0x0EB3}, propertyGeneralCategory{lbprSA, gcLo}},     //     [2] LAO VOWEL SIGN AA..LAO VOWEL SIGN AM
+	{runeRange{0x0EBD, 0x0EBD}, propertyGeneralCategory{lbprSA, gcLo}},     //         LAO SEMIVOWEL SIGN NYO
+	{runeRange{0x0EC6, 0x0EC6}, propertyGeneralCategory{lbprSA, gcLm}},     //         LAO KO LA
+	{runeRange{0x0ED0, 0x0ED9}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] LAO DIGIT ZERO..LAO DIGIT NINE
+	{runeRange{0x0F00, 0x0F00}, propertyGeneralCategory{lbprAL, gcLo}},     //         TIBETAN SYLLABLE OM
+	{runeRange{0x0F04, 0x0F04}, propertyGeneralCategory{lbprBB, gcPo}},     //         TIBETAN MARK INITIAL YIG MGO MDUN MA
+	{runeRange{0x0F06, 0x0F07}, propertyGeneralCategory{lbprBB, gcPo}},     //     [2] TIBETAN MARK CARET YIG MGO PHUR SHAD MA..TIBETAN MARK YIG MGO TSHEG SHAD MA
+	{runeRange{0x0F09, 0x0F0A}, propertyGeneralCategory{lbprBB, gcPo}},     //     [2] TIBETAN MARK BSKUR YIG MGO..TIBETAN MARK BKA- SHOG YIG MGO
+	{runeRange{0x0F0C, 0x0F0C}, propertyGeneralCategory{lbprGL, gcPo}},     //         TIBETAN MARK DELIMITER TSHEG BSTAR
+	{runeRange{0x0F12, 0x0F12}, propertyGeneralCategory{lbprGL, gcPo}},     //         TIBETAN MARK RGYA GRAM SHAD
+	{runeRange{0x0F14, 0x0F14}, propertyGeneralCategory{lbprEX, gcPo}},     //         TIBETAN MARK GTER TSHEG
+	{runeRange{0x0F18, 0x0F19}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] TIBETAN ASTROLOGICAL SIGN -KHYUD PA..TIBETAN ASTROLOGICAL SIGN SDONG TSHUGS
+	{runeRange{0x0F20, 0x0F29}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] TIBETAN DIGIT ZERO..TIBETAN DIGIT NINE
+	{runeRange{0x0F34, 0x0F34}, propertyGeneralCategory{lbprBA, gcSo}},     //         TIBETAN MARK BSDUS RTAGS
+	{runeRange{0x0F36, 0x0F36}, propertyGeneralCategory{lbprAL, gcSo}},     //         TIBETAN MARK CARET -DZUD RTAGS BZHI MIG CAN
+	{runeRange{0x0F38, 0x0F38}, propertyGeneralCategory{lbprAL, gcSo}},     //         TIBETAN MARK CHE MGO
+	{runeRange{0x0F3A, 0x0F3A}, propertyGeneralCategory{lbprOP, gcPs}},     //         TIBETAN MARK GUG RTAGS GYON
+	{runeRange{0x0F3C, 0x0F3C}, propertyGeneralCategory{lbprOP, gcPs}},     //         TIBETAN MARK ANG KHANG GYON
+	{runeRange{0x0F3E, 0x0F3F}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] TIBETAN SIGN YAR TSHES..TIBETAN SIGN MAR TSHES
+	{runeRange{0x0F49, 0x0F6C}, propertyGeneralCategory{lbprAL, gcLo}},     //    [36] TIBETAN LETTER NYA..TIBETAN LETTER RRA
+	{runeRange{0x0F7F, 0x0F7F}, propertyGeneralCategory{lbprBA, gcMc}},     //         TIBETAN SIGN RNAM BCAD
+	{runeRange{0x0F85, 0x0F85}, propertyGeneralCategory{lbprBA, gcPo}},     //         TIBETAN MARK PALUTA
+	{runeRange{0x0F88, 0x0F8C}, propertyGeneralCategory{lbprAL, gcLo}},     //     [5] TIBETAN SIGN LCE TSA CAN..TIBETAN SIGN INVERTED MCHU CAN
+	{runeRange{0x0F99, 0x0FBC}, propertyGeneralCategory{lbprCM, gcMn}},     //    [36] TIBETAN SUBJOINED LETTER NYA..TIBETAN SUBJOINED LETTER FIXED-FORM RA
+	{runeRange{0x0FC0, 0x0FC5}, propertyGeneralCategory{lbprAL, gcSo}},     //     [6] TIBETAN CANTILLATION SIGN HEAVY BEAT..TIBETAN SYMBOL RDO RJE
+	{runeRange{0x0FC7, 0x0FCC}, propertyGeneralCategory{lbprAL, gcSo}},     //     [6] TIBETAN SYMBOL RDO RJE RGYA GRAM..TIBETAN SYMBOL NOR BU BZHI -KHYIL
+	{runeRange{0x0FD0, 0x0FD1}, propertyGeneralCategory{lbprBB, gcPo}},     //     [2] TIBETAN MARK BSKA- SHOG GI MGO RGYAN..TIBETAN MARK MNYAM YIG GI MGO RGYAN
+	{runeRange{0x0FD3, 0x0FD3}, propertyGeneralCategory{lbprBB, gcPo}},     //         TIBETAN MARK INITIAL BRDA RNYING YIG MGO MDUN MA
+	{runeRange{0x0FD5, 0x0FD8}, propertyGeneralCategory{lbprAL, gcSo}},     //     [4] RIGHT-FACING SVASTI SIGN..LEFT-FACING SVASTI SIGN WITH DOTS
+	{runeRange{0x1000, 0x102A}, propertyGeneralCategory{lbprSA, gcLo}},     //    [43] MYANMAR LETTER KA..MYANMAR LETTER AU
+	{runeRange{0x102D, 0x1030}, propertyGeneralCategory{lbprSA, gcMn}},     //     [4] MYANMAR VOWEL SIGN I..MYANMAR VOWEL SIGN UU
+	{runeRange{0x1032, 0x1037}, propertyGeneralCategory{lbprSA, gcMn}},     //     [6] MYANMAR VOWEL SIGN AI..MYANMAR SIGN DOT BELOW
+	{runeRange{0x1039, 0x103A}, propertyGeneralCategory{lbprSA, gcMn}},     //     [2] MYANMAR SIGN VIRAMA..MYANMAR SIGN ASAT
+	{runeRange{0x103D, 0x103E}, propertyGeneralCategory{lbprSA, gcMn}},     //     [2] MYANMAR CONSONANT SIGN MEDIAL WA..MYANMAR CONSONANT SIGN MEDIAL HA
+	{runeRange{0x1040, 0x1049}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] MYANMAR DIGIT ZERO..MYANMAR DIGIT NINE
+	{runeRange{0x104C, 0x104F}, propertyGeneralCategory{lbprAL, gcPo}},     //     [4] MYANMAR SYMBOL LOCATIVE..MYANMAR SYMBOL GENITIVE
+	{runeRange{0x1056, 0x1057}, propertyGeneralCategory{lbprSA, gcMc}},     //     [2] MYANMAR VOWEL SIGN VOCALIC R..MYANMAR VOWEL SIGN VOCALIC RR
+	{runeRange{0x105A, 0x105D}, propertyGeneralCategory{lbprSA, gcLo}},     //     [4] MYANMAR LETTER MON NGA..MYANMAR LETTER MON BBE
+	{runeRange{0x1061, 0x1061}, propertyGeneralCategory{lbprSA, gcLo}},     //         MYANMAR LETTER SGAW KAREN SHA
+	{runeRange{0x1065, 0x1066}, propertyGeneralCategory{lbprSA, gcLo}},     //     [2] MYANMAR LETTER WESTERN PWO KAREN THA..MYANMAR LETTER WESTERN PWO KAREN PWA
+	{runeRange{0x106E, 0x1070}, propertyGeneralCategory{lbprSA, gcLo}},     //     [3] MYANMAR LETTER EASTERN PWO KAREN NNA..MYANMAR LETTER EASTERN PWO KAREN GHWA
+	{runeRange{0x1075, 0x1081}, propertyGeneralCategory{lbprSA, gcLo}},     //    [13] MYANMAR LETTER SHAN KA..MYANMAR LETTER SHAN HA
+	{runeRange{0x1083, 0x1084}, propertyGeneralCategory{lbprSA, gcMc}},     //     [2] MYANMAR VOWEL SIGN SHAN AA..MYANMAR VOWEL SIGN SHAN E
+	{runeRange{0x1087, 0x108C}, propertyGeneralCategory{lbprSA, gcMc}},     //     [6] MYANMAR SIGN SHAN TONE-2..MYANMAR SIGN SHAN COUNCIL TONE-3
+	{runeRange{0x108E, 0x108E}, propertyGeneralCategory{lbprSA, gcLo}},     //         MYANMAR LETTER RUMAI PALAUNG FA
+	{runeRange{0x1090, 0x1099}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] MYANMAR SHAN DIGIT ZERO..MYANMAR SHAN DIGIT NINE
+	{runeRange{0x109D, 0x109D}, propertyGeneralCategory{lbprSA, gcMn}},     //         MYANMAR VOWEL SIGN AITON AI
+	{runeRange{0x10A0, 0x10C5}, propertyGeneralCategory{lbprAL, gcLu}},     //    [38] GEORGIAN CAPITAL LETTER AN..GEORGIAN CAPITAL LETTER HOE
+	{runeRange{0x10CD, 0x10CD}, propertyGeneralCategory{lbprAL, gcLu}},     //         GEORGIAN CAPITAL LETTER AEN
+	{runeRange{0x10FB, 0x10FB}, propertyGeneralCategory{lbprAL, gcPo}},     //         GEORGIAN PARAGRAPH SEPARATOR
+	{runeRange{0x10FD, 0x10FF}, propertyGeneralCategory{lbprAL, gcLl}},     //     [3] GEORGIAN LETTER AEN..GEORGIAN LETTER LABIAL SIGN
+	{runeRange{0x1160, 0x11A7}, propertyGeneralCategory{lbprJV, gcLo}},     //    [72] HANGUL JUNGSEONG FILLER..HANGUL JUNGSEONG O-YAE
+	{runeRange{0x1200, 0x1248}, propertyGeneralCategory{lbprAL, gcLo}},     //    [73] ETHIOPIC SYLLABLE HA..ETHIOPIC SYLLABLE QWA
+	{runeRange{0x1250, 0x1256}, propertyGeneralCategory{lbprAL, gcLo}},     //     [7] ETHIOPIC SYLLABLE QHA..ETHIOPIC SYLLABLE QHO
+	{runeRange{0x125A, 0x125D}, propertyGeneralCategory{lbprAL, gcLo}},     //     [4] ETHIOPIC SYLLABLE QHWI..ETHIOPIC SYLLABLE QHWE
+	{runeRange{0x128A, 0x128D}, propertyGeneralCategory{lbprAL, gcLo}},     //     [4] ETHIOPIC SYLLABLE XWI..ETHIOPIC SYLLABLE XWE
+	{runeRange{0x12B2, 0x12B5}, propertyGeneralCategory{lbprAL, gcLo}},     //     [4] ETHIOPIC SYLLABLE KWI..ETHIOPIC SYLLABLE KWE
+	{runeRange{0x12C0, 0x12C0}, propertyGeneralCategory{lbprAL, gcLo}},     //         ETHIOPIC SYLLABLE KXWA
+	{runeRange{0x12C8, 0x12D6}, propertyGeneralCategory{lbprAL, gcLo}},     //    [15] ETHIOPIC SYLLABLE WA..ETHIOPIC SYLLABLE PHARYNGEAL O
+	{runeRange{0x1312, 0x1315}, propertyGeneralCategory{lbprAL, gcLo}},     //     [4] ETHIOPIC SYLLABLE GWI..ETHIOPIC SYLLABLE GWE
+	{runeRange{0x135D, 0x135F}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] ETHIOPIC COMBINING GEMINATION AND VOWEL LENGTH MARK..ETHIOPIC COMBINING GEMINATION MARK
+	{runeRange{0x1361, 0x1361}, propertyGeneralCategory{lbprBA, gcPo}},     //         ETHIOPIC WORDSPACE
+	{runeRange{0x1369, 0x137C}, propertyGeneralCategory{lbprAL, gcNo}},     //    [20] ETHIOPIC DIGIT ONE..ETHIOPIC NUMBER TEN THOUSAND
+	{runeRange{0x1390, 0x1399}, propertyGeneralCategory{lbprAL, gcSo}},     //    [10] ETHIOPIC TONAL MARK YIZET..ETHIOPIC TONAL MARK KURT
+	{runeRange{0x13F8, 0x13FD}, propertyGeneralCategory{lbprAL, gcLl}},     //     [6] CHEROKEE SMALL LETTER YE..CHEROKEE SMALL LETTER MV
+	{runeRange{0x1401, 0x166C}, propertyGeneralCategory{lbprAL, gcLo}},     //   [620] CANADIAN SYLLABICS E..CANADIAN SYLLABICS CARRIER TTSA
+	{runeRange{0x166E, 0x166E}, propertyGeneralCategory{lbprAL, gcPo}},     //         CANADIAN SYLLABICS FULL STOP
+	{runeRange{0x1680, 0x1680}, propertyGeneralCategory{lbprBA, gcZs}},     //         OGHAM SPACE MARK
+	{runeRange{0x169B, 0x169B}, propertyGeneralCategory{lbprOP, gcPs}},     //         OGHAM FEATHER MARK
+	{runeRange{0x16A0, 0x16EA}, propertyGeneralCategory{lbprAL, gcLo}},     //    [75] RUNIC LETTER FEHU FEOH FE F..RUNIC LETTER X
+	{runeRange{0x16EE, 0x16F0}, propertyGeneralCategory{lbprAL, gcNl}},     //     [3] RUNIC ARLAUG SYMBOL..RUNIC BELGTHOR SYMBOL
+	{runeRange{0x1700, 0x1711}, propertyGeneralCategory{lbprAL, gcLo}},     //    [18] TAGALOG LETTER A..TAGALOG LETTER HA
+	{runeRange{0x1715, 0x1715}, propertyGeneralCategory{lbprCM, gcMc}},     //         TAGALOG SIGN PAMUDPOD
+	{runeRange{0x1720, 0x1731}, propertyGeneralCategory{lbprAL, gcLo}},     //    [18] HANUNOO LETTER A..HANUNOO LETTER HA
+	{runeRange{0x1734, 0x1734}, propertyGeneralCategory{lbprCM, gcMc}},     //         HANUNOO SIGN PAMUDPOD
+	{runeRange{0x1740, 0x1751}, propertyGeneralCategory{lbprAL, gcLo}},     //    [18] BUHID LETTER A..BUHID LETTER HA
+	{runeRange{0x1760, 0x176C}, propertyGeneralCategory{lbprAL, gcLo}},     //    [13] TAGBANWA LETTER A..TAGBANWA LETTER YA
+	{runeRange{0x1772, 0x1773}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] TAGBANWA VOWEL SIGN I..TAGBANWA VOWEL SIGN U
+	{runeRange{0x17B4, 0x17B5}, propertyGeneralCategory{lbprSA, gcMn}},     //     [2] KHMER VOWEL INHERENT AQ..KHMER VOWEL INHERENT AA
+	{runeRange{0x17B7, 0x17BD}, propertyGeneralCategory{lbprSA, gcMn}},     //     [7] KHMER VOWEL SIGN I..KHMER VOWEL SIGN UA
+	{runeRange{0x17C6, 0x17C6}, propertyGeneralCategory{lbprSA, gcMn}},     //         KHMER SIGN NIKAHIT
+	{runeRange{0x17C9, 0x17D3}, propertyGeneralCategory{lbprSA, gcMn}},     //    [11] KHMER SIGN MUUSIKATOAN..KHMER SIGN BATHAMASAT
+	{runeRange{0x17D6, 0x17D6}, propertyGeneralCategory{lbprNS, gcPo}},     //         KHMER SIGN CAMNUC PII KUUH
+	{runeRange{0x17D8, 0x17D8}, propertyGeneralCategory{lbprBA, gcPo}},     //         KHMER SIGN BEYYAL
+	{runeRange{0x17DA, 0x17DA}, propertyGeneralCategory{lbprBA, gcPo}},     //         KHMER SIGN KOOMUUT
+	{runeRange{0x17DC, 0x17DC}, propertyGeneralCategory{lbprSA, gcLo}},     //         KHMER SIGN AVAKRAHASANYA
+	{runeRange{0x17E0, 0x17E9}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] KHMER DIGIT ZERO..KHMER DIGIT NINE
+	{runeRange{0x1800, 0x1801}, propertyGeneralCategory{lbprAL, gcPo}},     //     [2] MONGOLIAN BIRGA..MONGOLIAN ELLIPSIS
+	{runeRange{0x1804, 0x1805}, propertyGeneralCategory{lbprBA, gcPo}},     //     [2] MONGOLIAN COLON..MONGOLIAN FOUR DOTS
+	{runeRange{0x1807, 0x1807}, propertyGeneralCategory{lbprAL, gcPo}},     //         MONGOLIAN SIBE SYLLABLE BOUNDARY MARKER
+	{runeRange{0x180A, 0x180A}, propertyGeneralCategory{lbprAL, gcPo}},     //         MONGOLIAN NIRUGU
+	{runeRange{0x180E, 0x180E}, propertyGeneralCategory{lbprGL, gcCf}},     //         MONGOLIAN VOWEL SEPARATOR
+	{runeRange{0x1810, 0x1819}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] MONGOLIAN DIGIT ZERO..MONGOLIAN DIGIT NINE
+	{runeRange{0x1843, 0x1843}, propertyGeneralCategory{lbprAL, gcLm}},     //         MONGOLIAN LETTER TODO LONG VOWEL SIGN
+	{runeRange{0x1880, 0x1884}, propertyGeneralCategory{lbprAL, gcLo}},     //     [5] MONGOLIAN LETTER ALI GALI ANUSVARA ONE..MONGOLIAN LETTER ALI GALI INVERTED UBADAMA
+	{runeRange{0x1887, 0x18A8}, propertyGeneralCategory{lbprAL, gcLo}},     //    [34] MONGOLIAN LETTER ALI GALI A..MONGOLIAN LETTER MANCHU ALI GALI BHA
+	{runeRange{0x18AA, 0x18AA}, propertyGeneralCategory{lbprAL, gcLo}},     //         MONGOLIAN LETTER MANCHU ALI GALI LHA
+	{runeRange{0x1900, 0x191E}, propertyGeneralCategory{lbprAL, gcLo}},     //    [31] LIMBU VOWEL-CARRIER LETTER..LIMBU LETTER TRA
+	{runeRange{0x1923, 0x1926}, propertyGeneralCategory{lbprCM, gcMc}},     //     [4] LIMBU VOWEL SIGN EE..LIMBU VOWEL SIGN AU
+	{runeRange{0x1929, 0x192B}, propertyGeneralCategory{lbprCM, gcMc}},     //     [3] LIMBU SUBJOINED LETTER YA..LIMBU SUBJOINED LETTER WA
+	{runeRange{0x1932, 0x1932}, propertyGeneralCategory{lbprCM, gcMn}},     //         LIMBU SMALL LETTER ANUSVARA
+	{runeRange{0x1939, 0x193B}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] LIMBU SIGN MUKPHRENG..LIMBU SIGN SA-I
+	{runeRange{0x1944, 0x1945}, propertyGeneralCategory{lbprEX, gcPo}},     //     [2] LIMBU EXCLAMATION MARK..LIMBU QUESTION MARK
+	{runeRange{0x1950, 0x196D}, propertyGeneralCategory{lbprSA, gcLo}},     //    [30] TAI LE LETTER KA..TAI LE LETTER AI
+	{runeRange{0x1980, 0x19AB}, propertyGeneralCategory{lbprSA, gcLo}},     //    [44] NEW TAI LUE LETTER HIGH QA..NEW TAI LUE LETTER LOW SUA
+	{runeRange{0x19D0, 0x19D9}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] NEW TAI LUE DIGIT ZERO..NEW TAI LUE DIGIT NINE
+	{runeRange{0x19DE, 0x19DF}, propertyGeneralCategory{lbprSA, gcSo}},     //     [2] NEW TAI LUE SIGN LAE..NEW TAI LUE SIGN LAEV
+	{runeRange{0x1A00, 0x1A16}, propertyGeneralCategory{lbprAL, gcLo}},     //    [23] BUGINESE LETTER KA..BUGINESE LETTER HA
+	{runeRange{0x1A19, 0x1A1A}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] BUGINESE VOWEL SIGN E..BUGINESE VOWEL SIGN O
+	{runeRange{0x1A1E, 0x1A1F}, propertyGeneralCategory{lbprAL, gcPo}},     //     [2] BUGINESE PALLAWA..BUGINESE END OF SECTION
+	{runeRange{0x1A55, 0x1A55}, propertyGeneralCategory{lbprSA, gcMc}},     //         TAI THAM CONSONANT SIGN MEDIAL RA
+	{runeRange{0x1A57, 0x1A57}, propertyGeneralCategory{lbprSA, gcMc}},     //         TAI THAM CONSONANT SIGN LA TANG LAI
+	{runeRange{0x1A60, 0x1A60}, propertyGeneralCategory{lbprSA, gcMn}},     //         TAI THAM SIGN SAKOT
+	{runeRange{0x1A62, 0x1A62}, propertyGeneralCategory{lbprSA, gcMn}},     //         TAI THAM VOWEL SIGN MAI SAT
+	{runeRange{0x1A65, 0x1A6C}, propertyGeneralCategory{lbprSA, gcMn}},     //     [8] TAI THAM VOWEL SIGN I..TAI THAM VOWEL SIGN OA BELOW
+	{runeRange{0x1A73, 0x1A7C}, propertyGeneralCategory{lbprSA, gcMn}},     //    [10] TAI THAM VOWEL SIGN OA ABOVE..TAI THAM SIGN KHUEN-LUE KARAN
+	{runeRange{0x1A80, 0x1A89}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] TAI THAM HORA DIGIT ZERO..TAI THAM HORA DIGIT NINE
+	{runeRange{0x1AA0, 0x1AA6}, propertyGeneralCategory{lbprSA, gcPo}},     //     [7] TAI THAM SIGN WIANG..TAI THAM SIGN REVERSED ROTATED RANA
+	{runeRange{0x1AA8, 0x1AAD}, propertyGeneralCategory{lbprSA, gcPo}},     //     [6] TAI THAM SIGN KAAN..TAI THAM SIGN CAANG
+	{runeRange{0x1ABE, 0x1ABE}, propertyGeneralCategory{lbprCM, gcMe}},     //         COMBINING PARENTHESES OVERLAY
+	{runeRange{0x1B00, 0x1B03}, propertyGeneralCategory{lbprCM, gcMn}},     //     [4] BALINESE SIGN ULU RICEM..BALINESE SIGN SURANG
+	{runeRange{0x1B05, 0x1B33}, propertyGeneralCategory{lbprAL, gcLo}},     //    [47] BALINESE LETTER AKARA..BALINESE LETTER HA
+	{runeRange{0x1B35, 0x1B35}, propertyGeneralCategory{lbprCM, gcMc}},     //         BALINESE VOWEL SIGN TEDUNG
+	{runeRange{0x1B3B, 0x1B3B}, propertyGeneralCategory{lbprCM, gcMc}},     //         BALINESE VOWEL SIGN RA REPA TEDUNG
+	{runeRange{0x1B3D, 0x1B41}, propertyGeneralCategory{lbprCM, gcMc}},     //     [5] BALINESE VOWEL SIGN LA LENGA TEDUNG..BALINESE VOWEL SIGN TALING REPA TEDUNG
+	{runeRange{0x1B43, 0x1B44}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] BALINESE VOWEL SIGN PEPET TEDUNG..BALINESE ADEG ADEG
+	{runeRange{0x1B50, 0x1B59}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] BALINESE DIGIT ZERO..BALINESE DIGIT NINE
+	{runeRange{0x1B5C, 0x1B5C}, propertyGeneralCategory{lbprAL, gcPo}},     //         BALINESE WINDU
+	{runeRange{0x1B61, 0x1B6A}, propertyGeneralCategory{lbprAL, gcSo}},     //    [10] BALINESE MUSICAL SYMBOL DONG..BALINESE MUSICAL SYMBOL DANG GEDE
+	{runeRange{0x1B74, 0x1B7C}, propertyGeneralCategory{lbprAL, gcSo}},     //     [9] BALINESE MUSICAL SYMBOL RIGHT-HAND OPEN DUG..BALINESE MUSICAL SYMBOL LEFT-HAND OPEN PING
+	{runeRange{0x1B80, 0x1B81}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] SUNDANESE SIGN PANYECEK..SUNDANESE SIGN PANGLAYAR
+	{runeRange{0x1B83, 0x1BA0}, propertyGeneralCategory{lbprAL, gcLo}},     //    [30] SUNDANESE LETTER A..SUNDANESE LETTER HA
+	{runeRange{0x1BA2, 0x1BA5}, propertyGeneralCategory{lbprCM, gcMn}},     //     [4] SUNDANESE CONSONANT SIGN PANYAKRA..SUNDANESE VOWEL SIGN PANYUKU
+	{runeRange{0x1BA8, 0x1BA9}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] SUNDANESE VOWEL SIGN PAMEPET..SUNDANESE VOWEL SIGN PANEULEUNG
+	{runeRange{0x1BAB, 0x1BAD}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] SUNDANESE SIGN VIRAMA..SUNDANESE CONSONANT SIGN PASANGAN WA
+	{runeRange{0x1BB0, 0x1BB9}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] SUNDANESE DIGIT ZERO..SUNDANESE DIGIT NINE
+	{runeRange{0x1BC0, 0x1BE5}, propertyGeneralCategory{lbprAL, gcLo}},     //    [38] BATAK LETTER A..BATAK LETTER U
+	{runeRange{0x1BE7, 0x1BE7}, propertyGeneralCategory{lbprCM, gcMc}},     //         BATAK VOWEL SIGN E
+	{runeRange{0x1BEA, 0x1BEC}, propertyGeneralCategory{lbprCM, gcMc}},     //     [3] BATAK VOWEL SIGN I..BATAK VOWEL SIGN O
+	{runeRange{0x1BEE, 0x1BEE}, propertyGeneralCategory{lbprCM, gcMc}},     //         BATAK VOWEL SIGN U
+	{runeRange{0x1BF2, 0x1BF3}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] BATAK PANGOLAT..BATAK PANONGONAN
+	{runeRange{0x1C00, 0x1C23}, propertyGeneralCategory{lbprAL, gcLo}},     //    [36] LEPCHA LETTER KA..LEPCHA LETTER A
+	{runeRange{0x1C2C, 0x1C33}, propertyGeneralCategory{lbprCM, gcMn}},     //     [8] LEPCHA VOWEL SIGN E..LEPCHA CONSONANT SIGN T
+	{runeRange{0x1C36, 0x1C37}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] LEPCHA SIGN RAN..LEPCHA SIGN NUKTA
+	{runeRange{0x1C40, 0x1C49}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] LEPCHA DIGIT ZERO..LEPCHA DIGIT NINE
+	{runeRange{0x1C50, 0x1C59}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] OL CHIKI DIGIT ZERO..OL CHIKI DIGIT NINE
+	{runeRange{0x1C78, 0x1C7D}, propertyGeneralCategory{lbprAL, gcLm}},     //     [6] OL CHIKI MU TTUDDAG..OL CHIKI AHAD
+	{runeRange{0x1C80, 0x1C88}, propertyGeneralCategory{lbprAL, gcLl}},     //     [9] CYRILLIC SMALL LETTER ROUNDED VE..CYRILLIC SMALL LETTER UNBLENDED UK
+	{runeRange{0x1CBD, 0x1CBF}, propertyGeneralCategory{lbprAL, gcLu}},     //     [3] GEORGIAN MTAVRULI CAPITAL LETTER AEN..GEORGIAN MTAVRULI CAPITAL LETTER LABIAL SIGN
+	{runeRange{0x1CD0, 0x1CD2}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] VEDIC TONE KARSHANA..VEDIC TONE PRENKHA
+	{runeRange{0x1CD4, 0x1CE0}, propertyGeneralCategory{lbprCM, gcMn}},     //    [13] VEDIC SIGN YAJURVEDIC MIDLINE SVARITA..VEDIC TONE RIGVEDIC KASHMIRI INDEPENDENT SVARITA
+	{runeRange{0x1CE2, 0x1CE8}, propertyGeneralCategory{lbprCM, gcMn}},     //     [7] VEDIC SIGN VISARGA SVARITA..VEDIC SIGN VISARGA ANUDATTA WITH TAIL
+	{runeRange{0x1CED, 0x1CED}, propertyGeneralCategory{lbprCM, gcMn}},     //         VEDIC SIGN TIRYAK
+	{runeRange{0x1CF4, 0x1CF4}, propertyGeneralCategory{lbprCM, gcMn}},     //         VEDIC TONE CANDRA ABOVE
+	{runeRange{0x1CF7, 0x1CF7}, propertyGeneralCategory{lbprCM, gcMc}},     //         VEDIC SIGN ATIKRAMA
+	{runeRange{0x1CFA, 0x1CFA}, propertyGeneralCategory{lbprAL, gcLo}},     //         VEDIC SIGN DOUBLE ANUSVARA ANTARGOMUKHA
+	{runeRange{0x1D2C, 0x1D6A}, propertyGeneralCategory{lbprAL, gcLm}},     //    [63] MODIFIER LETTER CAPITAL A..GREEK SUBSCRIPT SMALL LETTER CHI
+	{runeRange{0x1D78, 0x1D78}, propertyGeneralCategory{lbprAL, gcLm}},     //         MODIFIER LETTER CYRILLIC EN
+	{runeRange{0x1D80, 0x1D9A}, propertyGeneralCategory{lbprAL, gcLl}},     //    [27] LATIN SMALL LETTER B WITH PALATAL HOOK..LATIN SMALL LETTER EZH WITH RETROFLEX HOOK
+	{runeRange{0x1DC0, 0x1DCC}, propertyGeneralCategory{lbprCM, gcMn}},     //    [13] COMBINING DOTTED GRAVE ACCENT..COMBINING MACRON-BREVE
+	{runeRange{0x1DCE, 0x1DFB}, propertyGeneralCategory{lbprCM, gcMn}},     //    [46] COMBINING OGONEK ABOVE..COMBINING DELETION MARK
+	{runeRange{0x1DFD, 0x1DFF}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] COMBINING ALMOST EQUAL TO BELOW..COMBINING RIGHT ARROWHEAD AND DOWN ARROWHEAD BELOW
+	{runeRange{0x1F00, 0x1F15}, propertyGeneralCategory{lbprAL, gcLC}},     //    [22] GREEK SMALL LETTER ALPHA WITH PSILI..GREEK SMALL LETTER EPSILON WITH DASIA AND OXIA
+	{runeRange{0x1F20, 0x1F45}, propertyGeneralCategory{lbprAL, gcLC}},     //    [38] GREEK SMALL LETTER ETA WITH PSILI..GREEK SMALL LETTER OMICRON WITH DASIA AND OXIA
+	{runeRange{0x1F50, 0x1F57}, propertyGeneralCategory{lbprAL, gcLl}},     //     [8] GREEK SMALL LETTER UPSILON WITH PSILI..GREEK SMALL LETTER UPSILON WITH DASIA AND PERISPOMENI
+	{runeRange{0x1F5B, 0x1F5B}, propertyGeneralCategory{lbprAL, gcLu}},     //         GREEK CAPITAL LETTER UPSILON WITH DASIA AND VARIA
+	{runeRange{0x1F5F, 0x1F7D}, propertyGeneralCategory{lbprAL, gcLC}},     //    [31] GREEK CAPITAL LETTER UPSILON WITH DASIA AND PERISPOMENI..GREEK SMALL LETTER OMEGA WITH OXIA
+	{runeRange{0x1FB6, 0x1FBC}, propertyGeneralCategory{lbprAL, gcLC}},     //     [7] GREEK SMALL LETTER ALPHA WITH PERISPOMENI..GREEK CAPITAL LETTER ALPHA WITH PROSGEGRAMMENI
+	{runeRange{0x1FBE, 0x1FBE}, propertyGeneralCategory{lbprAL, gcLl}},     //         GREEK PROSGEGRAMMENI
+	{runeRange{0x1FC2, 0x1FC4}, propertyGeneralCategory{lbprAL, gcLl}},     //     [3] GREEK SMALL LETTER ETA WITH VARIA AND YPOGEGRAMMENI..GREEK SMALL LETTER ETA WITH OXIA AND YPOGEGRAMMENI
+	{runeRange{0x1FCD, 0x1FCF}, propertyGeneralCategory{lbprAL, gcSk}},     //     [3] GREEK PSILI AND VARIA..GREEK PSILI AND PERISPOMENI
+	{runeRange{0x1FD6, 0x1FDB}, propertyGeneralCategory{lbprAL, gcLC}},     //     [6] GREEK SMALL LETTER IOTA WITH PERISPOMENI..GREEK CAPITAL LETTER IOTA WITH OXIA
+	{runeRange{0x1FE0, 0x1FEC}, propertyGeneralCategory{lbprAL, gcLC}},     //    [13] GREEK SMALL LETTER UPSILON WITH VRACHY..GREEK CAPITAL LETTER RHO WITH DASIA
+	{runeRange{0x1FF2, 0x1FF4}, propertyGeneralCategory{lbprAL, gcLl}},     //     [3] GREEK SMALL LETTER OMEGA WITH VARIA AND YPOGEGRAMMENI..GREEK SMALL LETTER OMEGA WITH OXIA AND YPOGEGRAMMENI
+	{runeRange{0x1FFD, 0x1FFD}, propertyGeneralCategory{lbprBB, gcSk}},     //         GREEK OXIA
+	{runeRange{0x2000, 0x2006}, propertyGeneralCategory{lbprBA, gcZs}},     //     [7] EN QUAD..SIX-PER-EM SPACE
+	{runeRange{0x2008, 0x200A}, propertyGeneralCategory{lbprBA, gcZs}},     //     [3] PUNCTUATION SPACE..HAIR SPACE
+	{runeRange{0x200C, 0x200C}, propertyGeneralCategory{lbprCM, gcCf}},     //         ZERO WIDTH NON-JOINER
+	{runeRange{0x200E, 0x200F}, propertyGeneralCategory{lbprCM, gcCf}},     //     [2] LEFT-TO-RIGHT MARK..RIGHT-TO-LEFT MARK
+	{runeRange{0x2011, 0x2011}, propertyGeneralCategory{lbprGL, gcPd}},     //         NON-BREAKING HYPHEN
+	{runeRange{0x2014, 0x2014}, propertyGeneralCategory{lbprB2, gcPd}},     //         EM DASH
+	{runeRange{0x2016, 0x2016}, propertyGeneralCategory{lbprAI, gcPo}},     //         DOUBLE VERTICAL LINE
+	{runeRange{0x2018, 0x2018}, propertyGeneralCategory{lbprQU, gcPi}},     //         LEFT SINGLE QUOTATION MARK
+	{runeRange{0x201A, 0x201A}, propertyGeneralCategory{lbprOP, gcPs}},     //         SINGLE LOW-9 QUOTATION MARK
+	{runeRange{0x201D, 0x201D}, propertyGeneralCategory{lbprQU, gcPf}},     //         RIGHT DOUBLE QUOTATION MARK
+	{runeRange{0x201F, 0x201F}, propertyGeneralCategory{lbprQU, gcPi}},     //         DOUBLE HIGH-REVERSED-9 QUOTATION MARK
+	{runeRange{0x2022, 0x2023}, propertyGeneralCategory{lbprAL, gcPo}},     //     [2] BULLET..TRIANGULAR BULLET
+	{runeRange{0x2027, 0x2027}, propertyGeneralCategory{lbprBA, gcPo}},     //         HYPHENATION POINT
+	{runeRange{0x2029, 0x2029}, propertyGeneralCategory{lbprBK, gcZp}},     //         PARAGRAPH SEPARATOR
+	{runeRange{0x202F, 0x202F}, propertyGeneralCategory{lbprGL, gcZs}},     //         NARROW NO-BREAK SPACE
+	{runeRange{0x2038, 0x2038}, propertyGeneralCategory{lbprAL, gcPo}},     //         CARET
+	{runeRange{0x203A, 0x203A}, propertyGeneralCategory{lbprQU, gcPf}},     //         SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
+	{runeRange{0x203C, 0x203D}, propertyGeneralCategory{lbprNS, gcPo}},     //     [2] DOUBLE EXCLAMATION MARK..INTERROBANG
+	{runeRange{0x203F, 0x2040}, propertyGeneralCategory{lbprAL, gcPc}},     //     [2] UNDERTIE..CHARACTER TIE
+	{runeRange{0x2044, 0x2044}, propertyGeneralCategory{lbprIS, gcSm}},     //         FRACTION SLASH
+	{runeRange{0x2046, 0x2046}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT SQUARE BRACKET WITH QUILL
+	{runeRange{0x204A, 0x2051}, propertyGeneralCategory{lbprAL, gcPo}},     //     [8] TIRONIAN SIGN ET..TWO ASTERISKS ALIGNED VERTICALLY
+	{runeRange{0x2053, 0x2053}, propertyGeneralCategory{lbprAL, gcPo}},     //         SWUNG DASH
+	{runeRange{0x2055, 0x2055}, propertyGeneralCategory{lbprAL, gcPo}},     //         FLOWER PUNCTUATION MARK
+	{runeRange{0x2057, 0x2057}, propertyGeneralCategory{lbprPO, gcPo}},     //         QUADRUPLE PRIME
+	{runeRange{0x205C, 0x205C}, propertyGeneralCategory{lbprAL, gcPo}},     //         DOTTED CROSS
+	{runeRange{0x205F, 0x205F}, propertyGeneralCategory{lbprBA, gcZs}},     //         MEDIUM MATHEMATICAL SPACE
+	{runeRange{0x2061, 0x2064}, propertyGeneralCategory{lbprAL, gcCf}},     //     [4] FUNCTION APPLICATION..INVISIBLE PLUS
+	{runeRange{0x2070, 0x2070}, propertyGeneralCategory{lbprAL, gcNo}},     //         SUPERSCRIPT ZERO
+	{runeRange{0x2074, 0x2074}, propertyGeneralCategory{lbprAI, gcNo}},     //         SUPERSCRIPT FOUR
+	{runeRange{0x207A, 0x207C}, propertyGeneralCategory{lbprAL, gcSm}},     //     [3] SUPERSCRIPT PLUS SIGN..SUPERSCRIPT EQUALS SIGN
+	{runeRange{0x207E, 0x207E}, propertyGeneralCategory{lbprCL, gcPe}},     //         SUPERSCRIPT RIGHT PARENTHESIS
+	{runeRange{0x2080, 0x2080}, propertyGeneralCategory{lbprAL, gcNo}},     //         SUBSCRIPT ZERO
+	{runeRange{0x2085, 0x2089}, propertyGeneralCategory{lbprAL, gcNo}},     //     [5] SUBSCRIPT FIVE..SUBSCRIPT NINE
+	{runeRange{0x208D, 0x208D}, propertyGeneralCategory{lbprOP, gcPs}},     //         SUBSCRIPT LEFT PARENTHESIS
+	{runeRange{0x2090, 0x209C}, propertyGeneralCategory{lbprAL, gcLm}},     //    [13] LATIN SUBSCRIPT SMALL LETTER A..LATIN SUBSCRIPT SMALL LETTER T
+	{runeRange{0x20A7, 0x20A7}, propertyGeneralCategory{lbprPO, gcSc}},     //         PESETA SIGN
+	{runeRange{0x20B6, 0x20B6}, propertyGeneralCategory{lbprPO, gcSc}},     //         LIVRE TOURNOIS SIGN
+	{runeRange{0x20BB, 0x20BB}, propertyGeneralCategory{lbprPO, gcSc}},     //         NORDIC MARK SIGN
+	{runeRange{0x20BE, 0x20BE}, propertyGeneralCategory{lbprPO, gcSc}},     //         LARI SIGN
+	{runeRange{0x20C0, 0x20C0}, propertyGeneralCategory{lbprPO, gcSc}},     //         SOM SIGN
+	{runeRange{0x20D0, 0x20DC}, propertyGeneralCategory{lbprCM, gcMn}},     //    [13] COMBINING LEFT HARPOON ABOVE..COMBINING FOUR DOTS ABOVE
+	{runeRange{0x20E1, 0x20E1}, propertyGeneralCategory{lbprCM, gcMn}},     //         COMBINING LEFT RIGHT ARROW ABOVE
+	{runeRange{0x20E5, 0x20F0}, propertyGeneralCategory{lbprCM, gcMn}},     //    [12] COMBINING REVERSE SOLIDUS OVERLAY..COMBINING ASTERISK ABOVE
+	{runeRange{0x2102, 0x2102}, propertyGeneralCategory{lbprAL, gcLu}},     //         DOUBLE-STRUCK CAPITAL C
+	{runeRange{0x2104, 0x2104}, propertyGeneralCategory{lbprAL, gcSo}},     //         CENTRE LINE SYMBOL
+	{runeRange{0x2106, 0x2106}, propertyGeneralCategory{lbprAL, gcSo}},     //         CADA UNA
+	{runeRange{0x2108, 0x2108}, propertyGeneralCategory{lbprAL, gcSo}},     //         SCRUPLE
+	{runeRange{0x210A, 0x2112}, propertyGeneralCategory{lbprAL, gcLC}},     //     [9] SCRIPT SMALL G..SCRIPT CAPITAL L
+	{runeRange{0x2114, 0x2114}, propertyGeneralCategory{lbprAL, gcSo}},     //         L B BAR SYMBOL
+	{runeRange{0x2116, 0x2116}, propertyGeneralCategory{lbprPR, gcSo}},     //         NUMERO SIGN
+	{runeRange{0x2118, 0x2118}, propertyGeneralCategory{lbprAL, gcSm}},     //         SCRIPT CAPITAL P
+	{runeRange{0x211E, 0x2120}, propertyGeneralCategory{lbprAL, gcSo}},     //     [3] PRESCRIPTION TAKE..SERVICE MARK
+	{runeRange{0x2123, 0x2123}, propertyGeneralCategory{lbprAL, gcSo}},     //         VERSICLE
+	{runeRange{0x2125, 0x2125}, propertyGeneralCategory{lbprAL, gcSo}},     //         OUNCE SIGN
+	{runeRange{0x2127, 0x2127}, propertyGeneralCategory{lbprAL, gcSo}},     //         INVERTED OHM SIGN
+	{runeRange{0x2129, 0x2129}, propertyGeneralCategory{lbprAL, gcSo}},     //         TURNED GREEK SMALL LETTER IOTA
+	{runeRange{0x212B, 0x212B}, propertyGeneralCategory{lbprAI, gcLu}},     //         ANGSTROM SIGN
+	{runeRange{0x212E, 0x212E}, propertyGeneralCategory{lbprAL, gcSo}},     //         ESTIMATED SYMBOL
+	{runeRange{0x2135, 0x2138}, propertyGeneralCategory{lbprAL, gcLo}},     //     [4] ALEF SYMBOL..DALET SYMBOL
+	{runeRange{0x213A, 0x213B}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] ROTATED CAPITAL Q..FACSIMILE SIGN
+	{runeRange{0x2140, 0x2144}, propertyGeneralCategory{lbprAL, gcSm}},     //     [5] DOUBLE-STRUCK N-ARY SUMMATION..TURNED SANS-SERIF CAPITAL Y
+	{runeRange{0x214A, 0x214A}, propertyGeneralCategory{lbprAL, gcSo}},     //         PROPERTY LINE
+	{runeRange{0x214C, 0x214D}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] PER SIGN..AKTIESELSKAB
+	{runeRange{0x214F, 0x214F}, propertyGeneralCategory{lbprAL, gcSo}},     //         SYMBOL FOR SAMARITAN SOURCE
+	{runeRange{0x2154, 0x2155}, propertyGeneralCategory{lbprAI, gcNo}},     //     [2] VULGAR FRACTION TWO THIRDS..VULGAR FRACTION ONE FIFTH
+	{runeRange{0x215B, 0x215B}, propertyGeneralCategory{lbprAI, gcNo}},     //         VULGAR FRACTION ONE EIGHTH
+	{runeRange{0x215E, 0x215E}, propertyGeneralCategory{lbprAI, gcNo}},     //         VULGAR FRACTION SEVEN EIGHTHS
+	{runeRange{0x2160, 0x216B}, propertyGeneralCategory{lbprAI, gcNl}},     //    [12] ROMAN NUMERAL ONE..ROMAN NUMERAL TWELVE
+	{runeRange{0x2170, 0x2179}, propertyGeneralCategory{lbprAI, gcNl}},     //    [10] SMALL ROMAN NUMERAL ONE..SMALL ROMAN NUMERAL TEN
+	{runeRange{0x2183, 0x2184}, propertyGeneralCategory{lbprAL, gcLC}},     //     [2] ROMAN NUMERAL REVERSED ONE HUNDRED..LATIN SMALL LETTER REVERSED C
+	{runeRange{0x2189, 0x2189}, propertyGeneralCategory{lbprAI, gcNo}},     //         VULGAR FRACTION ZERO THIRDS
+	{runeRange{0x2190, 0x2194}, propertyGeneralCategory{lbprAI, gcSm}},     //     [5] LEFTWARDS ARROW..LEFT RIGHT ARROW
+	{runeRange{0x219A, 0x219B}, propertyGeneralCategory{lbprAL, gcSm}},     //     [2] LEFTWARDS ARROW WITH STROKE..RIGHTWARDS ARROW WITH STROKE
+	{runeRange{0x21A0, 0x21A0}, propertyGeneralCategory{lbprAL, gcSm}},     //         RIGHTWARDS TWO HEADED ARROW
+	{runeRange{0x21A3, 0x21A3}, propertyGeneralCategory{lbprAL, gcSm}},     //         RIGHTWARDS ARROW WITH TAIL
+	{runeRange{0x21A6, 0x21A6}, propertyGeneralCategory{lbprAL, gcSm}},     //         RIGHTWARDS ARROW FROM BAR
+	{runeRange{0x21AE, 0x21AE}, propertyGeneralCategory{lbprAL, gcSm}},     //         LEFT RIGHT ARROW WITH STROKE
+	{runeRange{0x21CE, 0x21CF}, propertyGeneralCategory{lbprAL, gcSm}},     //     [2] LEFT RIGHT DOUBLE ARROW WITH STROKE..RIGHTWARDS DOUBLE ARROW WITH STROKE
+	{runeRange{0x21D2, 0x21D2}, propertyGeneralCategory{lbprAI, gcSm}},     //         RIGHTWARDS DOUBLE ARROW
+	{runeRange{0x21D4, 0x21D4}, propertyGeneralCategory{lbprAI, gcSm}},     //         LEFT RIGHT DOUBLE ARROW
+	{runeRange{0x21F4, 0x21FF}, propertyGeneralCategory{lbprAL, gcSm}},     //    [12] RIGHT ARROW WITH SMALL CIRCLE..LEFT RIGHT OPEN-HEADED ARROW
+	{runeRange{0x2201, 0x2201}, propertyGeneralCategory{lbprAL, gcSm}},     //         COMPLEMENT
+	{runeRange{0x2204, 0x2206}, propertyGeneralCategory{lbprAL, gcSm}},     //     [3] THERE DOES NOT EXIST..INCREMENT
+	{runeRange{0x2209, 0x220A}, propertyGeneralCategory{lbprAL, gcSm}},     //     [2] NOT AN ELEMENT OF..SMALL ELEMENT OF
+	{runeRange{0x220C, 0x220E}, propertyGeneralCategory{lbprAL, gcSm}},     //     [3] DOES NOT CONTAIN AS MEMBER..END OF PROOF
+	{runeRange{0x2210, 0x2210}, propertyGeneralCategory{lbprAL, gcSm}},     //         N-ARY COPRODUCT
+	{runeRange{0x2212, 0x2213}, propertyGeneralCategory{lbprPR, gcSm}},     //     [2] MINUS SIGN..MINUS-OR-PLUS SIGN
+	{runeRange{0x2215, 0x2215}, propertyGeneralCategory{lbprAI, gcSm}},     //         DIVISION SLASH
+	{runeRange{0x221A, 0x221A}, propertyGeneralCategory{lbprAI, gcSm}},     //         SQUARE ROOT
+	{runeRange{0x221D, 0x2220}, propertyGeneralCategory{lbprAI, gcSm}},     //     [4] PROPORTIONAL TO..ANGLE
+	{runeRange{0x2223, 0x2223}, propertyGeneralCategory{lbprAI, gcSm}},     //         DIVIDES
+	{runeRange{0x2225, 0x2225}, propertyGeneralCategory{lbprAI, gcSm}},     //         PARALLEL TO
+	{runeRange{0x2227, 0x222C}, propertyGeneralCategory{lbprAI, gcSm}},     //     [6] LOGICAL AND..DOUBLE INTEGRAL
+	{runeRange{0x222E, 0x222E}, propertyGeneralCategory{lbprAI, gcSm}},     //         CONTOUR INTEGRAL
+	{runeRange{0x2234, 0x2237}, propertyGeneralCategory{lbprAI, gcSm}},     //     [4] THEREFORE..PROPORTION
+	{runeRange{0x223C, 0x223D}, propertyGeneralCategory{lbprAI, gcSm}},     //     [2] TILDE OPERATOR..REVERSED TILDE
+	{runeRange{0x2248, 0x2248}, propertyGeneralCategory{lbprAI, gcSm}},     //         ALMOST EQUAL TO
+	{runeRange{0x224C, 0x224C}, propertyGeneralCategory{lbprAI, gcSm}},     //         ALL EQUAL TO
+	{runeRange{0x2252, 0x2252}, propertyGeneralCategory{lbprAI, gcSm}},     //         APPROXIMATELY EQUAL TO OR THE IMAGE OF
+	{runeRange{0x2260, 0x2261}, propertyGeneralCategory{lbprAI, gcSm}},     //     [2] NOT EQUAL TO..IDENTICAL TO
+	{runeRange{0x2264, 0x2267}, propertyGeneralCategory{lbprAI, gcSm}},     //     [4] LESS-THAN OR EQUAL TO..GREATER-THAN OVER EQUAL TO
+	{runeRange{0x226A, 0x226B}, propertyGeneralCategory{lbprAI, gcSm}},     //     [2] MUCH LESS-THAN..MUCH GREATER-THAN
+	{runeRange{0x226E, 0x226F}, propertyGeneralCategory{lbprAI, gcSm}},     //     [2] NOT LESS-THAN..NOT GREATER-THAN
+	{runeRange{0x2282, 0x2283}, propertyGeneralCategory{lbprAI, gcSm}},     //     [2] SUBSET OF..SUPERSET OF
+	{runeRange{0x2286, 0x2287}, propertyGeneralCategory{lbprAI, gcSm}},     //     [2] SUBSET OF OR EQUAL TO..SUPERSET OF OR EQUAL TO
+	{runeRange{0x2295, 0x2295}, propertyGeneralCategory{lbprAI, gcSm}},     //         CIRCLED PLUS
+	{runeRange{0x2299, 0x2299}, propertyGeneralCategory{lbprAI, gcSm}},     //         CIRCLED DOT OPERATOR
+	{runeRange{0x22A5, 0x22A5}, propertyGeneralCategory{lbprAI, gcSm}},     //         UP TACK
+	{runeRange{0x22BF, 0x22BF}, propertyGeneralCategory{lbprAI, gcSm}},     //         RIGHT TRIANGLE
+	{runeRange{0x22EF, 0x22EF}, propertyGeneralCategory{lbprIN, gcSm}},     //         MIDLINE HORIZONTAL ELLIPSIS
+	{runeRange{0x2300, 0x2307}, propertyGeneralCategory{lbprAL, gcSo}},     //     [8] DIAMETER SIGN..WAVY LINE
+	{runeRange{0x2309, 0x2309}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT CEILING
+	{runeRange{0x230B, 0x230B}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT FLOOR
+	{runeRange{0x2312, 0x2312}, propertyGeneralCategory{lbprAI, gcSo}},     //         ARC
+	{runeRange{0x231A, 0x231B}, propertyGeneralCategory{lbprID, gcSo}},     //     [2] WATCH..HOURGLASS
+	{runeRange{0x2320, 0x2321}, propertyGeneralCategory{lbprAL, gcSm}},     //     [2] TOP HALF INTEGRAL..BOTTOM HALF INTEGRAL
+	{runeRange{0x2329, 0x2329}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT-POINTING ANGLE BRACKET
+	{runeRange{0x232B, 0x237B}, propertyGeneralCategory{lbprAL, gcSo}},     //    [81] ERASE TO THE LEFT..NOT CHECK MARK
+	{runeRange{0x237D, 0x239A}, propertyGeneralCategory{lbprAL, gcSo}},     //    [30] SHOULDERED OPEN BOX..CLEAR SCREEN SYMBOL
+	{runeRange{0x23B4, 0x23DB}, propertyGeneralCategory{lbprAL, gcSo}},     //    [40] TOP SQUARE BRACKET..FUSE
+	{runeRange{0x23E2, 0x23EF}, propertyGeneralCategory{lbprAL, gcSo}},     //    [14] WHITE TRAPEZIUM..BLACK RIGHT-POINTING TRIANGLE WITH DOUBLE VERTICAL BAR
+	{runeRange{0x23F4, 0x23FF}, propertyGeneralCategory{lbprAL, gcSo}},     //    [12] BLACK MEDIUM LEFT-POINTING TRIANGLE..OBSERVER EYE SYMBOL
+	{runeRange{0x2440, 0x244A}, propertyGeneralCategory{lbprAL, gcSo}},     //    [11] OCR HOOK..OCR DOUBLE BACKSLASH
+	{runeRange{0x249C, 0x24E9}, propertyGeneralCategory{lbprAI, gcSo}},     //    [78] PARENTHESIZED LATIN SMALL LETTER A..CIRCLED LATIN SMALL LETTER Z
+	{runeRange{0x24FF, 0x24FF}, propertyGeneralCategory{lbprAL, gcNo}},     //         NEGATIVE CIRCLED DIGIT ZERO
+	{runeRange{0x254C, 0x254F}, propertyGeneralCategory{lbprAL, gcSo}},     //     [4] BOX DRAWINGS LIGHT DOUBLE DASH HORIZONTAL..BOX DRAWINGS HEAVY DOUBLE DASH VERTICAL
+	{runeRange{0x2575, 0x257F}, propertyGeneralCategory{lbprAL, gcSo}},     //    [11] BOX DRAWINGS LIGHT UP..BOX DRAWINGS HEAVY UP AND LIGHT DOWN
+	{runeRange{0x2590, 0x2591}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] RIGHT HALF BLOCK..LIGHT SHADE
+	{runeRange{0x2596, 0x259F}, propertyGeneralCategory{lbprAL, gcSo}},     //    [10] QUADRANT LOWER LEFT..QUADRANT UPPER RIGHT AND LOWER LEFT AND LOWER RIGHT
+	{runeRange{0x25A2, 0x25A2}, propertyGeneralCategory{lbprAL, gcSo}},     //         WHITE SQUARE WITH ROUNDED CORNERS
+	{runeRange{0x25AA, 0x25B1}, propertyGeneralCategory{lbprAL, gcSo}},     //     [8] BLACK SMALL SQUARE..WHITE PARALLELOGRAM
+	{runeRange{0x25B4, 0x25B5}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] BLACK UP-POINTING SMALL TRIANGLE..WHITE UP-POINTING SMALL TRIANGLE
+	{runeRange{0x25B7, 0x25B7}, propertyGeneralCategory{lbprAI, gcSm}},     //         WHITE RIGHT-POINTING TRIANGLE
+	{runeRange{0x25BC, 0x25BD}, propertyGeneralCategory{lbprAI, gcSo}},     //     [2] BLACK DOWN-POINTING TRIANGLE..WHITE DOWN-POINTING TRIANGLE
+	{runeRange{0x25C0, 0x25C0}, propertyGeneralCategory{lbprAI, gcSo}},     //         BLACK LEFT-POINTING TRIANGLE
+	{runeRange{0x25C2, 0x25C5}, propertyGeneralCategory{lbprAL, gcSo}},     //     [4] BLACK LEFT-POINTING SMALL TRIANGLE..WHITE LEFT-POINTING POINTER
+	{runeRange{0x25C9, 0x25CA}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] FISHEYE..LOZENGE
+	{runeRange{0x25CC, 0x25CD}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] DOTTED CIRCLE..CIRCLE WITH VERTICAL FILL
+	{runeRange{0x25D2, 0x25E1}, propertyGeneralCategory{lbprAL, gcSo}},     //    [16] CIRCLE WITH LOWER HALF BLACK..LOWER HALF CIRCLE
+	{runeRange{0x25E6, 0x25EE}, propertyGeneralCategory{lbprAL, gcSo}},     //     [9] WHITE BULLET..UP-POINTING TRIANGLE WITH RIGHT HALF BLACK
+	{runeRange{0x25F0, 0x25F7}, propertyGeneralCategory{lbprAL, gcSo}},     //     [8] WHITE SQUARE WITH UPPER LEFT QUADRANT..WHITE CIRCLE WITH UPPER RIGHT QUADRANT
+	{runeRange{0x2600, 0x2603}, propertyGeneralCategory{lbprID, gcSo}},     //     [4] BLACK SUN WITH RAYS..SNOWMAN
+	{runeRange{0x2605, 0x2606}, propertyGeneralCategory{lbprAI, gcSo}},     //     [2] BLACK STAR..WHITE STAR
+	{runeRange{0x2609, 0x2609}, propertyGeneralCategory{lbprAI, gcSo}},     //         SUN
+	{runeRange{0x260E, 0x260F}, propertyGeneralCategory{lbprAI, gcSo}},     //     [2] BLACK TELEPHONE..WHITE TELEPHONE
+	{runeRange{0x2614, 0x2615}, propertyGeneralCategory{lbprID, gcSo}},     //     [2] UMBRELLA WITH RAIN DROPS..HOT BEVERAGE
+	{runeRange{0x2618, 0x2618}, propertyGeneralCategory{lbprID, gcSo}},     //         SHAMROCK
+	{runeRange{0x261A, 0x261C}, propertyGeneralCategory{lbprID, gcSo}},     //     [3] BLACK LEFT POINTING INDEX..WHITE LEFT POINTING INDEX
+	{runeRange{0x261E, 0x261F}, propertyGeneralCategory{lbprID, gcSo}},     //     [2] WHITE RIGHT POINTING INDEX..WHITE DOWN POINTING INDEX
+	{runeRange{0x2639, 0x263B}, propertyGeneralCategory{lbprID, gcSo}},     //     [3] WHITE FROWNING FACE..BLACK SMILING FACE
+	{runeRange{0x2640, 0x2640}, propertyGeneralCategory{lbprAI, gcSo}},     //         FEMALE SIGN
+	{runeRange{0x2642, 0x2642}, propertyGeneralCategory{lbprAI, gcSo}},     //         MALE SIGN
+	{runeRange{0x2660, 0x2661}, propertyGeneralCategory{lbprAI, gcSo}},     //     [2] BLACK SPADE SUIT..WHITE HEART SUIT
+	{runeRange{0x2663, 0x2665}, propertyGeneralCategory{lbprAI, gcSo}},     //     [3] BLACK CLUB SUIT..BLACK HEART SUIT
+	{runeRange{0x2667, 0x2667}, propertyGeneralCategory{lbprAI, gcSo}},     //         WHITE CLUB SUIT
+	{runeRange{0x2669, 0x266A}, propertyGeneralCategory{lbprAI, gcSo}},     //     [2] QUARTER NOTE..EIGHTH NOTE
+	{runeRange{0x266C, 0x266D}, propertyGeneralCategory{lbprAI, gcSo}},     //     [2] BEAMED SIXTEENTH NOTES..MUSIC FLAT SIGN
+	{runeRange{0x266F, 0x266F}, propertyGeneralCategory{lbprAI, gcSm}},     //         MUSIC SHARP SIGN
+	{runeRange{0x267F, 0x267F}, propertyGeneralCategory{lbprID, gcSo}},     //         WHEELCHAIR SYMBOL
+	{runeRange{0x269E, 0x269F}, propertyGeneralCategory{lbprAI, gcSo}},     //     [2] THREE LINES CONVERGING RIGHT..THREE LINES CONVERGING LEFT
+	{runeRange{0x26BD, 0x26C8}, propertyGeneralCategory{lbprID, gcSo}},     //    [12] SOCCER BALL..THUNDER CLOUD AND RAIN
+	{runeRange{0x26CD, 0x26CD}, propertyGeneralCategory{lbprID, gcSo}},     //         DISABLED CAR
+	{runeRange{0x26CF, 0x26D1}, propertyGeneralCategory{lbprID, gcSo}},     //     [3] PICK..HELMET WITH WHITE CROSS
+	{runeRange{0x26D3, 0x26D4}, propertyGeneralCategory{lbprID, gcSo}},     //     [2] CHAINS..NO ENTRY
+	{runeRange{0x26D8, 0x26D9}, propertyGeneralCategory{lbprID, gcSo}},     //     [2] BLACK LEFT LANE MERGE..WHITE LEFT LANE MERGE
+	{runeRange{0x26DC, 0x26DC}, propertyGeneralCategory{lbprID, gcSo}},     //         LEFT CLOSED ENTRY
+	{runeRange{0x26DF, 0x26E1}, propertyGeneralCategory{lbprID, gcSo}},     //     [3] BLACK TRUCK..RESTRICTED LEFT ENTRY-2
+	{runeRange{0x26E3, 0x26E3}, propertyGeneralCategory{lbprAI, gcSo}},     //         HEAVY CIRCLE WITH STROKE AND TWO DOTS ABOVE
+	{runeRange{0x26E8, 0x26E9}, propertyGeneralCategory{lbprAI, gcSo}},     //     [2] BLACK CROSS ON SHIELD..SHINTO SHRINE
+	{runeRange{0x26EB, 0x26F0}, propertyGeneralCategory{lbprAI, gcSo}},     //     [6] CASTLE..MOUNTAIN
+	{runeRange{0x26F6, 0x26F6}, propertyGeneralCategory{lbprAI, gcSo}},     //         SQUARE FOUR CORNERS
+	{runeRange{0x26F9, 0x26F9}, propertyGeneralCategory{lbprEB, gcSo}},     //         PERSON WITH BALL
+	{runeRange{0x26FB, 0x26FC}, propertyGeneralCategory{lbprAI, gcSo}},     //     [2] JAPANESE BANK SYMBOL..HEADSTONE GRAVEYARD SYMBOL
+	{runeRange{0x2700, 0x2704}, propertyGeneralCategory{lbprID, gcSo}},     //     [5] BLACK SAFETY SCISSORS..WHITE SCISSORS
+	{runeRange{0x2708, 0x2709}, propertyGeneralCategory{lbprID, gcSo}},     //     [2] AIRPLANE..ENVELOPE
+	{runeRange{0x270E, 0x2756}, propertyGeneralCategory{lbprAL, gcSo}},     //    [73] LOWER RIGHT PENCIL..BLACK DIAMOND MINUS WHITE X
+	{runeRange{0x2758, 0x275A}, propertyGeneralCategory{lbprAL, gcSo}},     //     [3] LIGHT VERTICAL BAR..HEAVY VERTICAL BAR
+	{runeRange{0x2761, 0x2761}, propertyGeneralCategory{lbprAL, gcSo}},     //         CURVED STEM PARAGRAPH SIGN ORNAMENT
+	{runeRange{0x2764, 0x2764}, propertyGeneralCategory{lbprID, gcSo}},     //         HEAVY BLACK HEART
+	{runeRange{0x2768, 0x2768}, propertyGeneralCategory{lbprOP, gcPs}},     //         MEDIUM LEFT PARENTHESIS ORNAMENT
+	{runeRange{0x276A, 0x276A}, propertyGeneralCategory{lbprOP, gcPs}},     //         MEDIUM FLATTENED LEFT PARENTHESIS ORNAMENT
+	{runeRange{0x276C, 0x276C}, propertyGeneralCategory{lbprOP, gcPs}},     //         MEDIUM LEFT-POINTING ANGLE BRACKET ORNAMENT
+	{runeRange{0x276E, 0x276E}, propertyGeneralCategory{lbprOP, gcPs}},     //         HEAVY LEFT-POINTING ANGLE QUOTATION MARK ORNAMENT
+	{runeRange{0x2770, 0x2770}, propertyGeneralCategory{lbprOP, gcPs}},     //         HEAVY LEFT-POINTING ANGLE BRACKET ORNAMENT
+	{runeRange{0x2772, 0x2772}, propertyGeneralCategory{lbprOP, gcPs}},     //         LIGHT LEFT TORTOISE SHELL BRACKET ORNAMENT
+	{runeRange{0x2774, 0x2774}, propertyGeneralCategory{lbprOP, gcPs}},     //         MEDIUM LEFT CURLY BRACKET ORNAMENT
+	{runeRange{0x2776, 0x2793}, propertyGeneralCategory{lbprAI, gcNo}},     //    [30] DINGBAT NEGATIVE CIRCLED DIGIT ONE..DINGBAT NEGATIVE CIRCLED SANS-SERIF NUMBER TEN
+	{runeRange{0x27C0, 0x27C4}, propertyGeneralCategory{lbprAL, gcSm}},     //     [5] THREE DIMENSIONAL ANGLE..OPEN SUPERSET
+	{runeRange{0x27C6, 0x27C6}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT S-SHAPED BAG DELIMITER
+	{runeRange{0x27E6, 0x27E6}, propertyGeneralCategory{lbprOP, gcPs}},     //         MATHEMATICAL LEFT WHITE SQUARE BRACKET
+	{runeRange{0x27E8, 0x27E8}, propertyGeneralCategory{lbprOP, gcPs}},     //         MATHEMATICAL LEFT ANGLE BRACKET
+	{runeRange{0x27EA, 0x27EA}, propertyGeneralCategory{lbprOP, gcPs}},     //         MATHEMATICAL LEFT DOUBLE ANGLE BRACKET
+	{runeRange{0x27EC, 0x27EC}, propertyGeneralCategory{lbprOP, gcPs}},     //         MATHEMATICAL LEFT WHITE TORTOISE SHELL BRACKET
+	{runeRange{0x27EE, 0x27EE}, propertyGeneralCategory{lbprOP, gcPs}},     //         MATHEMATICAL LEFT FLATTENED PARENTHESIS
+	{runeRange{0x27F0, 0x27FF}, propertyGeneralCategory{lbprAL, gcSm}},     //    [16] UPWARDS QUADRUPLE ARROW..LONG RIGHTWARDS SQUIGGLE ARROW
+	{runeRange{0x2900, 0x297F}, propertyGeneralCategory{lbprAL, gcSm}},     //   [128] RIGHTWARDS TWO-HEADED ARROW WITH VERTICAL STROKE..DOWN FISH TAIL
+	{runeRange{0x2983, 0x2983}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT WHITE CURLY BRACKET
+	{runeRange{0x2985, 0x2985}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT WHITE PARENTHESIS
+	{runeRange{0x2987, 0x2987}, propertyGeneralCategory{lbprOP, gcPs}},     //         Z NOTATION LEFT IMAGE BRACKET
+	{runeRange{0x2989, 0x2989}, propertyGeneralCategory{lbprOP, gcPs}},     //         Z NOTATION LEFT BINDING BRACKET
+	{runeRange{0x298B, 0x298B}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT SQUARE BRACKET WITH UNDERBAR
+	{runeRange{0x298D, 0x298D}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT SQUARE BRACKET WITH TICK IN TOP CORNER
+	{runeRange{0x298F, 0x298F}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT SQUARE BRACKET WITH TICK IN BOTTOM CORNER
+	{runeRange{0x2991, 0x2991}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT ANGLE BRACKET WITH DOT
+	{runeRange{0x2993, 0x2993}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT ARC LESS-THAN BRACKET
+	{runeRange{0x2995, 0x2995}, propertyGeneralCategory{lbprOP, gcPs}},     //         DOUBLE LEFT ARC GREATER-THAN BRACKET
+	{runeRange{0x2997, 0x2997}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT BLACK TORTOISE SHELL BRACKET
+	{runeRange{0x2999, 0x29D7}, propertyGeneralCategory{lbprAL, gcSm}},     //    [63] DOTTED FENCE..BLACK HOURGLASS
+	{runeRange{0x29D9, 0x29D9}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT WIGGLY FENCE
+	{runeRange{0x29DB, 0x29DB}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT DOUBLE WIGGLY FENCE
+	{runeRange{0x29FC, 0x29FC}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT-POINTING CURVED ANGLE BRACKET
+	{runeRange{0x29FE, 0x29FF}, propertyGeneralCategory{lbprAL, gcSm}},     //     [2] TINY..MINY
+	{runeRange{0x2B00, 0x2B2F}, propertyGeneralCategory{lbprAL, gcSo}},     //    [48] NORTH EAST WHITE ARROW..WHITE VERTICAL ELLIPSE
+	{runeRange{0x2B45, 0x2B46}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] LEFTWARDS QUADRUPLE ARROW..RIGHTWARDS QUADRUPLE ARROW
+	{runeRange{0x2B4D, 0x2B54}, propertyGeneralCategory{lbprAL, gcSo}},     //     [8] DOWNWARDS TRIANGLE-HEADED ZIGZAG ARROW..WHITE RIGHT-POINTING PENTAGON
+	{runeRange{0x2B5A, 0x2B73}, propertyGeneralCategory{lbprAL, gcSo}},     //    [26] SLANTED NORTH ARROW WITH HOOKED HEAD..DOWNWARDS TRIANGLE-HEADED ARROW TO BAR
+	{runeRange{0x2B97, 0x2BFF}, propertyGeneralCategory{lbprAL, gcSo}},     //   [105] SYMBOL FOR TYPE A ELECTRONICS..HELLSCHREIBER PAUSE SYMBOL
+	{runeRange{0x2C60, 0x2C7B}, propertyGeneralCategory{lbprAL, gcLC}},     //    [28] LATIN CAPITAL LETTER L WITH DOUBLE BAR..LATIN LETTER SMALL CAPITAL TURNED E
+	{runeRange{0x2C7E, 0x2C7F}, propertyGeneralCategory{lbprAL, gcLu}},     //     [2] LATIN CAPITAL LETTER S WITH SWASH TAIL..LATIN CAPITAL LETTER Z WITH SWASH TAIL
+	{runeRange{0x2CE5, 0x2CEA}, propertyGeneralCategory{lbprAL, gcSo}},     //     [6] COPTIC SYMBOL MI RO..COPTIC SYMBOL SHIMA SIMA
+	{runeRange{0x2CEF, 0x2CF1}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] COPTIC COMBINING NI ABOVE..COPTIC COMBINING SPIRITUS LENIS
+	{runeRange{0x2CF9, 0x2CF9}, propertyGeneralCategory{lbprEX, gcPo}},     //         COPTIC OLD NUBIAN FULL STOP
+	{runeRange{0x2CFD, 0x2CFD}, propertyGeneralCategory{lbprAL, gcNo}},     //         COPTIC FRACTION ONE HALF
+	{runeRange{0x2CFF, 0x2CFF}, propertyGeneralCategory{lbprBA, gcPo}},     //         COPTIC MORPHOLOGICAL DIVIDER
+	{runeRange{0x2D27, 0x2D27}, propertyGeneralCategory{lbprAL, gcLl}},     //         GEORGIAN SMALL LETTER YN
+	{runeRange{0x2D30, 0x2D67}, propertyGeneralCategory{lbprAL, gcLo}},     //    [56] TIFINAGH LETTER YA..TIFINAGH LETTER YO
+	{runeRange{0x2D70, 0x2D70}, propertyGeneralCategory{lbprBA, gcPo}},     //         TIFINAGH SEPARATOR MARK
+	{runeRange{0x2D80, 0x2D96}, propertyGeneralCategory{lbprAL, gcLo}},     //    [23] ETHIOPIC SYLLABLE LOA..ETHIOPIC SYLLABLE GGWE
+	{runeRange{0x2DA8, 0x2DAE}, propertyGeneralCategory{lbprAL, gcLo}},     //     [7] ETHIOPIC SYLLABLE CCA..ETHIOPIC SYLLABLE CCO
+	{runeRange{0x2DB8, 0x2DBE}, propertyGeneralCategory{lbprAL, gcLo}},     //     [7] ETHIOPIC SYLLABLE CCHA..ETHIOPIC SYLLABLE CCHO
+	{runeRange{0x2DC8, 0x2DCE}, propertyGeneralCategory{lbprAL, gcLo}},     //     [7] ETHIOPIC SYLLABLE KYA..ETHIOPIC SYLLABLE KYO
+	{runeRange{0x2DD8, 0x2DDE}, propertyGeneralCategory{lbprAL, gcLo}},     //     [7] ETHIOPIC SYLLABLE GYA..ETHIOPIC SYLLABLE GYO
+	{runeRange{0x2E00, 0x2E01}, propertyGeneralCategory{lbprQU, gcPo}},     //     [2] RIGHT ANGLE SUBSTITUTION MARKER..RIGHT ANGLE DOTTED SUBSTITUTION MARKER
+	{runeRange{0x2E03, 0x2E03}, propertyGeneralCategory{lbprQU, gcPf}},     //         RIGHT SUBSTITUTION BRACKET
+	{runeRange{0x2E05, 0x2E05}, propertyGeneralCategory{lbprQU, gcPf}},     //         RIGHT DOTTED SUBSTITUTION BRACKET
+	{runeRange{0x2E09, 0x2E09}, propertyGeneralCategory{lbprQU, gcPi}},     //         LEFT TRANSPOSITION BRACKET
+	{runeRange{0x2E0B, 0x2E0B}, propertyGeneralCategory{lbprQU, gcPo}},     //         RAISED SQUARE
+	{runeRange{0x2E0D, 0x2E0D}, propertyGeneralCategory{lbprQU, gcPf}},     //         RIGHT RAISED OMISSION BRACKET
+	{runeRange{0x2E16, 0x2E16}, propertyGeneralCategory{lbprAL, gcPo}},     //         DOTTED RIGHT-POINTING ANGLE
+	{runeRange{0x2E18, 0x2E18}, propertyGeneralCategory{lbprOP, gcPo}},     //         INVERTED INTERROBANG
+	{runeRange{0x2E1A, 0x2E1A}, propertyGeneralCategory{lbprAL, gcPd}},     //         HYPHEN WITH DIAERESIS
+	{runeRange{0x2E1C, 0x2E1C}, propertyGeneralCategory{lbprQU, gcPi}},     //         LEFT LOW PARAPHRASE BRACKET
+	{runeRange{0x2E1E, 0x2E1F}, propertyGeneralCategory{lbprAL, gcPo}},     //     [2] TILDE WITH DOT ABOVE..TILDE WITH DOT BELOW
+	{runeRange{0x2E21, 0x2E21}, propertyGeneralCategory{lbprQU, gcPf}},     //         RIGHT VERTICAL BAR WITH QUILL
+	{runeRange{0x2E23, 0x2E23}, propertyGeneralCategory{lbprCL, gcPe}},     //         TOP RIGHT HALF BRACKET
+	{runeRange{0x2E25, 0x2E25}, propertyGeneralCategory{lbprCL, gcPe}},     //         BOTTOM RIGHT HALF BRACKET
+	{runeRange{0x2E27, 0x2E27}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT SIDEWAYS U BRACKET
+	{runeRange{0x2E29, 0x2E29}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT DOUBLE PARENTHESIS
+	{runeRange{0x2E2E, 0x2E2E}, propertyGeneralCategory{lbprEX, gcPo}},     //         REVERSED QUESTION MARK
+	{runeRange{0x2E30, 0x2E31}, propertyGeneralCategory{lbprBA, gcPo}},     //     [2] RING POINT..WORD SEPARATOR MIDDLE DOT
+	{runeRange{0x2E33, 0x2E34}, propertyGeneralCategory{lbprBA, gcPo}},     //     [2] RAISED DOT..RAISED COMMA
+	{runeRange{0x2E3A, 0x2E3B}, propertyGeneralCategory{lbprB2, gcPd}},     //     [2] TWO-EM DASH..THREE-EM DASH
+	{runeRange{0x2E3F, 0x2E3F}, propertyGeneralCategory{lbprAL, gcPo}},     //         CAPITULUM
+	{runeRange{0x2E41, 0x2E41}, propertyGeneralCategory{lbprBA, gcPo}},     //         REVERSED COMMA
+	{runeRange{0x2E43, 0x2E4A}, propertyGeneralCategory{lbprBA, gcPo}},     //     [8] DASH WITH LEFT UPTURN..DOTTED SOLIDUS
+	{runeRange{0x2E4C, 0x2E4C}, propertyGeneralCategory{lbprBA, gcPo}},     //         MEDIEVAL COMMA
+	{runeRange{0x2E4E, 0x2E4F}, propertyGeneralCategory{lbprBA, gcPo}},     //     [2] PUNCTUS ELEVATUS MARK..CORNISH VERSE DIVIDER
+	{runeRange{0x2E52, 0x2E52}, propertyGeneralCategory{lbprAL, gcPo}},     //         TIRONIAN SIGN CAPITAL ET
+	{runeRange{0x2E55, 0x2E55}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT SQUARE BRACKET WITH STROKE
+	{runeRange{0x2E57, 0x2E57}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT SQUARE BRACKET WITH DOUBLE STROKE
+	{runeRange{0x2E59, 0x2E59}, propertyGeneralCategory{lbprOP, gcPs}},     //         TOP HALF LEFT PARENTHESIS
+	{runeRange{0x2E5B, 0x2E5B}, propertyGeneralCategory{lbprOP, gcPs}},     //         BOTTOM HALF LEFT PARENTHESIS
+	{runeRange{0x2E5D, 0x2E5D}, propertyGeneralCategory{lbprBA, gcPd}},     //         OBLIQUE HYPHEN
+	{runeRange{0x2E9B, 0x2EF3}, propertyGeneralCategory{lbprID, gcSo}},     //    [89] CJK RADICAL CHOKE..CJK RADICAL C-SIMPLIFIED TURTLE
+	{runeRange{0x2FF0, 0x2FFB}, propertyGeneralCategory{lbprID, gcSo}},     //    [12] IDEOGRAPHIC DESCRIPTION CHARACTER LEFT TO RIGHT..IDEOGRAPHIC DESCRIPTION CHARACTER OVERLAID
+	{runeRange{0x3001, 0x3002}, propertyGeneralCategory{lbprCL, gcPo}},     //     [2] IDEOGRAPHIC COMMA..IDEOGRAPHIC FULL STOP
+	{runeRange{0x3004, 0x3004}, propertyGeneralCategory{lbprID, gcSo}},     //         JAPANESE INDUSTRIAL STANDARD SYMBOL
+	{runeRange{0x3006, 0x3006}, propertyGeneralCategory{lbprID, gcLo}},     //         IDEOGRAPHIC CLOSING MARK
+	{runeRange{0x3008, 0x3008}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT ANGLE BRACKET
+	{runeRange{0x300A, 0x300A}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT DOUBLE ANGLE BRACKET
+	{runeRange{0x300C, 0x300C}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT CORNER BRACKET
+	{runeRange{0x300E, 0x300E}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT WHITE CORNER BRACKET
+	{runeRange{0x3010, 0x3010}, propertyGeneralCategory{lbprOP, gcPs}},     //         LEFT BLACK LENTICULAR BRACKET
+	{runeRange{0x3012, 0x3013}, propertyGeneralCategory{lbprID, gcSo}},     //     [2] POSTAL MARK..GETA MARK
+	{runeRange{0x3015, 0x3015}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT TORTOISE SHELL BRACKET
+	{runeRange{0x3017, 0x3017}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT WHITE LENTICULAR BRACKET
+	{runeRange{0x3019, 0x3019}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT WHITE TORTOISE SHELL BRACKET
+	{runeRange{0x301B, 0x301B}, propertyGeneralCategory{lbprCL, gcPe}},     //         RIGHT WHITE SQUARE BRACKET
+	{runeRange{0x301D, 0x301D}, propertyGeneralCategory{lbprOP, gcPs}},     //         REVERSED DOUBLE PRIME QUOTATION MARK
+	{runeRange{0x3020, 0x3020}, propertyGeneralCategory{lbprID, gcSo}},     //         POSTAL MARK FACE
+	{runeRange{0x302A, 0x302D}, propertyGeneralCategory{lbprCM, gcMn}},     //     [4] IDEOGRAPHIC LEVEL TONE MARK..IDEOGRAPHIC ENTERING TONE MARK
+	{runeRange{0x3030, 0x3030}, propertyGeneralCategory{lbprID, gcPd}},     //         WAVY DASH
+	{runeRange{0x3035, 0x3035}, propertyGeneralCategory{lbprCM, gcLm}},     //         VERTICAL KANA REPEAT MARK LOWER HALF
+	{runeRange{0x3038, 0x303A}, propertyGeneralCategory{lbprID, gcNl}},     //     [3] HANGZHOU NUMERAL TEN..HANGZHOU NUMERAL THIRTY
+	{runeRange{0x303C, 0x303C}, propertyGeneralCategory{lbprNS, gcLo}},     //         MASU MARK
+	{runeRange{0x303E, 0x303F}, propertyGeneralCategory{lbprID, gcSo}},     //     [2] IDEOGRAPHIC VARIATION INDICATOR..IDEOGRAPHIC HALF FILL SPACE
+	{runeRange{0x3042, 0x3042}, propertyGeneralCategory{lbprID, gcLo}},     //         HIRAGANA LETTER A
+	{runeRange{0x3044, 0x3044}, propertyGeneralCategory{lbprID, gcLo}},     //         HIRAGANA LETTER I
+	{runeRange{0x3046, 0x3046}, propertyGeneralCategory{lbprID, gcLo}},     //         HIRAGANA LETTER U
+	{runeRange{0x3048, 0x3048}, propertyGeneralCategory{lbprID, gcLo}},     //         HIRAGANA LETTER E
+	{runeRange{0x304A, 0x3062}, propertyGeneralCategory{lbprID, gcLo}},     //    [25] HIRAGANA LETTER O..HIRAGANA LETTER DI
+	{runeRange{0x3064, 0x3082}, propertyGeneralCategory{lbprID, gcLo}},     //    [31] HIRAGANA LETTER TU..HIRAGANA LETTER MO
+	{runeRange{0x3084, 0x3084}, propertyGeneralCategory{lbprID, gcLo}},     //         HIRAGANA LETTER YA
+	{runeRange{0x3086, 0x3086}, propertyGeneralCategory{lbprID, gcLo}},     //         HIRAGANA LETTER YU
+	{runeRange{0x3088, 0x308D}, propertyGeneralCategory{lbprID, gcLo}},     //     [6] HIRAGANA LETTER YO..HIRAGANA LETTER RO
+	{runeRange{0x308F, 0x3094}, propertyGeneralCategory{lbprID, gcLo}},     //     [6] HIRAGANA LETTER WA..HIRAGANA LETTER VU
+	{runeRange{0x3099, 0x309A}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] COMBINING KATAKANA-HIRAGANA VOICED SOUND MARK..COMBINING KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK
+	{runeRange{0x309D, 0x309E}, propertyGeneralCategory{lbprNS, gcLm}},     //     [2] HIRAGANA ITERATION MARK..HIRAGANA VOICED ITERATION MARK
+	{runeRange{0x30A0, 0x30A0}, propertyGeneralCategory{lbprNS, gcPd}},     //         KATAKANA-HIRAGANA DOUBLE HYPHEN
+	{runeRange{0x30A2, 0x30A2}, propertyGeneralCategory{lbprID, gcLo}},     //         KATAKANA LETTER A
+	{runeRange{0x30A4, 0x30A4}, propertyGeneralCategory{lbprID, gcLo}},     //         KATAKANA LETTER I
+	{runeRange{0x30A6, 0x30A6}, propertyGeneralCategory{lbprID, gcLo}},     //         KATAKANA LETTER U
+	{runeRange{0x30A8, 0x30A8}, propertyGeneralCategory{lbprID, gcLo}},     //         KATAKANA LETTER E
+	{runeRange{0x30AA, 0x30C2}, propertyGeneralCategory{lbprID, gcLo}},     //    [25] KATAKANA LETTER O..KATAKANA LETTER DI
+	{runeRange{0x30C4, 0x30E2}, propertyGeneralCategory{lbprID, gcLo}},     //    [31] KATAKANA LETTER TU..KATAKANA LETTER MO
+	{runeRange{0x30E4, 0x30E4}, propertyGeneralCategory{lbprID, gcLo}},     //         KATAKANA LETTER YA
+	{runeRange{0x30E6, 0x30E6}, propertyGeneralCategory{lbprID, gcLo}},     //         KATAKANA LETTER YU
+	{runeRange{0x30E8, 0x30ED}, propertyGeneralCategory{lbprID, gcLo}},     //     [6] KATAKANA LETTER YO..KATAKANA LETTER RO
+	{runeRange{0x30EF, 0x30F4}, propertyGeneralCategory{lbprID, gcLo}},     //     [6] KATAKANA LETTER WA..KATAKANA LETTER VU
+	{runeRange{0x30F7, 0x30FA}, propertyGeneralCategory{lbprID, gcLo}},     //     [4] KATAKANA LETTER VA..KATAKANA LETTER VO
+	{runeRange{0x30FC, 0x30FC}, propertyGeneralCategory{lbprCJ, gcLm}},     //         KATAKANA-HIRAGANA PROLONGED SOUND MARK
+	{runeRange{0x30FF, 0x30FF}, propertyGeneralCategory{lbprID, gcLo}},     //         KATAKANA DIGRAPH KOTO
+	{runeRange{0x3131, 0x318E}, propertyGeneralCategory{lbprID, gcLo}},     //    [94] HANGUL LETTER KIYEOK..HANGUL LETTER ARAEAE
+	{runeRange{0x3192, 0x3195}, propertyGeneralCategory{lbprID, gcNo}},     //     [4] IDEOGRAPHIC ANNOTATION ONE MARK..IDEOGRAPHIC ANNOTATION FOUR MARK
+	{runeRange{0x31A0, 0x31BF}, propertyGeneralCategory{lbprID, gcLo}},     //    [32] BOPOMOFO LETTER BU..BOPOMOFO LETTER AH
+	{runeRange{0x31F0, 0x31FF}, propertyGeneralCategory{lbprCJ, gcLo}},     //    [16] KATAKANA LETTER SMALL KU..KATAKANA LETTER SMALL RO
+	{runeRange{0x3220, 0x3229}, propertyGeneralCategory{lbprID, gcNo}},     //    [10] PARENTHESIZED IDEOGRAPH ONE..PARENTHESIZED IDEOGRAPH TEN
+	{runeRange{0x3248, 0x324F}, propertyGeneralCategory{lbprAI, gcNo}},     //     [8] CIRCLED NUMBER TEN ON BLACK SQUARE..CIRCLED NUMBER EIGHTY ON BLACK SQUARE
+	{runeRange{0x3251, 0x325F}, propertyGeneralCategory{lbprID, gcNo}},     //    [15] CIRCLED NUMBER TWENTY ONE..CIRCLED NUMBER THIRTY FIVE
+	{runeRange{0x3280, 0x3289}, propertyGeneralCategory{lbprID, gcNo}},     //    [10] CIRCLED IDEOGRAPH ONE..CIRCLED IDEOGRAPH TEN
+	{runeRange{0x32B1, 0x32BF}, propertyGeneralCategory{lbprID, gcNo}},     //    [15] CIRCLED NUMBER THIRTY SIX..CIRCLED NUMBER FIFTY
+	{runeRange{0x3300, 0x33FF}, propertyGeneralCategory{lbprID, gcSo}},     //   [256] SQUARE APAATO..SQUARE GAL
+	{runeRange{0x4DC0, 0x4DFF}, propertyGeneralCategory{lbprAL, gcSo}},     //    [64] HEXAGRAM FOR THE CREATIVE HEAVEN..HEXAGRAM FOR BEFORE COMPLETION
+	{runeRange{0xA000, 0xA014}, propertyGeneralCategory{lbprID, gcLo}},     //    [21] YI SYLLABLE IT..YI SYLLABLE E
+	{runeRange{0xA016, 0xA48C}, propertyGeneralCategory{lbprID, gcLo}},     //  [1143] YI SYLLABLE BIT..YI SYLLABLE YYR
+	{runeRange{0xA4D0, 0xA4F7}, propertyGeneralCategory{lbprAL, gcLo}},     //    [40] LISU LETTER BA..LISU LETTER OE
+	{runeRange{0xA4FE, 0xA4FF}, propertyGeneralCategory{lbprBA, gcPo}},     //     [2] LISU PUNCTUATION COMMA..LISU PUNCTUATION FULL STOP
+	{runeRange{0xA60C, 0xA60C}, propertyGeneralCategory{lbprAL, gcLm}},     //         VAI SYLLABLE LENGTHENER
+	{runeRange{0xA60E, 0xA60E}, propertyGeneralCategory{lbprEX, gcPo}},     //         VAI FULL STOP
+	{runeRange{0xA610, 0xA61F}, propertyGeneralCategory{lbprAL, gcLo}},     //    [16] VAI SYLLABLE NDOLE FA..VAI SYMBOL JONG
+	{runeRange{0xA62A, 0xA62B}, propertyGeneralCategory{lbprAL, gcLo}},     //     [2] VAI SYLLABLE NDOLE MA..VAI SYLLABLE NDOLE DO
+	{runeRange{0xA66E, 0xA66E}, propertyGeneralCategory{lbprAL, gcLo}},     //         CYRILLIC LETTER MULTIOCULAR O
+	{runeRange{0xA670, 0xA672}, propertyGeneralCategory{lbprCM, gcMe}},     //     [3] COMBINING CYRILLIC TEN MILLIONS SIGN..COMBINING CYRILLIC THOUSAND MILLIONS SIGN
+	{runeRange{0xA674, 0xA67D}, propertyGeneralCategory{lbprCM, gcMn}},     //    [10] COMBINING CYRILLIC LETTER UKRAINIAN IE..COMBINING CYRILLIC PAYEROK
+	{runeRange{0xA67F, 0xA67F}, propertyGeneralCategory{lbprAL, gcLm}},     //         CYRILLIC PAYEROK
+	{runeRange{0xA69C, 0xA69D}, propertyGeneralCategory{lbprAL, gcLm}},     //     [2] MODIFIER LETTER CYRILLIC HARD SIGN..MODIFIER LETTER CYRILLIC SOFT SIGN
+	{runeRange{0xA6A0, 0xA6E5}, propertyGeneralCategory{lbprAL, gcLo}},     //    [70] BAMUM LETTER A..BAMUM LETTER KI
+	{runeRange{0xA6F0, 0xA6F1}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] BAMUM COMBINING MARK KOQNDON..BAMUM COMBINING MARK TUKWENTIS
+	{runeRange{0xA6F3, 0xA6F7}, propertyGeneralCategory{lbprBA, gcPo}},     //     [5] BAMUM FULL STOP..BAMUM QUESTION MARK
+	{runeRange{0xA717, 0xA71F}, propertyGeneralCategory{lbprAL, gcLm}},     //     [9] MODIFIER LETTER DOT VERTICAL BAR..MODIFIER LETTER LOW INVERTED EXCLAMATION MARK
+	{runeRange{0xA722, 0xA76F}, propertyGeneralCategory{lbprAL, gcLC}},     //    [78] LATIN CAPITAL LETTER EGYPTOLOGICAL ALEF..LATIN SMALL LETTER CON
+	{runeRange{0xA771, 0xA787}, propertyGeneralCategory{lbprAL, gcLC}},     //    [23] LATIN SMALL LETTER DUM..LATIN SMALL LETTER INSULAR T
+	{runeRange{0xA789, 0xA78A}, propertyGeneralCategory{lbprAL, gcSk}},     //     [2] MODIFIER LETTER COLON..MODIFIER LETTER SHORT EQUALS SIGN
+	{runeRange{0xA78F, 0xA78F}, propertyGeneralCategory{lbprAL, gcLo}},     //         LATIN LETTER SINOLOGICAL DOT
+	{runeRange{0xA7D0, 0xA7D1}, propertyGeneralCategory{lbprAL, gcLC}},     //     [2] LATIN CAPITAL LETTER CLOSED INSULAR G..LATIN SMALL LETTER CLOSED INSULAR G
+	{runeRange{0xA7D5, 0xA7D9}, propertyGeneralCategory{lbprAL, gcLC}},     //     [5] LATIN SMALL LETTER DOUBLE WYNN..LATIN SMALL LETTER SIGMOID S
+	{runeRange{0xA7F5, 0xA7F6}, propertyGeneralCategory{lbprAL, gcLC}},     //     [2] LATIN CAPITAL LETTER REVERSED HALF H..LATIN SMALL LETTER REVERSED HALF H
+	{runeRange{0xA7F8, 0xA7F9}, propertyGeneralCategory{lbprAL, gcLm}},     //     [2] MODIFIER LETTER CAPITAL H WITH STROKE..MODIFIER LETTER SMALL LIGATURE OE
+	{runeRange{0xA7FB, 0xA7FF}, propertyGeneralCategory{lbprAL, gcLo}},     //     [5] LATIN EPIGRAPHIC LETTER REVERSED F..LATIN EPIGRAPHIC LETTER ARCHAIC M
+	{runeRange{0xA802, 0xA802}, propertyGeneralCategory{lbprCM, gcMn}},     //         SYLOTI NAGRI SIGN DVISVARA
+	{runeRange{0xA806, 0xA806}, propertyGeneralCategory{lbprCM, gcMn}},     //         SYLOTI NAGRI SIGN HASANTA
+	{runeRange{0xA80B, 0xA80B}, propertyGeneralCategory{lbprCM, gcMn}},     //         SYLOTI NAGRI SIGN ANUSVARA
+	{runeRange{0xA823, 0xA824}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] SYLOTI NAGRI VOWEL SIGN A..SYLOTI NAGRI VOWEL SIGN I
+	{runeRange{0xA827, 0xA827}, propertyGeneralCategory{lbprCM, gcMc}},     //         SYLOTI NAGRI VOWEL SIGN OO
+	{runeRange{0xA82C, 0xA82C}, propertyGeneralCategory{lbprCM, gcMn}},     //         SYLOTI NAGRI SIGN ALTERNATE HASANTA
+	{runeRange{0xA836, 0xA837}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] NORTH INDIC QUARTER MARK..NORTH INDIC PLACEHOLDER MARK
+	{runeRange{0xA839, 0xA839}, propertyGeneralCategory{lbprAL, gcSo}},     //         NORTH INDIC QUANTITY MARK
+	{runeRange{0xA874, 0xA875}, propertyGeneralCategory{lbprBB, gcPo}},     //     [2] PHAGS-PA SINGLE HEAD MARK..PHAGS-PA DOUBLE HEAD MARK
+	{runeRange{0xA880, 0xA881}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] SAURASHTRA SIGN ANUSVARA..SAURASHTRA SIGN VISARGA
+	{runeRange{0xA8B4, 0xA8C3}, propertyGeneralCategory{lbprCM, gcMc}},     //    [16] SAURASHTRA CONSONANT SIGN HAARU..SAURASHTRA VOWEL SIGN AU
+	{runeRange{0xA8CE, 0xA8CF}, propertyGeneralCategory{lbprBA, gcPo}},     //     [2] SAURASHTRA DANDA..SAURASHTRA DOUBLE DANDA
+	{runeRange{0xA8E0, 0xA8F1}, propertyGeneralCategory{lbprCM, gcMn}},     //    [18] COMBINING DEVANAGARI DIGIT ZERO..COMBINING DEVANAGARI SIGN AVAGRAHA
+	{runeRange{0xA8F8, 0xA8FA}, propertyGeneralCategory{lbprAL, gcPo}},     //     [3] DEVANAGARI SIGN PUSHPIKA..DEVANAGARI CARET
+	{runeRange{0xA8FC, 0xA8FC}, propertyGeneralCategory{lbprBB, gcPo}},     //         DEVANAGARI SIGN SIDDHAM
+	{runeRange{0xA8FF, 0xA8FF}, propertyGeneralCategory{lbprCM, gcMn}},     //         DEVANAGARI VOWEL SIGN AY
+	{runeRange{0xA90A, 0xA925}, propertyGeneralCategory{lbprAL, gcLo}},     //    [28] KAYAH LI LETTER KA..KAYAH LI LETTER OO
+	{runeRange{0xA92E, 0xA92F}, propertyGeneralCategory{lbprBA, gcPo}},     //     [2] KAYAH LI SIGN CWI..KAYAH LI SIGN SHYA
+	{runeRange{0xA947, 0xA951}, propertyGeneralCategory{lbprCM, gcMn}},     //    [11] REJANG VOWEL SIGN I..REJANG CONSONANT SIGN R
+	{runeRange{0xA95F, 0xA95F}, propertyGeneralCategory{lbprAL, gcPo}},     //         REJANG SECTION MARK
+	{runeRange{0xA980, 0xA982}, propertyGeneralCategory{lbprCM, gcMn}},     //     [3] JAVANESE SIGN PANYANGGA..JAVANESE SIGN LAYAR
+	{runeRange{0xA984, 0xA9B2}, propertyGeneralCategory{lbprAL, gcLo}},     //    [47] JAVANESE LETTER A..JAVANESE LETTER HA
+	{runeRange{0xA9B4, 0xA9B5}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] JAVANESE VOWEL SIGN TARUNG..JAVANESE VOWEL SIGN TOLONG
+	{runeRange{0xA9BA, 0xA9BB}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] JAVANESE VOWEL SIGN TALING..JAVANESE VOWEL SIGN DIRGA MURE
+	{runeRange{0xA9BE, 0xA9C0}, propertyGeneralCategory{lbprCM, gcMc}},     //     [3] JAVANESE CONSONANT SIGN PENGKAL..JAVANESE PANGKON
+	{runeRange{0xA9C7, 0xA9C9}, propertyGeneralCategory{lbprBA, gcPo}},     //     [3] JAVANESE PADA PANGKAT..JAVANESE PADA LUNGSI
+	{runeRange{0xA9CF, 0xA9CF}, propertyGeneralCategory{lbprAL, gcLm}},     //         JAVANESE PANGRANGKEP
+	{runeRange{0xA9DE, 0xA9DF}, propertyGeneralCategory{lbprAL, gcPo}},     //     [2] JAVANESE PADA TIRTA TUMETES..JAVANESE PADA ISEN-ISEN
+	{runeRange{0xA9E5, 0xA9E5}, propertyGeneralCategory{lbprSA, gcMn}},     //         MYANMAR SIGN SHAN SAW
+	{runeRange{0xA9E7, 0xA9EF}, propertyGeneralCategory{lbprSA, gcLo}},     //     [9] MYANMAR LETTER TAI LAING NYA..MYANMAR LETTER TAI LAING NNA
+	{runeRange{0xA9FA, 0xA9FE}, propertyGeneralCategory{lbprSA, gcLo}},     //     [5] MYANMAR LETTER TAI LAING LLA..MYANMAR LETTER TAI LAING BHA
+	{runeRange{0xAA29, 0xAA2E}, propertyGeneralCategory{lbprCM, gcMn}},     //     [6] CHAM VOWEL SIGN AA..CHAM VOWEL SIGN OE
+	{runeRange{0xAA31, 0xAA32}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] CHAM VOWEL SIGN AU..CHAM VOWEL SIGN UE
+	{runeRange{0xAA35, 0xAA36}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] CHAM CONSONANT SIGN LA..CHAM CONSONANT SIGN WA
+	{runeRange{0xAA43, 0xAA43}, propertyGeneralCategory{lbprCM, gcMn}},     //         CHAM CONSONANT SIGN FINAL NG
+	{runeRange{0xAA4C, 0xAA4C}, propertyGeneralCategory{lbprCM, gcMn}},     //         CHAM CONSONANT SIGN FINAL M
+	{runeRange{0xAA50, 0xAA59}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] CHAM DIGIT ZERO..CHAM DIGIT NINE
+	{runeRange{0xAA5D, 0xAA5F}, propertyGeneralCategory{lbprBA, gcPo}},     //     [3] CHAM PUNCTUATION DANDA..CHAM PUNCTUATION TRIPLE DANDA
+	{runeRange{0xAA70, 0xAA70}, propertyGeneralCategory{lbprSA, gcLm}},     //         MYANMAR MODIFIER LETTER KHAMTI REDUPLICATION
+	{runeRange{0xAA77, 0xAA79}, propertyGeneralCategory{lbprSA, gcSo}},     //     [3] MYANMAR SYMBOL AITON EXCLAMATION..MYANMAR SYMBOL AITON TWO
+	{runeRange{0xAA7B, 0xAA7B}, propertyGeneralCategory{lbprSA, gcMc}},     //         MYANMAR SIGN PAO KAREN TONE
+	{runeRange{0xAA7D, 0xAA7D}, propertyGeneralCategory{lbprSA, gcMc}},     //         MYANMAR SIGN TAI LAING TONE-5
+	{runeRange{0xAA80, 0xAAAF}, propertyGeneralCategory{lbprSA, gcLo}},     //    [48] TAI VIET LETTER LOW KO..TAI VIET LETTER HIGH O
+	{runeRange{0xAAB1, 0xAAB1}, propertyGeneralCategory{lbprSA, gcLo}},     //         TAI VIET VOWEL AA
+	{runeRange{0xAAB5, 0xAAB6}, propertyGeneralCategory{lbprSA, gcLo}},     //     [2] TAI VIET VOWEL E..TAI VIET VOWEL O
+	{runeRange{0xAAB9, 0xAABD}, propertyGeneralCategory{lbprSA, gcLo}},     //     [5] TAI VIET VOWEL UEA..TAI VIET VOWEL AN
+	{runeRange{0xAAC0, 0xAAC0}, propertyGeneralCategory{lbprSA, gcLo}},     //         TAI VIET TONE MAI NUENG
+	{runeRange{0xAAC2, 0xAAC2}, propertyGeneralCategory{lbprSA, gcLo}},     //         TAI VIET TONE MAI SONG
+	{runeRange{0xAADD, 0xAADD}, propertyGeneralCategory{lbprSA, gcLm}},     //         TAI VIET SYMBOL SAM
+	{runeRange{0xAAE0, 0xAAEA}, propertyGeneralCategory{lbprAL, gcLo}},     //    [11] MEETEI MAYEK LETTER E..MEETEI MAYEK LETTER SSA
+	{runeRange{0xAAEC, 0xAAED}, propertyGeneralCategory{lbprCM, gcMn}},     //     [2] MEETEI MAYEK VOWEL SIGN UU..MEETEI MAYEK VOWEL SIGN AAI
+	{runeRange{0xAAF0, 0xAAF1}, propertyGeneralCategory{lbprBA, gcPo}},     //     [2] MEETEI MAYEK CHEIKHAN..MEETEI MAYEK AHANG KHUDAM
+	{runeRange{0xAAF3, 0xAAF4}, propertyGeneralCategory{lbprAL, gcLm}},     //     [2] MEETEI MAYEK SYLLABLE REPETITION MARK..MEETEI MAYEK WORD REPETITION MARK
+	{runeRange{0xAAF6, 0xAAF6}, propertyGeneralCategory{lbprCM, gcMn}},     //         MEETEI MAYEK VIRAMA
+	{runeRange{0xAB09, 0xAB0E}, propertyGeneralCategory{lbprAL, gcLo}},     //     [6] ETHIOPIC SYLLABLE DDHU..ETHIOPIC SYLLABLE DDHO
+	{runeRange{0xAB20, 0xAB26}, propertyGeneralCategory{lbprAL, gcLo}},     //     [7] ETHIOPIC SYLLABLE CCHHA..ETHIOPIC SYLLABLE CCHHO
+	{runeRange{0xAB30, 0xAB5A}, propertyGeneralCategory{lbprAL, gcLl}},     //    [43] LATIN SMALL LETTER BARRED ALPHA..LATIN SMALL LETTER Y WITH SHORT RIGHT LEG
+	{runeRange{0xAB5C, 0xAB5F}, propertyGeneralCategory{lbprAL, gcLm}},     //     [4] MODIFIER LETTER SMALL HENG..MODIFIER LETTER SMALL U WITH LEFT HOOK
+	{runeRange{0xAB69, 0xAB69}, propertyGeneralCategory{lbprAL, gcLm}},     //         MODIFIER LETTER SMALL TURNED W
+	{runeRange{0xAB70, 0xABBF}, propertyGeneralCategory{lbprAL, gcLl}},     //    [80] CHEROKEE SMALL LETTER A..CHEROKEE SMALL LETTER YA
+	{runeRange{0xABE3, 0xABE4}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] MEETEI MAYEK VOWEL SIGN ONAP..MEETEI MAYEK VOWEL SIGN INAP
+	{runeRange{0xABE6, 0xABE7}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] MEETEI MAYEK VOWEL SIGN YENAP..MEETEI MAYEK VOWEL SIGN SOUNAP
+	{runeRange{0xABE9, 0xABEA}, propertyGeneralCategory{lbprCM, gcMc}},     //     [2] MEETEI MAYEK VOWEL SIGN CHEINAP..MEETEI MAYEK VOWEL SIGN NUNG
+	{runeRange{0xABEC, 0xABEC}, propertyGeneralCategory{lbprCM, gcMc}},     //         MEETEI MAYEK LUM IYEK
+	{runeRange{0xABF0, 0xABF9}, propertyGeneralCategory{lbprNU, gcNd}},     //    [10] MEETEI MAYEK DIGIT ZERO..MEETEI MAYEK DIGIT NINE
+	{runeRange{0xAC01, 0xAC1B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GAG..HANGUL SYLLABLE GAH
+	{runeRange{0xAC1D, 0xAC37}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GAEG..HANGUL SYLLABLE GAEH
+	{runeRange{0xAC39, 0xAC53}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GYAG..HANGUL SYLLABLE GYAH
+	{runeRange{0xAC55, 0xAC6F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GYAEG..HANGUL SYLLABLE GYAEH
+	{runeRange{0xAC71, 0xAC8B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GEOG..HANGUL SYLLABLE GEOH
+	{runeRange{0xAC8D, 0xACA7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GEG..HANGUL SYLLABLE GEH
+	{runeRange{0xACA9, 0xACC3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GYEOG..HANGUL SYLLABLE GYEOH
+	{runeRange{0xACC5, 0xACDF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GYEG..HANGUL SYLLABLE GYEH
+	{runeRange{0xACE1, 0xACFB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GOG..HANGUL SYLLABLE GOH
+	{runeRange{0xACFD, 0xAD17}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GWAG..HANGUL SYLLABLE GWAH
+	{runeRange{0xAD19, 0xAD33}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GWAEG..HANGUL SYLLABLE GWAEH
+	{runeRange{0xAD35, 0xAD4F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GOEG..HANGUL SYLLABLE GOEH
+	{runeRange{0xAD51, 0xAD6B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GYOG..HANGUL SYLLABLE GYOH
+	{runeRange{0xAD6D, 0xAD87}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GUG..HANGUL SYLLABLE GUH
+	{runeRange{0xAD89, 0xADA3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GWEOG..HANGUL SYLLABLE GWEOH
+	{runeRange{0xADA5, 0xADBF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GWEG..HANGUL SYLLABLE GWEH
+	{runeRange{0xADC1, 0xADDB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GWIG..HANGUL SYLLABLE GWIH
+	{runeRange{0xADDD, 0xADF7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GYUG..HANGUL SYLLABLE GYUH
+	{runeRange{0xADF9, 0xAE13}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GEUG..HANGUL SYLLABLE GEUH
+	{runeRange{0xAE15, 0xAE2F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GYIG..HANGUL SYLLABLE GYIH
+	{runeRange{0xAE31, 0xAE4B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GIG..HANGUL SYLLABLE GIH
+	{runeRange{0xAE4D, 0xAE67}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGAG..HANGUL SYLLABLE GGAH
+	{runeRange{0xAE69, 0xAE83}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGAEG..HANGUL SYLLABLE GGAEH
+	{runeRange{0xAE85, 0xAE9F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGYAG..HANGUL SYLLABLE GGYAH
+	{runeRange{0xAEA1, 0xAEBB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGYAEG..HANGUL SYLLABLE GGYAEH
+	{runeRange{0xAEBD, 0xAED7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGEOG..HANGUL SYLLABLE GGEOH
+	{runeRange{0xAED9, 0xAEF3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGEG..HANGUL SYLLABLE GGEH
+	{runeRange{0xAEF5, 0xAF0F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGYEOG..HANGUL SYLLABLE GGYEOH
+	{runeRange{0xAF11, 0xAF2B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGYEG..HANGUL SYLLABLE GGYEH
+	{runeRange{0xAF2D, 0xAF47}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGOG..HANGUL SYLLABLE GGOH
+	{runeRange{0xAF49, 0xAF63}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGWAG..HANGUL SYLLABLE GGWAH
+	{runeRange{0xAF65, 0xAF7F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGWAEG..HANGUL SYLLABLE GGWAEH
+	{runeRange{0xAF81, 0xAF9B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGOEG..HANGUL SYLLABLE GGOEH
+	{runeRange{0xAF9D, 0xAFB7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGYOG..HANGUL SYLLABLE GGYOH
+	{runeRange{0xAFB9, 0xAFD3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGUG..HANGUL SYLLABLE GGUH
+	{runeRange{0xAFD5, 0xAFEF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGWEOG..HANGUL SYLLABLE GGWEOH
+	{runeRange{0xAFF1, 0xB00B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGWEG..HANGUL SYLLABLE GGWEH
+	{runeRange{0xB00D, 0xB027}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGWIG..HANGUL SYLLABLE GGWIH
+	{runeRange{0xB029, 0xB043}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGYUG..HANGUL SYLLABLE GGYUH
+	{runeRange{0xB045, 0xB05F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGEUG..HANGUL SYLLABLE GGEUH
+	{runeRange{0xB061, 0xB07B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGYIG..HANGUL SYLLABLE GGYIH
+	{runeRange{0xB07D, 0xB097}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE GGIG..HANGUL SYLLABLE GGIH
+	{runeRange{0xB099, 0xB0B3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NAG..HANGUL SYLLABLE NAH
+	{runeRange{0xB0B5, 0xB0CF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NAEG..HANGUL SYLLABLE NAEH
+	{runeRange{0xB0D1, 0xB0EB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NYAG..HANGUL SYLLABLE NYAH
+	{runeRange{0xB0ED, 0xB107}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NYAEG..HANGUL SYLLABLE NYAEH
+	{runeRange{0xB109, 0xB123}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NEOG..HANGUL SYLLABLE NEOH
+	{runeRange{0xB125, 0xB13F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NEG..HANGUL SYLLABLE NEH
+	{runeRange{0xB141, 0xB15B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NYEOG..HANGUL SYLLABLE NYEOH
+	{runeRange{0xB15D, 0xB177}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NYEG..HANGUL SYLLABLE NYEH
+	{runeRange{0xB179, 0xB193}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NOG..HANGUL SYLLABLE NOH
+	{runeRange{0xB195, 0xB1AF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NWAG..HANGUL SYLLABLE NWAH
+	{runeRange{0xB1B1, 0xB1CB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NWAEG..HANGUL SYLLABLE NWAEH
+	{runeRange{0xB1CD, 0xB1E7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NOEG..HANGUL SYLLABLE NOEH
+	{runeRange{0xB1E9, 0xB203}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NYOG..HANGUL SYLLABLE NYOH
+	{runeRange{0xB205, 0xB21F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NUG..HANGUL SYLLABLE NUH
+	{runeRange{0xB221, 0xB23B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NWEOG..HANGUL SYLLABLE NWEOH
+	{runeRange{0xB23D, 0xB257}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NWEG..HANGUL SYLLABLE NWEH
+	{runeRange{0xB259, 0xB273}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NWIG..HANGUL SYLLABLE NWIH
+	{runeRange{0xB275, 0xB28F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NYUG..HANGUL SYLLABLE NYUH
+	{runeRange{0xB291, 0xB2AB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NEUG..HANGUL SYLLABLE NEUH
+	{runeRange{0xB2AD, 0xB2C7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NYIG..HANGUL SYLLABLE NYIH
+	{runeRange{0xB2C9, 0xB2E3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE NIG..HANGUL SYLLABLE NIH
+	{runeRange{0xB2E5, 0xB2FF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DAG..HANGUL SYLLABLE DAH
+	{runeRange{0xB301, 0xB31B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DAEG..HANGUL SYLLABLE DAEH
+	{runeRange{0xB31D, 0xB337}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DYAG..HANGUL SYLLABLE DYAH
+	{runeRange{0xB339, 0xB353}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DYAEG..HANGUL SYLLABLE DYAEH
+	{runeRange{0xB355, 0xB36F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DEOG..HANGUL SYLLABLE DEOH
+	{runeRange{0xB371, 0xB38B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DEG..HANGUL SYLLABLE DEH
+	{runeRange{0xB38D, 0xB3A7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DYEOG..HANGUL SYLLABLE DYEOH
+	{runeRange{0xB3A9, 0xB3C3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DYEG..HANGUL SYLLABLE DYEH
+	{runeRange{0xB3C5, 0xB3DF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DOG..HANGUL SYLLABLE DOH
+	{runeRange{0xB3E1, 0xB3FB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DWAG..HANGUL SYLLABLE DWAH
+	{runeRange{0xB3FD, 0xB417}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DWAEG..HANGUL SYLLABLE DWAEH
+	{runeRange{0xB419, 0xB433}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DOEG..HANGUL SYLLABLE DOEH
+	{runeRange{0xB435, 0xB44F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DYOG..HANGUL SYLLABLE DYOH
+	{runeRange{0xB451, 0xB46B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DUG..HANGUL SYLLABLE DUH
+	{runeRange{0xB46D, 0xB487}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DWEOG..HANGUL SYLLABLE DWEOH
+	{runeRange{0xB489, 0xB4A3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DWEG..HANGUL SYLLABLE DWEH
+	{runeRange{0xB4A5, 0xB4BF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DWIG..HANGUL SYLLABLE DWIH
+	{runeRange{0xB4C1, 0xB4DB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DYUG..HANGUL SYLLABLE DYUH
+	{runeRange{0xB4DD, 0xB4F7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DEUG..HANGUL SYLLABLE DEUH
+	{runeRange{0xB4F9, 0xB513}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DYIG..HANGUL SYLLABLE DYIH
+	{runeRange{0xB515, 0xB52F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DIG..HANGUL SYLLABLE DIH
+	{runeRange{0xB531, 0xB54B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDAG..HANGUL SYLLABLE DDAH
+	{runeRange{0xB54D, 0xB567}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDAEG..HANGUL SYLLABLE DDAEH
+	{runeRange{0xB569, 0xB583}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDYAG..HANGUL SYLLABLE DDYAH
+	{runeRange{0xB585, 0xB59F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDYAEG..HANGUL SYLLABLE DDYAEH
+	{runeRange{0xB5A1, 0xB5BB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDEOG..HANGUL SYLLABLE DDEOH
+	{runeRange{0xB5BD, 0xB5D7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDEG..HANGUL SYLLABLE DDEH
+	{runeRange{0xB5D9, 0xB5F3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDYEOG..HANGUL SYLLABLE DDYEOH
+	{runeRange{0xB5F5, 0xB60F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDYEG..HANGUL SYLLABLE DDYEH
+	{runeRange{0xB611, 0xB62B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDOG..HANGUL SYLLABLE DDOH
+	{runeRange{0xB62D, 0xB647}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDWAG..HANGUL SYLLABLE DDWAH
+	{runeRange{0xB649, 0xB663}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDWAEG..HANGUL SYLLABLE DDWAEH
+	{runeRange{0xB665, 0xB67F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDOEG..HANGUL SYLLABLE DDOEH
+	{runeRange{0xB681, 0xB69B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDYOG..HANGUL SYLLABLE DDYOH
+	{runeRange{0xB69D, 0xB6B7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDUG..HANGUL SYLLABLE DDUH
+	{runeRange{0xB6B9, 0xB6D3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDWEOG..HANGUL SYLLABLE DDWEOH
+	{runeRange{0xB6D5, 0xB6EF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDWEG..HANGUL SYLLABLE DDWEH
+	{runeRange{0xB6F1, 0xB70B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDWIG..HANGUL SYLLABLE DDWIH
+	{runeRange{0xB70D, 0xB727}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDYUG..HANGUL SYLLABLE DDYUH
+	{runeRange{0xB729, 0xB743}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDEUG..HANGUL SYLLABLE DDEUH
+	{runeRange{0xB745, 0xB75F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDYIG..HANGUL SYLLABLE DDYIH
+	{runeRange{0xB761, 0xB77B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE DDIG..HANGUL SYLLABLE DDIH
+	{runeRange{0xB77D, 0xB797}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE RAG..HANGUL SYLLABLE RAH
+	{runeRange{0xB799, 0xB7B3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE RAEG..HANGUL SYLLABLE RAEH
+	{runeRange{0xB7B5, 0xB7CF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE RYAG..HANGUL SYLLABLE RYAH
+	{runeRange{0xB7D1, 0xB7EB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE RYAEG..HANGUL SYLLABLE RYAEH
+	{runeRange{0xB7ED, 0xB807}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE REOG..HANGUL SYLLABLE REOH
+	{runeRange{0xB809, 0xB823}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE REG..HANGUL SYLLABLE REH
+	{runeRange{0xB825, 0xB83F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE RYEOG..HANGUL SYLLABLE RYEOH
+	{runeRange{0xB841, 0xB85B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE RYEG..HANGUL SYLLABLE RYEH
+	{runeRange{0xB85D, 0xB877}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE ROG..HANGUL SYLLABLE ROH
+	{runeRange{0xB879, 0xB893}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE RWAG..HANGUL SYLLABLE RWAH
+	{runeRange{0xB895, 0xB8AF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE RWAEG..HANGUL SYLLABLE RWAEH
+	{runeRange{0xB8B1, 0xB8CB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE ROEG..HANGUL SYLLABLE ROEH
+	{runeRange{0xB8CD, 0xB8E7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE RYOG..HANGUL SYLLABLE RYOH
+	{runeRange{0xB8E9, 0xB903}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE RUG..HANGUL SYLLABLE RUH
+	{runeRange{0xB905, 0xB91F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE RWEOG..HANGUL SYLLABLE RWEOH
+	{runeRange{0xB921, 0xB93B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE RWEG..HANGUL SYLLABLE RWEH
+	{runeRange{0xB93D, 0xB957}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE RWIG..HANGUL SYLLABLE RWIH
+	{runeRange{0xB959, 0xB973}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE RYUG..HANGUL SYLLABLE RYUH
+	{runeRange{0xB975, 0xB98F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE REUG..HANGUL SYLLABLE REUH
+	{runeRange{0xB991, 0xB9AB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE RYIG..HANGUL SYLLABLE RYIH
+	{runeRange{0xB9AD, 0xB9C7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE RIG..HANGUL SYLLABLE RIH
+	{runeRange{0xB9C9, 0xB9E3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MAG..HANGUL SYLLABLE MAH
+	{runeRange{0xB9E5, 0xB9FF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MAEG..HANGUL SYLLABLE MAEH
+	{runeRange{0xBA01, 0xBA1B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MYAG..HANGUL SYLLABLE MYAH
+	{runeRange{0xBA1D, 0xBA37}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MYAEG..HANGUL SYLLABLE MYAEH
+	{runeRange{0xBA39, 0xBA53}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MEOG..HANGUL SYLLABLE MEOH
+	{runeRange{0xBA55, 0xBA6F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MEG..HANGUL SYLLABLE MEH
+	{runeRange{0xBA71, 0xBA8B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MYEOG..HANGUL SYLLABLE MYEOH
+	{runeRange{0xBA8D, 0xBAA7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MYEG..HANGUL SYLLABLE MYEH
+	{runeRange{0xBAA9, 0xBAC3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MOG..HANGUL SYLLABLE MOH
+	{runeRange{0xBAC5, 0xBADF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MWAG..HANGUL SYLLABLE MWAH
+	{runeRange{0xBAE1, 0xBAFB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MWAEG..HANGUL SYLLABLE MWAEH
+	{runeRange{0xBAFD, 0xBB17}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MOEG..HANGUL SYLLABLE MOEH
+	{runeRange{0xBB19, 0xBB33}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MYOG..HANGUL SYLLABLE MYOH
+	{runeRange{0xBB35, 0xBB4F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MUG..HANGUL SYLLABLE MUH
+	{runeRange{0xBB51, 0xBB6B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MWEOG..HANGUL SYLLABLE MWEOH
+	{runeRange{0xBB6D, 0xBB87}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MWEG..HANGUL SYLLABLE MWEH
+	{runeRange{0xBB89, 0xBBA3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MWIG..HANGUL SYLLABLE MWIH
+	{runeRange{0xBBA5, 0xBBBF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MYUG..HANGUL SYLLABLE MYUH
+	{runeRange{0xBBC1, 0xBBDB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MEUG..HANGUL SYLLABLE MEUH
+	{runeRange{0xBBDD, 0xBBF7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MYIG..HANGUL SYLLABLE MYIH
+	{runeRange{0xBBF9, 0xBC13}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE MIG..HANGUL SYLLABLE MIH
+	{runeRange{0xBC15, 0xBC2F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BAG..HANGUL SYLLABLE BAH
+	{runeRange{0xBC31, 0xBC4B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BAEG..HANGUL SYLLABLE BAEH
+	{runeRange{0xBC4D, 0xBC67}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BYAG..HANGUL SYLLABLE BYAH
+	{runeRange{0xBC69, 0xBC83}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BYAEG..HANGUL SYLLABLE BYAEH
+	{runeRange{0xBC85, 0xBC9F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BEOG..HANGUL SYLLABLE BEOH
+	{runeRange{0xBCA1, 0xBCBB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BEG..HANGUL SYLLABLE BEH
+	{runeRange{0xBCBD, 0xBCD7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BYEOG..HANGUL SYLLABLE BYEOH
+	{runeRange{0xBCD9, 0xBCF3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BYEG..HANGUL SYLLABLE BYEH
+	{runeRange{0xBCF5, 0xBD0F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BOG..HANGUL SYLLABLE BOH
+	{runeRange{0xBD11, 0xBD2B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BWAG..HANGUL SYLLABLE BWAH
+	{runeRange{0xBD2D, 0xBD47}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BWAEG..HANGUL SYLLABLE BWAEH
+	{runeRange{0xBD49, 0xBD63}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BOEG..HANGUL SYLLABLE BOEH
+	{runeRange{0xBD65, 0xBD7F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BYOG..HANGUL SYLLABLE BYOH
+	{runeRange{0xBD81, 0xBD9B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BUG..HANGUL SYLLABLE BUH
+	{runeRange{0xBD9D, 0xBDB7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BWEOG..HANGUL SYLLABLE BWEOH
+	{runeRange{0xBDB9, 0xBDD3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BWEG..HANGUL SYLLABLE BWEH
+	{runeRange{0xBDD5, 0xBDEF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BWIG..HANGUL SYLLABLE BWIH
+	{runeRange{0xBDF1, 0xBE0B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BYUG..HANGUL SYLLABLE BYUH
+	{runeRange{0xBE0D, 0xBE27}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BEUG..HANGUL SYLLABLE BEUH
+	{runeRange{0xBE29, 0xBE43}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BYIG..HANGUL SYLLABLE BYIH
+	{runeRange{0xBE45, 0xBE5F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BIG..HANGUL SYLLABLE BIH
+	{runeRange{0xBE61, 0xBE7B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBAG..HANGUL SYLLABLE BBAH
+	{runeRange{0xBE7D, 0xBE97}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBAEG..HANGUL SYLLABLE BBAEH
+	{runeRange{0xBE99, 0xBEB3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBYAG..HANGUL SYLLABLE BBYAH
+	{runeRange{0xBEB5, 0xBECF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBYAEG..HANGUL SYLLABLE BBYAEH
+	{runeRange{0xBED1, 0xBEEB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBEOG..HANGUL SYLLABLE BBEOH
+	{runeRange{0xBEED, 0xBF07}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBEG..HANGUL SYLLABLE BBEH
+	{runeRange{0xBF09, 0xBF23}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBYEOG..HANGUL SYLLABLE BBYEOH
+	{runeRange{0xBF25, 0xBF3F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBYEG..HANGUL SYLLABLE BBYEH
+	{runeRange{0xBF41, 0xBF5B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBOG..HANGUL SYLLABLE BBOH
+	{runeRange{0xBF5D, 0xBF77}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBWAG..HANGUL SYLLABLE BBWAH
+	{runeRange{0xBF79, 0xBF93}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBWAEG..HANGUL SYLLABLE BBWAEH
+	{runeRange{0xBF95, 0xBFAF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBOEG..HANGUL SYLLABLE BBOEH
+	{runeRange{0xBFB1, 0xBFCB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBYOG..HANGUL SYLLABLE BBYOH
+	{runeRange{0xBFCD, 0xBFE7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBUG..HANGUL SYLLABLE BBUH
+	{runeRange{0xBFE9, 0xC003}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBWEOG..HANGUL SYLLABLE BBWEOH
+	{runeRange{0xC005, 0xC01F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBWEG..HANGUL SYLLABLE BBWEH
+	{runeRange{0xC021, 0xC03B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBWIG..HANGUL SYLLABLE BBWIH
+	{runeRange{0xC03D, 0xC057}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBYUG..HANGUL SYLLABLE BBYUH
+	{runeRange{0xC059, 0xC073}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBEUG..HANGUL SYLLABLE BBEUH
+	{runeRange{0xC075, 0xC08F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBYIG..HANGUL SYLLABLE BBYIH
+	{runeRange{0xC091, 0xC0AB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE BBIG..HANGUL SYLLABLE BBIH
+	{runeRange{0xC0AD, 0xC0C7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SAG..HANGUL SYLLABLE SAH
+	{runeRange{0xC0C9, 0xC0E3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SAEG..HANGUL SYLLABLE SAEH
+	{runeRange{0xC0E5, 0xC0FF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SYAG..HANGUL SYLLABLE SYAH
+	{runeRange{0xC101, 0xC11B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SYAEG..HANGUL SYLLABLE SYAEH
+	{runeRange{0xC11D, 0xC137}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SEOG..HANGUL SYLLABLE SEOH
+	{runeRange{0xC139, 0xC153}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SEG..HANGUL SYLLABLE SEH
+	{runeRange{0xC155, 0xC16F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SYEOG..HANGUL SYLLABLE SYEOH
+	{runeRange{0xC171, 0xC18B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SYEG..HANGUL SYLLABLE SYEH
+	{runeRange{0xC18D, 0xC1A7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SOG..HANGUL SYLLABLE SOH
+	{runeRange{0xC1A9, 0xC1C3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SWAG..HANGUL SYLLABLE SWAH
+	{runeRange{0xC1C5, 0xC1DF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SWAEG..HANGUL SYLLABLE SWAEH
+	{runeRange{0xC1E1, 0xC1FB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SOEG..HANGUL SYLLABLE SOEH
+	{runeRange{0xC1FD, 0xC217}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SYOG..HANGUL SYLLABLE SYOH
+	{runeRange{0xC219, 0xC233}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SUG..HANGUL SYLLABLE SUH
+	{runeRange{0xC235, 0xC24F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SWEOG..HANGUL SYLLABLE SWEOH
+	{runeRange{0xC251, 0xC26B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SWEG..HANGUL SYLLABLE SWEH
+	{runeRange{0xC26D, 0xC287}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SWIG..HANGUL SYLLABLE SWIH
+	{runeRange{0xC289, 0xC2A3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SYUG..HANGUL SYLLABLE SYUH
+	{runeRange{0xC2A5, 0xC2BF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SEUG..HANGUL SYLLABLE SEUH
+	{runeRange{0xC2C1, 0xC2DB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SYIG..HANGUL SYLLABLE SYIH
+	{runeRange{0xC2DD, 0xC2F7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SIG..HANGUL SYLLABLE SIH
+	{runeRange{0xC2F9, 0xC313}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSAG..HANGUL SYLLABLE SSAH
+	{runeRange{0xC315, 0xC32F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSAEG..HANGUL SYLLABLE SSAEH
+	{runeRange{0xC331, 0xC34B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSYAG..HANGUL SYLLABLE SSYAH
+	{runeRange{0xC34D, 0xC367}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSYAEG..HANGUL SYLLABLE SSYAEH
+	{runeRange{0xC369, 0xC383}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSEOG..HANGUL SYLLABLE SSEOH
+	{runeRange{0xC385, 0xC39F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSEG..HANGUL SYLLABLE SSEH
+	{runeRange{0xC3A1, 0xC3BB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSYEOG..HANGUL SYLLABLE SSYEOH
+	{runeRange{0xC3BD, 0xC3D7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSYEG..HANGUL SYLLABLE SSYEH
+	{runeRange{0xC3D9, 0xC3F3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSOG..HANGUL SYLLABLE SSOH
+	{runeRange{0xC3F5, 0xC40F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSWAG..HANGUL SYLLABLE SSWAH
+	{runeRange{0xC411, 0xC42B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSWAEG..HANGUL SYLLABLE SSWAEH
+	{runeRange{0xC42D, 0xC447}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSOEG..HANGUL SYLLABLE SSOEH
+	{runeRange{0xC449, 0xC463}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSYOG..HANGUL SYLLABLE SSYOH
+	{runeRange{0xC465, 0xC47F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSUG..HANGUL SYLLABLE SSUH
+	{runeRange{0xC481, 0xC49B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSWEOG..HANGUL SYLLABLE SSWEOH
+	{runeRange{0xC49D, 0xC4B7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSWEG..HANGUL SYLLABLE SSWEH
+	{runeRange{0xC4B9, 0xC4D3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSWIG..HANGUL SYLLABLE SSWIH
+	{runeRange{0xC4D5, 0xC4EF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSYUG..HANGUL SYLLABLE SSYUH
+	{runeRange{0xC4F1, 0xC50B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSEUG..HANGUL SYLLABLE SSEUH
+	{runeRange{0xC50D, 0xC527}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSYIG..HANGUL SYLLABLE SSYIH
+	{runeRange{0xC529, 0xC543}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE SSIG..HANGUL SYLLABLE SSIH
+	{runeRange{0xC545, 0xC55F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE AG..HANGUL SYLLABLE AH
+	{runeRange{0xC561, 0xC57B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE AEG..HANGUL SYLLABLE AEH
+	{runeRange{0xC57D, 0xC597}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE YAG..HANGUL SYLLABLE YAH
+	{runeRange{0xC599, 0xC5B3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE YAEG..HANGUL SYLLABLE YAEH
+	{runeRange{0xC5B5, 0xC5CF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE EOG..HANGUL SYLLABLE EOH
+	{runeRange{0xC5D1, 0xC5EB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE EG..HANGUL SYLLABLE EH
+	{runeRange{0xC5ED, 0xC607}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE YEOG..HANGUL SYLLABLE YEOH
+	{runeRange{0xC609, 0xC623}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE YEG..HANGUL SYLLABLE YEH
+	{runeRange{0xC625, 0xC63F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE OG..HANGUL SYLLABLE OH
+	{runeRange{0xC641, 0xC65B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE WAG..HANGUL SYLLABLE WAH
+	{runeRange{0xC65D, 0xC677}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE WAEG..HANGUL SYLLABLE WAEH
+	{runeRange{0xC679, 0xC693}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE OEG..HANGUL SYLLABLE OEH
+	{runeRange{0xC695, 0xC6AF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE YOG..HANGUL SYLLABLE YOH
+	{runeRange{0xC6B1, 0xC6CB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE UG..HANGUL SYLLABLE UH
+	{runeRange{0xC6CD, 0xC6E7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE WEOG..HANGUL SYLLABLE WEOH
+	{runeRange{0xC6E9, 0xC703}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE WEG..HANGUL SYLLABLE WEH
+	{runeRange{0xC705, 0xC71F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE WIG..HANGUL SYLLABLE WIH
+	{runeRange{0xC721, 0xC73B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE YUG..HANGUL SYLLABLE YUH
+	{runeRange{0xC73D, 0xC757}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE EUG..HANGUL SYLLABLE EUH
+	{runeRange{0xC759, 0xC773}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE YIG..HANGUL SYLLABLE YIH
+	{runeRange{0xC775, 0xC78F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE IG..HANGUL SYLLABLE IH
+	{runeRange{0xC791, 0xC7AB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JAG..HANGUL SYLLABLE JAH
+	{runeRange{0xC7AD, 0xC7C7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JAEG..HANGUL SYLLABLE JAEH
+	{runeRange{0xC7C9, 0xC7E3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JYAG..HANGUL SYLLABLE JYAH
+	{runeRange{0xC7E5, 0xC7FF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JYAEG..HANGUL SYLLABLE JYAEH
+	{runeRange{0xC801, 0xC81B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JEOG..HANGUL SYLLABLE JEOH
+	{runeRange{0xC81D, 0xC837}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JEG..HANGUL SYLLABLE JEH
+	{runeRange{0xC839, 0xC853}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JYEOG..HANGUL SYLLABLE JYEOH
+	{runeRange{0xC855, 0xC86F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JYEG..HANGUL SYLLABLE JYEH
+	{runeRange{0xC871, 0xC88B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JOG..HANGUL SYLLABLE JOH
+	{runeRange{0xC88D, 0xC8A7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JWAG..HANGUL SYLLABLE JWAH
+	{runeRange{0xC8A9, 0xC8C3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JWAEG..HANGUL SYLLABLE JWAEH
+	{runeRange{0xC8C5, 0xC8DF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JOEG..HANGUL SYLLABLE JOEH
+	{runeRange{0xC8E1, 0xC8FB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JYOG..HANGUL SYLLABLE JYOH
+	{runeRange{0xC8FD, 0xC917}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JUG..HANGUL SYLLABLE JUH
+	{runeRange{0xC919, 0xC933}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JWEOG..HANGUL SYLLABLE JWEOH
+	{runeRange{0xC935, 0xC94F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JWEG..HANGUL SYLLABLE JWEH
+	{runeRange{0xC951, 0xC96B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JWIG..HANGUL SYLLABLE JWIH
+	{runeRange{0xC96D, 0xC987}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JYUG..HANGUL SYLLABLE JYUH
+	{runeRange{0xC989, 0xC9A3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JEUG..HANGUL SYLLABLE JEUH
+	{runeRange{0xC9A5, 0xC9BF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JYIG..HANGUL SYLLABLE JYIH
+	{runeRange{0xC9C1, 0xC9DB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JIG..HANGUL SYLLABLE JIH
+	{runeRange{0xC9DD, 0xC9F7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJAG..HANGUL SYLLABLE JJAH
+	{runeRange{0xC9F9, 0xCA13}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJAEG..HANGUL SYLLABLE JJAEH
+	{runeRange{0xCA15, 0xCA2F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJYAG..HANGUL SYLLABLE JJYAH
+	{runeRange{0xCA31, 0xCA4B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJYAEG..HANGUL SYLLABLE JJYAEH
+	{runeRange{0xCA4D, 0xCA67}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJEOG..HANGUL SYLLABLE JJEOH
+	{runeRange{0xCA69, 0xCA83}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJEG..HANGUL SYLLABLE JJEH
+	{runeRange{0xCA85, 0xCA9F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJYEOG..HANGUL SYLLABLE JJYEOH
+	{runeRange{0xCAA1, 0xCABB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJYEG..HANGUL SYLLABLE JJYEH
+	{runeRange{0xCABD, 0xCAD7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJOG..HANGUL SYLLABLE JJOH
+	{runeRange{0xCAD9, 0xCAF3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJWAG..HANGUL SYLLABLE JJWAH
+	{runeRange{0xCAF5, 0xCB0F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJWAEG..HANGUL SYLLABLE JJWAEH
+	{runeRange{0xCB11, 0xCB2B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJOEG..HANGUL SYLLABLE JJOEH
+	{runeRange{0xCB2D, 0xCB47}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJYOG..HANGUL SYLLABLE JJYOH
+	{runeRange{0xCB49, 0xCB63}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJUG..HANGUL SYLLABLE JJUH
+	{runeRange{0xCB65, 0xCB7F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJWEOG..HANGUL SYLLABLE JJWEOH
+	{runeRange{0xCB81, 0xCB9B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJWEG..HANGUL SYLLABLE JJWEH
+	{runeRange{0xCB9D, 0xCBB7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJWIG..HANGUL SYLLABLE JJWIH
+	{runeRange{0xCBB9, 0xCBD3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJYUG..HANGUL SYLLABLE JJYUH
+	{runeRange{0xCBD5, 0xCBEF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJEUG..HANGUL SYLLABLE JJEUH
+	{runeRange{0xCBF1, 0xCC0B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJYIG..HANGUL SYLLABLE JJYIH
+	{runeRange{0xCC0D, 0xCC27}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE JJIG..HANGUL SYLLABLE JJIH
+	{runeRange{0xCC29, 0xCC43}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CAG..HANGUL SYLLABLE CAH
+	{runeRange{0xCC45, 0xCC5F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CAEG..HANGUL SYLLABLE CAEH
+	{runeRange{0xCC61, 0xCC7B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CYAG..HANGUL SYLLABLE CYAH
+	{runeRange{0xCC7D, 0xCC97}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CYAEG..HANGUL SYLLABLE CYAEH
+	{runeRange{0xCC99, 0xCCB3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CEOG..HANGUL SYLLABLE CEOH
+	{runeRange{0xCCB5, 0xCCCF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CEG..HANGUL SYLLABLE CEH
+	{runeRange{0xCCD1, 0xCCEB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CYEOG..HANGUL SYLLABLE CYEOH
+	{runeRange{0xCCED, 0xCD07}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CYEG..HANGUL SYLLABLE CYEH
+	{runeRange{0xCD09, 0xCD23}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE COG..HANGUL SYLLABLE COH
+	{runeRange{0xCD25, 0xCD3F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CWAG..HANGUL SYLLABLE CWAH
+	{runeRange{0xCD41, 0xCD5B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CWAEG..HANGUL SYLLABLE CWAEH
+	{runeRange{0xCD5D, 0xCD77}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE COEG..HANGUL SYLLABLE COEH
+	{runeRange{0xCD79, 0xCD93}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CYOG..HANGUL SYLLABLE CYOH
+	{runeRange{0xCD95, 0xCDAF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CUG..HANGUL SYLLABLE CUH
+	{runeRange{0xCDB1, 0xCDCB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CWEOG..HANGUL SYLLABLE CWEOH
+	{runeRange{0xCDCD, 0xCDE7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CWEG..HANGUL SYLLABLE CWEH
+	{runeRange{0xCDE9, 0xCE03}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CWIG..HANGUL SYLLABLE CWIH
+	{runeRange{0xCE05, 0xCE1F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CYUG..HANGUL SYLLABLE CYUH
+	{runeRange{0xCE21, 0xCE3B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CEUG..HANGUL SYLLABLE CEUH
+	{runeRange{0xCE3D, 0xCE57}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CYIG..HANGUL SYLLABLE CYIH
+	{runeRange{0xCE59, 0xCE73}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE CIG..HANGUL SYLLABLE CIH
+	{runeRange{0xCE75, 0xCE8F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KAG..HANGUL SYLLABLE KAH
+	{runeRange{0xCE91, 0xCEAB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KAEG..HANGUL SYLLABLE KAEH
+	{runeRange{0xCEAD, 0xCEC7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KYAG..HANGUL SYLLABLE KYAH
+	{runeRange{0xCEC9, 0xCEE3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KYAEG..HANGUL SYLLABLE KYAEH
+	{runeRange{0xCEE5, 0xCEFF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KEOG..HANGUL SYLLABLE KEOH
+	{runeRange{0xCF01, 0xCF1B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KEG..HANGUL SYLLABLE KEH
+	{runeRange{0xCF1D, 0xCF37}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KYEOG..HANGUL SYLLABLE KYEOH
+	{runeRange{0xCF39, 0xCF53}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KYEG..HANGUL SYLLABLE KYEH
+	{runeRange{0xCF55, 0xCF6F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KOG..HANGUL SYLLABLE KOH
+	{runeRange{0xCF71, 0xCF8B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KWAG..HANGUL SYLLABLE KWAH
+	{runeRange{0xCF8D, 0xCFA7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KWAEG..HANGUL SYLLABLE KWAEH
+	{runeRange{0xCFA9, 0xCFC3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KOEG..HANGUL SYLLABLE KOEH
+	{runeRange{0xCFC5, 0xCFDF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KYOG..HANGUL SYLLABLE KYOH
+	{runeRange{0xCFE1, 0xCFFB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KUG..HANGUL SYLLABLE KUH
+	{runeRange{0xCFFD, 0xD017}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KWEOG..HANGUL SYLLABLE KWEOH
+	{runeRange{0xD019, 0xD033}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KWEG..HANGUL SYLLABLE KWEH
+	{runeRange{0xD035, 0xD04F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KWIG..HANGUL SYLLABLE KWIH
+	{runeRange{0xD051, 0xD06B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KYUG..HANGUL SYLLABLE KYUH
+	{runeRange{0xD06D, 0xD087}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KEUG..HANGUL SYLLABLE KEUH
+	{runeRange{0xD089, 0xD0A3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KYIG..HANGUL SYLLABLE KYIH
+	{runeRange{0xD0A5, 0xD0BF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE KIG..HANGUL SYLLABLE KIH
+	{runeRange{0xD0C1, 0xD0DB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TAG..HANGUL SYLLABLE TAH
+	{runeRange{0xD0DD, 0xD0F7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TAEG..HANGUL SYLLABLE TAEH
+	{runeRange{0xD0F9, 0xD113}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TYAG..HANGUL SYLLABLE TYAH
+	{runeRange{0xD115, 0xD12F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TYAEG..HANGUL SYLLABLE TYAEH
+	{runeRange{0xD131, 0xD14B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TEOG..HANGUL SYLLABLE TEOH
+	{runeRange{0xD14D, 0xD167}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TEG..HANGUL SYLLABLE TEH
+	{runeRange{0xD169, 0xD183}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TYEOG..HANGUL SYLLABLE TYEOH
+	{runeRange{0xD185, 0xD19F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TYEG..HANGUL SYLLABLE TYEH
+	{runeRange{0xD1A1, 0xD1BB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TOG..HANGUL SYLLABLE TOH
+	{runeRange{0xD1BD, 0xD1D7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TWAG..HANGUL SYLLABLE TWAH
+	{runeRange{0xD1D9, 0xD1F3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TWAEG..HANGUL SYLLABLE TWAEH
+	{runeRange{0xD1F5, 0xD20F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TOEG..HANGUL SYLLABLE TOEH
+	{runeRange{0xD211, 0xD22B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TYOG..HANGUL SYLLABLE TYOH
+	{runeRange{0xD22D, 0xD247}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TUG..HANGUL SYLLABLE TUH
+	{runeRange{0xD249, 0xD263}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TWEOG..HANGUL SYLLABLE TWEOH
+	{runeRange{0xD265, 0xD27F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TWEG..HANGUL SYLLABLE TWEH
+	{runeRange{0xD281, 0xD29B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TWIG..HANGUL SYLLABLE TWIH
+	{runeRange{0xD29D, 0xD2B7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TYUG..HANGUL SYLLABLE TYUH
+	{runeRange{0xD2B9, 0xD2D3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TEUG..HANGUL SYLLABLE TEUH
+	{runeRange{0xD2D5, 0xD2EF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TYIG..HANGUL SYLLABLE TYIH
+	{runeRange{0xD2F1, 0xD30B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE TIG..HANGUL SYLLABLE TIH
+	{runeRange{0xD30D, 0xD327}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PAG..HANGUL SYLLABLE PAH
+	{runeRange{0xD329, 0xD343}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PAEG..HANGUL SYLLABLE PAEH
+	{runeRange{0xD345, 0xD35F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PYAG..HANGUL SYLLABLE PYAH
+	{runeRange{0xD361, 0xD37B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PYAEG..HANGUL SYLLABLE PYAEH
+	{runeRange{0xD37D, 0xD397}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PEOG..HANGUL SYLLABLE PEOH
+	{runeRange{0xD399, 0xD3B3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PEG..HANGUL SYLLABLE PEH
+	{runeRange{0xD3B5, 0xD3CF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PYEOG..HANGUL SYLLABLE PYEOH
+	{runeRange{0xD3D1, 0xD3EB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PYEG..HANGUL SYLLABLE PYEH
+	{runeRange{0xD3ED, 0xD407}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE POG..HANGUL SYLLABLE POH
+	{runeRange{0xD409, 0xD423}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PWAG..HANGUL SYLLABLE PWAH
+	{runeRange{0xD425, 0xD43F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PWAEG..HANGUL SYLLABLE PWAEH
+	{runeRange{0xD441, 0xD45B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE POEG..HANGUL SYLLABLE POEH
+	{runeRange{0xD45D, 0xD477}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PYOG..HANGUL SYLLABLE PYOH
+	{runeRange{0xD479, 0xD493}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PUG..HANGUL SYLLABLE PUH
+	{runeRange{0xD495, 0xD4AF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PWEOG..HANGUL SYLLABLE PWEOH
+	{runeRange{0xD4B1, 0xD4CB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PWEG..HANGUL SYLLABLE PWEH
+	{runeRange{0xD4CD, 0xD4E7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PWIG..HANGUL SYLLABLE PWIH
+	{runeRange{0xD4E9, 0xD503}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PYUG..HANGUL SYLLABLE PYUH
+	{runeRange{0xD505, 0xD51F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PEUG..HANGUL SYLLABLE PEUH
+	{runeRange{0xD521, 0xD53B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PYIG..HANGUL SYLLABLE PYIH
+	{runeRange{0xD53D, 0xD557}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE PIG..HANGUL SYLLABLE PIH
+	{runeRange{0xD559, 0xD573}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HAG..HANGUL SYLLABLE HAH
+	{runeRange{0xD575, 0xD58F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HAEG..HANGUL SYLLABLE HAEH
+	{runeRange{0xD591, 0xD5AB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HYAG..HANGUL SYLLABLE HYAH
+	{runeRange{0xD5AD, 0xD5C7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HYAEG..HANGUL SYLLABLE HYAEH
+	{runeRange{0xD5C9, 0xD5E3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HEOG..HANGUL SYLLABLE HEOH
+	{runeRange{0xD5E5, 0xD5FF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HEG..HANGUL SYLLABLE HEH
+	{runeRange{0xD601, 0xD61B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HYEOG..HANGUL SYLLABLE HYEOH
+	{runeRange{0xD61D, 0xD637}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HYEG..HANGUL SYLLABLE HYEH
+	{runeRange{0xD639, 0xD653}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HOG..HANGUL SYLLABLE HOH
+	{runeRange{0xD655, 0xD66F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HWAG..HANGUL SYLLABLE HWAH
+	{runeRange{0xD671, 0xD68B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HWAEG..HANGUL SYLLABLE HWAEH
+	{runeRange{0xD68D, 0xD6A7}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HOEG..HANGUL SYLLABLE HOEH
+	{runeRange{0xD6A9, 0xD6C3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HYOG..HANGUL SYLLABLE HYOH
+	{runeRange{0xD6C5, 0xD6DF}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HUG..HANGUL SYLLABLE HUH
+	{runeRange{0xD6E1, 0xD6FB}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HWEOG..HANGUL SYLLABLE HWEOH
+	{runeRange{0xD6FD, 0xD717}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HWEG..HANGUL SYLLABLE HWEH
+	{runeRange{0xD719, 0xD733}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HWIG..HANGUL SYLLABLE HWIH
+	{runeRange{0xD735, 0xD74F}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HYUG..HANGUL SYLLABLE HYUH
+	{runeRange{0xD751, 0xD76B}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HEUG..HANGUL SYLLABLE HEUH
+	{runeRange{0xD76D, 0xD787}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HYIG..HANGUL SYLLABLE HYIH
+	{runeRange{0xD789, 0xD7A3}, propertyGeneralCategory{lbprH3, gcLo}},     //    [27] HANGUL SYLLABLE HIG..HANGUL SYLLABLE HIH
+	{runeRange{0xD7CB, 0xD7FB}, propertyGeneralCategory{lbprJT, gcLo}},     //    [49] HANGUL JONGSEONG NIEUN-RIEUL..HANGUL JONGSEONG PHIEUPH-THIEUTH
+	{runeRange{0xDB80, 0xDBFF}, propertyGeneralCategory{lbprSG, gcCs}},     //   [128] <surrogate-DB80>..<surrogate-DBFF>
+	{runeRange{0xE000, 0xF8FF}, propertyGeneralCategory{lbprXX, gcCo}},     //  [6400] <private-use-E000>..<private-use-F8FF>
+	{runeRange{0xFA6E, 0xFA6F}, propertyGeneralCategory{lbprID, gcCn}},     //     [2] <reserved-FA6E>..<reserved-FA6F>
+	{runeRange{0xFADA, 0xFAFF}, propertyGeneralCategory{lbprID, gcCn}},     //    [38] <reserved-FADA>..<reserved-FAFF>
+	{runeRange{0xFB13, 0xFB17}, propertyGeneralCategory{lbprAL, gcLl}},     //     [5] ARMENIAN SMALL LIGATURE MEN NOW..ARMENIAN SMALL LIGATURE MEN XEH
+	{runeRange{0xFB1E, 0xFB1E}, propertyGeneralCategory{lbprCM, gcMn}},     //         HEBREW POINT JUDEO-SPANISH VARIKA
+	{runeRange{0xFB29, 0xFB29}, propertyGeneralCategory{lbprAL, gcSm}},     //         HEBREW LETTER ALTERNATIVE PLUS SIGN
+	{runeRange{0xFB38, 0xFB3C}, propertyGeneralCategory{lbprHL, gcLo}},     //     [5] HEBREW LETTER TET WITH DAGESH..HEBREW LETTER LAMED WITH DAGESH
+	{runeRange{0xFB40, 0xFB41}, propertyGeneralCategory{lbprHL, gcLo}},     //     [2] HEBREW LETTER NUN WITH DAGESH..HEBREW LETTER SAMEKH WITH DAGESH
+	{runeRange{0xFB46, 0xFB4F}, propertyGeneralCategory{lbprHL, gcLo}},     //    [10] HEBREW LETTER TSADI WITH DAGESH..HEBREW LIGATURE ALEF LAMED
+	{runeRange{0xFBB2, 0xFBC2}, propertyGeneralCategory{lbprAL, gcSk}},     //    [17] ARABIC SYMBOL DOT ABOVE..ARABIC SYMBOL WASLA ABOVE
+	{runeRange{0xFD3E, 0xFD3E}, propertyGeneralCategory{lbprCL, gcPe}},     //         ORNATE LEFT PARENTHESIS
+	{runeRange{0xFD40, 0xFD4F}, propertyGeneralCategory{lbprAL, gcSo}},     //    [16] ARABIC LIGATURE RAHIMAHU ALLAAH..ARABIC LIGATURE RAHIMAHUM ALLAAH
+	{runeRange{0xFD92, 0xFDC7}, propertyGeneralCategory{lbprAL, gcLo}},     //    [54] ARABIC LIGATURE MEEM WITH JEEM WITH KHAH INITIAL FORM..ARABIC LIGATURE NOON WITH JEEM WITH YEH FINAL FORM
+	{runeRange{0xFDF0, 0xFDFB}, propertyGeneralCategory{lbprAL, gcLo}},     //    [12] ARABIC LIGATURE SALLA USED AS KORANIC STOP SIGN ISOLATED FORM..ARABIC LIGATURE JALLAJALALOUHOU
+	{runeRange{0xFDFD, 0xFDFF}, propertyGeneralCategory{lbprAL, gcSo}},     //     [3] ARABIC LIGATURE BISMILLAH AR-RAHMAN AR-RAHEEM..ARABIC LIGATURE AZZA WA JALL
+	{runeRange{0xFE10, 0xFE10}, propertyGeneralCategory{lbprIS, gcPo}},     //         PRESENTATION FORM FOR VERTICAL COMMA
+	{runeRange{0xFE13, 0xFE14}, propertyGeneralCategory{lbprIS, gcPo}},     //     [2] PRESENTATION FORM FOR VERTICAL COLON..PRESENTATION FORM FOR VERTICAL SEMICOLON
+	{runeRange{0xFE17, 0xFE17}, propertyGeneralCategory{lbprOP, gcPs}},     //         PRESENTATION FORM FOR VERTICAL LEFT WHITE LENTICULAR BRACKET
+	{runeRange{0xFE19, 0xFE19}, propertyGeneralCategory{lbprIN, gcPo}},     //         PRESENTATION FORM FOR VERTICAL HORIZONTAL ELLIPSIS
+	{runeRange{0xFE30, 0xFE30}, propertyGeneralCategory{lbprID, gcPo}},     //         PRESENTATION FORM FOR VERTICAL TWO DOT LEADER
+	{runeRange{0xFE33, 0xFE34}, propertyGeneralCategory{lbprID, gcPc}},     //     [2] PRESENTATION FORM FOR VERTICAL LOW LINE..PRESENTATION FORM FOR VERTICAL WAVY LOW LINE
+	{runeRange{0xFE36, 0xFE36}, propertyGeneralCategory{lbprCL, gcPe}},     //         PRESENTATION FORM FOR VERTICAL RIGHT PARENTHESIS
+	{runeRange{0xFE38, 0xFE38}, propertyGeneralCategory{lbprCL, gcPe}},     //         PRESENTATION FORM FOR VERTICAL RIGHT CURLY BRACKET
+	{runeRange{0xFE3A, 0xFE3A}, propertyGeneralCategory{lbprCL, gcPe}},     //         PRESENTATION FORM FOR VERTICAL RIGHT TORTOISE SHELL BRACKET
+	{runeRange{0xFE3C, 0xFE3C}, propertyGeneralCategory{lbprCL, gcPe}},     //         PRESENTATION FORM FOR VERTICAL RIGHT BLACK LENTICULAR BRACKET
+	{runeRange{0xFE3E, 0xFE3E}, propertyGeneralCategory{lbprCL, gcPe}},     //         PRESENTATION FORM FOR VERTICAL RIGHT DOUBLE ANGLE BRACKET
+	{runeRange{0xFE40, 0xFE40}, propertyGeneralCategory{lbprCL, gcPe}},     //         PRESENTATION FORM FOR VERTICAL RIGHT ANGLE BRACKET
+	{runeRange{0xFE42, 0xFE42}, propertyGeneralCategory{lbprCL, gcPe}},     //         PRESENTATION FORM FOR VERTICAL RIGHT CORNER BRACKET
+	{runeRange{0xFE44, 0xFE44}, propertyGeneralCategory{lbprCL, gcPe}},     //         PRESENTATION FORM FOR VERTICAL RIGHT WHITE CORNER BRACKET
+	{runeRange{0xFE47, 0xFE47}, propertyGeneralCategory{lbprOP, gcPs}},     //         PRESENTATION FORM FOR VERTICAL LEFT SQUARE BRACKET
+	{runeRange{0xFE49, 0xFE4C}, propertyGeneralCategory{lbprID, gcPo}},     //     [4] DASHED OVERLINE..DOUBLE WAVY OVERLINE
+	{runeRange{0xFE50, 0xFE50}, propertyGeneralCategory{lbprCL, gcPo}},     //         SMALL COMMA
+	{runeRange{0xFE52, 0xFE52}, propertyGeneralCategory{lbprCL, gcPo}},     //         SMALL FULL STOP
+	{runeRange{0xFE56, 0xFE57}, propertyGeneralCategory{lbprEX, gcPo}},     //     [2] SMALL QUESTION MARK..SMALL EXCLAMATION MARK
+	{runeRange{0xFE59, 0xFE59}, propertyGeneralCategory{lbprOP, gcPs}},     //         SMALL LEFT PARENTHESIS
+	{runeRange{0xFE5B, 0xFE5B}, propertyGeneralCategory{lbprOP, gcPs}},     //         SMALL LEFT CURLY BRACKET
+	{runeRange{0xFE5D, 0xFE5D}, propertyGeneralCategory{lbprOP, gcPs}},     //         SMALL LEFT TORTOISE SHELL BRACKET
+	{runeRange{0xFE5F, 0xFE61}, propertyGeneralCategory{lbprID, gcPo}},     //     [3] SMALL NUMBER SIGN..SMALL ASTERISK
+	{runeRange{0xFE63, 0xFE63}, propertyGeneralCategory{lbprID, gcPd}},     //         SMALL HYPHEN-MINUS
+	{runeRange{0xFE68, 0xFE68}, propertyGeneralCategory{lbprID, gcPo}},     //         SMALL REVERSE SOLIDUS
+	{runeRange{0xFE6A, 0xFE6A}, propertyGeneralCategory{lbprPO, gcPo}},     //         SMALL PERCENT SIGN
+	{runeRange{0xFE70, 0xFE74}, propertyGeneralCategory{lbprAL, gcLo}},     //     [5] ARABIC FATHATAN ISOLATED FORM..ARABIC KASRATAN ISOLATED FORM
+	{runeRange{0xFEFF, 0xFEFF}, propertyGeneralCategory{lbprWJ, gcCf}},     //         ZERO WIDTH NO-BREAK SPACE
+	{runeRange{0xFF02, 0xFF03}, propertyGeneralCategory{lbprID, gcPo}},     //     [2] FULLWIDTH QUOTATION MARK..FULLWIDTH NUMBER SIGN
+	{runeRange{0xFF05, 0xFF05}, propertyGeneralCategory{lbprPO, gcPo}},     //         FULLWIDTH PERCENT SIGN
+	{runeRange{0xFF08, 0xFF08}, propertyGeneralCategory{lbprOP, gcPs}},     //         FULLWIDTH LEFT PARENTHESIS
+	{runeRange{0xFF0A, 0xFF0A}, propertyGeneralCategory{lbprID, gcPo}},     //         FULLWIDTH ASTERISK
+	{runeRange{0xFF0C, 0xFF0C}, propertyGeneralCategory{lbprCL, gcPo}},     //         FULLWIDTH COMMA
+	{runeRange{0xFF0E, 0xFF0E}, propertyGeneralCategory{lbprCL, gcPo}},     //         FULLWIDTH FULL STOP
+	{runeRange{0xFF10, 0xFF19}, propertyGeneralCategory{lbprID, gcNd}},     //    [10] FULLWIDTH DIGIT ZERO..FULLWIDTH DIGIT NINE
+	{runeRange{0xFF1C, 0xFF1E}, propertyGeneralCategory{lbprID, gcSm}},     //     [3] FULLWIDTH LESS-THAN SIGN..FULLWIDTH GREATER-THAN SIGN
+	{runeRange{0xFF20, 0xFF20}, propertyGeneralCategory{lbprID, gcPo}},     //         FULLWIDTH COMMERCIAL AT
+	{runeRange{0xFF3B, 0xFF3B}, propertyGeneralCategory{lbprOP, gcPs}},     //         FULLWIDTH LEFT SQUARE BRACKET
+	{runeRange{0xFF3D, 0xFF3D}, propertyGeneralCategory{lbprCL, gcPe}},     //         FULLWIDTH RIGHT SQUARE BRACKET
+	{runeRange{0xFF3F, 0xFF3F}, propertyGeneralCategory{lbprID, gcPc}},     //         FULLWIDTH LOW LINE
+	{runeRange{0xFF41, 0xFF5A}, propertyGeneralCategory{lbprID, gcLl}},     //    [26] FULLWIDTH LATIN SMALL LETTER A..FULLWIDTH LATIN SMALL LETTER Z
+	{runeRange{0xFF5C, 0xFF5C}, propertyGeneralCategory{lbprID, gcSm}},     //         FULLWIDTH VERTICAL LINE
+	{runeRange{0xFF5E, 0xFF5E}, propertyGeneralCategory{lbprID, gcSm}},     //         FULLWIDTH TILDE
+	{runeRange{0xFF60, 0xFF60}, propertyGeneralCategory{lbprCL, gcPe}},     //         FULLWIDTH RIGHT WHITE PARENTHESIS
+	{runeRange{0xFF62, 0xFF62}, propertyGeneralCategory{lbprOP, gcPs}},     //         HALFWIDTH LEFT CORNER BRACKET
+	{runeRange{0xFF64, 0xFF64}, propertyGeneralCategory{lbprCL, gcPo}},     //         HALFWIDTH IDEOGRAPHIC COMMA
+	{runeRange{0xFF66, 0xFF66}, propertyGeneralCategory{lbprID, gcLo}},     //         HALFWIDTH KATAKANA LETTER WO
+	{runeRange{0xFF70, 0xFF70}, propertyGeneralCategory{lbprCJ, gcLm}},     //         HALFWIDTH KATAKANA-HIRAGANA PROLONGED SOUND MARK
+	{runeRange{0xFF9E, 0xFF9F}, propertyGeneralCategory{lbprNS, gcLm}},     //     [2] HALFWIDTH KATAKANA VOICED SOUND MARK..HALFWIDTH KATAKANA SEMI-VOICED SOUND MARK
+	{runeRange{0xFFC2, 0xFFC7}, propertyGeneralCategory{lbprID, gcLo}},     //     [6] HALFWIDTH HANGUL LETTER A..HALFWIDTH HANGUL LETTER E
+	{runeRange{0xFFD2, 0xFFD7}, propertyGeneralCategory{lbprID, gcLo}},     //     [6] HALFWIDTH HANGUL LETTER YO..HALFWIDTH HANGUL LETTER YU
+	{runeRange{0xFFE0, 0xFFE0}, propertyGeneralCategory{lbprPO, gcSc}},     //         FULLWIDTH CENT SIGN
+	{runeRange{0xFFE2, 0xFFE2}, propertyGeneralCategory{lbprID, gcSm}},     //         FULLWIDTH NOT SIGN
+	{runeRange{0xFFE4, 0xFFE4}, propertyGeneralCategory{lbprID, gcSo}},     //         FULLWIDTH BROKEN BAR
+	{runeRange{0xFFE8, 0xFFE8}, propertyGeneralCategory{lbprAL, gcSo}},     //         HALFWIDTH FORMS LIGHT VERTICAL
+	{runeRange{0xFFED, 0xFFEE}, propertyGeneralCategory{lbprAL, gcSo}},     //     [2] HALFWIDTH BLACK SQUARE..HALFWIDTH WHITE CIRCLE
+	{runeRange{0xFFFC, 0xFFFC}, propertyGeneralCategory{lbprCB, gcSo}},     //         OBJECT REPLACEMENT CHARACTER
+	{runeRange{0x10000, 0x1000B}, propertyGeneralCategory{lbprAL, gcLo}},   //    [12] LINEAR B SYLLABLE B008 A..LINEAR B SYLLABLE B046 JE
+	{runeRange{0x10028, 0x1003A}, propertyGeneralCategory{lbprAL, gcLo}},   //    [19] LINEAR B SYLLABLE B060 RA..LINEAR B SYLLABLE B042 WO
+	{runeRange{0x1003F, 0x1004D}, propertyGeneralCategory{lbprAL, gcLo}},   //    [15] LINEAR B SYLLABLE B020 ZO..LINEAR B SYLLABLE B091 TWO
+	{runeRange{0x10080, 0x100FA}, propertyGeneralCategory{lbprAL, gcLo}},   //   [123] LINEAR B IDEOGRAM B100 MAN..LINEAR B IDEOGRAM VESSEL B305
+	{runeRange{0x10107, 0x10133}, propertyGeneralCategory{lbprAL, gcNo}},   //    [45] AEGEAN NUMBER ONE..AEGEAN NUMBER NINETY THOUSAND
+	{runeRange{0x10140, 0x10174}, propertyGeneralCategory{lbprAL, gcNl}},   //    [53] GREEK ACROPHONIC ATTIC ONE QUARTER..GREEK ACROPHONIC STRATIAN FIFTY MNAS
+	{runeRange{0x10179, 0x10189}, propertyGeneralCategory{lbprAL, gcSo}},   //    [17] GREEK YEAR SIGN..GREEK TRYBLION BASE SIGN
+	{runeRange{0x1018C, 0x1018E}, propertyGeneralCategory{lbprAL, gcSo}},   //     [3] GREEK SINUSOID SIGN..NOMISMA SIGN
+	{runeRange{0x101A0, 0x101A0}, propertyGeneralCategory{lbprAL, gcSo}},   //         GREEK SYMBOL TAU RHO
+	{runeRange{0x101FD, 0x101FD}, propertyGeneralCategory{lbprCM, gcMn}},   //         PHAISTOS DISC SIGN COMBINING OBLIQUE STROKE
+	{runeRange{0x102A0, 0x102D0}, propertyGeneralCategory{lbprAL, gcLo}},   //    [49] CARIAN LETTER A..CARIAN LETTER UUU3
+	{runeRange{0x102E1, 0x102FB}, propertyGeneralCategory{lbprAL, gcNo}},   //    [27] COPTIC EPACT DIGIT ONE..COPTIC EPACT NUMBER NINE HUNDRED
+	{runeRange{0x10320, 0x10323}, propertyGeneralCategory{lbprAL, gcNo}},   //     [4] OLD ITALIC NUMERAL ONE..OLD ITALIC NUMERAL FIFTY
+	{runeRange{0x10330, 0x10340}, propertyGeneralCategory{lbprAL, gcLo}},   //    [17] GOTHIC LETTER AHSA..GOTHIC LETTER PAIRTHRA
+	{runeRange{0x10342, 0x10349}, propertyGeneralCategory{lbprAL, gcLo}},   //     [8] GOTHIC LETTER RAIDA..GOTHIC LETTER OTHAL
+	{runeRange{0x10350, 0x10375}, propertyGeneralCategory{lbprAL, gcLo}},   //    [38] OLD PERMIC LETTER AN..OLD PERMIC LETTER IA
+	{runeRange{0x10380, 0x1039D}, propertyGeneralCategory{lbprAL, gcLo}},   //    [30] UGARITIC LETTER ALPA..UGARITIC LETTER SSU
+	{runeRange{0x103A0, 0x103C3}, propertyGeneralCategory{lbprAL, gcLo}},   //    [36] OLD PERSIAN SIGN A..OLD PERSIAN SIGN HA
+	{runeRange{0x103D0, 0x103D0}, propertyGeneralCategory{lbprBA, gcPo}},   //         OLD PERSIAN WORD DIVIDER
+	{runeRange{0x10400, 0x1044F}, propertyGeneralCategory{lbprAL, gcLC}},   //    [80] DESERET CAPITAL LETTER LONG I..DESERET SMALL LETTER EW
+	{runeRange{0x10480, 0x1049D}, propertyGeneralCategory{lbprAL, gcLo}},   //    [30] OSMANYA LETTER ALEF..OSMANYA LETTER OO
+	{runeRange{0x104B0, 0x104D3}, propertyGeneralCategory{lbprAL, gcLu}},   //    [36] OSAGE CAPITAL LETTER A..OSAGE CAPITAL LETTER ZHA
+	{runeRange{0x10500, 0x10527}, propertyGeneralCategory{lbprAL, gcLo}},   //    [40] ELBASAN LETTER A..ELBASAN LETTER KHE
+	{runeRange{0x1056F, 0x1056F}, propertyGeneralCategory{lbprAL, gcPo}},   //         CAUCASIAN ALBANIAN CITATION MARK
+	{runeRange{0x1057C, 0x1058A}, propertyGeneralCategory{lbprAL, gcLu}},   //    [15] VITHKUQI CAPITAL LETTER HA..VITHKUQI CAPITAL LETTER RE
+	{runeRange{0x10594, 0x10595}, propertyGeneralCategory{lbprAL, gcLu}},   //     [2] VITHKUQI CAPITAL LETTER Y..VITHKUQI CAPITAL LETTER ZE
+	{runeRange{0x105A3, 0x105B1}, propertyGeneralCategory{lbprAL, gcLl}},   //    [15] VITHKUQI SMALL LETTER HA..VITHKUQI SMALL LETTER RE
+	{runeRange{0x105BB, 0x105BC}, propertyGeneralCategory{lbprAL, gcLl}},   //     [2] VITHKUQI SMALL LETTER Y..VITHKUQI SMALL LETTER ZE
+	{runeRange{0x10740, 0x10755}, propertyGeneralCategory{lbprAL, gcLo}},   //    [22] LINEAR A SIGN A701 A..LINEAR A SIGN A732 JE
+	{runeRange{0x10780, 0x10785}, propertyGeneralCategory{lbprAL, gcLm}},   //     [6] MODIFIER LETTER SMALL CAPITAL AA..MODIFIER LETTER SMALL B WITH HOOK
+	{runeRange{0x107B2, 0x107BA}, propertyGeneralCategory{lbprAL, gcLm}},   //     [9] MODIFIER LETTER SMALL CAPITAL Y..MODIFIER LETTER SMALL S WITH CURL
+	{runeRange{0x10808, 0x10808}, propertyGeneralCategory{lbprAL, gcLo}},   //         CYPRIOT SYLLABLE JO
+	{runeRange{0x10837, 0x10838}, propertyGeneralCategory{lbprAL, gcLo}},   //     [2] CYPRIOT SYLLABLE XA..CYPRIOT SYLLABLE XE
+	{runeRange{0x1083F, 0x1083F}, propertyGeneralCategory{lbprAL, gcLo}},   //         CYPRIOT SYLLABLE ZO
+	{runeRange{0x10857, 0x10857}, propertyGeneralCategory{lbprBA, gcPo}},   //         IMPERIAL ARAMAIC SECTION SIGN
+	{runeRange{0x10860, 0x10876}, propertyGeneralCategory{lbprAL, gcLo}},   //    [23] PALMYRENE LETTER ALEPH..PALMYRENE LETTER TAW
+	{runeRange{0x10879, 0x1087F}, propertyGeneralCategory{lbprAL, gcNo}},   //     [7] PALMYRENE NUMBER ONE..PALMYRENE NUMBER TWENTY
+	{runeRange{0x108A7, 0x108AF}, propertyGeneralCategory{lbprAL, gcNo}},   //     [9] NABATAEAN NUMBER ONE..NABATAEAN NUMBER ONE HUNDRED
+	{runeRange{0x108F4, 0x108F5}, propertyGeneralCategory{lbprAL, gcLo}},   //     [2] HATRAN LETTER SHIN..HATRAN LETTER TAW
+	{runeRange{0x10900, 0x10915}, propertyGeneralCategory{lbprAL, gcLo}},   //    [22] PHOENICIAN LETTER ALF..PHOENICIAN LETTER TAU
+	{runeRange{0x1091F, 0x1091F}, propertyGeneralCategory{lbprBA, gcPo}},   //         PHOENICIAN WORD SEPARATOR
+	{runeRange{0x1093F, 0x1093F}, propertyGeneralCategory{lbprAL, gcPo}},   //         LYDIAN TRIANGULAR MARK
+	{runeRange{0x109A0, 0x109B7}, propertyGeneralCategory{lbprAL, gcLo}},   //    [24] MEROITIC CURSIVE LETTER A..MEROITIC CURSIVE LETTER DA
+	{runeRange{0x109BE, 0x109BF}, propertyGeneralCategory{lbprAL, gcLo}},   //     [2] MEROITIC CURSIVE LOGOGRAM RMT..MEROITIC CURSIVE LOGOGRAM IMN
+	{runeRange{0x109D2, 0x109FF}, propertyGeneralCategory{lbprAL, gcNo}},   //    [46] MEROITIC CURSIVE NUMBER ONE HUNDRED..MEROITIC CURSIVE FRACTION TEN TWELFTHS
+	{runeRange{0x10A01, 0x10A03}, propertyGeneralCategory{lbprCM, gcMn}},   //     [3] KHAROSHTHI VOWEL SIGN I..KHAROSHTHI VOWEL SIGN VOCALIC R
+	{runeRange{0x10A0C, 0x10A0F}, propertyGeneralCategory{lbprCM, gcMn}},   //     [4] KHAROSHTHI VOWEL LENGTH MARK..KHAROSHTHI SIGN VISARGA
+	{runeRange{0x10A15, 0x10A17}, propertyGeneralCategory{lbprAL, gcLo}},   //     [3] KHAROSHTHI LETTER CA..KHAROSHTHI LETTER JA
+	{runeRange{0x10A38, 0x10A3A}, propertyGeneralCategory{lbprCM, gcMn}},   //     [3] KHAROSHTHI SIGN BAR ABOVE..KHAROSHTHI SIGN DOT BELOW
+	{runeRange{0x10A40, 0x10A48}, propertyGeneralCategory{lbprAL, gcNo}},   //     [9] KHAROSHTHI DIGIT ONE..KHAROSHTHI FRACTION ONE HALF
+	{runeRange{0x10A58, 0x10A58}, propertyGeneralCategory{lbprAL, gcPo}},   //         KHAROSHTHI PUNCTUATION LINES
+	{runeRange{0x10A7D, 0x10A7E}, propertyGeneralCategory{lbprAL, gcNo}},   //     [2] OLD SOUTH ARABIAN NUMBER ONE..OLD SOUTH ARABIAN NUMBER FIFTY
+	{runeRange{0x10A80, 0x10A9C}, propertyGeneralCategory{lbprAL, gcLo}},   //    [29] OLD NORTH ARABIAN LETTER HEH..OLD NORTH ARABIAN LETTER ZAH
+	{runeRange{0x10AC0, 0x10AC7}, propertyGeneralCategory{lbprAL, gcLo}},   //     [8] MANICHAEAN LETTER ALEPH..MANICHAEAN LETTER WAW
+	{runeRange{0x10AC9, 0x10AE4}, propertyGeneralCategory{lbprAL, gcLo}},   //    [28] MANICHAEAN LETTER ZAYIN..MANICHAEAN LETTER TAW
+	{runeRange{0x10AEB, 0x10AEF}, propertyGeneralCategory{lbprAL, gcNo}},   //     [5] MANICHAEAN NUMBER ONE..MANICHAEAN NUMBER ONE HUNDRED
+	{runeRange{0x10AF6, 0x10AF6}, propertyGeneralCategory{lbprIN, gcPo}},   //         MANICHAEAN PUNCTUATION LINE FILLER
+	{runeRange{0x10B39, 0x10B3F}, propertyGeneralCategory{lbprBA, gcPo}},   //     [7] AVESTAN ABBREVIATION MARK..LARGE ONE RING OVER TWO RINGS PUNCTUATION
+	{runeRange{0x10B58, 0x10B5F}, propertyGeneralCategory{lbprAL, gcNo}},   //     [8] INSCRIPTIONAL PARTHIAN NUMBER ONE..INSCRIPTIONAL PARTHIAN NUMBER ONE THOUSAND
+	{runeRange{0x10B78, 0x10B7F}, propertyGeneralCategory{lbprAL, gcNo}},   //     [8] INSCRIPTIONAL PAHLAVI NUMBER ONE..INSCRIPTIONAL PAHLAVI NUMBER ONE THOUSAND
+	{runeRange{0x10B99, 0x10B9C}, propertyGeneralCategory{lbprAL, gcPo}},   //     [4] PSALTER PAHLAVI SECTION MARK..PSALTER PAHLAVI FOUR DOTS WITH DOT
+	{runeRange{0x10C00, 0x10C48}, propertyGeneralCategory{lbprAL, gcLo}},   //    [73] OLD TURKIC LETTER ORKHON A..OLD TURKIC LETTER ORKHON BASH
+	{runeRange{0x10CC0, 0x10CF2}, propertyGeneralCategory{lbprAL, gcLl}},   //    [51] OLD HUNGARIAN SMALL LETTER A..OLD HUNGARIAN SMALL LETTER US
+	{runeRange{0x10D00, 0x10D23}, propertyGeneralCategory{lbprAL, gcLo}},   //    [36] HANIFI ROHINGYA LETTER A..HANIFI ROHINGYA MARK NA KHONNA
+	{runeRange{0x10D30, 0x10D39}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] HANIFI ROHINGYA DIGIT ZERO..HANIFI ROHINGYA DIGIT NINE
+	{runeRange{0x10E80, 0x10EA9}, propertyGeneralCategory{lbprAL, gcLo}},   //    [42] YEZIDI LETTER ELIF..YEZIDI LETTER ET
+	{runeRange{0x10EAD, 0x10EAD}, propertyGeneralCategory{lbprBA, gcPd}},   //         YEZIDI HYPHENATION MARK
+	{runeRange{0x10EFD, 0x10EFF}, propertyGeneralCategory{lbprCM, gcMn}},   //     [3] ARABIC SMALL LOW WORD SAKTA..ARABIC SMALL LOW WORD MADDA
+	{runeRange{0x10F1D, 0x10F26}, propertyGeneralCategory{lbprAL, gcNo}},   //    [10] OLD SOGDIAN NUMBER ONE..OLD SOGDIAN FRACTION ONE HALF
+	{runeRange{0x10F30, 0x10F45}, propertyGeneralCategory{lbprAL, gcLo}},   //    [22] SOGDIAN LETTER ALEPH..SOGDIAN INDEPENDENT SHIN
+	{runeRange{0x10F51, 0x10F54}, propertyGeneralCategory{lbprAL, gcNo}},   //     [4] SOGDIAN NUMBER ONE..SOGDIAN NUMBER ONE HUNDRED
+	{runeRange{0x10F70, 0x10F81}, propertyGeneralCategory{lbprAL, gcLo}},   //    [18] OLD UYGHUR LETTER ALEPH..OLD UYGHUR LETTER LESH
+	{runeRange{0x10F86, 0x10F89}, propertyGeneralCategory{lbprAL, gcPo}},   //     [4] OLD UYGHUR PUNCTUATION BAR..OLD UYGHUR PUNCTUATION FOUR DOTS
+	{runeRange{0x10FC5, 0x10FCB}, propertyGeneralCategory{lbprAL, gcNo}},   //     [7] CHORASMIAN NUMBER ONE..CHORASMIAN NUMBER ONE HUNDRED
+	{runeRange{0x11000, 0x11000}, propertyGeneralCategory{lbprCM, gcMc}},   //         BRAHMI SIGN CANDRABINDU
+	{runeRange{0x11002, 0x11002}, propertyGeneralCategory{lbprCM, gcMc}},   //         BRAHMI SIGN VISARGA
+	{runeRange{0x11038, 0x11046}, propertyGeneralCategory{lbprCM, gcMn}},   //    [15] BRAHMI VOWEL SIGN AA..BRAHMI VIRAMA
+	{runeRange{0x11049, 0x1104D}, propertyGeneralCategory{lbprAL, gcPo}},   //     [5] BRAHMI PUNCTUATION DOT..BRAHMI PUNCTUATION LOTUS
+	{runeRange{0x11066, 0x1106F}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] BRAHMI DIGIT ZERO..BRAHMI DIGIT NINE
+	{runeRange{0x11071, 0x11072}, propertyGeneralCategory{lbprAL, gcLo}},   //     [2] BRAHMI LETTER OLD TAMIL SHORT E..BRAHMI LETTER OLD TAMIL SHORT O
+	{runeRange{0x11075, 0x11075}, propertyGeneralCategory{lbprAL, gcLo}},   //         BRAHMI LETTER OLD TAMIL LLA
+	{runeRange{0x11080, 0x11081}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] KAITHI SIGN CANDRABINDU..KAITHI SIGN ANUSVARA
+	{runeRange{0x11083, 0x110AF}, propertyGeneralCategory{lbprAL, gcLo}},   //    [45] KAITHI LETTER A..KAITHI LETTER HA
+	{runeRange{0x110B3, 0x110B6}, propertyGeneralCategory{lbprCM, gcMn}},   //     [4] KAITHI VOWEL SIGN U..KAITHI VOWEL SIGN AI
+	{runeRange{0x110B9, 0x110BA}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] KAITHI SIGN VIRAMA..KAITHI SIGN NUKTA
+	{runeRange{0x110BD, 0x110BD}, propertyGeneralCategory{lbprAL, gcCf}},   //         KAITHI NUMBER SIGN
+	{runeRange{0x110C2, 0x110C2}, propertyGeneralCategory{lbprCM, gcMn}},   //         KAITHI VOWEL SIGN VOCALIC R
+	{runeRange{0x110D0, 0x110E8}, propertyGeneralCategory{lbprAL, gcLo}},   //    [25] SORA SOMPENG LETTER SAH..SORA SOMPENG LETTER MAE
+	{runeRange{0x11100, 0x11102}, propertyGeneralCategory{lbprCM, gcMn}},   //     [3] CHAKMA SIGN CANDRABINDU..CHAKMA SIGN VISARGA
+	{runeRange{0x11127, 0x1112B}, propertyGeneralCategory{lbprCM, gcMn}},   //     [5] CHAKMA VOWEL SIGN A..CHAKMA VOWEL SIGN UU
+	{runeRange{0x1112D, 0x11134}, propertyGeneralCategory{lbprCM, gcMn}},   //     [8] CHAKMA VOWEL SIGN AI..CHAKMA MAAYYAA
+	{runeRange{0x11140, 0x11143}, propertyGeneralCategory{lbprBA, gcPo}},   //     [4] CHAKMA SECTION MARK..CHAKMA QUESTION MARK
+	{runeRange{0x11145, 0x11146}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] CHAKMA VOWEL SIGN AA..CHAKMA VOWEL SIGN EI
+	{runeRange{0x11150, 0x11172}, propertyGeneralCategory{lbprAL, gcLo}},   //    [35] MAHAJANI LETTER A..MAHAJANI LETTER RRA
+	{runeRange{0x11174, 0x11174}, propertyGeneralCategory{lbprAL, gcPo}},   //         MAHAJANI ABBREVIATION SIGN
+	{runeRange{0x11176, 0x11176}, propertyGeneralCategory{lbprAL, gcLo}},   //         MAHAJANI LIGATURE SHRI
+	{runeRange{0x11182, 0x11182}, propertyGeneralCategory{lbprCM, gcMc}},   //         SHARADA SIGN VISARGA
+	{runeRange{0x111B3, 0x111B5}, propertyGeneralCategory{lbprCM, gcMc}},   //     [3] SHARADA VOWEL SIGN AA..SHARADA VOWEL SIGN II
+	{runeRange{0x111BF, 0x111C0}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] SHARADA VOWEL SIGN AU..SHARADA SIGN VIRAMA
+	{runeRange{0x111C5, 0x111C6}, propertyGeneralCategory{lbprBA, gcPo}},   //     [2] SHARADA DANDA..SHARADA DOUBLE DANDA
+	{runeRange{0x111C8, 0x111C8}, propertyGeneralCategory{lbprBA, gcPo}},   //         SHARADA SEPARATOR
+	{runeRange{0x111CD, 0x111CD}, propertyGeneralCategory{lbprAL, gcPo}},   //         SHARADA SUTRA MARK
+	{runeRange{0x111CF, 0x111CF}, propertyGeneralCategory{lbprCM, gcMn}},   //         SHARADA SIGN INVERTED CANDRABINDU
+	{runeRange{0x111DA, 0x111DA}, propertyGeneralCategory{lbprAL, gcLo}},   //         SHARADA EKAM
+	{runeRange{0x111DC, 0x111DC}, propertyGeneralCategory{lbprAL, gcLo}},   //         SHARADA HEADSTROKE
+	{runeRange{0x111E1, 0x111F4}, propertyGeneralCategory{lbprAL, gcNo}},   //    [20] SINHALA ARCHAIC DIGIT ONE..SINHALA ARCHAIC NUMBER ONE THOUSAND
+	{runeRange{0x11213, 0x1122B}, propertyGeneralCategory{lbprAL, gcLo}},   //    [25] KHOJKI LETTER NYA..KHOJKI LETTER LLA
+	{runeRange{0x1122F, 0x11231}, propertyGeneralCategory{lbprCM, gcMn}},   //     [3] KHOJKI VOWEL SIGN U..KHOJKI VOWEL SIGN AI
+	{runeRange{0x11234, 0x11234}, propertyGeneralCategory{lbprCM, gcMn}},   //         KHOJKI SIGN ANUSVARA
+	{runeRange{0x11236, 0x11237}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] KHOJKI SIGN NUKTA..KHOJKI SIGN SHADDA
+	{runeRange{0x1123A, 0x1123A}, propertyGeneralCategory{lbprAL, gcPo}},   //         KHOJKI WORD SEPARATOR
+	{runeRange{0x1123D, 0x1123D}, propertyGeneralCategory{lbprAL, gcPo}},   //         KHOJKI ABBREVIATION SIGN
+	{runeRange{0x1123F, 0x11240}, propertyGeneralCategory{lbprAL, gcLo}},   //     [2] KHOJKI LETTER QA..KHOJKI LETTER SHORT I
+	{runeRange{0x11280, 0x11286}, propertyGeneralCategory{lbprAL, gcLo}},   //     [7] MULTANI LETTER A..MULTANI LETTER GA
+	{runeRange{0x1128A, 0x1128D}, propertyGeneralCategory{lbprAL, gcLo}},   //     [4] MULTANI LETTER CA..MULTANI LETTER JJA
+	{runeRange{0x1129F, 0x112A8}, propertyGeneralCategory{lbprAL, gcLo}},   //    [10] MULTANI LETTER BHA..MULTANI LETTER RHA
+	{runeRange{0x112B0, 0x112DE}, propertyGeneralCategory{lbprAL, gcLo}},   //    [47] KHUDAWADI LETTER A..KHUDAWADI LETTER HA
+	{runeRange{0x112E0, 0x112E2}, propertyGeneralCategory{lbprCM, gcMc}},   //     [3] KHUDAWADI VOWEL SIGN AA..KHUDAWADI VOWEL SIGN II
+	{runeRange{0x112F0, 0x112F9}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] KHUDAWADI DIGIT ZERO..KHUDAWADI DIGIT NINE
+	{runeRange{0x11302, 0x11303}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] GRANTHA SIGN ANUSVARA..GRANTHA SIGN VISARGA
+	{runeRange{0x1130F, 0x11310}, propertyGeneralCategory{lbprAL, gcLo}},   //     [2] GRANTHA LETTER EE..GRANTHA LETTER AI
+	{runeRange{0x1132A, 0x11330}, propertyGeneralCategory{lbprAL, gcLo}},   //     [7] GRANTHA LETTER PA..GRANTHA LETTER RA
+	{runeRange{0x11335, 0x11339}, propertyGeneralCategory{lbprAL, gcLo}},   //     [5] GRANTHA LETTER VA..GRANTHA LETTER HA
+	{runeRange{0x1133D, 0x1133D}, propertyGeneralCategory{lbprAL, gcLo}},   //         GRANTHA SIGN AVAGRAHA
+	{runeRange{0x11340, 0x11340}, propertyGeneralCategory{lbprCM, gcMn}},   //         GRANTHA VOWEL SIGN II
+	{runeRange{0x11347, 0x11348}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] GRANTHA VOWEL SIGN EE..GRANTHA VOWEL SIGN AI
+	{runeRange{0x11350, 0x11350}, propertyGeneralCategory{lbprAL, gcLo}},   //         GRANTHA OM
+	{runeRange{0x1135D, 0x11361}, propertyGeneralCategory{lbprAL, gcLo}},   //     [5] GRANTHA SIGN PLUTA..GRANTHA LETTER VOCALIC LL
+	{runeRange{0x11366, 0x1136C}, propertyGeneralCategory{lbprCM, gcMn}},   //     [7] COMBINING GRANTHA DIGIT ZERO..COMBINING GRANTHA DIGIT SIX
+	{runeRange{0x11400, 0x11434}, propertyGeneralCategory{lbprAL, gcLo}},   //    [53] NEWA LETTER A..NEWA LETTER HA
+	{runeRange{0x11438, 0x1143F}, propertyGeneralCategory{lbprCM, gcMn}},   //     [8] NEWA VOWEL SIGN U..NEWA VOWEL SIGN AI
+	{runeRange{0x11442, 0x11444}, propertyGeneralCategory{lbprCM, gcMn}},   //     [3] NEWA SIGN VIRAMA..NEWA SIGN ANUSVARA
+	{runeRange{0x11446, 0x11446}, propertyGeneralCategory{lbprCM, gcMn}},   //         NEWA SIGN NUKTA
+	{runeRange{0x1144B, 0x1144E}, propertyGeneralCategory{lbprBA, gcPo}},   //     [4] NEWA DANDA..NEWA GAP FILLER
+	{runeRange{0x11450, 0x11459}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] NEWA DIGIT ZERO..NEWA DIGIT NINE
+	{runeRange{0x1145D, 0x1145D}, propertyGeneralCategory{lbprAL, gcPo}},   //         NEWA INSERTION SIGN
+	{runeRange{0x1145F, 0x11461}, propertyGeneralCategory{lbprAL, gcLo}},   //     [3] NEWA LETTER VEDIC ANUSVARA..NEWA SIGN UPADHMANIYA
+	{runeRange{0x114B0, 0x114B2}, propertyGeneralCategory{lbprCM, gcMc}},   //     [3] TIRHUTA VOWEL SIGN AA..TIRHUTA VOWEL SIGN II
+	{runeRange{0x114B9, 0x114B9}, propertyGeneralCategory{lbprCM, gcMc}},   //         TIRHUTA VOWEL SIGN E
+	{runeRange{0x114BB, 0x114BE}, propertyGeneralCategory{lbprCM, gcMc}},   //     [4] TIRHUTA VOWEL SIGN AI..TIRHUTA VOWEL SIGN AU
+	{runeRange{0x114C1, 0x114C1}, propertyGeneralCategory{lbprCM, gcMc}},   //         TIRHUTA SIGN VISARGA
+	{runeRange{0x114C4, 0x114C5}, propertyGeneralCategory{lbprAL, gcLo}},   //     [2] TIRHUTA SIGN AVAGRAHA..TIRHUTA GVANG
+	{runeRange{0x114C7, 0x114C7}, propertyGeneralCategory{lbprAL, gcLo}},   //         TIRHUTA OM
+	{runeRange{0x11580, 0x115AE}, propertyGeneralCategory{lbprAL, gcLo}},   //    [47] SIDDHAM LETTER A..SIDDHAM LETTER HA
+	{runeRange{0x115B2, 0x115B5}, propertyGeneralCategory{lbprCM, gcMn}},   //     [4] SIDDHAM VOWEL SIGN U..SIDDHAM VOWEL SIGN VOCALIC RR
+	{runeRange{0x115BC, 0x115BD}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] SIDDHAM SIGN CANDRABINDU..SIDDHAM SIGN ANUSVARA
+	{runeRange{0x115BF, 0x115C0}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] SIDDHAM SIGN VIRAMA..SIDDHAM SIGN NUKTA
+	{runeRange{0x115C2, 0x115C3}, propertyGeneralCategory{lbprBA, gcPo}},   //     [2] SIDDHAM DANDA..SIDDHAM DOUBLE DANDA
+	{runeRange{0x115C6, 0x115C8}, propertyGeneralCategory{lbprAL, gcPo}},   //     [3] SIDDHAM REPETITION MARK-1..SIDDHAM REPETITION MARK-3
+	{runeRange{0x115D8, 0x115DB}, propertyGeneralCategory{lbprAL, gcLo}},   //     [4] SIDDHAM LETTER THREE-CIRCLE ALTERNATE I..SIDDHAM LETTER ALTERNATE U
+	{runeRange{0x11600, 0x1162F}, propertyGeneralCategory{lbprAL, gcLo}},   //    [48] MODI LETTER A..MODI LETTER LLA
+	{runeRange{0x11633, 0x1163A}, propertyGeneralCategory{lbprCM, gcMn}},   //     [8] MODI VOWEL SIGN U..MODI VOWEL SIGN AI
+	{runeRange{0x1163D, 0x1163D}, propertyGeneralCategory{lbprCM, gcMn}},   //         MODI SIGN ANUSVARA
+	{runeRange{0x1163F, 0x11640}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] MODI SIGN VIRAMA..MODI SIGN ARDHACANDRA
+	{runeRange{0x11643, 0x11643}, propertyGeneralCategory{lbprAL, gcPo}},   //         MODI ABBREVIATION SIGN
+	{runeRange{0x11650, 0x11659}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] MODI DIGIT ZERO..MODI DIGIT NINE
+	{runeRange{0x11680, 0x116AA}, propertyGeneralCategory{lbprAL, gcLo}},   //    [43] TAKRI LETTER A..TAKRI LETTER RRA
+	{runeRange{0x116AC, 0x116AC}, propertyGeneralCategory{lbprCM, gcMc}},   //         TAKRI SIGN VISARGA
+	{runeRange{0x116AE, 0x116AF}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] TAKRI VOWEL SIGN I..TAKRI VOWEL SIGN II
+	{runeRange{0x116B6, 0x116B6}, propertyGeneralCategory{lbprCM, gcMc}},   //         TAKRI SIGN VIRAMA
+	{runeRange{0x116B8, 0x116B8}, propertyGeneralCategory{lbprAL, gcLo}},   //         TAKRI LETTER ARCHAIC KHA
+	{runeRange{0x116C0, 0x116C9}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] TAKRI DIGIT ZERO..TAKRI DIGIT NINE
+	{runeRange{0x1171D, 0x1171F}, propertyGeneralCategory{lbprSA, gcMn}},   //     [3] AHOM CONSONANT SIGN MEDIAL LA..AHOM CONSONANT SIGN MEDIAL LIGATING RA
+	{runeRange{0x11722, 0x11725}, propertyGeneralCategory{lbprSA, gcMn}},   //     [4] AHOM VOWEL SIGN I..AHOM VOWEL SIGN UU
+	{runeRange{0x11727, 0x1172B}, propertyGeneralCategory{lbprSA, gcMn}},   //     [5] AHOM VOWEL SIGN AW..AHOM SIGN KILLER
+	{runeRange{0x1173A, 0x1173B}, propertyGeneralCategory{lbprSA, gcNo}},   //     [2] AHOM NUMBER TEN..AHOM NUMBER TWENTY
+	{runeRange{0x1173F, 0x1173F}, propertyGeneralCategory{lbprSA, gcSo}},   //         AHOM SYMBOL VI
+	{runeRange{0x11800, 0x1182B}, propertyGeneralCategory{lbprAL, gcLo}},   //    [44] DOGRA LETTER A..DOGRA LETTER RRA
+	{runeRange{0x1182F, 0x11837}, propertyGeneralCategory{lbprCM, gcMn}},   //     [9] DOGRA VOWEL SIGN U..DOGRA SIGN ANUSVARA
+	{runeRange{0x11839, 0x1183A}, propertyGeneralCategory{lbprCM, gcMn}},   //     [2] DOGRA SIGN VIRAMA..DOGRA SIGN NUKTA
+	{runeRange{0x118A0, 0x118DF}, propertyGeneralCategory{lbprAL, gcLC}},   //    [64] WARANG CITI CAPITAL LETTER NGAA..WARANG CITI SMALL LETTER VIYO
+	{runeRange{0x118EA, 0x118F2}, propertyGeneralCategory{lbprAL, gcNo}},   //     [9] WARANG CITI NUMBER TEN..WARANG CITI NUMBER NINETY
+	{runeRange{0x11900, 0x11906}, propertyGeneralCategory{lbprAL, gcLo}},   //     [7] DIVES AKURU LETTER A..DIVES AKURU LETTER E
+	{runeRange{0x1190C, 0x11913}, propertyGeneralCategory{lbprAL, gcLo}},   //     [8] DIVES AKURU LETTER KA..DIVES AKURU LETTER JA
+	{runeRange{0x11918, 0x1192F}, propertyGeneralCategory{lbprAL, gcLo}},   //    [24] DIVES AKURU LETTER DDA..DIVES AKURU LETTER ZA
+	{runeRange{0x11937, 0x11938}, propertyGeneralCategory{lbprCM, gcMc}},   //     [2] DIVES AKURU VOWEL SIGN AI..DIVES AKURU VOWEL SIGN O
+	{runeRange{0x1193D, 0x1193D}, propertyGeneralCategory{lbprCM, gcMc}},   //         DIVES AKURU SIGN HALANTA
+	{runeRange{0x1193F, 0x1193F}, propertyGeneralCategory{lbprAL, gcLo}},   //         DIVES AKURU PREFIXED NASAL SIGN
+	{runeRange{0x11941, 0x11941}, propertyGeneralCategory{lbprAL, gcLo}},   //         DIVES AKURU INITIAL RA
+	{runeRange{0x11943, 0x11943}, propertyGeneralCategory{lbprCM, gcMn}},   //         DIVES AKURU SIGN NUKTA
+	{runeRange{0x11950, 0x11959}, propertyGeneralCategory{lbprNU, gcNd}},   //    [10] DIVES AKURU DIGIT ZERO..DIVES AKURU DIGIT NINE
+	{runeRange{0x119AA, 0x119D0}, propertyGeneralCategory{lbprAL, gcLo}},   //    [39] NANDINAGARI LETTER E..NANDINAGARI LETTER RRA
+	{runeRange{0x119D4, 0x119D7}, propertyGeneralCategory{lbprCM, gcMn}},   //     [4] NANDINAGARI VOWEL SIGN U..NANDINAGARI VOWEL SIGN VOCALIC RR
+	{runeRange{0x119DC, 0x119DF}, propertyGeneralCategory{lbprCM, gcMc}},   //     [4] NANDINAGARI VOWEL SIGN O..NANDINAGARI SIGN VISARGA
+	{runeRange{0x119E1, 0x119E1}, propertyGeneralCategory{lbprAL, gcLo}},   //         NANDINAGARI SIGN AVAGRAHA
+	{runeRange{0x119E3, 0x119E3}, propertyGeneralCategory{lbprAL, gcLo}},   //         NANDINAGARI HEADSTROKE
+	{runeRange{0x11A00, 0x11A00}, propertyGeneralCategory{lbprAL, gcLo}},   //         ZANABAZAR SQUARE LETTER A
+	{runeRange{0x11A0B, 0x11A32}, propertyGeneralCategory{lbprAL, gcLo}},   //    [40] ZANABAZAR SQUARE LETTER KA..ZANABAZAR SQUARE LETTER KSSA
 }

--- a/properties.go
+++ b/properties.go
@@ -213,17 +213,15 @@ type dictionary[T any] []dictionaryEntry[T]
 
 // search returns the value associated with the given rune in the dictionary.
 func (d dictionary[T]) search(r rune) T {
-	from := 0
-	to := len(d)
-	for to > from {
-		middle := int(uint(from+to) >> 1) // avoid overflow when computing middle
-		entry := d[middle]
+	k := 0
+	for k < len(d) {
+		entry := d[k]
 		if r < entry.runeRange.Lo {
-			to = middle
+			k = 2*k + 1
 			continue
 		}
 		if r > entry.runeRange.Hi {
-			from = middle + 1
+			k = 2*k + 2
 			continue
 		}
 		return entry.value

--- a/sentenceproperties.go
+++ b/sentenceproperties.go
@@ -6,2836 +6,2836 @@ package uniseg
 // https://www.unicode.org/Public/15.0.0/ucd/auxiliary/SentenceBreakProperty.txt
 // See https://www.unicode.org/license.html for the Unicode license agreement.
 var sentenceBreakCodePoints = dictionary[sbProperty]{
-	{runeRange{0x0009, 0x0009}, sbprSp},        // Cc       <control-0009>
-	{runeRange{0x000A, 0x000A}, sbprLF},        // Cc       <control-000A>
-	{runeRange{0x000B, 0x000C}, sbprSp},        // Cc   [2] <control-000B>..<control-000C>
-	{runeRange{0x000D, 0x000D}, sbprCR},        // Cc       <control-000D>
-	{runeRange{0x0020, 0x0020}, sbprSp},        // Zs       SPACE
-	{runeRange{0x0021, 0x0021}, sbprSTerm},     // Po       EXCLAMATION MARK
-	{runeRange{0x0022, 0x0022}, sbprClose},     // Po       QUOTATION MARK
-	{runeRange{0x0027, 0x0027}, sbprClose},     // Po       APOSTROPHE
-	{runeRange{0x0028, 0x0028}, sbprClose},     // Ps       LEFT PARENTHESIS
-	{runeRange{0x0029, 0x0029}, sbprClose},     // Pe       RIGHT PARENTHESIS
-	{runeRange{0x002C, 0x002C}, sbprSContinue}, // Po       COMMA
-	{runeRange{0x002D, 0x002D}, sbprSContinue}, // Pd       HYPHEN-MINUS
-	{runeRange{0x002E, 0x002E}, sbprATerm},     // Po       FULL STOP
-	{runeRange{0x0030, 0x0039}, sbprNumeric},   // Nd  [10] DIGIT ZERO..DIGIT NINE
-	{runeRange{0x003A, 0x003A}, sbprSContinue}, // Po       COLON
-	{runeRange{0x003F, 0x003F}, sbprSTerm},     // Po       QUESTION MARK
-	{runeRange{0x0041, 0x005A}, sbprUpper},     // L&  [26] LATIN CAPITAL LETTER A..LATIN CAPITAL LETTER Z
-	{runeRange{0x005B, 0x005B}, sbprClose},     // Ps       LEFT SQUARE BRACKET
-	{runeRange{0x005D, 0x005D}, sbprClose},     // Pe       RIGHT SQUARE BRACKET
-	{runeRange{0x0061, 0x007A}, sbprLower},     // L&  [26] LATIN SMALL LETTER A..LATIN SMALL LETTER Z
-	{runeRange{0x007B, 0x007B}, sbprClose},     // Ps       LEFT CURLY BRACKET
-	{runeRange{0x007D, 0x007D}, sbprClose},     // Pe       RIGHT CURLY BRACKET
-	{runeRange{0x0085, 0x0085}, sbprSep},       // Cc       <control-0085>
-	{runeRange{0x00A0, 0x00A0}, sbprSp},        // Zs       NO-BREAK SPACE
-	{runeRange{0x00AA, 0x00AA}, sbprLower},     // Lo       FEMININE ORDINAL INDICATOR
-	{runeRange{0x00AB, 0x00AB}, sbprClose},     // Pi       LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
-	{runeRange{0x00AD, 0x00AD}, sbprFormat},    // Cf       SOFT HYPHEN
-	{runeRange{0x00B5, 0x00B5}, sbprLower},     // L&       MICRO SIGN
-	{runeRange{0x00BA, 0x00BA}, sbprLower},     // Lo       MASCULINE ORDINAL INDICATOR
-	{runeRange{0x00BB, 0x00BB}, sbprClose},     // Pf       RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
-	{runeRange{0x00C0, 0x00D6}, sbprUpper},     // L&  [23] LATIN CAPITAL LETTER A WITH GRAVE..LATIN CAPITAL LETTER O WITH DIAERESIS
-	{runeRange{0x00D8, 0x00DE}, sbprUpper},     // L&   [7] LATIN CAPITAL LETTER O WITH STROKE..LATIN CAPITAL LETTER THORN
-	{runeRange{0x00DF, 0x00F6}, sbprLower},     // L&  [24] LATIN SMALL LETTER SHARP S..LATIN SMALL LETTER O WITH DIAERESIS
-	{runeRange{0x00F8, 0x00FF}, sbprLower},     // L&   [8] LATIN SMALL LETTER O WITH STROKE..LATIN SMALL LETTER Y WITH DIAERESIS
-	{runeRange{0x0100, 0x0100}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH MACRON
-	{runeRange{0x0101, 0x0101}, sbprLower},     // L&       LATIN SMALL LETTER A WITH MACRON
-	{runeRange{0x0102, 0x0102}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH BREVE
-	{runeRange{0x0103, 0x0103}, sbprLower},     // L&       LATIN SMALL LETTER A WITH BREVE
-	{runeRange{0x0104, 0x0104}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH OGONEK
-	{runeRange{0x0105, 0x0105}, sbprLower},     // L&       LATIN SMALL LETTER A WITH OGONEK
-	{runeRange{0x0106, 0x0106}, sbprUpper},     // L&       LATIN CAPITAL LETTER C WITH ACUTE
-	{runeRange{0x0107, 0x0107}, sbprLower},     // L&       LATIN SMALL LETTER C WITH ACUTE
-	{runeRange{0x0108, 0x0108}, sbprUpper},     // L&       LATIN CAPITAL LETTER C WITH CIRCUMFLEX
-	{runeRange{0x0109, 0x0109}, sbprLower},     // L&       LATIN SMALL LETTER C WITH CIRCUMFLEX
-	{runeRange{0x010A, 0x010A}, sbprUpper},     // L&       LATIN CAPITAL LETTER C WITH DOT ABOVE
-	{runeRange{0x010B, 0x010B}, sbprLower},     // L&       LATIN SMALL LETTER C WITH DOT ABOVE
-	{runeRange{0x010C, 0x010C}, sbprUpper},     // L&       LATIN CAPITAL LETTER C WITH CARON
-	{runeRange{0x010D, 0x010D}, sbprLower},     // L&       LATIN SMALL LETTER C WITH CARON
-	{runeRange{0x010E, 0x010E}, sbprUpper},     // L&       LATIN CAPITAL LETTER D WITH CARON
-	{runeRange{0x010F, 0x010F}, sbprLower},     // L&       LATIN SMALL LETTER D WITH CARON
-	{runeRange{0x0110, 0x0110}, sbprUpper},     // L&       LATIN CAPITAL LETTER D WITH STROKE
-	{runeRange{0x0111, 0x0111}, sbprLower},     // L&       LATIN SMALL LETTER D WITH STROKE
-	{runeRange{0x0112, 0x0112}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH MACRON
-	{runeRange{0x0113, 0x0113}, sbprLower},     // L&       LATIN SMALL LETTER E WITH MACRON
-	{runeRange{0x0114, 0x0114}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH BREVE
-	{runeRange{0x0115, 0x0115}, sbprLower},     // L&       LATIN SMALL LETTER E WITH BREVE
-	{runeRange{0x0116, 0x0116}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH DOT ABOVE
-	{runeRange{0x0117, 0x0117}, sbprLower},     // L&       LATIN SMALL LETTER E WITH DOT ABOVE
-	{runeRange{0x0118, 0x0118}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH OGONEK
-	{runeRange{0x0119, 0x0119}, sbprLower},     // L&       LATIN SMALL LETTER E WITH OGONEK
-	{runeRange{0x011A, 0x011A}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH CARON
-	{runeRange{0x011B, 0x011B}, sbprLower},     // L&       LATIN SMALL LETTER E WITH CARON
-	{runeRange{0x011C, 0x011C}, sbprUpper},     // L&       LATIN CAPITAL LETTER G WITH CIRCUMFLEX
-	{runeRange{0x011D, 0x011D}, sbprLower},     // L&       LATIN SMALL LETTER G WITH CIRCUMFLEX
-	{runeRange{0x011E, 0x011E}, sbprUpper},     // L&       LATIN CAPITAL LETTER G WITH BREVE
-	{runeRange{0x011F, 0x011F}, sbprLower},     // L&       LATIN SMALL LETTER G WITH BREVE
-	{runeRange{0x0120, 0x0120}, sbprUpper},     // L&       LATIN CAPITAL LETTER G WITH DOT ABOVE
-	{runeRange{0x0121, 0x0121}, sbprLower},     // L&       LATIN SMALL LETTER G WITH DOT ABOVE
-	{runeRange{0x0122, 0x0122}, sbprUpper},     // L&       LATIN CAPITAL LETTER G WITH CEDILLA
-	{runeRange{0x0123, 0x0123}, sbprLower},     // L&       LATIN SMALL LETTER G WITH CEDILLA
-	{runeRange{0x0124, 0x0124}, sbprUpper},     // L&       LATIN CAPITAL LETTER H WITH CIRCUMFLEX
-	{runeRange{0x0125, 0x0125}, sbprLower},     // L&       LATIN SMALL LETTER H WITH CIRCUMFLEX
-	{runeRange{0x0126, 0x0126}, sbprUpper},     // L&       LATIN CAPITAL LETTER H WITH STROKE
-	{runeRange{0x0127, 0x0127}, sbprLower},     // L&       LATIN SMALL LETTER H WITH STROKE
-	{runeRange{0x0128, 0x0128}, sbprUpper},     // L&       LATIN CAPITAL LETTER I WITH TILDE
-	{runeRange{0x0129, 0x0129}, sbprLower},     // L&       LATIN SMALL LETTER I WITH TILDE
-	{runeRange{0x012A, 0x012A}, sbprUpper},     // L&       LATIN CAPITAL LETTER I WITH MACRON
-	{runeRange{0x012B, 0x012B}, sbprLower},     // L&       LATIN SMALL LETTER I WITH MACRON
-	{runeRange{0x012C, 0x012C}, sbprUpper},     // L&       LATIN CAPITAL LETTER I WITH BREVE
-	{runeRange{0x012D, 0x012D}, sbprLower},     // L&       LATIN SMALL LETTER I WITH BREVE
-	{runeRange{0x012E, 0x012E}, sbprUpper},     // L&       LATIN CAPITAL LETTER I WITH OGONEK
-	{runeRange{0x012F, 0x012F}, sbprLower},     // L&       LATIN SMALL LETTER I WITH OGONEK
-	{runeRange{0x0130, 0x0130}, sbprUpper},     // L&       LATIN CAPITAL LETTER I WITH DOT ABOVE
-	{runeRange{0x0131, 0x0131}, sbprLower},     // L&       LATIN SMALL LETTER DOTLESS I
-	{runeRange{0x0132, 0x0132}, sbprUpper},     // L&       LATIN CAPITAL LIGATURE IJ
-	{runeRange{0x0133, 0x0133}, sbprLower},     // L&       LATIN SMALL LIGATURE IJ
-	{runeRange{0x0134, 0x0134}, sbprUpper},     // L&       LATIN CAPITAL LETTER J WITH CIRCUMFLEX
-	{runeRange{0x0135, 0x0135}, sbprLower},     // L&       LATIN SMALL LETTER J WITH CIRCUMFLEX
-	{runeRange{0x0136, 0x0136}, sbprUpper},     // L&       LATIN CAPITAL LETTER K WITH CEDILLA
-	{runeRange{0x0137, 0x0138}, sbprLower},     // L&   [2] LATIN SMALL LETTER K WITH CEDILLA..LATIN SMALL LETTER KRA
-	{runeRange{0x0139, 0x0139}, sbprUpper},     // L&       LATIN CAPITAL LETTER L WITH ACUTE
-	{runeRange{0x013A, 0x013A}, sbprLower},     // L&       LATIN SMALL LETTER L WITH ACUTE
-	{runeRange{0x013B, 0x013B}, sbprUpper},     // L&       LATIN CAPITAL LETTER L WITH CEDILLA
-	{runeRange{0x013C, 0x013C}, sbprLower},     // L&       LATIN SMALL LETTER L WITH CEDILLA
-	{runeRange{0x013D, 0x013D}, sbprUpper},     // L&       LATIN CAPITAL LETTER L WITH CARON
-	{runeRange{0x013E, 0x013E}, sbprLower},     // L&       LATIN SMALL LETTER L WITH CARON
-	{runeRange{0x013F, 0x013F}, sbprUpper},     // L&       LATIN CAPITAL LETTER L WITH MIDDLE DOT
-	{runeRange{0x0140, 0x0140}, sbprLower},     // L&       LATIN SMALL LETTER L WITH MIDDLE DOT
-	{runeRange{0x0141, 0x0141}, sbprUpper},     // L&       LATIN CAPITAL LETTER L WITH STROKE
-	{runeRange{0x0142, 0x0142}, sbprLower},     // L&       LATIN SMALL LETTER L WITH STROKE
-	{runeRange{0x0143, 0x0143}, sbprUpper},     // L&       LATIN CAPITAL LETTER N WITH ACUTE
-	{runeRange{0x0144, 0x0144}, sbprLower},     // L&       LATIN SMALL LETTER N WITH ACUTE
-	{runeRange{0x0145, 0x0145}, sbprUpper},     // L&       LATIN CAPITAL LETTER N WITH CEDILLA
-	{runeRange{0x0146, 0x0146}, sbprLower},     // L&       LATIN SMALL LETTER N WITH CEDILLA
-	{runeRange{0x0147, 0x0147}, sbprUpper},     // L&       LATIN CAPITAL LETTER N WITH CARON
-	{runeRange{0x0148, 0x0149}, sbprLower},     // L&   [2] LATIN SMALL LETTER N WITH CARON..LATIN SMALL LETTER N PRECEDED BY APOSTROPHE
-	{runeRange{0x014A, 0x014A}, sbprUpper},     // L&       LATIN CAPITAL LETTER ENG
-	{runeRange{0x014B, 0x014B}, sbprLower},     // L&       LATIN SMALL LETTER ENG
-	{runeRange{0x014C, 0x014C}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH MACRON
-	{runeRange{0x014D, 0x014D}, sbprLower},     // L&       LATIN SMALL LETTER O WITH MACRON
-	{runeRange{0x014E, 0x014E}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH BREVE
-	{runeRange{0x014F, 0x014F}, sbprLower},     // L&       LATIN SMALL LETTER O WITH BREVE
-	{runeRange{0x0150, 0x0150}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH DOUBLE ACUTE
-	{runeRange{0x0151, 0x0151}, sbprLower},     // L&       LATIN SMALL LETTER O WITH DOUBLE ACUTE
-	{runeRange{0x0152, 0x0152}, sbprUpper},     // L&       LATIN CAPITAL LIGATURE OE
-	{runeRange{0x0153, 0x0153}, sbprLower},     // L&       LATIN SMALL LIGATURE OE
-	{runeRange{0x0154, 0x0154}, sbprUpper},     // L&       LATIN CAPITAL LETTER R WITH ACUTE
-	{runeRange{0x0155, 0x0155}, sbprLower},     // L&       LATIN SMALL LETTER R WITH ACUTE
-	{runeRange{0x0156, 0x0156}, sbprUpper},     // L&       LATIN CAPITAL LETTER R WITH CEDILLA
-	{runeRange{0x0157, 0x0157}, sbprLower},     // L&       LATIN SMALL LETTER R WITH CEDILLA
-	{runeRange{0x0158, 0x0158}, sbprUpper},     // L&       LATIN CAPITAL LETTER R WITH CARON
-	{runeRange{0x0159, 0x0159}, sbprLower},     // L&       LATIN SMALL LETTER R WITH CARON
-	{runeRange{0x015A, 0x015A}, sbprUpper},     // L&       LATIN CAPITAL LETTER S WITH ACUTE
-	{runeRange{0x015B, 0x015B}, sbprLower},     // L&       LATIN SMALL LETTER S WITH ACUTE
-	{runeRange{0x015C, 0x015C}, sbprUpper},     // L&       LATIN CAPITAL LETTER S WITH CIRCUMFLEX
-	{runeRange{0x015D, 0x015D}, sbprLower},     // L&       LATIN SMALL LETTER S WITH CIRCUMFLEX
-	{runeRange{0x015E, 0x015E}, sbprUpper},     // L&       LATIN CAPITAL LETTER S WITH CEDILLA
-	{runeRange{0x015F, 0x015F}, sbprLower},     // L&       LATIN SMALL LETTER S WITH CEDILLA
-	{runeRange{0x0160, 0x0160}, sbprUpper},     // L&       LATIN CAPITAL LETTER S WITH CARON
-	{runeRange{0x0161, 0x0161}, sbprLower},     // L&       LATIN SMALL LETTER S WITH CARON
-	{runeRange{0x0162, 0x0162}, sbprUpper},     // L&       LATIN CAPITAL LETTER T WITH CEDILLA
-	{runeRange{0x0163, 0x0163}, sbprLower},     // L&       LATIN SMALL LETTER T WITH CEDILLA
-	{runeRange{0x0164, 0x0164}, sbprUpper},     // L&       LATIN CAPITAL LETTER T WITH CARON
-	{runeRange{0x0165, 0x0165}, sbprLower},     // L&       LATIN SMALL LETTER T WITH CARON
-	{runeRange{0x0166, 0x0166}, sbprUpper},     // L&       LATIN CAPITAL LETTER T WITH STROKE
-	{runeRange{0x0167, 0x0167}, sbprLower},     // L&       LATIN SMALL LETTER T WITH STROKE
-	{runeRange{0x0168, 0x0168}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH TILDE
-	{runeRange{0x0169, 0x0169}, sbprLower},     // L&       LATIN SMALL LETTER U WITH TILDE
-	{runeRange{0x016A, 0x016A}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH MACRON
-	{runeRange{0x016B, 0x016B}, sbprLower},     // L&       LATIN SMALL LETTER U WITH MACRON
-	{runeRange{0x016C, 0x016C}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH BREVE
-	{runeRange{0x016D, 0x016D}, sbprLower},     // L&       LATIN SMALL LETTER U WITH BREVE
-	{runeRange{0x016E, 0x016E}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH RING ABOVE
-	{runeRange{0x016F, 0x016F}, sbprLower},     // L&       LATIN SMALL LETTER U WITH RING ABOVE
-	{runeRange{0x0170, 0x0170}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH DOUBLE ACUTE
-	{runeRange{0x0171, 0x0171}, sbprLower},     // L&       LATIN SMALL LETTER U WITH DOUBLE ACUTE
-	{runeRange{0x0172, 0x0172}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH OGONEK
-	{runeRange{0x0173, 0x0173}, sbprLower},     // L&       LATIN SMALL LETTER U WITH OGONEK
-	{runeRange{0x0174, 0x0174}, sbprUpper},     // L&       LATIN CAPITAL LETTER W WITH CIRCUMFLEX
-	{runeRange{0x0175, 0x0175}, sbprLower},     // L&       LATIN SMALL LETTER W WITH CIRCUMFLEX
-	{runeRange{0x0176, 0x0176}, sbprUpper},     // L&       LATIN CAPITAL LETTER Y WITH CIRCUMFLEX
-	{runeRange{0x0177, 0x0177}, sbprLower},     // L&       LATIN SMALL LETTER Y WITH CIRCUMFLEX
-	{runeRange{0x0178, 0x0179}, sbprUpper},     // L&   [2] LATIN CAPITAL LETTER Y WITH DIAERESIS..LATIN CAPITAL LETTER Z WITH ACUTE
-	{runeRange{0x017A, 0x017A}, sbprLower},     // L&       LATIN SMALL LETTER Z WITH ACUTE
-	{runeRange{0x017B, 0x017B}, sbprUpper},     // L&       LATIN CAPITAL LETTER Z WITH DOT ABOVE
-	{runeRange{0x017C, 0x017C}, sbprLower},     // L&       LATIN SMALL LETTER Z WITH DOT ABOVE
-	{runeRange{0x017D, 0x017D}, sbprUpper},     // L&       LATIN CAPITAL LETTER Z WITH CARON
-	{runeRange{0x017E, 0x0180}, sbprLower},     // L&   [3] LATIN SMALL LETTER Z WITH CARON..LATIN SMALL LETTER B WITH STROKE
-	{runeRange{0x0181, 0x0182}, sbprUpper},     // L&   [2] LATIN CAPITAL LETTER B WITH HOOK..LATIN CAPITAL LETTER B WITH TOPBAR
-	{runeRange{0x0183, 0x0183}, sbprLower},     // L&       LATIN SMALL LETTER B WITH TOPBAR
-	{runeRange{0x0184, 0x0184}, sbprUpper},     // L&       LATIN CAPITAL LETTER TONE SIX
-	{runeRange{0x0185, 0x0185}, sbprLower},     // L&       LATIN SMALL LETTER TONE SIX
-	{runeRange{0x0186, 0x0187}, sbprUpper},     // L&   [2] LATIN CAPITAL LETTER OPEN O..LATIN CAPITAL LETTER C WITH HOOK
-	{runeRange{0x0188, 0x0188}, sbprLower},     // L&       LATIN SMALL LETTER C WITH HOOK
-	{runeRange{0x0189, 0x018B}, sbprUpper},     // L&   [3] LATIN CAPITAL LETTER AFRICAN D..LATIN CAPITAL LETTER D WITH TOPBAR
-	{runeRange{0x018C, 0x018D}, sbprLower},     // L&   [2] LATIN SMALL LETTER D WITH TOPBAR..LATIN SMALL LETTER TURNED DELTA
-	{runeRange{0x018E, 0x0191}, sbprUpper},     // L&   [4] LATIN CAPITAL LETTER REVERSED E..LATIN CAPITAL LETTER F WITH HOOK
-	{runeRange{0x0192, 0x0192}, sbprLower},     // L&       LATIN SMALL LETTER F WITH HOOK
-	{runeRange{0x0193, 0x0194}, sbprUpper},     // L&   [2] LATIN CAPITAL LETTER G WITH HOOK..LATIN CAPITAL LETTER GAMMA
-	{runeRange{0x0195, 0x0195}, sbprLower},     // L&       LATIN SMALL LETTER HV
-	{runeRange{0x0196, 0x0198}, sbprUpper},     // L&   [3] LATIN CAPITAL LETTER IOTA..LATIN CAPITAL LETTER K WITH HOOK
-	{runeRange{0x0199, 0x019B}, sbprLower},     // L&   [3] LATIN SMALL LETTER K WITH HOOK..LATIN SMALL LETTER LAMBDA WITH STROKE
-	{runeRange{0x019C, 0x019D}, sbprUpper},     // L&   [2] LATIN CAPITAL LETTER TURNED M..LATIN CAPITAL LETTER N WITH LEFT HOOK
-	{runeRange{0x019E, 0x019E}, sbprLower},     // L&       LATIN SMALL LETTER N WITH LONG RIGHT LEG
-	{runeRange{0x019F, 0x01A0}, sbprUpper},     // L&   [2] LATIN CAPITAL LETTER O WITH MIDDLE TILDE..LATIN CAPITAL LETTER O WITH HORN
-	{runeRange{0x01A1, 0x01A1}, sbprLower},     // L&       LATIN SMALL LETTER O WITH HORN
-	{runeRange{0x01A2, 0x01A2}, sbprUpper},     // L&       LATIN CAPITAL LETTER OI
-	{runeRange{0x01A3, 0x01A3}, sbprLower},     // L&       LATIN SMALL LETTER OI
-	{runeRange{0x01A4, 0x01A4}, sbprUpper},     // L&       LATIN CAPITAL LETTER P WITH HOOK
-	{runeRange{0x01A5, 0x01A5}, sbprLower},     // L&       LATIN SMALL LETTER P WITH HOOK
-	{runeRange{0x01A6, 0x01A7}, sbprUpper},     // L&   [2] LATIN LETTER YR..LATIN CAPITAL LETTER TONE TWO
-	{runeRange{0x01A8, 0x01A8}, sbprLower},     // L&       LATIN SMALL LETTER TONE TWO
-	{runeRange{0x01A9, 0x01A9}, sbprUpper},     // L&       LATIN CAPITAL LETTER ESH
-	{runeRange{0x01AA, 0x01AB}, sbprLower},     // L&   [2] LATIN LETTER REVERSED ESH LOOP..LATIN SMALL LETTER T WITH PALATAL HOOK
-	{runeRange{0x01AC, 0x01AC}, sbprUpper},     // L&       LATIN CAPITAL LETTER T WITH HOOK
-	{runeRange{0x01AD, 0x01AD}, sbprLower},     // L&       LATIN SMALL LETTER T WITH HOOK
-	{runeRange{0x01AE, 0x01AF}, sbprUpper},     // L&   [2] LATIN CAPITAL LETTER T WITH RETROFLEX HOOK..LATIN CAPITAL LETTER U WITH HORN
-	{runeRange{0x01B0, 0x01B0}, sbprLower},     // L&       LATIN SMALL LETTER U WITH HORN
-	{runeRange{0x01B1, 0x01B3}, sbprUpper},     // L&   [3] LATIN CAPITAL LETTER UPSILON..LATIN CAPITAL LETTER Y WITH HOOK
-	{runeRange{0x01B4, 0x01B4}, sbprLower},     // L&       LATIN SMALL LETTER Y WITH HOOK
-	{runeRange{0x01B5, 0x01B5}, sbprUpper},     // L&       LATIN CAPITAL LETTER Z WITH STROKE
-	{runeRange{0x01B6, 0x01B6}, sbprLower},     // L&       LATIN SMALL LETTER Z WITH STROKE
-	{runeRange{0x01B7, 0x01B8}, sbprUpper},     // L&   [2] LATIN CAPITAL LETTER EZH..LATIN CAPITAL LETTER EZH REVERSED
-	{runeRange{0x01B9, 0x01BA}, sbprLower},     // L&   [2] LATIN SMALL LETTER EZH REVERSED..LATIN SMALL LETTER EZH WITH TAIL
-	{runeRange{0x01BB, 0x01BB}, sbprOLetter},   // Lo       LATIN LETTER TWO WITH STROKE
-	{runeRange{0x01BC, 0x01BC}, sbprUpper},     // L&       LATIN CAPITAL LETTER TONE FIVE
-	{runeRange{0x01BD, 0x01BF}, sbprLower},     // L&   [3] LATIN SMALL LETTER TONE FIVE..LATIN LETTER WYNN
-	{runeRange{0x01C0, 0x01C3}, sbprOLetter},   // Lo   [4] LATIN LETTER DENTAL CLICK..LATIN LETTER RETROFLEX CLICK
-	{runeRange{0x01C4, 0x01C5}, sbprUpper},     // L&   [2] LATIN CAPITAL LETTER DZ WITH CARON..LATIN CAPITAL LETTER D WITH SMALL LETTER Z WITH CARON
-	{runeRange{0x01C6, 0x01C6}, sbprLower},     // L&       LATIN SMALL LETTER DZ WITH CARON
-	{runeRange{0x01C7, 0x01C8}, sbprUpper},     // L&   [2] LATIN CAPITAL LETTER LJ..LATIN CAPITAL LETTER L WITH SMALL LETTER J
-	{runeRange{0x01C9, 0x01C9}, sbprLower},     // L&       LATIN SMALL LETTER LJ
-	{runeRange{0x01CA, 0x01CB}, sbprUpper},     // L&   [2] LATIN CAPITAL LETTER NJ..LATIN CAPITAL LETTER N WITH SMALL LETTER J
-	{runeRange{0x01CC, 0x01CC}, sbprLower},     // L&       LATIN SMALL LETTER NJ
-	{runeRange{0x01CD, 0x01CD}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH CARON
-	{runeRange{0x01CE, 0x01CE}, sbprLower},     // L&       LATIN SMALL LETTER A WITH CARON
-	{runeRange{0x01CF, 0x01CF}, sbprUpper},     // L&       LATIN CAPITAL LETTER I WITH CARON
-	{runeRange{0x01D0, 0x01D0}, sbprLower},     // L&       LATIN SMALL LETTER I WITH CARON
-	{runeRange{0x01D1, 0x01D1}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH CARON
-	{runeRange{0x01D2, 0x01D2}, sbprLower},     // L&       LATIN SMALL LETTER O WITH CARON
-	{runeRange{0x01D3, 0x01D3}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH CARON
-	{runeRange{0x01D4, 0x01D4}, sbprLower},     // L&       LATIN SMALL LETTER U WITH CARON
-	{runeRange{0x01D5, 0x01D5}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH DIAERESIS AND MACRON
-	{runeRange{0x01D6, 0x01D6}, sbprLower},     // L&       LATIN SMALL LETTER U WITH DIAERESIS AND MACRON
-	{runeRange{0x01D7, 0x01D7}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH DIAERESIS AND ACUTE
-	{runeRange{0x01D8, 0x01D8}, sbprLower},     // L&       LATIN SMALL LETTER U WITH DIAERESIS AND ACUTE
-	{runeRange{0x01D9, 0x01D9}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH DIAERESIS AND CARON
-	{runeRange{0x01DA, 0x01DA}, sbprLower},     // L&       LATIN SMALL LETTER U WITH DIAERESIS AND CARON
-	{runeRange{0x01DB, 0x01DB}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH DIAERESIS AND GRAVE
-	{runeRange{0x01DC, 0x01DD}, sbprLower},     // L&   [2] LATIN SMALL LETTER U WITH DIAERESIS AND GRAVE..LATIN SMALL LETTER TURNED E
-	{runeRange{0x01DE, 0x01DE}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH DIAERESIS AND MACRON
-	{runeRange{0x01DF, 0x01DF}, sbprLower},     // L&       LATIN SMALL LETTER A WITH DIAERESIS AND MACRON
-	{runeRange{0x01E0, 0x01E0}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH DOT ABOVE AND MACRON
-	{runeRange{0x01E1, 0x01E1}, sbprLower},     // L&       LATIN SMALL LETTER A WITH DOT ABOVE AND MACRON
-	{runeRange{0x01E2, 0x01E2}, sbprUpper},     // L&       LATIN CAPITAL LETTER AE WITH MACRON
-	{runeRange{0x01E3, 0x01E3}, sbprLower},     // L&       LATIN SMALL LETTER AE WITH MACRON
-	{runeRange{0x01E4, 0x01E4}, sbprUpper},     // L&       LATIN CAPITAL LETTER G WITH STROKE
-	{runeRange{0x01E5, 0x01E5}, sbprLower},     // L&       LATIN SMALL LETTER G WITH STROKE
-	{runeRange{0x01E6, 0x01E6}, sbprUpper},     // L&       LATIN CAPITAL LETTER G WITH CARON
-	{runeRange{0x01E7, 0x01E7}, sbprLower},     // L&       LATIN SMALL LETTER G WITH CARON
-	{runeRange{0x01E8, 0x01E8}, sbprUpper},     // L&       LATIN CAPITAL LETTER K WITH CARON
-	{runeRange{0x01E9, 0x01E9}, sbprLower},     // L&       LATIN SMALL LETTER K WITH CARON
-	{runeRange{0x01EA, 0x01EA}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH OGONEK
-	{runeRange{0x01EB, 0x01EB}, sbprLower},     // L&       LATIN SMALL LETTER O WITH OGONEK
-	{runeRange{0x01EC, 0x01EC}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH OGONEK AND MACRON
-	{runeRange{0x01ED, 0x01ED}, sbprLower},     // L&       LATIN SMALL LETTER O WITH OGONEK AND MACRON
-	{runeRange{0x01EE, 0x01EE}, sbprUpper},     // L&       LATIN CAPITAL LETTER EZH WITH CARON
-	{runeRange{0x01EF, 0x01F0}, sbprLower},     // L&   [2] LATIN SMALL LETTER EZH WITH CARON..LATIN SMALL LETTER J WITH CARON
-	{runeRange{0x01F1, 0x01F2}, sbprUpper},     // L&   [2] LATIN CAPITAL LETTER DZ..LATIN CAPITAL LETTER D WITH SMALL LETTER Z
-	{runeRange{0x01F3, 0x01F3}, sbprLower},     // L&       LATIN SMALL LETTER DZ
-	{runeRange{0x01F4, 0x01F4}, sbprUpper},     // L&       LATIN CAPITAL LETTER G WITH ACUTE
-	{runeRange{0x01F5, 0x01F5}, sbprLower},     // L&       LATIN SMALL LETTER G WITH ACUTE
-	{runeRange{0x01F6, 0x01F8}, sbprUpper},     // L&   [3] LATIN CAPITAL LETTER HWAIR..LATIN CAPITAL LETTER N WITH GRAVE
-	{runeRange{0x01F9, 0x01F9}, sbprLower},     // L&       LATIN SMALL LETTER N WITH GRAVE
-	{runeRange{0x01FA, 0x01FA}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH RING ABOVE AND ACUTE
-	{runeRange{0x01FB, 0x01FB}, sbprLower},     // L&       LATIN SMALL LETTER A WITH RING ABOVE AND ACUTE
-	{runeRange{0x01FC, 0x01FC}, sbprUpper},     // L&       LATIN CAPITAL LETTER AE WITH ACUTE
-	{runeRange{0x01FD, 0x01FD}, sbprLower},     // L&       LATIN SMALL LETTER AE WITH ACUTE
-	{runeRange{0x01FE, 0x01FE}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH STROKE AND ACUTE
-	{runeRange{0x01FF, 0x01FF}, sbprLower},     // L&       LATIN SMALL LETTER O WITH STROKE AND ACUTE
-	{runeRange{0x0200, 0x0200}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH DOUBLE GRAVE
-	{runeRange{0x0201, 0x0201}, sbprLower},     // L&       LATIN SMALL LETTER A WITH DOUBLE GRAVE
-	{runeRange{0x0202, 0x0202}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH INVERTED BREVE
-	{runeRange{0x0203, 0x0203}, sbprLower},     // L&       LATIN SMALL LETTER A WITH INVERTED BREVE
-	{runeRange{0x0204, 0x0204}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH DOUBLE GRAVE
-	{runeRange{0x0205, 0x0205}, sbprLower},     // L&       LATIN SMALL LETTER E WITH DOUBLE GRAVE
-	{runeRange{0x0206, 0x0206}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH INVERTED BREVE
-	{runeRange{0x0207, 0x0207}, sbprLower},     // L&       LATIN SMALL LETTER E WITH INVERTED BREVE
-	{runeRange{0x0208, 0x0208}, sbprUpper},     // L&       LATIN CAPITAL LETTER I WITH DOUBLE GRAVE
-	{runeRange{0x0209, 0x0209}, sbprLower},     // L&       LATIN SMALL LETTER I WITH DOUBLE GRAVE
-	{runeRange{0x020A, 0x020A}, sbprUpper},     // L&       LATIN CAPITAL LETTER I WITH INVERTED BREVE
-	{runeRange{0x020B, 0x020B}, sbprLower},     // L&       LATIN SMALL LETTER I WITH INVERTED BREVE
-	{runeRange{0x020C, 0x020C}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH DOUBLE GRAVE
-	{runeRange{0x020D, 0x020D}, sbprLower},     // L&       LATIN SMALL LETTER O WITH DOUBLE GRAVE
-	{runeRange{0x020E, 0x020E}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH INVERTED BREVE
-	{runeRange{0x020F, 0x020F}, sbprLower},     // L&       LATIN SMALL LETTER O WITH INVERTED BREVE
-	{runeRange{0x0210, 0x0210}, sbprUpper},     // L&       LATIN CAPITAL LETTER R WITH DOUBLE GRAVE
-	{runeRange{0x0211, 0x0211}, sbprLower},     // L&       LATIN SMALL LETTER R WITH DOUBLE GRAVE
-	{runeRange{0x0212, 0x0212}, sbprUpper},     // L&       LATIN CAPITAL LETTER R WITH INVERTED BREVE
-	{runeRange{0x0213, 0x0213}, sbprLower},     // L&       LATIN SMALL LETTER R WITH INVERTED BREVE
-	{runeRange{0x0214, 0x0214}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH DOUBLE GRAVE
-	{runeRange{0x0215, 0x0215}, sbprLower},     // L&       LATIN SMALL LETTER U WITH DOUBLE GRAVE
-	{runeRange{0x0216, 0x0216}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH INVERTED BREVE
-	{runeRange{0x0217, 0x0217}, sbprLower},     // L&       LATIN SMALL LETTER U WITH INVERTED BREVE
-	{runeRange{0x0218, 0x0218}, sbprUpper},     // L&       LATIN CAPITAL LETTER S WITH COMMA BELOW
-	{runeRange{0x0219, 0x0219}, sbprLower},     // L&       LATIN SMALL LETTER S WITH COMMA BELOW
-	{runeRange{0x021A, 0x021A}, sbprUpper},     // L&       LATIN CAPITAL LETTER T WITH COMMA BELOW
-	{runeRange{0x021B, 0x021B}, sbprLower},     // L&       LATIN SMALL LETTER T WITH COMMA BELOW
-	{runeRange{0x021C, 0x021C}, sbprUpper},     // L&       LATIN CAPITAL LETTER YOGH
-	{runeRange{0x021D, 0x021D}, sbprLower},     // L&       LATIN SMALL LETTER YOGH
-	{runeRange{0x021E, 0x021E}, sbprUpper},     // L&       LATIN CAPITAL LETTER H WITH CARON
-	{runeRange{0x021F, 0x021F}, sbprLower},     // L&       LATIN SMALL LETTER H WITH CARON
-	{runeRange{0x0220, 0x0220}, sbprUpper},     // L&       LATIN CAPITAL LETTER N WITH LONG RIGHT LEG
-	{runeRange{0x0221, 0x0221}, sbprLower},     // L&       LATIN SMALL LETTER D WITH CURL
-	{runeRange{0x0222, 0x0222}, sbprUpper},     // L&       LATIN CAPITAL LETTER OU
-	{runeRange{0x0223, 0x0223}, sbprLower},     // L&       LATIN SMALL LETTER OU
-	{runeRange{0x0224, 0x0224}, sbprUpper},     // L&       LATIN CAPITAL LETTER Z WITH HOOK
-	{runeRange{0x0225, 0x0225}, sbprLower},     // L&       LATIN SMALL LETTER Z WITH HOOK
-	{runeRange{0x0226, 0x0226}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH DOT ABOVE
-	{runeRange{0x0227, 0x0227}, sbprLower},     // L&       LATIN SMALL LETTER A WITH DOT ABOVE
-	{runeRange{0x0228, 0x0228}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH CEDILLA
-	{runeRange{0x0229, 0x0229}, sbprLower},     // L&       LATIN SMALL LETTER E WITH CEDILLA
-	{runeRange{0x022A, 0x022A}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH DIAERESIS AND MACRON
-	{runeRange{0x022B, 0x022B}, sbprLower},     // L&       LATIN SMALL LETTER O WITH DIAERESIS AND MACRON
-	{runeRange{0x022C, 0x022C}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH TILDE AND MACRON
-	{runeRange{0x022D, 0x022D}, sbprLower},     // L&       LATIN SMALL LETTER O WITH TILDE AND MACRON
-	{runeRange{0x022E, 0x022E}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH DOT ABOVE
-	{runeRange{0x022F, 0x022F}, sbprLower},     // L&       LATIN SMALL LETTER O WITH DOT ABOVE
-	{runeRange{0x0230, 0x0230}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH DOT ABOVE AND MACRON
-	{runeRange{0x0231, 0x0231}, sbprLower},     // L&       LATIN SMALL LETTER O WITH DOT ABOVE AND MACRON
-	{runeRange{0x0232, 0x0232}, sbprUpper},     // L&       LATIN CAPITAL LETTER Y WITH MACRON
-	{runeRange{0x0233, 0x0239}, sbprLower},     // L&   [7] LATIN SMALL LETTER Y WITH MACRON..LATIN SMALL LETTER QP DIGRAPH
-	{runeRange{0x023A, 0x023B}, sbprUpper},     // L&   [2] LATIN CAPITAL LETTER A WITH STROKE..LATIN CAPITAL LETTER C WITH STROKE
-	{runeRange{0x023C, 0x023C}, sbprLower},     // L&       LATIN SMALL LETTER C WITH STROKE
-	{runeRange{0x023D, 0x023E}, sbprUpper},     // L&   [2] LATIN CAPITAL LETTER L WITH BAR..LATIN CAPITAL LETTER T WITH DIAGONAL STROKE
-	{runeRange{0x023F, 0x0240}, sbprLower},     // L&   [2] LATIN SMALL LETTER S WITH SWASH TAIL..LATIN SMALL LETTER Z WITH SWASH TAIL
-	{runeRange{0x0241, 0x0241}, sbprUpper},     // L&       LATIN CAPITAL LETTER GLOTTAL STOP
-	{runeRange{0x0242, 0x0242}, sbprLower},     // L&       LATIN SMALL LETTER GLOTTAL STOP
-	{runeRange{0x0243, 0x0246}, sbprUpper},     // L&   [4] LATIN CAPITAL LETTER B WITH STROKE..LATIN CAPITAL LETTER E WITH STROKE
-	{runeRange{0x0247, 0x0247}, sbprLower},     // L&       LATIN SMALL LETTER E WITH STROKE
-	{runeRange{0x0248, 0x0248}, sbprUpper},     // L&       LATIN CAPITAL LETTER J WITH STROKE
-	{runeRange{0x0249, 0x0249}, sbprLower},     // L&       LATIN SMALL LETTER J WITH STROKE
-	{runeRange{0x024A, 0x024A}, sbprUpper},     // L&       LATIN CAPITAL LETTER SMALL Q WITH HOOK TAIL
-	{runeRange{0x024B, 0x024B}, sbprLower},     // L&       LATIN SMALL LETTER Q WITH HOOK TAIL
-	{runeRange{0x024C, 0x024C}, sbprUpper},     // L&       LATIN CAPITAL LETTER R WITH STROKE
-	{runeRange{0x024D, 0x024D}, sbprLower},     // L&       LATIN SMALL LETTER R WITH STROKE
-	{runeRange{0x024E, 0x024E}, sbprUpper},     // L&       LATIN CAPITAL LETTER Y WITH STROKE
-	{runeRange{0x024F, 0x0293}, sbprLower},     // L&  [69] LATIN SMALL LETTER Y WITH STROKE..LATIN SMALL LETTER EZH WITH CURL
-	{runeRange{0x0294, 0x0294}, sbprOLetter},   // Lo       LATIN LETTER GLOTTAL STOP
-	{runeRange{0x0295, 0x02AF}, sbprLower},     // L&  [27] LATIN LETTER PHARYNGEAL VOICED FRICATIVE..LATIN SMALL LETTER TURNED H WITH FISHHOOK AND TAIL
-	{runeRange{0x02B0, 0x02B8}, sbprLower},     // Lm   [9] MODIFIER LETTER SMALL H..MODIFIER LETTER SMALL Y
-	{runeRange{0x02B9, 0x02BF}, sbprOLetter},   // Lm   [7] MODIFIER LETTER PRIME..MODIFIER LETTER LEFT HALF RING
-	{runeRange{0x02C0, 0x02C1}, sbprLower},     // Lm   [2] MODIFIER LETTER GLOTTAL STOP..MODIFIER LETTER REVERSED GLOTTAL STOP
-	{runeRange{0x02C6, 0x02D1}, sbprOLetter},   // Lm  [12] MODIFIER LETTER CIRCUMFLEX ACCENT..MODIFIER LETTER HALF TRIANGULAR COLON
-	{runeRange{0x02E0, 0x02E4}, sbprLower},     // Lm   [5] MODIFIER LETTER SMALL GAMMA..MODIFIER LETTER SMALL REVERSED GLOTTAL STOP
-	{runeRange{0x02EC, 0x02EC}, sbprOLetter},   // Lm       MODIFIER LETTER VOICING
-	{runeRange{0x02EE, 0x02EE}, sbprOLetter},   // Lm       MODIFIER LETTER DOUBLE APOSTROPHE
-	{runeRange{0x0300, 0x036F}, sbprExtend},    // Mn [112] COMBINING GRAVE ACCENT..COMBINING LATIN SMALL LETTER X
-	{runeRange{0x0370, 0x0370}, sbprUpper},     // L&       GREEK CAPITAL LETTER HETA
-	{runeRange{0x0371, 0x0371}, sbprLower},     // L&       GREEK SMALL LETTER HETA
-	{runeRange{0x0372, 0x0372}, sbprUpper},     // L&       GREEK CAPITAL LETTER ARCHAIC SAMPI
-	{runeRange{0x0373, 0x0373}, sbprLower},     // L&       GREEK SMALL LETTER ARCHAIC SAMPI
-	{runeRange{0x0374, 0x0374}, sbprOLetter},   // Lm       GREEK NUMERAL SIGN
-	{runeRange{0x0376, 0x0376}, sbprUpper},     // L&       GREEK CAPITAL LETTER PAMPHYLIAN DIGAMMA
-	{runeRange{0x0377, 0x0377}, sbprLower},     // L&       GREEK SMALL LETTER PAMPHYLIAN DIGAMMA
-	{runeRange{0x037A, 0x037A}, sbprLower},     // Lm       GREEK YPOGEGRAMMENI
-	{runeRange{0x037B, 0x037D}, sbprLower},     // L&   [3] GREEK SMALL REVERSED LUNATE SIGMA SYMBOL..GREEK SMALL REVERSED DOTTED LUNATE SIGMA SYMBOL
-	{runeRange{0x037F, 0x037F}, sbprUpper},     // L&       GREEK CAPITAL LETTER YOT
-	{runeRange{0x0386, 0x0386}, sbprUpper},     // L&       GREEK CAPITAL LETTER ALPHA WITH TONOS
-	{runeRange{0x0388, 0x038A}, sbprUpper},     // L&   [3] GREEK CAPITAL LETTER EPSILON WITH TONOS..GREEK CAPITAL LETTER IOTA WITH TONOS
-	{runeRange{0x038C, 0x038C}, sbprUpper},     // L&       GREEK CAPITAL LETTER OMICRON WITH TONOS
-	{runeRange{0x038E, 0x038F}, sbprUpper},     // L&   [2] GREEK CAPITAL LETTER UPSILON WITH TONOS..GREEK CAPITAL LETTER OMEGA WITH TONOS
-	{runeRange{0x0390, 0x0390}, sbprLower},     // L&       GREEK SMALL LETTER IOTA WITH DIALYTIKA AND TONOS
-	{runeRange{0x0391, 0x03A1}, sbprUpper},     // L&  [17] GREEK CAPITAL LETTER ALPHA..GREEK CAPITAL LETTER RHO
-	{runeRange{0x03A3, 0x03AB}, sbprUpper},     // L&   [9] GREEK CAPITAL LETTER SIGMA..GREEK CAPITAL LETTER UPSILON WITH DIALYTIKA
-	{runeRange{0x03AC, 0x03CE}, sbprLower},     // L&  [35] GREEK SMALL LETTER ALPHA WITH TONOS..GREEK SMALL LETTER OMEGA WITH TONOS
-	{runeRange{0x03CF, 0x03CF}, sbprUpper},     // L&       GREEK CAPITAL KAI SYMBOL
-	{runeRange{0x03D0, 0x03D1}, sbprLower},     // L&   [2] GREEK BETA SYMBOL..GREEK THETA SYMBOL
-	{runeRange{0x03D2, 0x03D4}, sbprUpper},     // L&   [3] GREEK UPSILON WITH HOOK SYMBOL..GREEK UPSILON WITH DIAERESIS AND HOOK SYMBOL
-	{runeRange{0x03D5, 0x03D7}, sbprLower},     // L&   [3] GREEK PHI SYMBOL..GREEK KAI SYMBOL
-	{runeRange{0x03D8, 0x03D8}, sbprUpper},     // L&       GREEK LETTER ARCHAIC KOPPA
-	{runeRange{0x03D9, 0x03D9}, sbprLower},     // L&       GREEK SMALL LETTER ARCHAIC KOPPA
-	{runeRange{0x03DA, 0x03DA}, sbprUpper},     // L&       GREEK LETTER STIGMA
-	{runeRange{0x03DB, 0x03DB}, sbprLower},     // L&       GREEK SMALL LETTER STIGMA
-	{runeRange{0x03DC, 0x03DC}, sbprUpper},     // L&       GREEK LETTER DIGAMMA
-	{runeRange{0x03DD, 0x03DD}, sbprLower},     // L&       GREEK SMALL LETTER DIGAMMA
-	{runeRange{0x03DE, 0x03DE}, sbprUpper},     // L&       GREEK LETTER KOPPA
-	{runeRange{0x03DF, 0x03DF}, sbprLower},     // L&       GREEK SMALL LETTER KOPPA
-	{runeRange{0x03E0, 0x03E0}, sbprUpper},     // L&       GREEK LETTER SAMPI
-	{runeRange{0x03E1, 0x03E1}, sbprLower},     // L&       GREEK SMALL LETTER SAMPI
-	{runeRange{0x03E2, 0x03E2}, sbprUpper},     // L&       COPTIC CAPITAL LETTER SHEI
-	{runeRange{0x03E3, 0x03E3}, sbprLower},     // L&       COPTIC SMALL LETTER SHEI
-	{runeRange{0x03E4, 0x03E4}, sbprUpper},     // L&       COPTIC CAPITAL LETTER FEI
-	{runeRange{0x03E5, 0x03E5}, sbprLower},     // L&       COPTIC SMALL LETTER FEI
-	{runeRange{0x03E6, 0x03E6}, sbprUpper},     // L&       COPTIC CAPITAL LETTER KHEI
-	{runeRange{0x03E7, 0x03E7}, sbprLower},     // L&       COPTIC SMALL LETTER KHEI
-	{runeRange{0x03E8, 0x03E8}, sbprUpper},     // L&       COPTIC CAPITAL LETTER HORI
-	{runeRange{0x03E9, 0x03E9}, sbprLower},     // L&       COPTIC SMALL LETTER HORI
-	{runeRange{0x03EA, 0x03EA}, sbprUpper},     // L&       COPTIC CAPITAL LETTER GANGIA
-	{runeRange{0x03EB, 0x03EB}, sbprLower},     // L&       COPTIC SMALL LETTER GANGIA
-	{runeRange{0x03EC, 0x03EC}, sbprUpper},     // L&       COPTIC CAPITAL LETTER SHIMA
-	{runeRange{0x03ED, 0x03ED}, sbprLower},     // L&       COPTIC SMALL LETTER SHIMA
-	{runeRange{0x03EE, 0x03EE}, sbprUpper},     // L&       COPTIC CAPITAL LETTER DEI
-	{runeRange{0x03EF, 0x03F3}, sbprLower},     // L&   [5] COPTIC SMALL LETTER DEI..GREEK LETTER YOT
-	{runeRange{0x03F4, 0x03F4}, sbprUpper},     // L&       GREEK CAPITAL THETA SYMBOL
-	{runeRange{0x03F5, 0x03F5}, sbprLower},     // L&       GREEK LUNATE EPSILON SYMBOL
-	{runeRange{0x03F7, 0x03F7}, sbprUpper},     // L&       GREEK CAPITAL LETTER SHO
-	{runeRange{0x03F8, 0x03F8}, sbprLower},     // L&       GREEK SMALL LETTER SHO
-	{runeRange{0x03F9, 0x03FA}, sbprUpper},     // L&   [2] GREEK CAPITAL LUNATE SIGMA SYMBOL..GREEK CAPITAL LETTER SAN
-	{runeRange{0x03FB, 0x03FC}, sbprLower},     // L&   [2] GREEK SMALL LETTER SAN..GREEK RHO WITH STROKE SYMBOL
-	{runeRange{0x03FD, 0x042F}, sbprUpper},     // L&  [51] GREEK CAPITAL REVERSED LUNATE SIGMA SYMBOL..CYRILLIC CAPITAL LETTER YA
-	{runeRange{0x0430, 0x045F}, sbprLower},     // L&  [48] CYRILLIC SMALL LETTER A..CYRILLIC SMALL LETTER DZHE
-	{runeRange{0x0460, 0x0460}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER OMEGA
-	{runeRange{0x0461, 0x0461}, sbprLower},     // L&       CYRILLIC SMALL LETTER OMEGA
-	{runeRange{0x0462, 0x0462}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER YAT
-	{runeRange{0x0463, 0x0463}, sbprLower},     // L&       CYRILLIC SMALL LETTER YAT
-	{runeRange{0x0464, 0x0464}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER IOTIFIED E
-	{runeRange{0x0465, 0x0465}, sbprLower},     // L&       CYRILLIC SMALL LETTER IOTIFIED E
-	{runeRange{0x0466, 0x0466}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER LITTLE YUS
-	{runeRange{0x0467, 0x0467}, sbprLower},     // L&       CYRILLIC SMALL LETTER LITTLE YUS
-	{runeRange{0x0468, 0x0468}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER IOTIFIED LITTLE YUS
-	{runeRange{0x0469, 0x0469}, sbprLower},     // L&       CYRILLIC SMALL LETTER IOTIFIED LITTLE YUS
-	{runeRange{0x046A, 0x046A}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER BIG YUS
-	{runeRange{0x046B, 0x046B}, sbprLower},     // L&       CYRILLIC SMALL LETTER BIG YUS
-	{runeRange{0x046C, 0x046C}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER IOTIFIED BIG YUS
-	{runeRange{0x046D, 0x046D}, sbprLower},     // L&       CYRILLIC SMALL LETTER IOTIFIED BIG YUS
-	{runeRange{0x046E, 0x046E}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER KSI
-	{runeRange{0x046F, 0x046F}, sbprLower},     // L&       CYRILLIC SMALL LETTER KSI
-	{runeRange{0x0470, 0x0470}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER PSI
-	{runeRange{0x0471, 0x0471}, sbprLower},     // L&       CYRILLIC SMALL LETTER PSI
-	{runeRange{0x0472, 0x0472}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER FITA
-	{runeRange{0x0473, 0x0473}, sbprLower},     // L&       CYRILLIC SMALL LETTER FITA
-	{runeRange{0x0474, 0x0474}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER IZHITSA
-	{runeRange{0x0475, 0x0475}, sbprLower},     // L&       CYRILLIC SMALL LETTER IZHITSA
-	{runeRange{0x0476, 0x0476}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER IZHITSA WITH DOUBLE GRAVE ACCENT
-	{runeRange{0x0477, 0x0477}, sbprLower},     // L&       CYRILLIC SMALL LETTER IZHITSA WITH DOUBLE GRAVE ACCENT
-	{runeRange{0x0478, 0x0478}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER UK
-	{runeRange{0x0479, 0x0479}, sbprLower},     // L&       CYRILLIC SMALL LETTER UK
-	{runeRange{0x047A, 0x047A}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER ROUND OMEGA
-	{runeRange{0x047B, 0x047B}, sbprLower},     // L&       CYRILLIC SMALL LETTER ROUND OMEGA
-	{runeRange{0x047C, 0x047C}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER OMEGA WITH TITLO
-	{runeRange{0x047D, 0x047D}, sbprLower},     // L&       CYRILLIC SMALL LETTER OMEGA WITH TITLO
-	{runeRange{0x047E, 0x047E}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER OT
-	{runeRange{0x047F, 0x047F}, sbprLower},     // L&       CYRILLIC SMALL LETTER OT
-	{runeRange{0x0480, 0x0480}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER KOPPA
-	{runeRange{0x0481, 0x0481}, sbprLower},     // L&       CYRILLIC SMALL LETTER KOPPA
-	{runeRange{0x0483, 0x0487}, sbprExtend},    // Mn   [5] COMBINING CYRILLIC TITLO..COMBINING CYRILLIC POKRYTIE
-	{runeRange{0x0488, 0x0489}, sbprExtend},    // Me   [2] COMBINING CYRILLIC HUNDRED THOUSANDS SIGN..COMBINING CYRILLIC MILLIONS SIGN
-	{runeRange{0x048A, 0x048A}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER SHORT I WITH TAIL
-	{runeRange{0x048B, 0x048B}, sbprLower},     // L&       CYRILLIC SMALL LETTER SHORT I WITH TAIL
-	{runeRange{0x048C, 0x048C}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER SEMISOFT SIGN
-	{runeRange{0x048D, 0x048D}, sbprLower},     // L&       CYRILLIC SMALL LETTER SEMISOFT SIGN
-	{runeRange{0x048E, 0x048E}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER ER WITH TICK
-	{runeRange{0x048F, 0x048F}, sbprLower},     // L&       CYRILLIC SMALL LETTER ER WITH TICK
-	{runeRange{0x0490, 0x0490}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER GHE WITH UPTURN
-	{runeRange{0x0491, 0x0491}, sbprLower},     // L&       CYRILLIC SMALL LETTER GHE WITH UPTURN
-	{runeRange{0x0492, 0x0492}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER GHE WITH STROKE
-	{runeRange{0x0493, 0x0493}, sbprLower},     // L&       CYRILLIC SMALL LETTER GHE WITH STROKE
-	{runeRange{0x0494, 0x0494}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER GHE WITH MIDDLE HOOK
-	{runeRange{0x0495, 0x0495}, sbprLower},     // L&       CYRILLIC SMALL LETTER GHE WITH MIDDLE HOOK
-	{runeRange{0x0496, 0x0496}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER ZHE WITH DESCENDER
-	{runeRange{0x0497, 0x0497}, sbprLower},     // L&       CYRILLIC SMALL LETTER ZHE WITH DESCENDER
-	{runeRange{0x0498, 0x0498}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER ZE WITH DESCENDER
-	{runeRange{0x0499, 0x0499}, sbprLower},     // L&       CYRILLIC SMALL LETTER ZE WITH DESCENDER
-	{runeRange{0x049A, 0x049A}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER KA WITH DESCENDER
-	{runeRange{0x049B, 0x049B}, sbprLower},     // L&       CYRILLIC SMALL LETTER KA WITH DESCENDER
-	{runeRange{0x049C, 0x049C}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER KA WITH VERTICAL STROKE
-	{runeRange{0x049D, 0x049D}, sbprLower},     // L&       CYRILLIC SMALL LETTER KA WITH VERTICAL STROKE
-	{runeRange{0x049E, 0x049E}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER KA WITH STROKE
-	{runeRange{0x049F, 0x049F}, sbprLower},     // L&       CYRILLIC SMALL LETTER KA WITH STROKE
-	{runeRange{0x04A0, 0x04A0}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER BASHKIR KA
-	{runeRange{0x04A1, 0x04A1}, sbprLower},     // L&       CYRILLIC SMALL LETTER BASHKIR KA
-	{runeRange{0x04A2, 0x04A2}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER EN WITH DESCENDER
-	{runeRange{0x04A3, 0x04A3}, sbprLower},     // L&       CYRILLIC SMALL LETTER EN WITH DESCENDER
-	{runeRange{0x04A4, 0x04A4}, sbprUpper},     // L&       CYRILLIC CAPITAL LIGATURE EN GHE
-	{runeRange{0x04A5, 0x04A5}, sbprLower},     // L&       CYRILLIC SMALL LIGATURE EN GHE
-	{runeRange{0x04A6, 0x04A6}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER PE WITH MIDDLE HOOK
-	{runeRange{0x04A7, 0x04A7}, sbprLower},     // L&       CYRILLIC SMALL LETTER PE WITH MIDDLE HOOK
-	{runeRange{0x04A8, 0x04A8}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER ABKHASIAN HA
-	{runeRange{0x04A9, 0x04A9}, sbprLower},     // L&       CYRILLIC SMALL LETTER ABKHASIAN HA
-	{runeRange{0x04AA, 0x04AA}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER ES WITH DESCENDER
-	{runeRange{0x04AB, 0x04AB}, sbprLower},     // L&       CYRILLIC SMALL LETTER ES WITH DESCENDER
-	{runeRange{0x04AC, 0x04AC}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER TE WITH DESCENDER
-	{runeRange{0x04AD, 0x04AD}, sbprLower},     // L&       CYRILLIC SMALL LETTER TE WITH DESCENDER
-	{runeRange{0x04AE, 0x04AE}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER STRAIGHT U
-	{runeRange{0x04AF, 0x04AF}, sbprLower},     // L&       CYRILLIC SMALL LETTER STRAIGHT U
-	{runeRange{0x04B0, 0x04B0}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER STRAIGHT U WITH STROKE
-	{runeRange{0x04B1, 0x04B1}, sbprLower},     // L&       CYRILLIC SMALL LETTER STRAIGHT U WITH STROKE
-	{runeRange{0x04B2, 0x04B2}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER HA WITH DESCENDER
-	{runeRange{0x04B3, 0x04B3}, sbprLower},     // L&       CYRILLIC SMALL LETTER HA WITH DESCENDER
-	{runeRange{0x04B4, 0x04B4}, sbprUpper},     // L&       CYRILLIC CAPITAL LIGATURE TE TSE
-	{runeRange{0x04B5, 0x04B5}, sbprLower},     // L&       CYRILLIC SMALL LIGATURE TE TSE
-	{runeRange{0x04B6, 0x04B6}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER CHE WITH DESCENDER
-	{runeRange{0x04B7, 0x04B7}, sbprLower},     // L&       CYRILLIC SMALL LETTER CHE WITH DESCENDER
-	{runeRange{0x04B8, 0x04B8}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER CHE WITH VERTICAL STROKE
-	{runeRange{0x04B9, 0x04B9}, sbprLower},     // L&       CYRILLIC SMALL LETTER CHE WITH VERTICAL STROKE
-	{runeRange{0x04BA, 0x04BA}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER SHHA
-	{runeRange{0x04BB, 0x04BB}, sbprLower},     // L&       CYRILLIC SMALL LETTER SHHA
-	{runeRange{0x04BC, 0x04BC}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER ABKHASIAN CHE
-	{runeRange{0x04BD, 0x04BD}, sbprLower},     // L&       CYRILLIC SMALL LETTER ABKHASIAN CHE
-	{runeRange{0x04BE, 0x04BE}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER ABKHASIAN CHE WITH DESCENDER
-	{runeRange{0x04BF, 0x04BF}, sbprLower},     // L&       CYRILLIC SMALL LETTER ABKHASIAN CHE WITH DESCENDER
-	{runeRange{0x04C0, 0x04C1}, sbprUpper},     // L&   [2] CYRILLIC LETTER PALOCHKA..CYRILLIC CAPITAL LETTER ZHE WITH BREVE
-	{runeRange{0x04C2, 0x04C2}, sbprLower},     // L&       CYRILLIC SMALL LETTER ZHE WITH BREVE
-	{runeRange{0x04C3, 0x04C3}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER KA WITH HOOK
-	{runeRange{0x04C4, 0x04C4}, sbprLower},     // L&       CYRILLIC SMALL LETTER KA WITH HOOK
-	{runeRange{0x04C5, 0x04C5}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER EL WITH TAIL
-	{runeRange{0x04C6, 0x04C6}, sbprLower},     // L&       CYRILLIC SMALL LETTER EL WITH TAIL
-	{runeRange{0x04C7, 0x04C7}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER EN WITH HOOK
-	{runeRange{0x04C8, 0x04C8}, sbprLower},     // L&       CYRILLIC SMALL LETTER EN WITH HOOK
-	{runeRange{0x04C9, 0x04C9}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER EN WITH TAIL
-	{runeRange{0x04CA, 0x04CA}, sbprLower},     // L&       CYRILLIC SMALL LETTER EN WITH TAIL
-	{runeRange{0x04CB, 0x04CB}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER KHAKASSIAN CHE
-	{runeRange{0x04CC, 0x04CC}, sbprLower},     // L&       CYRILLIC SMALL LETTER KHAKASSIAN CHE
-	{runeRange{0x04CD, 0x04CD}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER EM WITH TAIL
-	{runeRange{0x04CE, 0x04CF}, sbprLower},     // L&   [2] CYRILLIC SMALL LETTER EM WITH TAIL..CYRILLIC SMALL LETTER PALOCHKA
-	{runeRange{0x04D0, 0x04D0}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER A WITH BREVE
-	{runeRange{0x04D1, 0x04D1}, sbprLower},     // L&       CYRILLIC SMALL LETTER A WITH BREVE
-	{runeRange{0x04D2, 0x04D2}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER A WITH DIAERESIS
-	{runeRange{0x04D3, 0x04D3}, sbprLower},     // L&       CYRILLIC SMALL LETTER A WITH DIAERESIS
-	{runeRange{0x04D4, 0x04D4}, sbprUpper},     // L&       CYRILLIC CAPITAL LIGATURE A IE
-	{runeRange{0x04D5, 0x04D5}, sbprLower},     // L&       CYRILLIC SMALL LIGATURE A IE
-	{runeRange{0x04D6, 0x04D6}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER IE WITH BREVE
-	{runeRange{0x04D7, 0x04D7}, sbprLower},     // L&       CYRILLIC SMALL LETTER IE WITH BREVE
-	{runeRange{0x04D8, 0x04D8}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER SCHWA
-	{runeRange{0x04D9, 0x04D9}, sbprLower},     // L&       CYRILLIC SMALL LETTER SCHWA
-	{runeRange{0x04DA, 0x04DA}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER SCHWA WITH DIAERESIS
-	{runeRange{0x04DB, 0x04DB}, sbprLower},     // L&       CYRILLIC SMALL LETTER SCHWA WITH DIAERESIS
-	{runeRange{0x04DC, 0x04DC}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER ZHE WITH DIAERESIS
-	{runeRange{0x04DD, 0x04DD}, sbprLower},     // L&       CYRILLIC SMALL LETTER ZHE WITH DIAERESIS
-	{runeRange{0x04DE, 0x04DE}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER ZE WITH DIAERESIS
-	{runeRange{0x04DF, 0x04DF}, sbprLower},     // L&       CYRILLIC SMALL LETTER ZE WITH DIAERESIS
-	{runeRange{0x04E0, 0x04E0}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER ABKHASIAN DZE
-	{runeRange{0x04E1, 0x04E1}, sbprLower},     // L&       CYRILLIC SMALL LETTER ABKHASIAN DZE
-	{runeRange{0x04E2, 0x04E2}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER I WITH MACRON
-	{runeRange{0x04E3, 0x04E3}, sbprLower},     // L&       CYRILLIC SMALL LETTER I WITH MACRON
-	{runeRange{0x04E4, 0x04E4}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER I WITH DIAERESIS
-	{runeRange{0x04E5, 0x04E5}, sbprLower},     // L&       CYRILLIC SMALL LETTER I WITH DIAERESIS
-	{runeRange{0x04E6, 0x04E6}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER O WITH DIAERESIS
-	{runeRange{0x04E7, 0x04E7}, sbprLower},     // L&       CYRILLIC SMALL LETTER O WITH DIAERESIS
-	{runeRange{0x04E8, 0x04E8}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER BARRED O
-	{runeRange{0x04E9, 0x04E9}, sbprLower},     // L&       CYRILLIC SMALL LETTER BARRED O
-	{runeRange{0x04EA, 0x04EA}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER BARRED O WITH DIAERESIS
-	{runeRange{0x04EB, 0x04EB}, sbprLower},     // L&       CYRILLIC SMALL LETTER BARRED O WITH DIAERESIS
-	{runeRange{0x04EC, 0x04EC}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER E WITH DIAERESIS
-	{runeRange{0x04ED, 0x04ED}, sbprLower},     // L&       CYRILLIC SMALL LETTER E WITH DIAERESIS
-	{runeRange{0x04EE, 0x04EE}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER U WITH MACRON
-	{runeRange{0x04EF, 0x04EF}, sbprLower},     // L&       CYRILLIC SMALL LETTER U WITH MACRON
-	{runeRange{0x04F0, 0x04F0}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER U WITH DIAERESIS
-	{runeRange{0x04F1, 0x04F1}, sbprLower},     // L&       CYRILLIC SMALL LETTER U WITH DIAERESIS
-	{runeRange{0x04F2, 0x04F2}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER U WITH DOUBLE ACUTE
-	{runeRange{0x04F3, 0x04F3}, sbprLower},     // L&       CYRILLIC SMALL LETTER U WITH DOUBLE ACUTE
-	{runeRange{0x04F4, 0x04F4}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER CHE WITH DIAERESIS
-	{runeRange{0x04F5, 0x04F5}, sbprLower},     // L&       CYRILLIC SMALL LETTER CHE WITH DIAERESIS
-	{runeRange{0x04F6, 0x04F6}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER GHE WITH DESCENDER
-	{runeRange{0x04F7, 0x04F7}, sbprLower},     // L&       CYRILLIC SMALL LETTER GHE WITH DESCENDER
-	{runeRange{0x04F8, 0x04F8}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER YERU WITH DIAERESIS
-	{runeRange{0x04F9, 0x04F9}, sbprLower},     // L&       CYRILLIC SMALL LETTER YERU WITH DIAERESIS
-	{runeRange{0x04FA, 0x04FA}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER GHE WITH STROKE AND HOOK
-	{runeRange{0x04FB, 0x04FB}, sbprLower},     // L&       CYRILLIC SMALL LETTER GHE WITH STROKE AND HOOK
-	{runeRange{0x04FC, 0x04FC}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER HA WITH HOOK
-	{runeRange{0x04FD, 0x04FD}, sbprLower},     // L&       CYRILLIC SMALL LETTER HA WITH HOOK
-	{runeRange{0x04FE, 0x04FE}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER HA WITH STROKE
-	{runeRange{0x04FF, 0x04FF}, sbprLower},     // L&       CYRILLIC SMALL LETTER HA WITH STROKE
-	{runeRange{0x0500, 0x0500}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER KOMI DE
-	{runeRange{0x0501, 0x0501}, sbprLower},     // L&       CYRILLIC SMALL LETTER KOMI DE
-	{runeRange{0x0502, 0x0502}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER KOMI DJE
-	{runeRange{0x0503, 0x0503}, sbprLower},     // L&       CYRILLIC SMALL LETTER KOMI DJE
-	{runeRange{0x0504, 0x0504}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER KOMI ZJE
-	{runeRange{0x0505, 0x0505}, sbprLower},     // L&       CYRILLIC SMALL LETTER KOMI ZJE
-	{runeRange{0x0506, 0x0506}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER KOMI DZJE
-	{runeRange{0x0507, 0x0507}, sbprLower},     // L&       CYRILLIC SMALL LETTER KOMI DZJE
-	{runeRange{0x0508, 0x0508}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER KOMI LJE
-	{runeRange{0x0509, 0x0509}, sbprLower},     // L&       CYRILLIC SMALL LETTER KOMI LJE
-	{runeRange{0x050A, 0x050A}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER KOMI NJE
-	{runeRange{0x050B, 0x050B}, sbprLower},     // L&       CYRILLIC SMALL LETTER KOMI NJE
-	{runeRange{0x050C, 0x050C}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER KOMI SJE
-	{runeRange{0x050D, 0x050D}, sbprLower},     // L&       CYRILLIC SMALL LETTER KOMI SJE
-	{runeRange{0x050E, 0x050E}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER KOMI TJE
-	{runeRange{0x050F, 0x050F}, sbprLower},     // L&       CYRILLIC SMALL LETTER KOMI TJE
-	{runeRange{0x0510, 0x0510}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER REVERSED ZE
-	{runeRange{0x0511, 0x0511}, sbprLower},     // L&       CYRILLIC SMALL LETTER REVERSED ZE
-	{runeRange{0x0512, 0x0512}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER EL WITH HOOK
-	{runeRange{0x0513, 0x0513}, sbprLower},     // L&       CYRILLIC SMALL LETTER EL WITH HOOK
-	{runeRange{0x0514, 0x0514}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER LHA
-	{runeRange{0x0515, 0x0515}, sbprLower},     // L&       CYRILLIC SMALL LETTER LHA
-	{runeRange{0x0516, 0x0516}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER RHA
-	{runeRange{0x0517, 0x0517}, sbprLower},     // L&       CYRILLIC SMALL LETTER RHA
-	{runeRange{0x0518, 0x0518}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER YAE
-	{runeRange{0x0519, 0x0519}, sbprLower},     // L&       CYRILLIC SMALL LETTER YAE
-	{runeRange{0x051A, 0x051A}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER QA
-	{runeRange{0x051B, 0x051B}, sbprLower},     // L&       CYRILLIC SMALL LETTER QA
-	{runeRange{0x051C, 0x051C}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER WE
-	{runeRange{0x051D, 0x051D}, sbprLower},     // L&       CYRILLIC SMALL LETTER WE
-	{runeRange{0x051E, 0x051E}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER ALEUT KA
-	{runeRange{0x051F, 0x051F}, sbprLower},     // L&       CYRILLIC SMALL LETTER ALEUT KA
-	{runeRange{0x0520, 0x0520}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER EL WITH MIDDLE HOOK
-	{runeRange{0x0521, 0x0521}, sbprLower},     // L&       CYRILLIC SMALL LETTER EL WITH MIDDLE HOOK
-	{runeRange{0x0522, 0x0522}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER EN WITH MIDDLE HOOK
-	{runeRange{0x0523, 0x0523}, sbprLower},     // L&       CYRILLIC SMALL LETTER EN WITH MIDDLE HOOK
-	{runeRange{0x0524, 0x0524}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER PE WITH DESCENDER
-	{runeRange{0x0525, 0x0525}, sbprLower},     // L&       CYRILLIC SMALL LETTER PE WITH DESCENDER
-	{runeRange{0x0526, 0x0526}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER SHHA WITH DESCENDER
-	{runeRange{0x0527, 0x0527}, sbprLower},     // L&       CYRILLIC SMALL LETTER SHHA WITH DESCENDER
-	{runeRange{0x0528, 0x0528}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER EN WITH LEFT HOOK
-	{runeRange{0x0529, 0x0529}, sbprLower},     // L&       CYRILLIC SMALL LETTER EN WITH LEFT HOOK
-	{runeRange{0x052A, 0x052A}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER DZZHE
-	{runeRange{0x052B, 0x052B}, sbprLower},     // L&       CYRILLIC SMALL LETTER DZZHE
-	{runeRange{0x052C, 0x052C}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER DCHE
-	{runeRange{0x052D, 0x052D}, sbprLower},     // L&       CYRILLIC SMALL LETTER DCHE
-	{runeRange{0x052E, 0x052E}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER EL WITH DESCENDER
-	{runeRange{0x052F, 0x052F}, sbprLower},     // L&       CYRILLIC SMALL LETTER EL WITH DESCENDER
-	{runeRange{0x0531, 0x0556}, sbprUpper},     // L&  [38] ARMENIAN CAPITAL LETTER AYB..ARMENIAN CAPITAL LETTER FEH
-	{runeRange{0x0559, 0x0559}, sbprOLetter},   // Lm       ARMENIAN MODIFIER LETTER LEFT HALF RING
-	{runeRange{0x055D, 0x055D}, sbprSContinue}, // Po       ARMENIAN COMMA
-	{runeRange{0x0560, 0x0588}, sbprLower},     // L&  [41] ARMENIAN SMALL LETTER TURNED AYB..ARMENIAN SMALL LETTER YI WITH STROKE
-	{runeRange{0x0589, 0x0589}, sbprSTerm},     // Po       ARMENIAN FULL STOP
-	{runeRange{0x0591, 0x05BD}, sbprExtend},    // Mn  [45] HEBREW ACCENT ETNAHTA..HEBREW POINT METEG
-	{runeRange{0x05BF, 0x05BF}, sbprExtend},    // Mn       HEBREW POINT RAFE
-	{runeRange{0x05C1, 0x05C2}, sbprExtend},    // Mn   [2] HEBREW POINT SHIN DOT..HEBREW POINT SIN DOT
-	{runeRange{0x05C4, 0x05C5}, sbprExtend},    // Mn   [2] HEBREW MARK UPPER DOT..HEBREW MARK LOWER DOT
-	{runeRange{0x05C7, 0x05C7}, sbprExtend},    // Mn       HEBREW POINT QAMATS QATAN
-	{runeRange{0x05D0, 0x05EA}, sbprOLetter},   // Lo  [27] HEBREW LETTER ALEF..HEBREW LETTER TAV
-	{runeRange{0x05EF, 0x05F2}, sbprOLetter},   // Lo   [4] HEBREW YOD TRIANGLE..HEBREW LIGATURE YIDDISH DOUBLE YOD
-	{runeRange{0x05F3, 0x05F3}, sbprOLetter},   // Po       HEBREW PUNCTUATION GERESH
-	{runeRange{0x0600, 0x0605}, sbprFormat},    // Cf   [6] ARABIC NUMBER SIGN..ARABIC NUMBER MARK ABOVE
-	{runeRange{0x060C, 0x060D}, sbprSContinue}, // Po   [2] ARABIC COMMA..ARABIC DATE SEPARATOR
-	{runeRange{0x0610, 0x061A}, sbprExtend},    // Mn  [11] ARABIC SIGN SALLALLAHOU ALAYHE WASSALLAM..ARABIC SMALL KASRA
-	{runeRange{0x061C, 0x061C}, sbprFormat},    // Cf       ARABIC LETTER MARK
-	{runeRange{0x061D, 0x061F}, sbprSTerm},     // Po   [3] ARABIC END OF TEXT MARK..ARABIC QUESTION MARK
-	{runeRange{0x0620, 0x063F}, sbprOLetter},   // Lo  [32] ARABIC LETTER KASHMIRI YEH..ARABIC LETTER FARSI YEH WITH THREE DOTS ABOVE
-	{runeRange{0x0640, 0x0640}, sbprOLetter},   // Lm       ARABIC TATWEEL
-	{runeRange{0x0641, 0x064A}, sbprOLetter},   // Lo  [10] ARABIC LETTER FEH..ARABIC LETTER YEH
-	{runeRange{0x064B, 0x065F}, sbprExtend},    // Mn  [21] ARABIC FATHATAN..ARABIC WAVY HAMZA BELOW
-	{runeRange{0x0660, 0x0669}, sbprNumeric},   // Nd  [10] ARABIC-INDIC DIGIT ZERO..ARABIC-INDIC DIGIT NINE
-	{runeRange{0x066B, 0x066C}, sbprNumeric},   // Po   [2] ARABIC DECIMAL SEPARATOR..ARABIC THOUSANDS SEPARATOR
-	{runeRange{0x066E, 0x066F}, sbprOLetter},   // Lo   [2] ARABIC LETTER DOTLESS BEH..ARABIC LETTER DOTLESS QAF
-	{runeRange{0x0670, 0x0670}, sbprExtend},    // Mn       ARABIC LETTER SUPERSCRIPT ALEF
-	{runeRange{0x0671, 0x06D3}, sbprOLetter},   // Lo  [99] ARABIC LETTER ALEF WASLA..ARABIC LETTER YEH BARREE WITH HAMZA ABOVE
-	{runeRange{0x06D4, 0x06D4}, sbprSTerm},     // Po       ARABIC FULL STOP
-	{runeRange{0x06D5, 0x06D5}, sbprOLetter},   // Lo       ARABIC LETTER AE
-	{runeRange{0x06D6, 0x06DC}, sbprExtend},    // Mn   [7] ARABIC SMALL HIGH LIGATURE SAD WITH LAM WITH ALEF MAKSURA..ARABIC SMALL HIGH SEEN
-	{runeRange{0x06DD, 0x06DD}, sbprFormat},    // Cf       ARABIC END OF AYAH
-	{runeRange{0x06DF, 0x06E4}, sbprExtend},    // Mn   [6] ARABIC SMALL HIGH ROUNDED ZERO..ARABIC SMALL HIGH MADDA
-	{runeRange{0x06E5, 0x06E6}, sbprOLetter},   // Lm   [2] ARABIC SMALL WAW..ARABIC SMALL YEH
-	{runeRange{0x06E7, 0x06E8}, sbprExtend},    // Mn   [2] ARABIC SMALL HIGH YEH..ARABIC SMALL HIGH NOON
-	{runeRange{0x06EA, 0x06ED}, sbprExtend},    // Mn   [4] ARABIC EMPTY CENTRE LOW STOP..ARABIC SMALL LOW MEEM
-	{runeRange{0x06EE, 0x06EF}, sbprOLetter},   // Lo   [2] ARABIC LETTER DAL WITH INVERTED V..ARABIC LETTER REH WITH INVERTED V
-	{runeRange{0x06F0, 0x06F9}, sbprNumeric},   // Nd  [10] EXTENDED ARABIC-INDIC DIGIT ZERO..EXTENDED ARABIC-INDIC DIGIT NINE
-	{runeRange{0x06FA, 0x06FC}, sbprOLetter},   // Lo   [3] ARABIC LETTER SHEEN WITH DOT BELOW..ARABIC LETTER GHAIN WITH DOT BELOW
-	{runeRange{0x06FF, 0x06FF}, sbprOLetter},   // Lo       ARABIC LETTER HEH WITH INVERTED V
-	{runeRange{0x0700, 0x0702}, sbprSTerm},     // Po   [3] SYRIAC END OF PARAGRAPH..SYRIAC SUBLINEAR FULL STOP
-	{runeRange{0x070F, 0x070F}, sbprFormat},    // Cf       SYRIAC ABBREVIATION MARK
-	{runeRange{0x0710, 0x0710}, sbprOLetter},   // Lo       SYRIAC LETTER ALAPH
-	{runeRange{0x0711, 0x0711}, sbprExtend},    // Mn       SYRIAC LETTER SUPERSCRIPT ALAPH
-	{runeRange{0x0712, 0x072F}, sbprOLetter},   // Lo  [30] SYRIAC LETTER BETH..SYRIAC LETTER PERSIAN DHALATH
-	{runeRange{0x0730, 0x074A}, sbprExtend},    // Mn  [27] SYRIAC PTHAHA ABOVE..SYRIAC BARREKH
-	{runeRange{0x074D, 0x07A5}, sbprOLetter},   // Lo  [89] SYRIAC LETTER SOGDIAN ZHAIN..THAANA LETTER WAAVU
-	{runeRange{0x07A6, 0x07B0}, sbprExtend},    // Mn  [11] THAANA ABAFILI..THAANA SUKUN
-	{runeRange{0x07B1, 0x07B1}, sbprOLetter},   // Lo       THAANA LETTER NAA
-	{runeRange{0x07C0, 0x07C9}, sbprNumeric},   // Nd  [10] NKO DIGIT ZERO..NKO DIGIT NINE
-	{runeRange{0x07CA, 0x07EA}, sbprOLetter},   // Lo  [33] NKO LETTER A..NKO LETTER JONA RA
-	{runeRange{0x07EB, 0x07F3}, sbprExtend},    // Mn   [9] NKO COMBINING SHORT HIGH TONE..NKO COMBINING DOUBLE DOT ABOVE
-	{runeRange{0x07F4, 0x07F5}, sbprOLetter},   // Lm   [2] NKO HIGH TONE APOSTROPHE..NKO LOW TONE APOSTROPHE
-	{runeRange{0x07F8, 0x07F8}, sbprSContinue}, // Po       NKO COMMA
-	{runeRange{0x07F9, 0x07F9}, sbprSTerm},     // Po       NKO EXCLAMATION MARK
-	{runeRange{0x07FA, 0x07FA}, sbprOLetter},   // Lm       NKO LAJANYALAN
-	{runeRange{0x07FD, 0x07FD}, sbprExtend},    // Mn       NKO DANTAYALAN
-	{runeRange{0x0800, 0x0815}, sbprOLetter},   // Lo  [22] SAMARITAN LETTER ALAF..SAMARITAN LETTER TAAF
-	{runeRange{0x0816, 0x0819}, sbprExtend},    // Mn   [4] SAMARITAN MARK IN..SAMARITAN MARK DAGESH
-	{runeRange{0x081A, 0x081A}, sbprOLetter},   // Lm       SAMARITAN MODIFIER LETTER EPENTHETIC YUT
-	{runeRange{0x081B, 0x0823}, sbprExtend},    // Mn   [9] SAMARITAN MARK EPENTHETIC YUT..SAMARITAN VOWEL SIGN A
-	{runeRange{0x0824, 0x0824}, sbprOLetter},   // Lm       SAMARITAN MODIFIER LETTER SHORT A
-	{runeRange{0x0825, 0x0827}, sbprExtend},    // Mn   [3] SAMARITAN VOWEL SIGN SHORT A..SAMARITAN VOWEL SIGN U
-	{runeRange{0x0828, 0x0828}, sbprOLetter},   // Lm       SAMARITAN MODIFIER LETTER I
-	{runeRange{0x0829, 0x082D}, sbprExtend},    // Mn   [5] SAMARITAN VOWEL SIGN LONG I..SAMARITAN MARK NEQUDAA
-	{runeRange{0x0837, 0x0837}, sbprSTerm},     // Po       SAMARITAN PUNCTUATION MELODIC QITSA
-	{runeRange{0x0839, 0x0839}, sbprSTerm},     // Po       SAMARITAN PUNCTUATION QITSA
-	{runeRange{0x083D, 0x083E}, sbprSTerm},     // Po   [2] SAMARITAN PUNCTUATION SOF MASHFAAT..SAMARITAN PUNCTUATION ANNAAU
-	{runeRange{0x0840, 0x0858}, sbprOLetter},   // Lo  [25] MANDAIC LETTER HALQA..MANDAIC LETTER AIN
-	{runeRange{0x0859, 0x085B}, sbprExtend},    // Mn   [3] MANDAIC AFFRICATION MARK..MANDAIC GEMINATION MARK
-	{runeRange{0x0860, 0x086A}, sbprOLetter},   // Lo  [11] SYRIAC LETTER MALAYALAM NGA..SYRIAC LETTER MALAYALAM SSA
-	{runeRange{0x0870, 0x0887}, sbprOLetter},   // Lo  [24] ARABIC LETTER ALEF WITH ATTACHED FATHA..ARABIC BASELINE ROUND DOT
-	{runeRange{0x0889, 0x088E}, sbprOLetter},   // Lo   [6] ARABIC LETTER NOON WITH INVERTED SMALL V..ARABIC VERTICAL TAIL
-	{runeRange{0x0890, 0x0891}, sbprFormat},    // Cf   [2] ARABIC POUND MARK ABOVE..ARABIC PIASTRE MARK ABOVE
-	{runeRange{0x0898, 0x089F}, sbprExtend},    // Mn   [8] ARABIC SMALL HIGH WORD AL-JUZ..ARABIC HALF MADDA OVER MADDA
-	{runeRange{0x08A0, 0x08C8}, sbprOLetter},   // Lo  [41] ARABIC LETTER BEH WITH SMALL V BELOW..ARABIC LETTER GRAF
-	{runeRange{0x08C9, 0x08C9}, sbprOLetter},   // Lm       ARABIC SMALL FARSI YEH
-	{runeRange{0x08CA, 0x08E1}, sbprExtend},    // Mn  [24] ARABIC SMALL HIGH FARSI YEH..ARABIC SMALL HIGH SIGN SAFHA
-	{runeRange{0x08E2, 0x08E2}, sbprFormat},    // Cf       ARABIC DISPUTED END OF AYAH
-	{runeRange{0x08E3, 0x0902}, sbprExtend},    // Mn  [32] ARABIC TURNED DAMMA BELOW..DEVANAGARI SIGN ANUSVARA
-	{runeRange{0x0903, 0x0903}, sbprExtend},    // Mc       DEVANAGARI SIGN VISARGA
-	{runeRange{0x0904, 0x0939}, sbprOLetter},   // Lo  [54] DEVANAGARI LETTER SHORT A..DEVANAGARI LETTER HA
-	{runeRange{0x093A, 0x093A}, sbprExtend},    // Mn       DEVANAGARI VOWEL SIGN OE
-	{runeRange{0x093B, 0x093B}, sbprExtend},    // Mc       DEVANAGARI VOWEL SIGN OOE
-	{runeRange{0x093C, 0x093C}, sbprExtend},    // Mn       DEVANAGARI SIGN NUKTA
-	{runeRange{0x093D, 0x093D}, sbprOLetter},   // Lo       DEVANAGARI SIGN AVAGRAHA
-	{runeRange{0x093E, 0x0940}, sbprExtend},    // Mc   [3] DEVANAGARI VOWEL SIGN AA..DEVANAGARI VOWEL SIGN II
-	{runeRange{0x0941, 0x0948}, sbprExtend},    // Mn   [8] DEVANAGARI VOWEL SIGN U..DEVANAGARI VOWEL SIGN AI
-	{runeRange{0x0949, 0x094C}, sbprExtend},    // Mc   [4] DEVANAGARI VOWEL SIGN CANDRA O..DEVANAGARI VOWEL SIGN AU
-	{runeRange{0x094D, 0x094D}, sbprExtend},    // Mn       DEVANAGARI SIGN VIRAMA
-	{runeRange{0x094E, 0x094F}, sbprExtend},    // Mc   [2] DEVANAGARI VOWEL SIGN PRISHTHAMATRA E..DEVANAGARI VOWEL SIGN AW
-	{runeRange{0x0950, 0x0950}, sbprOLetter},   // Lo       DEVANAGARI OM
-	{runeRange{0x0951, 0x0957}, sbprExtend},    // Mn   [7] DEVANAGARI STRESS SIGN UDATTA..DEVANAGARI VOWEL SIGN UUE
-	{runeRange{0x0958, 0x0961}, sbprOLetter},   // Lo  [10] DEVANAGARI LETTER QA..DEVANAGARI LETTER VOCALIC LL
-	{runeRange{0x0962, 0x0963}, sbprExtend},    // Mn   [2] DEVANAGARI VOWEL SIGN VOCALIC L..DEVANAGARI VOWEL SIGN VOCALIC LL
-	{runeRange{0x0964, 0x0965}, sbprSTerm},     // Po   [2] DEVANAGARI DANDA..DEVANAGARI DOUBLE DANDA
-	{runeRange{0x0966, 0x096F}, sbprNumeric},   // Nd  [10] DEVANAGARI DIGIT ZERO..DEVANAGARI DIGIT NINE
-	{runeRange{0x0971, 0x0971}, sbprOLetter},   // Lm       DEVANAGARI SIGN HIGH SPACING DOT
-	{runeRange{0x0972, 0x0980}, sbprOLetter},   // Lo  [15] DEVANAGARI LETTER CANDRA A..BENGALI ANJI
-	{runeRange{0x0981, 0x0981}, sbprExtend},    // Mn       BENGALI SIGN CANDRABINDU
-	{runeRange{0x0982, 0x0983}, sbprExtend},    // Mc   [2] BENGALI SIGN ANUSVARA..BENGALI SIGN VISARGA
-	{runeRange{0x0985, 0x098C}, sbprOLetter},   // Lo   [8] BENGALI LETTER A..BENGALI LETTER VOCALIC L
-	{runeRange{0x098F, 0x0990}, sbprOLetter},   // Lo   [2] BENGALI LETTER E..BENGALI LETTER AI
-	{runeRange{0x0993, 0x09A8}, sbprOLetter},   // Lo  [22] BENGALI LETTER O..BENGALI LETTER NA
-	{runeRange{0x09AA, 0x09B0}, sbprOLetter},   // Lo   [7] BENGALI LETTER PA..BENGALI LETTER RA
-	{runeRange{0x09B2, 0x09B2}, sbprOLetter},   // Lo       BENGALI LETTER LA
-	{runeRange{0x09B6, 0x09B9}, sbprOLetter},   // Lo   [4] BENGALI LETTER SHA..BENGALI LETTER HA
-	{runeRange{0x09BC, 0x09BC}, sbprExtend},    // Mn       BENGALI SIGN NUKTA
-	{runeRange{0x09BD, 0x09BD}, sbprOLetter},   // Lo       BENGALI SIGN AVAGRAHA
-	{runeRange{0x09BE, 0x09C0}, sbprExtend},    // Mc   [3] BENGALI VOWEL SIGN AA..BENGALI VOWEL SIGN II
-	{runeRange{0x09C1, 0x09C4}, sbprExtend},    // Mn   [4] BENGALI VOWEL SIGN U..BENGALI VOWEL SIGN VOCALIC RR
-	{runeRange{0x09C7, 0x09C8}, sbprExtend},    // Mc   [2] BENGALI VOWEL SIGN E..BENGALI VOWEL SIGN AI
-	{runeRange{0x09CB, 0x09CC}, sbprExtend},    // Mc   [2] BENGALI VOWEL SIGN O..BENGALI VOWEL SIGN AU
-	{runeRange{0x09CD, 0x09CD}, sbprExtend},    // Mn       BENGALI SIGN VIRAMA
-	{runeRange{0x09CE, 0x09CE}, sbprOLetter},   // Lo       BENGALI LETTER KHANDA TA
-	{runeRange{0x09D7, 0x09D7}, sbprExtend},    // Mc       BENGALI AU LENGTH MARK
-	{runeRange{0x09DC, 0x09DD}, sbprOLetter},   // Lo   [2] BENGALI LETTER RRA..BENGALI LETTER RHA
-	{runeRange{0x09DF, 0x09E1}, sbprOLetter},   // Lo   [3] BENGALI LETTER YYA..BENGALI LETTER VOCALIC LL
-	{runeRange{0x09E2, 0x09E3}, sbprExtend},    // Mn   [2] BENGALI VOWEL SIGN VOCALIC L..BENGALI VOWEL SIGN VOCALIC LL
-	{runeRange{0x09E6, 0x09EF}, sbprNumeric},   // Nd  [10] BENGALI DIGIT ZERO..BENGALI DIGIT NINE
-	{runeRange{0x09F0, 0x09F1}, sbprOLetter},   // Lo   [2] BENGALI LETTER RA WITH MIDDLE DIAGONAL..BENGALI LETTER RA WITH LOWER DIAGONAL
-	{runeRange{0x09FC, 0x09FC}, sbprOLetter},   // Lo       BENGALI LETTER VEDIC ANUSVARA
-	{runeRange{0x09FE, 0x09FE}, sbprExtend},    // Mn       BENGALI SANDHI MARK
-	{runeRange{0x0A01, 0x0A02}, sbprExtend},    // Mn   [2] GURMUKHI SIGN ADAK BINDI..GURMUKHI SIGN BINDI
-	{runeRange{0x0A03, 0x0A03}, sbprExtend},    // Mc       GURMUKHI SIGN VISARGA
-	{runeRange{0x0A05, 0x0A0A}, sbprOLetter},   // Lo   [6] GURMUKHI LETTER A..GURMUKHI LETTER UU
-	{runeRange{0x0A0F, 0x0A10}, sbprOLetter},   // Lo   [2] GURMUKHI LETTER EE..GURMUKHI LETTER AI
-	{runeRange{0x0A13, 0x0A28}, sbprOLetter},   // Lo  [22] GURMUKHI LETTER OO..GURMUKHI LETTER NA
-	{runeRange{0x0A2A, 0x0A30}, sbprOLetter},   // Lo   [7] GURMUKHI LETTER PA..GURMUKHI LETTER RA
-	{runeRange{0x0A32, 0x0A33}, sbprOLetter},   // Lo   [2] GURMUKHI LETTER LA..GURMUKHI LETTER LLA
-	{runeRange{0x0A35, 0x0A36}, sbprOLetter},   // Lo   [2] GURMUKHI LETTER VA..GURMUKHI LETTER SHA
-	{runeRange{0x0A38, 0x0A39}, sbprOLetter},   // Lo   [2] GURMUKHI LETTER SA..GURMUKHI LETTER HA
-	{runeRange{0x0A3C, 0x0A3C}, sbprExtend},    // Mn       GURMUKHI SIGN NUKTA
-	{runeRange{0x0A3E, 0x0A40}, sbprExtend},    // Mc   [3] GURMUKHI VOWEL SIGN AA..GURMUKHI VOWEL SIGN II
-	{runeRange{0x0A41, 0x0A42}, sbprExtend},    // Mn   [2] GURMUKHI VOWEL SIGN U..GURMUKHI VOWEL SIGN UU
-	{runeRange{0x0A47, 0x0A48}, sbprExtend},    // Mn   [2] GURMUKHI VOWEL SIGN EE..GURMUKHI VOWEL SIGN AI
-	{runeRange{0x0A4B, 0x0A4D}, sbprExtend},    // Mn   [3] GURMUKHI VOWEL SIGN OO..GURMUKHI SIGN VIRAMA
-	{runeRange{0x0A51, 0x0A51}, sbprExtend},    // Mn       GURMUKHI SIGN UDAAT
-	{runeRange{0x0A59, 0x0A5C}, sbprOLetter},   // Lo   [4] GURMUKHI LETTER KHHA..GURMUKHI LETTER RRA
-	{runeRange{0x0A5E, 0x0A5E}, sbprOLetter},   // Lo       GURMUKHI LETTER FA
-	{runeRange{0x0A66, 0x0A6F}, sbprNumeric},   // Nd  [10] GURMUKHI DIGIT ZERO..GURMUKHI DIGIT NINE
-	{runeRange{0x0A70, 0x0A71}, sbprExtend},    // Mn   [2] GURMUKHI TIPPI..GURMUKHI ADDAK
-	{runeRange{0x0A72, 0x0A74}, sbprOLetter},   // Lo   [3] GURMUKHI IRI..GURMUKHI EK ONKAR
-	{runeRange{0x0A75, 0x0A75}, sbprExtend},    // Mn       GURMUKHI SIGN YAKASH
-	{runeRange{0x0A81, 0x0A82}, sbprExtend},    // Mn   [2] GUJARATI SIGN CANDRABINDU..GUJARATI SIGN ANUSVARA
-	{runeRange{0x0A83, 0x0A83}, sbprExtend},    // Mc       GUJARATI SIGN VISARGA
-	{runeRange{0x0A85, 0x0A8D}, sbprOLetter},   // Lo   [9] GUJARATI LETTER A..GUJARATI VOWEL CANDRA E
-	{runeRange{0x0A8F, 0x0A91}, sbprOLetter},   // Lo   [3] GUJARATI LETTER E..GUJARATI VOWEL CANDRA O
-	{runeRange{0x0A93, 0x0AA8}, sbprOLetter},   // Lo  [22] GUJARATI LETTER O..GUJARATI LETTER NA
-	{runeRange{0x0AAA, 0x0AB0}, sbprOLetter},   // Lo   [7] GUJARATI LETTER PA..GUJARATI LETTER RA
-	{runeRange{0x0AB2, 0x0AB3}, sbprOLetter},   // Lo   [2] GUJARATI LETTER LA..GUJARATI LETTER LLA
-	{runeRange{0x0AB5, 0x0AB9}, sbprOLetter},   // Lo   [5] GUJARATI LETTER VA..GUJARATI LETTER HA
-	{runeRange{0x0ABC, 0x0ABC}, sbprExtend},    // Mn       GUJARATI SIGN NUKTA
-	{runeRange{0x0ABD, 0x0ABD}, sbprOLetter},   // Lo       GUJARATI SIGN AVAGRAHA
-	{runeRange{0x0ABE, 0x0AC0}, sbprExtend},    // Mc   [3] GUJARATI VOWEL SIGN AA..GUJARATI VOWEL SIGN II
-	{runeRange{0x0AC1, 0x0AC5}, sbprExtend},    // Mn   [5] GUJARATI VOWEL SIGN U..GUJARATI VOWEL SIGN CANDRA E
-	{runeRange{0x0AC7, 0x0AC8}, sbprExtend},    // Mn   [2] GUJARATI VOWEL SIGN E..GUJARATI VOWEL SIGN AI
-	{runeRange{0x0AC9, 0x0AC9}, sbprExtend},    // Mc       GUJARATI VOWEL SIGN CANDRA O
-	{runeRange{0x0ACB, 0x0ACC}, sbprExtend},    // Mc   [2] GUJARATI VOWEL SIGN O..GUJARATI VOWEL SIGN AU
-	{runeRange{0x0ACD, 0x0ACD}, sbprExtend},    // Mn       GUJARATI SIGN VIRAMA
-	{runeRange{0x0AD0, 0x0AD0}, sbprOLetter},   // Lo       GUJARATI OM
-	{runeRange{0x0AE0, 0x0AE1}, sbprOLetter},   // Lo   [2] GUJARATI LETTER VOCALIC RR..GUJARATI LETTER VOCALIC LL
-	{runeRange{0x0AE2, 0x0AE3}, sbprExtend},    // Mn   [2] GUJARATI VOWEL SIGN VOCALIC L..GUJARATI VOWEL SIGN VOCALIC LL
-	{runeRange{0x0AE6, 0x0AEF}, sbprNumeric},   // Nd  [10] GUJARATI DIGIT ZERO..GUJARATI DIGIT NINE
-	{runeRange{0x0AF9, 0x0AF9}, sbprOLetter},   // Lo       GUJARATI LETTER ZHA
-	{runeRange{0x0AFA, 0x0AFF}, sbprExtend},    // Mn   [6] GUJARATI SIGN SUKUN..GUJARATI SIGN TWO-CIRCLE NUKTA ABOVE
-	{runeRange{0x0B01, 0x0B01}, sbprExtend},    // Mn       ORIYA SIGN CANDRABINDU
-	{runeRange{0x0B02, 0x0B03}, sbprExtend},    // Mc   [2] ORIYA SIGN ANUSVARA..ORIYA SIGN VISARGA
-	{runeRange{0x0B05, 0x0B0C}, sbprOLetter},   // Lo   [8] ORIYA LETTER A..ORIYA LETTER VOCALIC L
-	{runeRange{0x0B0F, 0x0B10}, sbprOLetter},   // Lo   [2] ORIYA LETTER E..ORIYA LETTER AI
-	{runeRange{0x0B13, 0x0B28}, sbprOLetter},   // Lo  [22] ORIYA LETTER O..ORIYA LETTER NA
-	{runeRange{0x0B2A, 0x0B30}, sbprOLetter},   // Lo   [7] ORIYA LETTER PA..ORIYA LETTER RA
-	{runeRange{0x0B32, 0x0B33}, sbprOLetter},   // Lo   [2] ORIYA LETTER LA..ORIYA LETTER LLA
-	{runeRange{0x0B35, 0x0B39}, sbprOLetter},   // Lo   [5] ORIYA LETTER VA..ORIYA LETTER HA
-	{runeRange{0x0B3C, 0x0B3C}, sbprExtend},    // Mn       ORIYA SIGN NUKTA
-	{runeRange{0x0B3D, 0x0B3D}, sbprOLetter},   // Lo       ORIYA SIGN AVAGRAHA
-	{runeRange{0x0B3E, 0x0B3E}, sbprExtend},    // Mc       ORIYA VOWEL SIGN AA
-	{runeRange{0x0B3F, 0x0B3F}, sbprExtend},    // Mn       ORIYA VOWEL SIGN I
-	{runeRange{0x0B40, 0x0B40}, sbprExtend},    // Mc       ORIYA VOWEL SIGN II
-	{runeRange{0x0B41, 0x0B44}, sbprExtend},    // Mn   [4] ORIYA VOWEL SIGN U..ORIYA VOWEL SIGN VOCALIC RR
-	{runeRange{0x0B47, 0x0B48}, sbprExtend},    // Mc   [2] ORIYA VOWEL SIGN E..ORIYA VOWEL SIGN AI
-	{runeRange{0x0B4B, 0x0B4C}, sbprExtend},    // Mc   [2] ORIYA VOWEL SIGN O..ORIYA VOWEL SIGN AU
-	{runeRange{0x0B4D, 0x0B4D}, sbprExtend},    // Mn       ORIYA SIGN VIRAMA
-	{runeRange{0x0B55, 0x0B56}, sbprExtend},    // Mn   [2] ORIYA SIGN OVERLINE..ORIYA AI LENGTH MARK
-	{runeRange{0x0B57, 0x0B57}, sbprExtend},    // Mc       ORIYA AU LENGTH MARK
-	{runeRange{0x0B5C, 0x0B5D}, sbprOLetter},   // Lo   [2] ORIYA LETTER RRA..ORIYA LETTER RHA
-	{runeRange{0x0B5F, 0x0B61}, sbprOLetter},   // Lo   [3] ORIYA LETTER YYA..ORIYA LETTER VOCALIC LL
-	{runeRange{0x0B62, 0x0B63}, sbprExtend},    // Mn   [2] ORIYA VOWEL SIGN VOCALIC L..ORIYA VOWEL SIGN VOCALIC LL
-	{runeRange{0x0B66, 0x0B6F}, sbprNumeric},   // Nd  [10] ORIYA DIGIT ZERO..ORIYA DIGIT NINE
-	{runeRange{0x0B71, 0x0B71}, sbprOLetter},   // Lo       ORIYA LETTER WA
-	{runeRange{0x0B82, 0x0B82}, sbprExtend},    // Mn       TAMIL SIGN ANUSVARA
-	{runeRange{0x0B83, 0x0B83}, sbprOLetter},   // Lo       TAMIL SIGN VISARGA
-	{runeRange{0x0B85, 0x0B8A}, sbprOLetter},   // Lo   [6] TAMIL LETTER A..TAMIL LETTER UU
-	{runeRange{0x0B8E, 0x0B90}, sbprOLetter},   // Lo   [3] TAMIL LETTER E..TAMIL LETTER AI
-	{runeRange{0x0B92, 0x0B95}, sbprOLetter},   // Lo   [4] TAMIL LETTER O..TAMIL LETTER KA
-	{runeRange{0x0B99, 0x0B9A}, sbprOLetter},   // Lo   [2] TAMIL LETTER NGA..TAMIL LETTER CA
-	{runeRange{0x0B9C, 0x0B9C}, sbprOLetter},   // Lo       TAMIL LETTER JA
-	{runeRange{0x0B9E, 0x0B9F}, sbprOLetter},   // Lo   [2] TAMIL LETTER NYA..TAMIL LETTER TTA
-	{runeRange{0x0BA3, 0x0BA4}, sbprOLetter},   // Lo   [2] TAMIL LETTER NNA..TAMIL LETTER TA
-	{runeRange{0x0BA8, 0x0BAA}, sbprOLetter},   // Lo   [3] TAMIL LETTER NA..TAMIL LETTER PA
-	{runeRange{0x0BAE, 0x0BB9}, sbprOLetter},   // Lo  [12] TAMIL LETTER MA..TAMIL LETTER HA
-	{runeRange{0x0BBE, 0x0BBF}, sbprExtend},    // Mc   [2] TAMIL VOWEL SIGN AA..TAMIL VOWEL SIGN I
-	{runeRange{0x0BC0, 0x0BC0}, sbprExtend},    // Mn       TAMIL VOWEL SIGN II
-	{runeRange{0x0BC1, 0x0BC2}, sbprExtend},    // Mc   [2] TAMIL VOWEL SIGN U..TAMIL VOWEL SIGN UU
-	{runeRange{0x0BC6, 0x0BC8}, sbprExtend},    // Mc   [3] TAMIL VOWEL SIGN E..TAMIL VOWEL SIGN AI
-	{runeRange{0x0BCA, 0x0BCC}, sbprExtend},    // Mc   [3] TAMIL VOWEL SIGN O..TAMIL VOWEL SIGN AU
-	{runeRange{0x0BCD, 0x0BCD}, sbprExtend},    // Mn       TAMIL SIGN VIRAMA
-	{runeRange{0x0BD0, 0x0BD0}, sbprOLetter},   // Lo       TAMIL OM
-	{runeRange{0x0BD7, 0x0BD7}, sbprExtend},    // Mc       TAMIL AU LENGTH MARK
-	{runeRange{0x0BE6, 0x0BEF}, sbprNumeric},   // Nd  [10] TAMIL DIGIT ZERO..TAMIL DIGIT NINE
-	{runeRange{0x0C00, 0x0C00}, sbprExtend},    // Mn       TELUGU SIGN COMBINING CANDRABINDU ABOVE
-	{runeRange{0x0C01, 0x0C03}, sbprExtend},    // Mc   [3] TELUGU SIGN CANDRABINDU..TELUGU SIGN VISARGA
-	{runeRange{0x0C04, 0x0C04}, sbprExtend},    // Mn       TELUGU SIGN COMBINING ANUSVARA ABOVE
-	{runeRange{0x0C05, 0x0C0C}, sbprOLetter},   // Lo   [8] TELUGU LETTER A..TELUGU LETTER VOCALIC L
-	{runeRange{0x0C0E, 0x0C10}, sbprOLetter},   // Lo   [3] TELUGU LETTER E..TELUGU LETTER AI
-	{runeRange{0x0C12, 0x0C28}, sbprOLetter},   // Lo  [23] TELUGU LETTER O..TELUGU LETTER NA
-	{runeRange{0x0C2A, 0x0C39}, sbprOLetter},   // Lo  [16] TELUGU LETTER PA..TELUGU LETTER HA
-	{runeRange{0x0C3C, 0x0C3C}, sbprExtend},    // Mn       TELUGU SIGN NUKTA
-	{runeRange{0x0C3D, 0x0C3D}, sbprOLetter},   // Lo       TELUGU SIGN AVAGRAHA
-	{runeRange{0x0C3E, 0x0C40}, sbprExtend},    // Mn   [3] TELUGU VOWEL SIGN AA..TELUGU VOWEL SIGN II
-	{runeRange{0x0C41, 0x0C44}, sbprExtend},    // Mc   [4] TELUGU VOWEL SIGN U..TELUGU VOWEL SIGN VOCALIC RR
-	{runeRange{0x0C46, 0x0C48}, sbprExtend},    // Mn   [3] TELUGU VOWEL SIGN E..TELUGU VOWEL SIGN AI
-	{runeRange{0x0C4A, 0x0C4D}, sbprExtend},    // Mn   [4] TELUGU VOWEL SIGN O..TELUGU SIGN VIRAMA
-	{runeRange{0x0C55, 0x0C56}, sbprExtend},    // Mn   [2] TELUGU LENGTH MARK..TELUGU AI LENGTH MARK
-	{runeRange{0x0C58, 0x0C5A}, sbprOLetter},   // Lo   [3] TELUGU LETTER TSA..TELUGU LETTER RRRA
-	{runeRange{0x0C5D, 0x0C5D}, sbprOLetter},   // Lo       TELUGU LETTER NAKAARA POLLU
-	{runeRange{0x0C60, 0x0C61}, sbprOLetter},   // Lo   [2] TELUGU LETTER VOCALIC RR..TELUGU LETTER VOCALIC LL
-	{runeRange{0x0C62, 0x0C63}, sbprExtend},    // Mn   [2] TELUGU VOWEL SIGN VOCALIC L..TELUGU VOWEL SIGN VOCALIC LL
-	{runeRange{0x0C66, 0x0C6F}, sbprNumeric},   // Nd  [10] TELUGU DIGIT ZERO..TELUGU DIGIT NINE
-	{runeRange{0x0C80, 0x0C80}, sbprOLetter},   // Lo       KANNADA SIGN SPACING CANDRABINDU
-	{runeRange{0x0C81, 0x0C81}, sbprExtend},    // Mn       KANNADA SIGN CANDRABINDU
-	{runeRange{0x0C82, 0x0C83}, sbprExtend},    // Mc   [2] KANNADA SIGN ANUSVARA..KANNADA SIGN VISARGA
-	{runeRange{0x0C85, 0x0C8C}, sbprOLetter},   // Lo   [8] KANNADA LETTER A..KANNADA LETTER VOCALIC L
-	{runeRange{0x0C8E, 0x0C90}, sbprOLetter},   // Lo   [3] KANNADA LETTER E..KANNADA LETTER AI
-	{runeRange{0x0C92, 0x0CA8}, sbprOLetter},   // Lo  [23] KANNADA LETTER O..KANNADA LETTER NA
-	{runeRange{0x0CAA, 0x0CB3}, sbprOLetter},   // Lo  [10] KANNADA LETTER PA..KANNADA LETTER LLA
-	{runeRange{0x0CB5, 0x0CB9}, sbprOLetter},   // Lo   [5] KANNADA LETTER VA..KANNADA LETTER HA
-	{runeRange{0x0CBC, 0x0CBC}, sbprExtend},    // Mn       KANNADA SIGN NUKTA
-	{runeRange{0x0CBD, 0x0CBD}, sbprOLetter},   // Lo       KANNADA SIGN AVAGRAHA
-	{runeRange{0x0CBE, 0x0CBE}, sbprExtend},    // Mc       KANNADA VOWEL SIGN AA
-	{runeRange{0x0CBF, 0x0CBF}, sbprExtend},    // Mn       KANNADA VOWEL SIGN I
-	{runeRange{0x0CC0, 0x0CC4}, sbprExtend},    // Mc   [5] KANNADA VOWEL SIGN II..KANNADA VOWEL SIGN VOCALIC RR
-	{runeRange{0x0CC6, 0x0CC6}, sbprExtend},    // Mn       KANNADA VOWEL SIGN E
-	{runeRange{0x0CC7, 0x0CC8}, sbprExtend},    // Mc   [2] KANNADA VOWEL SIGN EE..KANNADA VOWEL SIGN AI
-	{runeRange{0x0CCA, 0x0CCB}, sbprExtend},    // Mc   [2] KANNADA VOWEL SIGN O..KANNADA VOWEL SIGN OO
-	{runeRange{0x0CCC, 0x0CCD}, sbprExtend},    // Mn   [2] KANNADA VOWEL SIGN AU..KANNADA SIGN VIRAMA
-	{runeRange{0x0CD5, 0x0CD6}, sbprExtend},    // Mc   [2] KANNADA LENGTH MARK..KANNADA AI LENGTH MARK
-	{runeRange{0x0CDD, 0x0CDE}, sbprOLetter},   // Lo   [2] KANNADA LETTER NAKAARA POLLU..KANNADA LETTER FA
-	{runeRange{0x0CE0, 0x0CE1}, sbprOLetter},   // Lo   [2] KANNADA LETTER VOCALIC RR..KANNADA LETTER VOCALIC LL
-	{runeRange{0x0CE2, 0x0CE3}, sbprExtend},    // Mn   [2] KANNADA VOWEL SIGN VOCALIC L..KANNADA VOWEL SIGN VOCALIC LL
-	{runeRange{0x0CE6, 0x0CEF}, sbprNumeric},   // Nd  [10] KANNADA DIGIT ZERO..KANNADA DIGIT NINE
-	{runeRange{0x0CF1, 0x0CF2}, sbprOLetter},   // Lo   [2] KANNADA SIGN JIHVAMULIYA..KANNADA SIGN UPADHMANIYA
-	{runeRange{0x0CF3, 0x0CF3}, sbprExtend},    // Mc       KANNADA SIGN COMBINING ANUSVARA ABOVE RIGHT
-	{runeRange{0x0D00, 0x0D01}, sbprExtend},    // Mn   [2] MALAYALAM SIGN COMBINING ANUSVARA ABOVE..MALAYALAM SIGN CANDRABINDU
-	{runeRange{0x0D02, 0x0D03}, sbprExtend},    // Mc   [2] MALAYALAM SIGN ANUSVARA..MALAYALAM SIGN VISARGA
-	{runeRange{0x0D04, 0x0D0C}, sbprOLetter},   // Lo   [9] MALAYALAM LETTER VEDIC ANUSVARA..MALAYALAM LETTER VOCALIC L
-	{runeRange{0x0D0E, 0x0D10}, sbprOLetter},   // Lo   [3] MALAYALAM LETTER E..MALAYALAM LETTER AI
-	{runeRange{0x0D12, 0x0D3A}, sbprOLetter},   // Lo  [41] MALAYALAM LETTER O..MALAYALAM LETTER TTTA
-	{runeRange{0x0D3B, 0x0D3C}, sbprExtend},    // Mn   [2] MALAYALAM SIGN VERTICAL BAR VIRAMA..MALAYALAM SIGN CIRCULAR VIRAMA
-	{runeRange{0x0D3D, 0x0D3D}, sbprOLetter},   // Lo       MALAYALAM SIGN AVAGRAHA
-	{runeRange{0x0D3E, 0x0D40}, sbprExtend},    // Mc   [3] MALAYALAM VOWEL SIGN AA..MALAYALAM VOWEL SIGN II
-	{runeRange{0x0D41, 0x0D44}, sbprExtend},    // Mn   [4] MALAYALAM VOWEL SIGN U..MALAYALAM VOWEL SIGN VOCALIC RR
-	{runeRange{0x0D46, 0x0D48}, sbprExtend},    // Mc   [3] MALAYALAM VOWEL SIGN E..MALAYALAM VOWEL SIGN AI
-	{runeRange{0x0D4A, 0x0D4C}, sbprExtend},    // Mc   [3] MALAYALAM VOWEL SIGN O..MALAYALAM VOWEL SIGN AU
-	{runeRange{0x0D4D, 0x0D4D}, sbprExtend},    // Mn       MALAYALAM SIGN VIRAMA
-	{runeRange{0x0D4E, 0x0D4E}, sbprOLetter},   // Lo       MALAYALAM LETTER DOT REPH
-	{runeRange{0x0D54, 0x0D56}, sbprOLetter},   // Lo   [3] MALAYALAM LETTER CHILLU M..MALAYALAM LETTER CHILLU LLL
-	{runeRange{0x0D57, 0x0D57}, sbprExtend},    // Mc       MALAYALAM AU LENGTH MARK
-	{runeRange{0x0D5F, 0x0D61}, sbprOLetter},   // Lo   [3] MALAYALAM LETTER ARCHAIC II..MALAYALAM LETTER VOCALIC LL
-	{runeRange{0x0D62, 0x0D63}, sbprExtend},    // Mn   [2] MALAYALAM VOWEL SIGN VOCALIC L..MALAYALAM VOWEL SIGN VOCALIC LL
-	{runeRange{0x0D66, 0x0D6F}, sbprNumeric},   // Nd  [10] MALAYALAM DIGIT ZERO..MALAYALAM DIGIT NINE
-	{runeRange{0x0D7A, 0x0D7F}, sbprOLetter},   // Lo   [6] MALAYALAM LETTER CHILLU NN..MALAYALAM LETTER CHILLU K
-	{runeRange{0x0D81, 0x0D81}, sbprExtend},    // Mn       SINHALA SIGN CANDRABINDU
-	{runeRange{0x0D82, 0x0D83}, sbprExtend},    // Mc   [2] SINHALA SIGN ANUSVARAYA..SINHALA SIGN VISARGAYA
-	{runeRange{0x0D85, 0x0D96}, sbprOLetter},   // Lo  [18] SINHALA LETTER AYANNA..SINHALA LETTER AUYANNA
-	{runeRange{0x0D9A, 0x0DB1}, sbprOLetter},   // Lo  [24] SINHALA LETTER ALPAPRAANA KAYANNA..SINHALA LETTER DANTAJA NAYANNA
-	{runeRange{0x0DB3, 0x0DBB}, sbprOLetter},   // Lo   [9] SINHALA LETTER SANYAKA DAYANNA..SINHALA LETTER RAYANNA
-	{runeRange{0x0DBD, 0x0DBD}, sbprOLetter},   // Lo       SINHALA LETTER DANTAJA LAYANNA
-	{runeRange{0x0DC0, 0x0DC6}, sbprOLetter},   // Lo   [7] SINHALA LETTER VAYANNA..SINHALA LETTER FAYANNA
-	{runeRange{0x0DCA, 0x0DCA}, sbprExtend},    // Mn       SINHALA SIGN AL-LAKUNA
-	{runeRange{0x0DCF, 0x0DD1}, sbprExtend},    // Mc   [3] SINHALA VOWEL SIGN AELA-PILLA..SINHALA VOWEL SIGN DIGA AEDA-PILLA
-	{runeRange{0x0DD2, 0x0DD4}, sbprExtend},    // Mn   [3] SINHALA VOWEL SIGN KETTI IS-PILLA..SINHALA VOWEL SIGN KETTI PAA-PILLA
-	{runeRange{0x0DD6, 0x0DD6}, sbprExtend},    // Mn       SINHALA VOWEL SIGN DIGA PAA-PILLA
-	{runeRange{0x0DD8, 0x0DDF}, sbprExtend},    // Mc   [8] SINHALA VOWEL SIGN GAETTA-PILLA..SINHALA VOWEL SIGN GAYANUKITTA
-	{runeRange{0x0DE6, 0x0DEF}, sbprNumeric},   // Nd  [10] SINHALA LITH DIGIT ZERO..SINHALA LITH DIGIT NINE
-	{runeRange{0x0DF2, 0x0DF3}, sbprExtend},    // Mc   [2] SINHALA VOWEL SIGN DIGA GAETTA-PILLA..SINHALA VOWEL SIGN DIGA GAYANUKITTA
-	{runeRange{0x0E01, 0x0E30}, sbprOLetter},   // Lo  [48] THAI CHARACTER KO KAI..THAI CHARACTER SARA A
-	{runeRange{0x0E31, 0x0E31}, sbprExtend},    // Mn       THAI CHARACTER MAI HAN-AKAT
-	{runeRange{0x0E32, 0x0E33}, sbprOLetter},   // Lo   [2] THAI CHARACTER SARA AA..THAI CHARACTER SARA AM
-	{runeRange{0x0E34, 0x0E3A}, sbprExtend},    // Mn   [7] THAI CHARACTER SARA I..THAI CHARACTER PHINTHU
-	{runeRange{0x0E40, 0x0E45}, sbprOLetter},   // Lo   [6] THAI CHARACTER SARA E..THAI CHARACTER LAKKHANGYAO
-	{runeRange{0x0E46, 0x0E46}, sbprOLetter},   // Lm       THAI CHARACTER MAIYAMOK
-	{runeRange{0x0E47, 0x0E4E}, sbprExtend},    // Mn   [8] THAI CHARACTER MAITAIKHU..THAI CHARACTER YAMAKKAN
-	{runeRange{0x0E50, 0x0E59}, sbprNumeric},   // Nd  [10] THAI DIGIT ZERO..THAI DIGIT NINE
-	{runeRange{0x0E81, 0x0E82}, sbprOLetter},   // Lo   [2] LAO LETTER KO..LAO LETTER KHO SUNG
-	{runeRange{0x0E84, 0x0E84}, sbprOLetter},   // Lo       LAO LETTER KHO TAM
-	{runeRange{0x0E86, 0x0E8A}, sbprOLetter},   // Lo   [5] LAO LETTER PALI GHA..LAO LETTER SO TAM
-	{runeRange{0x0E8C, 0x0EA3}, sbprOLetter},   // Lo  [24] LAO LETTER PALI JHA..LAO LETTER LO LING
-	{runeRange{0x0EA5, 0x0EA5}, sbprOLetter},   // Lo       LAO LETTER LO LOOT
-	{runeRange{0x0EA7, 0x0EB0}, sbprOLetter},   // Lo  [10] LAO LETTER WO..LAO VOWEL SIGN A
-	{runeRange{0x0EB1, 0x0EB1}, sbprExtend},    // Mn       LAO VOWEL SIGN MAI KAN
-	{runeRange{0x0EB2, 0x0EB3}, sbprOLetter},   // Lo   [2] LAO VOWEL SIGN AA..LAO VOWEL SIGN AM
-	{runeRange{0x0EB4, 0x0EBC}, sbprExtend},    // Mn   [9] LAO VOWEL SIGN I..LAO SEMIVOWEL SIGN LO
-	{runeRange{0x0EBD, 0x0EBD}, sbprOLetter},   // Lo       LAO SEMIVOWEL SIGN NYO
-	{runeRange{0x0EC0, 0x0EC4}, sbprOLetter},   // Lo   [5] LAO VOWEL SIGN E..LAO VOWEL SIGN AI
-	{runeRange{0x0EC6, 0x0EC6}, sbprOLetter},   // Lm       LAO KO LA
-	{runeRange{0x0EC8, 0x0ECE}, sbprExtend},    // Mn   [7] LAO TONE MAI EK..LAO YAMAKKAN
-	{runeRange{0x0ED0, 0x0ED9}, sbprNumeric},   // Nd  [10] LAO DIGIT ZERO..LAO DIGIT NINE
-	{runeRange{0x0EDC, 0x0EDF}, sbprOLetter},   // Lo   [4] LAO HO NO..LAO LETTER KHMU NYO
-	{runeRange{0x0F00, 0x0F00}, sbprOLetter},   // Lo       TIBETAN SYLLABLE OM
-	{runeRange{0x0F18, 0x0F19}, sbprExtend},    // Mn   [2] TIBETAN ASTROLOGICAL SIGN -KHYUD PA..TIBETAN ASTROLOGICAL SIGN SDONG TSHUGS
-	{runeRange{0x0F20, 0x0F29}, sbprNumeric},   // Nd  [10] TIBETAN DIGIT ZERO..TIBETAN DIGIT NINE
-	{runeRange{0x0F35, 0x0F35}, sbprExtend},    // Mn       TIBETAN MARK NGAS BZUNG NYI ZLA
-	{runeRange{0x0F37, 0x0F37}, sbprExtend},    // Mn       TIBETAN MARK NGAS BZUNG SGOR RTAGS
-	{runeRange{0x0F39, 0x0F39}, sbprExtend},    // Mn       TIBETAN MARK TSA -PHRU
-	{runeRange{0x0F3A, 0x0F3A}, sbprClose},     // Ps       TIBETAN MARK GUG RTAGS GYON
-	{runeRange{0x0F3B, 0x0F3B}, sbprClose},     // Pe       TIBETAN MARK GUG RTAGS GYAS
-	{runeRange{0x0F3C, 0x0F3C}, sbprClose},     // Ps       TIBETAN MARK ANG KHANG GYON
-	{runeRange{0x0F3D, 0x0F3D}, sbprClose},     // Pe       TIBETAN MARK ANG KHANG GYAS
-	{runeRange{0x0F3E, 0x0F3F}, sbprExtend},    // Mc   [2] TIBETAN SIGN YAR TSHES..TIBETAN SIGN MAR TSHES
-	{runeRange{0x0F40, 0x0F47}, sbprOLetter},   // Lo   [8] TIBETAN LETTER KA..TIBETAN LETTER JA
-	{runeRange{0x0F49, 0x0F6C}, sbprOLetter},   // Lo  [36] TIBETAN LETTER NYA..TIBETAN LETTER RRA
-	{runeRange{0x0F71, 0x0F7E}, sbprExtend},    // Mn  [14] TIBETAN VOWEL SIGN AA..TIBETAN SIGN RJES SU NGA RO
-	{runeRange{0x0F7F, 0x0F7F}, sbprExtend},    // Mc       TIBETAN SIGN RNAM BCAD
-	{runeRange{0x0F80, 0x0F84}, sbprExtend},    // Mn   [5] TIBETAN VOWEL SIGN REVERSED I..TIBETAN MARK HALANTA
-	{runeRange{0x0F86, 0x0F87}, sbprExtend},    // Mn   [2] TIBETAN SIGN LCI RTAGS..TIBETAN SIGN YANG RTAGS
-	{runeRange{0x0F88, 0x0F8C}, sbprOLetter},   // Lo   [5] TIBETAN SIGN LCE TSA CAN..TIBETAN SIGN INVERTED MCHU CAN
-	{runeRange{0x0F8D, 0x0F97}, sbprExtend},    // Mn  [11] TIBETAN SUBJOINED SIGN LCE TSA CAN..TIBETAN SUBJOINED LETTER JA
-	{runeRange{0x0F99, 0x0FBC}, sbprExtend},    // Mn  [36] TIBETAN SUBJOINED LETTER NYA..TIBETAN SUBJOINED LETTER FIXED-FORM RA
-	{runeRange{0x0FC6, 0x0FC6}, sbprExtend},    // Mn       TIBETAN SYMBOL PADMA GDAN
-	{runeRange{0x1000, 0x102A}, sbprOLetter},   // Lo  [43] MYANMAR LETTER KA..MYANMAR LETTER AU
-	{runeRange{0x102B, 0x102C}, sbprExtend},    // Mc   [2] MYANMAR VOWEL SIGN TALL AA..MYANMAR VOWEL SIGN AA
-	{runeRange{0x102D, 0x1030}, sbprExtend},    // Mn   [4] MYANMAR VOWEL SIGN I..MYANMAR VOWEL SIGN UU
-	{runeRange{0x1031, 0x1031}, sbprExtend},    // Mc       MYANMAR VOWEL SIGN E
-	{runeRange{0x1032, 0x1037}, sbprExtend},    // Mn   [6] MYANMAR VOWEL SIGN AI..MYANMAR SIGN DOT BELOW
-	{runeRange{0x1038, 0x1038}, sbprExtend},    // Mc       MYANMAR SIGN VISARGA
-	{runeRange{0x1039, 0x103A}, sbprExtend},    // Mn   [2] MYANMAR SIGN VIRAMA..MYANMAR SIGN ASAT
-	{runeRange{0x103B, 0x103C}, sbprExtend},    // Mc   [2] MYANMAR CONSONANT SIGN MEDIAL YA..MYANMAR CONSONANT SIGN MEDIAL RA
-	{runeRange{0x103D, 0x103E}, sbprExtend},    // Mn   [2] MYANMAR CONSONANT SIGN MEDIAL WA..MYANMAR CONSONANT SIGN MEDIAL HA
-	{runeRange{0x103F, 0x103F}, sbprOLetter},   // Lo       MYANMAR LETTER GREAT SA
-	{runeRange{0x1040, 0x1049}, sbprNumeric},   // Nd  [10] MYANMAR DIGIT ZERO..MYANMAR DIGIT NINE
-	{runeRange{0x104A, 0x104B}, sbprSTerm},     // Po   [2] MYANMAR SIGN LITTLE SECTION..MYANMAR SIGN SECTION
-	{runeRange{0x1050, 0x1055}, sbprOLetter},   // Lo   [6] MYANMAR LETTER SHA..MYANMAR LETTER VOCALIC LL
-	{runeRange{0x1056, 0x1057}, sbprExtend},    // Mc   [2] MYANMAR VOWEL SIGN VOCALIC R..MYANMAR VOWEL SIGN VOCALIC RR
-	{runeRange{0x1058, 0x1059}, sbprExtend},    // Mn   [2] MYANMAR VOWEL SIGN VOCALIC L..MYANMAR VOWEL SIGN VOCALIC LL
-	{runeRange{0x105A, 0x105D}, sbprOLetter},   // Lo   [4] MYANMAR LETTER MON NGA..MYANMAR LETTER MON BBE
-	{runeRange{0x105E, 0x1060}, sbprExtend},    // Mn   [3] MYANMAR CONSONANT SIGN MON MEDIAL NA..MYANMAR CONSONANT SIGN MON MEDIAL LA
-	{runeRange{0x1061, 0x1061}, sbprOLetter},   // Lo       MYANMAR LETTER SGAW KAREN SHA
-	{runeRange{0x1062, 0x1064}, sbprExtend},    // Mc   [3] MYANMAR VOWEL SIGN SGAW KAREN EU..MYANMAR TONE MARK SGAW KAREN KE PHO
-	{runeRange{0x1065, 0x1066}, sbprOLetter},   // Lo   [2] MYANMAR LETTER WESTERN PWO KAREN THA..MYANMAR LETTER WESTERN PWO KAREN PWA
-	{runeRange{0x1067, 0x106D}, sbprExtend},    // Mc   [7] MYANMAR VOWEL SIGN WESTERN PWO KAREN EU..MYANMAR SIGN WESTERN PWO KAREN TONE-5
-	{runeRange{0x106E, 0x1070}, sbprOLetter},   // Lo   [3] MYANMAR LETTER EASTERN PWO KAREN NNA..MYANMAR LETTER EASTERN PWO KAREN GHWA
-	{runeRange{0x1071, 0x1074}, sbprExtend},    // Mn   [4] MYANMAR VOWEL SIGN GEBA KAREN I..MYANMAR VOWEL SIGN KAYAH EE
-	{runeRange{0x1075, 0x1081}, sbprOLetter},   // Lo  [13] MYANMAR LETTER SHAN KA..MYANMAR LETTER SHAN HA
-	{runeRange{0x1082, 0x1082}, sbprExtend},    // Mn       MYANMAR CONSONANT SIGN SHAN MEDIAL WA
-	{runeRange{0x1083, 0x1084}, sbprExtend},    // Mc   [2] MYANMAR VOWEL SIGN SHAN AA..MYANMAR VOWEL SIGN SHAN E
-	{runeRange{0x1085, 0x1086}, sbprExtend},    // Mn   [2] MYANMAR VOWEL SIGN SHAN E ABOVE..MYANMAR VOWEL SIGN SHAN FINAL Y
-	{runeRange{0x1087, 0x108C}, sbprExtend},    // Mc   [6] MYANMAR SIGN SHAN TONE-2..MYANMAR SIGN SHAN COUNCIL TONE-3
-	{runeRange{0x108D, 0x108D}, sbprExtend},    // Mn       MYANMAR SIGN SHAN COUNCIL EMPHATIC TONE
-	{runeRange{0x108E, 0x108E}, sbprOLetter},   // Lo       MYANMAR LETTER RUMAI PALAUNG FA
-	{runeRange{0x108F, 0x108F}, sbprExtend},    // Mc       MYANMAR SIGN RUMAI PALAUNG TONE-5
-	{runeRange{0x1090, 0x1099}, sbprNumeric},   // Nd  [10] MYANMAR SHAN DIGIT ZERO..MYANMAR SHAN DIGIT NINE
-	{runeRange{0x109A, 0x109C}, sbprExtend},    // Mc   [3] MYANMAR SIGN KHAMTI TONE-1..MYANMAR VOWEL SIGN AITON A
-	{runeRange{0x109D, 0x109D}, sbprExtend},    // Mn       MYANMAR VOWEL SIGN AITON AI
-	{runeRange{0x10A0, 0x10C5}, sbprUpper},     // L&  [38] GEORGIAN CAPITAL LETTER AN..GEORGIAN CAPITAL LETTER HOE
-	{runeRange{0x10C7, 0x10C7}, sbprUpper},     // L&       GEORGIAN CAPITAL LETTER YN
-	{runeRange{0x10CD, 0x10CD}, sbprUpper},     // L&       GEORGIAN CAPITAL LETTER AEN
-	{runeRange{0x10D0, 0x10FA}, sbprOLetter},   // L&  [43] GEORGIAN LETTER AN..GEORGIAN LETTER AIN
-	{runeRange{0x10FC, 0x10FC}, sbprLower},     // Lm       MODIFIER LETTER GEORGIAN NAR
-	{runeRange{0x10FD, 0x10FF}, sbprOLetter},   // L&   [3] GEORGIAN LETTER AEN..GEORGIAN LETTER LABIAL SIGN
-	{runeRange{0x1100, 0x1248}, sbprOLetter},   // Lo [329] HANGUL CHOSEONG KIYEOK..ETHIOPIC SYLLABLE QWA
-	{runeRange{0x124A, 0x124D}, sbprOLetter},   // Lo   [4] ETHIOPIC SYLLABLE QWI..ETHIOPIC SYLLABLE QWE
-	{runeRange{0x1250, 0x1256}, sbprOLetter},   // Lo   [7] ETHIOPIC SYLLABLE QHA..ETHIOPIC SYLLABLE QHO
-	{runeRange{0x1258, 0x1258}, sbprOLetter},   // Lo       ETHIOPIC SYLLABLE QHWA
-	{runeRange{0x125A, 0x125D}, sbprOLetter},   // Lo   [4] ETHIOPIC SYLLABLE QHWI..ETHIOPIC SYLLABLE QHWE
-	{runeRange{0x1260, 0x1288}, sbprOLetter},   // Lo  [41] ETHIOPIC SYLLABLE BA..ETHIOPIC SYLLABLE XWA
-	{runeRange{0x128A, 0x128D}, sbprOLetter},   // Lo   [4] ETHIOPIC SYLLABLE XWI..ETHIOPIC SYLLABLE XWE
-	{runeRange{0x1290, 0x12B0}, sbprOLetter},   // Lo  [33] ETHIOPIC SYLLABLE NA..ETHIOPIC SYLLABLE KWA
-	{runeRange{0x12B2, 0x12B5}, sbprOLetter},   // Lo   [4] ETHIOPIC SYLLABLE KWI..ETHIOPIC SYLLABLE KWE
-	{runeRange{0x12B8, 0x12BE}, sbprOLetter},   // Lo   [7] ETHIOPIC SYLLABLE KXA..ETHIOPIC SYLLABLE KXO
-	{runeRange{0x12C0, 0x12C0}, sbprOLetter},   // Lo       ETHIOPIC SYLLABLE KXWA
-	{runeRange{0x12C2, 0x12C5}, sbprOLetter},   // Lo   [4] ETHIOPIC SYLLABLE KXWI..ETHIOPIC SYLLABLE KXWE
-	{runeRange{0x12C8, 0x12D6}, sbprOLetter},   // Lo  [15] ETHIOPIC SYLLABLE WA..ETHIOPIC SYLLABLE PHARYNGEAL O
-	{runeRange{0x12D8, 0x1310}, sbprOLetter},   // Lo  [57] ETHIOPIC SYLLABLE ZA..ETHIOPIC SYLLABLE GWA
-	{runeRange{0x1312, 0x1315}, sbprOLetter},   // Lo   [4] ETHIOPIC SYLLABLE GWI..ETHIOPIC SYLLABLE GWE
-	{runeRange{0x1318, 0x135A}, sbprOLetter},   // Lo  [67] ETHIOPIC SYLLABLE GGA..ETHIOPIC SYLLABLE FYA
-	{runeRange{0x135D, 0x135F}, sbprExtend},    // Mn   [3] ETHIOPIC COMBINING GEMINATION AND VOWEL LENGTH MARK..ETHIOPIC COMBINING GEMINATION MARK
-	{runeRange{0x1362, 0x1362}, sbprSTerm},     // Po       ETHIOPIC FULL STOP
-	{runeRange{0x1367, 0x1368}, sbprSTerm},     // Po   [2] ETHIOPIC QUESTION MARK..ETHIOPIC PARAGRAPH SEPARATOR
-	{runeRange{0x1380, 0x138F}, sbprOLetter},   // Lo  [16] ETHIOPIC SYLLABLE SEBATBEIT MWA..ETHIOPIC SYLLABLE PWE
-	{runeRange{0x13A0, 0x13F5}, sbprUpper},     // L&  [86] CHEROKEE LETTER A..CHEROKEE LETTER MV
-	{runeRange{0x13F8, 0x13FD}, sbprLower},     // L&   [6] CHEROKEE SMALL LETTER YE..CHEROKEE SMALL LETTER MV
-	{runeRange{0x1401, 0x166C}, sbprOLetter},   // Lo [620] CANADIAN SYLLABICS E..CANADIAN SYLLABICS CARRIER TTSA
-	{runeRange{0x166E, 0x166E}, sbprSTerm},     // Po       CANADIAN SYLLABICS FULL STOP
-	{runeRange{0x166F, 0x167F}, sbprOLetter},   // Lo  [17] CANADIAN SYLLABICS QAI..CANADIAN SYLLABICS BLACKFOOT W
-	{runeRange{0x1680, 0x1680}, sbprSp},        // Zs       OGHAM SPACE MARK
-	{runeRange{0x1681, 0x169A}, sbprOLetter},   // Lo  [26] OGHAM LETTER BEITH..OGHAM LETTER PEITH
-	{runeRange{0x169B, 0x169B}, sbprClose},     // Ps       OGHAM FEATHER MARK
-	{runeRange{0x169C, 0x169C}, sbprClose},     // Pe       OGHAM REVERSED FEATHER MARK
-	{runeRange{0x16A0, 0x16EA}, sbprOLetter},   // Lo  [75] RUNIC LETTER FEHU FEOH FE F..RUNIC LETTER X
-	{runeRange{0x16EE, 0x16F0}, sbprOLetter},   // Nl   [3] RUNIC ARLAUG SYMBOL..RUNIC BELGTHOR SYMBOL
-	{runeRange{0x16F1, 0x16F8}, sbprOLetter},   // Lo   [8] RUNIC LETTER K..RUNIC LETTER FRANKS CASKET AESC
-	{runeRange{0x1700, 0x1711}, sbprOLetter},   // Lo  [18] TAGALOG LETTER A..TAGALOG LETTER HA
-	{runeRange{0x1712, 0x1714}, sbprExtend},    // Mn   [3] TAGALOG VOWEL SIGN I..TAGALOG SIGN VIRAMA
-	{runeRange{0x1715, 0x1715}, sbprExtend},    // Mc       TAGALOG SIGN PAMUDPOD
-	{runeRange{0x171F, 0x1731}, sbprOLetter},   // Lo  [19] TAGALOG LETTER ARCHAIC RA..HANUNOO LETTER HA
-	{runeRange{0x1732, 0x1733}, sbprExtend},    // Mn   [2] HANUNOO VOWEL SIGN I..HANUNOO VOWEL SIGN U
-	{runeRange{0x1734, 0x1734}, sbprExtend},    // Mc       HANUNOO SIGN PAMUDPOD
-	{runeRange{0x1735, 0x1736}, sbprSTerm},     // Po   [2] PHILIPPINE SINGLE PUNCTUATION..PHILIPPINE DOUBLE PUNCTUATION
-	{runeRange{0x1740, 0x1751}, sbprOLetter},   // Lo  [18] BUHID LETTER A..BUHID LETTER HA
-	{runeRange{0x1752, 0x1753}, sbprExtend},    // Mn   [2] BUHID VOWEL SIGN I..BUHID VOWEL SIGN U
-	{runeRange{0x1760, 0x176C}, sbprOLetter},   // Lo  [13] TAGBANWA LETTER A..TAGBANWA LETTER YA
-	{runeRange{0x176E, 0x1770}, sbprOLetter},   // Lo   [3] TAGBANWA LETTER LA..TAGBANWA LETTER SA
-	{runeRange{0x1772, 0x1773}, sbprExtend},    // Mn   [2] TAGBANWA VOWEL SIGN I..TAGBANWA VOWEL SIGN U
-	{runeRange{0x1780, 0x17B3}, sbprOLetter},   // Lo  [52] KHMER LETTER KA..KHMER INDEPENDENT VOWEL QAU
-	{runeRange{0x17B4, 0x17B5}, sbprExtend},    // Mn   [2] KHMER VOWEL INHERENT AQ..KHMER VOWEL INHERENT AA
-	{runeRange{0x17B6, 0x17B6}, sbprExtend},    // Mc       KHMER VOWEL SIGN AA
-	{runeRange{0x17B7, 0x17BD}, sbprExtend},    // Mn   [7] KHMER VOWEL SIGN I..KHMER VOWEL SIGN UA
-	{runeRange{0x17BE, 0x17C5}, sbprExtend},    // Mc   [8] KHMER VOWEL SIGN OE..KHMER VOWEL SIGN AU
-	{runeRange{0x17C6, 0x17C6}, sbprExtend},    // Mn       KHMER SIGN NIKAHIT
-	{runeRange{0x17C7, 0x17C8}, sbprExtend},    // Mc   [2] KHMER SIGN REAHMUK..KHMER SIGN YUUKALEAPINTU
-	{runeRange{0x17C9, 0x17D3}, sbprExtend},    // Mn  [11] KHMER SIGN MUUSIKATOAN..KHMER SIGN BATHAMASAT
-	{runeRange{0x17D7, 0x17D7}, sbprOLetter},   // Lm       KHMER SIGN LEK TOO
-	{runeRange{0x17DC, 0x17DC}, sbprOLetter},   // Lo       KHMER SIGN AVAKRAHASANYA
-	{runeRange{0x17DD, 0x17DD}, sbprExtend},    // Mn       KHMER SIGN ATTHACAN
-	{runeRange{0x17E0, 0x17E9}, sbprNumeric},   // Nd  [10] KHMER DIGIT ZERO..KHMER DIGIT NINE
-	{runeRange{0x1802, 0x1802}, sbprSContinue}, // Po       MONGOLIAN COMMA
-	{runeRange{0x1803, 0x1803}, sbprSTerm},     // Po       MONGOLIAN FULL STOP
-	{runeRange{0x1808, 0x1808}, sbprSContinue}, // Po       MONGOLIAN MANCHU COMMA
-	{runeRange{0x1809, 0x1809}, sbprSTerm},     // Po       MONGOLIAN MANCHU FULL STOP
-	{runeRange{0x180B, 0x180D}, sbprExtend},    // Mn   [3] MONGOLIAN FREE VARIATION SELECTOR ONE..MONGOLIAN FREE VARIATION SELECTOR THREE
-	{runeRange{0x180E, 0x180E}, sbprFormat},    // Cf       MONGOLIAN VOWEL SEPARATOR
-	{runeRange{0x180F, 0x180F}, sbprExtend},    // Mn       MONGOLIAN FREE VARIATION SELECTOR FOUR
-	{runeRange{0x1810, 0x1819}, sbprNumeric},   // Nd  [10] MONGOLIAN DIGIT ZERO..MONGOLIAN DIGIT NINE
-	{runeRange{0x1820, 0x1842}, sbprOLetter},   // Lo  [35] MONGOLIAN LETTER A..MONGOLIAN LETTER CHI
-	{runeRange{0x1843, 0x1843}, sbprOLetter},   // Lm       MONGOLIAN LETTER TODO LONG VOWEL SIGN
-	{runeRange{0x1844, 0x1878}, sbprOLetter},   // Lo  [53] MONGOLIAN LETTER TODO E..MONGOLIAN LETTER CHA WITH TWO DOTS
-	{runeRange{0x1880, 0x1884}, sbprOLetter},   // Lo   [5] MONGOLIAN LETTER ALI GALI ANUSVARA ONE..MONGOLIAN LETTER ALI GALI INVERTED UBADAMA
-	{runeRange{0x1885, 0x1886}, sbprExtend},    // Mn   [2] MONGOLIAN LETTER ALI GALI BALUDA..MONGOLIAN LETTER ALI GALI THREE BALUDA
-	{runeRange{0x1887, 0x18A8}, sbprOLetter},   // Lo  [34] MONGOLIAN LETTER ALI GALI A..MONGOLIAN LETTER MANCHU ALI GALI BHA
-	{runeRange{0x18A9, 0x18A9}, sbprExtend},    // Mn       MONGOLIAN LETTER ALI GALI DAGALGA
-	{runeRange{0x18AA, 0x18AA}, sbprOLetter},   // Lo       MONGOLIAN LETTER MANCHU ALI GALI LHA
-	{runeRange{0x18B0, 0x18F5}, sbprOLetter},   // Lo  [70] CANADIAN SYLLABICS OY..CANADIAN SYLLABICS CARRIER DENTAL S
-	{runeRange{0x1900, 0x191E}, sbprOLetter},   // Lo  [31] LIMBU VOWEL-CARRIER LETTER..LIMBU LETTER TRA
-	{runeRange{0x1920, 0x1922}, sbprExtend},    // Mn   [3] LIMBU VOWEL SIGN A..LIMBU VOWEL SIGN U
-	{runeRange{0x1923, 0x1926}, sbprExtend},    // Mc   [4] LIMBU VOWEL SIGN EE..LIMBU VOWEL SIGN AU
-	{runeRange{0x1927, 0x1928}, sbprExtend},    // Mn   [2] LIMBU VOWEL SIGN E..LIMBU VOWEL SIGN O
-	{runeRange{0x1929, 0x192B}, sbprExtend},    // Mc   [3] LIMBU SUBJOINED LETTER YA..LIMBU SUBJOINED LETTER WA
-	{runeRange{0x1930, 0x1931}, sbprExtend},    // Mc   [2] LIMBU SMALL LETTER KA..LIMBU SMALL LETTER NGA
-	{runeRange{0x1932, 0x1932}, sbprExtend},    // Mn       LIMBU SMALL LETTER ANUSVARA
-	{runeRange{0x1933, 0x1938}, sbprExtend},    // Mc   [6] LIMBU SMALL LETTER TA..LIMBU SMALL LETTER LA
-	{runeRange{0x1939, 0x193B}, sbprExtend},    // Mn   [3] LIMBU SIGN MUKPHRENG..LIMBU SIGN SA-I
-	{runeRange{0x1944, 0x1945}, sbprSTerm},     // Po   [2] LIMBU EXCLAMATION MARK..LIMBU QUESTION MARK
-	{runeRange{0x1946, 0x194F}, sbprNumeric},   // Nd  [10] LIMBU DIGIT ZERO..LIMBU DIGIT NINE
-	{runeRange{0x1950, 0x196D}, sbprOLetter},   // Lo  [30] TAI LE LETTER KA..TAI LE LETTER AI
-	{runeRange{0x1970, 0x1974}, sbprOLetter},   // Lo   [5] TAI LE LETTER TONE-2..TAI LE LETTER TONE-6
-	{runeRange{0x1980, 0x19AB}, sbprOLetter},   // Lo  [44] NEW TAI LUE LETTER HIGH QA..NEW TAI LUE LETTER LOW SUA
-	{runeRange{0x19B0, 0x19C9}, sbprOLetter},   // Lo  [26] NEW TAI LUE VOWEL SIGN VOWEL SHORTENER..NEW TAI LUE TONE MARK-2
-	{runeRange{0x19D0, 0x19D9}, sbprNumeric},   // Nd  [10] NEW TAI LUE DIGIT ZERO..NEW TAI LUE DIGIT NINE
-	{runeRange{0x1A00, 0x1A16}, sbprOLetter},   // Lo  [23] BUGINESE LETTER KA..BUGINESE LETTER HA
-	{runeRange{0x1A17, 0x1A18}, sbprExtend},    // Mn   [2] BUGINESE VOWEL SIGN I..BUGINESE VOWEL SIGN U
-	{runeRange{0x1A19, 0x1A1A}, sbprExtend},    // Mc   [2] BUGINESE VOWEL SIGN E..BUGINESE VOWEL SIGN O
-	{runeRange{0x1A1B, 0x1A1B}, sbprExtend},    // Mn       BUGINESE VOWEL SIGN AE
-	{runeRange{0x1A20, 0x1A54}, sbprOLetter},   // Lo  [53] TAI THAM LETTER HIGH KA..TAI THAM LETTER GREAT SA
-	{runeRange{0x1A55, 0x1A55}, sbprExtend},    // Mc       TAI THAM CONSONANT SIGN MEDIAL RA
-	{runeRange{0x1A56, 0x1A56}, sbprExtend},    // Mn       TAI THAM CONSONANT SIGN MEDIAL LA
-	{runeRange{0x1A57, 0x1A57}, sbprExtend},    // Mc       TAI THAM CONSONANT SIGN LA TANG LAI
-	{runeRange{0x1A58, 0x1A5E}, sbprExtend},    // Mn   [7] TAI THAM SIGN MAI KANG LAI..TAI THAM CONSONANT SIGN SA
-	{runeRange{0x1A60, 0x1A60}, sbprExtend},    // Mn       TAI THAM SIGN SAKOT
-	{runeRange{0x1A61, 0x1A61}, sbprExtend},    // Mc       TAI THAM VOWEL SIGN A
-	{runeRange{0x1A62, 0x1A62}, sbprExtend},    // Mn       TAI THAM VOWEL SIGN MAI SAT
-	{runeRange{0x1A63, 0x1A64}, sbprExtend},    // Mc   [2] TAI THAM VOWEL SIGN AA..TAI THAM VOWEL SIGN TALL AA
-	{runeRange{0x1A65, 0x1A6C}, sbprExtend},    // Mn   [8] TAI THAM VOWEL SIGN I..TAI THAM VOWEL SIGN OA BELOW
-	{runeRange{0x1A6D, 0x1A72}, sbprExtend},    // Mc   [6] TAI THAM VOWEL SIGN OY..TAI THAM VOWEL SIGN THAM AI
-	{runeRange{0x1A73, 0x1A7C}, sbprExtend},    // Mn  [10] TAI THAM VOWEL SIGN OA ABOVE..TAI THAM SIGN KHUEN-LUE KARAN
-	{runeRange{0x1A7F, 0x1A7F}, sbprExtend},    // Mn       TAI THAM COMBINING CRYPTOGRAMMIC DOT
-	{runeRange{0x1A80, 0x1A89}, sbprNumeric},   // Nd  [10] TAI THAM HORA DIGIT ZERO..TAI THAM HORA DIGIT NINE
-	{runeRange{0x1A90, 0x1A99}, sbprNumeric},   // Nd  [10] TAI THAM THAM DIGIT ZERO..TAI THAM THAM DIGIT NINE
-	{runeRange{0x1AA7, 0x1AA7}, sbprOLetter},   // Lm       TAI THAM SIGN MAI YAMOK
-	{runeRange{0x1AA8, 0x1AAB}, sbprSTerm},     // Po   [4] TAI THAM SIGN KAAN..TAI THAM SIGN SATKAANKUU
-	{runeRange{0x1AB0, 0x1ABD}, sbprExtend},    // Mn  [14] COMBINING DOUBLED CIRCUMFLEX ACCENT..COMBINING PARENTHESES BELOW
-	{runeRange{0x1ABE, 0x1ABE}, sbprExtend},    // Me       COMBINING PARENTHESES OVERLAY
-	{runeRange{0x1ABF, 0x1ACE}, sbprExtend},    // Mn  [16] COMBINING LATIN SMALL LETTER W BELOW..COMBINING LATIN SMALL LETTER INSULAR T
-	{runeRange{0x1B00, 0x1B03}, sbprExtend},    // Mn   [4] BALINESE SIGN ULU RICEM..BALINESE SIGN SURANG
-	{runeRange{0x1B04, 0x1B04}, sbprExtend},    // Mc       BALINESE SIGN BISAH
-	{runeRange{0x1B05, 0x1B33}, sbprOLetter},   // Lo  [47] BALINESE LETTER AKARA..BALINESE LETTER HA
-	{runeRange{0x1B34, 0x1B34}, sbprExtend},    // Mn       BALINESE SIGN REREKAN
-	{runeRange{0x1B35, 0x1B35}, sbprExtend},    // Mc       BALINESE VOWEL SIGN TEDUNG
-	{runeRange{0x1B36, 0x1B3A}, sbprExtend},    // Mn   [5] BALINESE VOWEL SIGN ULU..BALINESE VOWEL SIGN RA REPA
-	{runeRange{0x1B3B, 0x1B3B}, sbprExtend},    // Mc       BALINESE VOWEL SIGN RA REPA TEDUNG
-	{runeRange{0x1B3C, 0x1B3C}, sbprExtend},    // Mn       BALINESE VOWEL SIGN LA LENGA
-	{runeRange{0x1B3D, 0x1B41}, sbprExtend},    // Mc   [5] BALINESE VOWEL SIGN LA LENGA TEDUNG..BALINESE VOWEL SIGN TALING REPA TEDUNG
-	{runeRange{0x1B42, 0x1B42}, sbprExtend},    // Mn       BALINESE VOWEL SIGN PEPET
-	{runeRange{0x1B43, 0x1B44}, sbprExtend},    // Mc   [2] BALINESE VOWEL SIGN PEPET TEDUNG..BALINESE ADEG ADEG
-	{runeRange{0x1B45, 0x1B4C}, sbprOLetter},   // Lo   [8] BALINESE LETTER KAF SASAK..BALINESE LETTER ARCHAIC JNYA
-	{runeRange{0x1B50, 0x1B59}, sbprNumeric},   // Nd  [10] BALINESE DIGIT ZERO..BALINESE DIGIT NINE
-	{runeRange{0x1B5A, 0x1B5B}, sbprSTerm},     // Po   [2] BALINESE PANTI..BALINESE PAMADA
-	{runeRange{0x1B5E, 0x1B5F}, sbprSTerm},     // Po   [2] BALINESE CARIK SIKI..BALINESE CARIK PAREREN
-	{runeRange{0x1B6B, 0x1B73}, sbprExtend},    // Mn   [9] BALINESE MUSICAL SYMBOL COMBINING TEGEH..BALINESE MUSICAL SYMBOL COMBINING GONG
-	{runeRange{0x1B7D, 0x1B7E}, sbprSTerm},     // Po   [2] BALINESE PANTI LANTANG..BALINESE PAMADA LANTANG
-	{runeRange{0x1B80, 0x1B81}, sbprExtend},    // Mn   [2] SUNDANESE SIGN PANYECEK..SUNDANESE SIGN PANGLAYAR
-	{runeRange{0x1B82, 0x1B82}, sbprExtend},    // Mc       SUNDANESE SIGN PANGWISAD
-	{runeRange{0x1B83, 0x1BA0}, sbprOLetter},   // Lo  [30] SUNDANESE LETTER A..SUNDANESE LETTER HA
-	{runeRange{0x1BA1, 0x1BA1}, sbprExtend},    // Mc       SUNDANESE CONSONANT SIGN PAMINGKAL
-	{runeRange{0x1BA2, 0x1BA5}, sbprExtend},    // Mn   [4] SUNDANESE CONSONANT SIGN PANYAKRA..SUNDANESE VOWEL SIGN PANYUKU
-	{runeRange{0x1BA6, 0x1BA7}, sbprExtend},    // Mc   [2] SUNDANESE VOWEL SIGN PANAELAENG..SUNDANESE VOWEL SIGN PANOLONG
-	{runeRange{0x1BA8, 0x1BA9}, sbprExtend},    // Mn   [2] SUNDANESE VOWEL SIGN PAMEPET..SUNDANESE VOWEL SIGN PANEULEUNG
-	{runeRange{0x1BAA, 0x1BAA}, sbprExtend},    // Mc       SUNDANESE SIGN PAMAAEH
-	{runeRange{0x1BAB, 0x1BAD}, sbprExtend},    // Mn   [3] SUNDANESE SIGN VIRAMA..SUNDANESE CONSONANT SIGN PASANGAN WA
-	{runeRange{0x1BAE, 0x1BAF}, sbprOLetter},   // Lo   [2] SUNDANESE LETTER KHA..SUNDANESE LETTER SYA
-	{runeRange{0x1BB0, 0x1BB9}, sbprNumeric},   // Nd  [10] SUNDANESE DIGIT ZERO..SUNDANESE DIGIT NINE
-	{runeRange{0x1BBA, 0x1BE5}, sbprOLetter},   // Lo  [44] SUNDANESE AVAGRAHA..BATAK LETTER U
-	{runeRange{0x1BE6, 0x1BE6}, sbprExtend},    // Mn       BATAK SIGN TOMPI
-	{runeRange{0x1BE7, 0x1BE7}, sbprExtend},    // Mc       BATAK VOWEL SIGN E
-	{runeRange{0x1BE8, 0x1BE9}, sbprExtend},    // Mn   [2] BATAK VOWEL SIGN PAKPAK E..BATAK VOWEL SIGN EE
-	{runeRange{0x1BEA, 0x1BEC}, sbprExtend},    // Mc   [3] BATAK VOWEL SIGN I..BATAK VOWEL SIGN O
-	{runeRange{0x1BED, 0x1BED}, sbprExtend},    // Mn       BATAK VOWEL SIGN KARO O
-	{runeRange{0x1BEE, 0x1BEE}, sbprExtend},    // Mc       BATAK VOWEL SIGN U
-	{runeRange{0x1BEF, 0x1BF1}, sbprExtend},    // Mn   [3] BATAK VOWEL SIGN U FOR SIMALUNGUN SA..BATAK CONSONANT SIGN H
-	{runeRange{0x1BF2, 0x1BF3}, sbprExtend},    // Mc   [2] BATAK PANGOLAT..BATAK PANONGONAN
-	{runeRange{0x1C00, 0x1C23}, sbprOLetter},   // Lo  [36] LEPCHA LETTER KA..LEPCHA LETTER A
-	{runeRange{0x1C24, 0x1C2B}, sbprExtend},    // Mc   [8] LEPCHA SUBJOINED LETTER YA..LEPCHA VOWEL SIGN UU
-	{runeRange{0x1C2C, 0x1C33}, sbprExtend},    // Mn   [8] LEPCHA VOWEL SIGN E..LEPCHA CONSONANT SIGN T
-	{runeRange{0x1C34, 0x1C35}, sbprExtend},    // Mc   [2] LEPCHA CONSONANT SIGN NYIN-DO..LEPCHA CONSONANT SIGN KANG
-	{runeRange{0x1C36, 0x1C37}, sbprExtend},    // Mn   [2] LEPCHA SIGN RAN..LEPCHA SIGN NUKTA
-	{runeRange{0x1C3B, 0x1C3C}, sbprSTerm},     // Po   [2] LEPCHA PUNCTUATION TA-ROL..LEPCHA PUNCTUATION NYET THYOOM TA-ROL
-	{runeRange{0x1C40, 0x1C49}, sbprNumeric},   // Nd  [10] LEPCHA DIGIT ZERO..LEPCHA DIGIT NINE
-	{runeRange{0x1C4D, 0x1C4F}, sbprOLetter},   // Lo   [3] LEPCHA LETTER TTA..LEPCHA LETTER DDA
-	{runeRange{0x1C50, 0x1C59}, sbprNumeric},   // Nd  [10] OL CHIKI DIGIT ZERO..OL CHIKI DIGIT NINE
-	{runeRange{0x1C5A, 0x1C77}, sbprOLetter},   // Lo  [30] OL CHIKI LETTER LA..OL CHIKI LETTER OH
-	{runeRange{0x1C78, 0x1C7D}, sbprOLetter},   // Lm   [6] OL CHIKI MU TTUDDAG..OL CHIKI AHAD
-	{runeRange{0x1C7E, 0x1C7F}, sbprSTerm},     // Po   [2] OL CHIKI PUNCTUATION MUCAAD..OL CHIKI PUNCTUATION DOUBLE MUCAAD
-	{runeRange{0x1C80, 0x1C88}, sbprLower},     // L&   [9] CYRILLIC SMALL LETTER ROUNDED VE..CYRILLIC SMALL LETTER UNBLENDED UK
-	{runeRange{0x1C90, 0x1CBA}, sbprOLetter},   // L&  [43] GEORGIAN MTAVRULI CAPITAL LETTER AN..GEORGIAN MTAVRULI CAPITAL LETTER AIN
-	{runeRange{0x1CBD, 0x1CBF}, sbprOLetter},   // L&   [3] GEORGIAN MTAVRULI CAPITAL LETTER AEN..GEORGIAN MTAVRULI CAPITAL LETTER LABIAL SIGN
-	{runeRange{0x1CD0, 0x1CD2}, sbprExtend},    // Mn   [3] VEDIC TONE KARSHANA..VEDIC TONE PRENKHA
-	{runeRange{0x1CD4, 0x1CE0}, sbprExtend},    // Mn  [13] VEDIC SIGN YAJURVEDIC MIDLINE SVARITA..VEDIC TONE RIGVEDIC KASHMIRI INDEPENDENT SVARITA
-	{runeRange{0x1CE1, 0x1CE1}, sbprExtend},    // Mc       VEDIC TONE ATHARVAVEDIC INDEPENDENT SVARITA
-	{runeRange{0x1CE2, 0x1CE8}, sbprExtend},    // Mn   [7] VEDIC SIGN VISARGA SVARITA..VEDIC SIGN VISARGA ANUDATTA WITH TAIL
-	{runeRange{0x1CE9, 0x1CEC}, sbprOLetter},   // Lo   [4] VEDIC SIGN ANUSVARA ANTARGOMUKHA..VEDIC SIGN ANUSVARA VAMAGOMUKHA WITH TAIL
-	{runeRange{0x1CED, 0x1CED}, sbprExtend},    // Mn       VEDIC SIGN TIRYAK
-	{runeRange{0x1CEE, 0x1CF3}, sbprOLetter},   // Lo   [6] VEDIC SIGN HEXIFORM LONG ANUSVARA..VEDIC SIGN ROTATED ARDHAVISARGA
-	{runeRange{0x1CF4, 0x1CF4}, sbprExtend},    // Mn       VEDIC TONE CANDRA ABOVE
-	{runeRange{0x1CF5, 0x1CF6}, sbprOLetter},   // Lo   [2] VEDIC SIGN JIHVAMULIYA..VEDIC SIGN UPADHMANIYA
-	{runeRange{0x1CF7, 0x1CF7}, sbprExtend},    // Mc       VEDIC SIGN ATIKRAMA
-	{runeRange{0x1CF8, 0x1CF9}, sbprExtend},    // Mn   [2] VEDIC TONE RING ABOVE..VEDIC TONE DOUBLE RING ABOVE
-	{runeRange{0x1CFA, 0x1CFA}, sbprOLetter},   // Lo       VEDIC SIGN DOUBLE ANUSVARA ANTARGOMUKHA
-	{runeRange{0x1D00, 0x1D2B}, sbprLower},     // L&  [44] LATIN LETTER SMALL CAPITAL A..CYRILLIC LETTER SMALL CAPITAL EL
-	{runeRange{0x1D2C, 0x1D6A}, sbprLower},     // Lm  [63] MODIFIER LETTER CAPITAL A..GREEK SUBSCRIPT SMALL LETTER CHI
-	{runeRange{0x1D6B, 0x1D77}, sbprLower},     // L&  [13] LATIN SMALL LETTER UE..LATIN SMALL LETTER TURNED G
-	{runeRange{0x1D78, 0x1D78}, sbprLower},     // Lm       MODIFIER LETTER CYRILLIC EN
-	{runeRange{0x1D79, 0x1D9A}, sbprLower},     // L&  [34] LATIN SMALL LETTER INSULAR G..LATIN SMALL LETTER EZH WITH RETROFLEX HOOK
-	{runeRange{0x1D9B, 0x1DBF}, sbprLower},     // Lm  [37] MODIFIER LETTER SMALL TURNED ALPHA..MODIFIER LETTER SMALL THETA
-	{runeRange{0x1DC0, 0x1DFF}, sbprExtend},    // Mn  [64] COMBINING DOTTED GRAVE ACCENT..COMBINING RIGHT ARROWHEAD AND DOWN ARROWHEAD BELOW
-	{runeRange{0x1E00, 0x1E00}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH RING BELOW
-	{runeRange{0x1E01, 0x1E01}, sbprLower},     // L&       LATIN SMALL LETTER A WITH RING BELOW
-	{runeRange{0x1E02, 0x1E02}, sbprUpper},     // L&       LATIN CAPITAL LETTER B WITH DOT ABOVE
-	{runeRange{0x1E03, 0x1E03}, sbprLower},     // L&       LATIN SMALL LETTER B WITH DOT ABOVE
-	{runeRange{0x1E04, 0x1E04}, sbprUpper},     // L&       LATIN CAPITAL LETTER B WITH DOT BELOW
-	{runeRange{0x1E05, 0x1E05}, sbprLower},     // L&       LATIN SMALL LETTER B WITH DOT BELOW
-	{runeRange{0x1E06, 0x1E06}, sbprUpper},     // L&       LATIN CAPITAL LETTER B WITH LINE BELOW
-	{runeRange{0x1E07, 0x1E07}, sbprLower},     // L&       LATIN SMALL LETTER B WITH LINE BELOW
-	{runeRange{0x1E08, 0x1E08}, sbprUpper},     // L&       LATIN CAPITAL LETTER C WITH CEDILLA AND ACUTE
-	{runeRange{0x1E09, 0x1E09}, sbprLower},     // L&       LATIN SMALL LETTER C WITH CEDILLA AND ACUTE
-	{runeRange{0x1E0A, 0x1E0A}, sbprUpper},     // L&       LATIN CAPITAL LETTER D WITH DOT ABOVE
-	{runeRange{0x1E0B, 0x1E0B}, sbprLower},     // L&       LATIN SMALL LETTER D WITH DOT ABOVE
-	{runeRange{0x1E0C, 0x1E0C}, sbprUpper},     // L&       LATIN CAPITAL LETTER D WITH DOT BELOW
-	{runeRange{0x1E0D, 0x1E0D}, sbprLower},     // L&       LATIN SMALL LETTER D WITH DOT BELOW
-	{runeRange{0x1E0E, 0x1E0E}, sbprUpper},     // L&       LATIN CAPITAL LETTER D WITH LINE BELOW
-	{runeRange{0x1E0F, 0x1E0F}, sbprLower},     // L&       LATIN SMALL LETTER D WITH LINE BELOW
-	{runeRange{0x1E10, 0x1E10}, sbprUpper},     // L&       LATIN CAPITAL LETTER D WITH CEDILLA
-	{runeRange{0x1E11, 0x1E11}, sbprLower},     // L&       LATIN SMALL LETTER D WITH CEDILLA
-	{runeRange{0x1E12, 0x1E12}, sbprUpper},     // L&       LATIN CAPITAL LETTER D WITH CIRCUMFLEX BELOW
-	{runeRange{0x1E13, 0x1E13}, sbprLower},     // L&       LATIN SMALL LETTER D WITH CIRCUMFLEX BELOW
-	{runeRange{0x1E14, 0x1E14}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH MACRON AND GRAVE
-	{runeRange{0x1E15, 0x1E15}, sbprLower},     // L&       LATIN SMALL LETTER E WITH MACRON AND GRAVE
-	{runeRange{0x1E16, 0x1E16}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH MACRON AND ACUTE
-	{runeRange{0x1E17, 0x1E17}, sbprLower},     // L&       LATIN SMALL LETTER E WITH MACRON AND ACUTE
-	{runeRange{0x1E18, 0x1E18}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH CIRCUMFLEX BELOW
-	{runeRange{0x1E19, 0x1E19}, sbprLower},     // L&       LATIN SMALL LETTER E WITH CIRCUMFLEX BELOW
-	{runeRange{0x1E1A, 0x1E1A}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH TILDE BELOW
-	{runeRange{0x1E1B, 0x1E1B}, sbprLower},     // L&       LATIN SMALL LETTER E WITH TILDE BELOW
-	{runeRange{0x1E1C, 0x1E1C}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH CEDILLA AND BREVE
-	{runeRange{0x1E1D, 0x1E1D}, sbprLower},     // L&       LATIN SMALL LETTER E WITH CEDILLA AND BREVE
-	{runeRange{0x1E1E, 0x1E1E}, sbprUpper},     // L&       LATIN CAPITAL LETTER F WITH DOT ABOVE
-	{runeRange{0x1E1F, 0x1E1F}, sbprLower},     // L&       LATIN SMALL LETTER F WITH DOT ABOVE
-	{runeRange{0x1E20, 0x1E20}, sbprUpper},     // L&       LATIN CAPITAL LETTER G WITH MACRON
-	{runeRange{0x1E21, 0x1E21}, sbprLower},     // L&       LATIN SMALL LETTER G WITH MACRON
-	{runeRange{0x1E22, 0x1E22}, sbprUpper},     // L&       LATIN CAPITAL LETTER H WITH DOT ABOVE
-	{runeRange{0x1E23, 0x1E23}, sbprLower},     // L&       LATIN SMALL LETTER H WITH DOT ABOVE
-	{runeRange{0x1E24, 0x1E24}, sbprUpper},     // L&       LATIN CAPITAL LETTER H WITH DOT BELOW
-	{runeRange{0x1E25, 0x1E25}, sbprLower},     // L&       LATIN SMALL LETTER H WITH DOT BELOW
-	{runeRange{0x1E26, 0x1E26}, sbprUpper},     // L&       LATIN CAPITAL LETTER H WITH DIAERESIS
-	{runeRange{0x1E27, 0x1E27}, sbprLower},     // L&       LATIN SMALL LETTER H WITH DIAERESIS
-	{runeRange{0x1E28, 0x1E28}, sbprUpper},     // L&       LATIN CAPITAL LETTER H WITH CEDILLA
-	{runeRange{0x1E29, 0x1E29}, sbprLower},     // L&       LATIN SMALL LETTER H WITH CEDILLA
-	{runeRange{0x1E2A, 0x1E2A}, sbprUpper},     // L&       LATIN CAPITAL LETTER H WITH BREVE BELOW
-	{runeRange{0x1E2B, 0x1E2B}, sbprLower},     // L&       LATIN SMALL LETTER H WITH BREVE BELOW
-	{runeRange{0x1E2C, 0x1E2C}, sbprUpper},     // L&       LATIN CAPITAL LETTER I WITH TILDE BELOW
-	{runeRange{0x1E2D, 0x1E2D}, sbprLower},     // L&       LATIN SMALL LETTER I WITH TILDE BELOW
-	{runeRange{0x1E2E, 0x1E2E}, sbprUpper},     // L&       LATIN CAPITAL LETTER I WITH DIAERESIS AND ACUTE
-	{runeRange{0x1E2F, 0x1E2F}, sbprLower},     // L&       LATIN SMALL LETTER I WITH DIAERESIS AND ACUTE
-	{runeRange{0x1E30, 0x1E30}, sbprUpper},     // L&       LATIN CAPITAL LETTER K WITH ACUTE
-	{runeRange{0x1E31, 0x1E31}, sbprLower},     // L&       LATIN SMALL LETTER K WITH ACUTE
-	{runeRange{0x1E32, 0x1E32}, sbprUpper},     // L&       LATIN CAPITAL LETTER K WITH DOT BELOW
-	{runeRange{0x1E33, 0x1E33}, sbprLower},     // L&       LATIN SMALL LETTER K WITH DOT BELOW
-	{runeRange{0x1E34, 0x1E34}, sbprUpper},     // L&       LATIN CAPITAL LETTER K WITH LINE BELOW
-	{runeRange{0x1E35, 0x1E35}, sbprLower},     // L&       LATIN SMALL LETTER K WITH LINE BELOW
-	{runeRange{0x1E36, 0x1E36}, sbprUpper},     // L&       LATIN CAPITAL LETTER L WITH DOT BELOW
-	{runeRange{0x1E37, 0x1E37}, sbprLower},     // L&       LATIN SMALL LETTER L WITH DOT BELOW
-	{runeRange{0x1E38, 0x1E38}, sbprUpper},     // L&       LATIN CAPITAL LETTER L WITH DOT BELOW AND MACRON
-	{runeRange{0x1E39, 0x1E39}, sbprLower},     // L&       LATIN SMALL LETTER L WITH DOT BELOW AND MACRON
-	{runeRange{0x1E3A, 0x1E3A}, sbprUpper},     // L&       LATIN CAPITAL LETTER L WITH LINE BELOW
-	{runeRange{0x1E3B, 0x1E3B}, sbprLower},     // L&       LATIN SMALL LETTER L WITH LINE BELOW
-	{runeRange{0x1E3C, 0x1E3C}, sbprUpper},     // L&       LATIN CAPITAL LETTER L WITH CIRCUMFLEX BELOW
-	{runeRange{0x1E3D, 0x1E3D}, sbprLower},     // L&       LATIN SMALL LETTER L WITH CIRCUMFLEX BELOW
-	{runeRange{0x1E3E, 0x1E3E}, sbprUpper},     // L&       LATIN CAPITAL LETTER M WITH ACUTE
-	{runeRange{0x1E3F, 0x1E3F}, sbprLower},     // L&       LATIN SMALL LETTER M WITH ACUTE
-	{runeRange{0x1E40, 0x1E40}, sbprUpper},     // L&       LATIN CAPITAL LETTER M WITH DOT ABOVE
-	{runeRange{0x1E41, 0x1E41}, sbprLower},     // L&       LATIN SMALL LETTER M WITH DOT ABOVE
-	{runeRange{0x1E42, 0x1E42}, sbprUpper},     // L&       LATIN CAPITAL LETTER M WITH DOT BELOW
-	{runeRange{0x1E43, 0x1E43}, sbprLower},     // L&       LATIN SMALL LETTER M WITH DOT BELOW
-	{runeRange{0x1E44, 0x1E44}, sbprUpper},     // L&       LATIN CAPITAL LETTER N WITH DOT ABOVE
-	{runeRange{0x1E45, 0x1E45}, sbprLower},     // L&       LATIN SMALL LETTER N WITH DOT ABOVE
-	{runeRange{0x1E46, 0x1E46}, sbprUpper},     // L&       LATIN CAPITAL LETTER N WITH DOT BELOW
-	{runeRange{0x1E47, 0x1E47}, sbprLower},     // L&       LATIN SMALL LETTER N WITH DOT BELOW
-	{runeRange{0x1E48, 0x1E48}, sbprUpper},     // L&       LATIN CAPITAL LETTER N WITH LINE BELOW
-	{runeRange{0x1E49, 0x1E49}, sbprLower},     // L&       LATIN SMALL LETTER N WITH LINE BELOW
-	{runeRange{0x1E4A, 0x1E4A}, sbprUpper},     // L&       LATIN CAPITAL LETTER N WITH CIRCUMFLEX BELOW
-	{runeRange{0x1E4B, 0x1E4B}, sbprLower},     // L&       LATIN SMALL LETTER N WITH CIRCUMFLEX BELOW
-	{runeRange{0x1E4C, 0x1E4C}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH TILDE AND ACUTE
-	{runeRange{0x1E4D, 0x1E4D}, sbprLower},     // L&       LATIN SMALL LETTER O WITH TILDE AND ACUTE
-	{runeRange{0x1E4E, 0x1E4E}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH TILDE AND DIAERESIS
-	{runeRange{0x1E4F, 0x1E4F}, sbprLower},     // L&       LATIN SMALL LETTER O WITH TILDE AND DIAERESIS
-	{runeRange{0x1E50, 0x1E50}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH MACRON AND GRAVE
-	{runeRange{0x1E51, 0x1E51}, sbprLower},     // L&       LATIN SMALL LETTER O WITH MACRON AND GRAVE
-	{runeRange{0x1E52, 0x1E52}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH MACRON AND ACUTE
-	{runeRange{0x1E53, 0x1E53}, sbprLower},     // L&       LATIN SMALL LETTER O WITH MACRON AND ACUTE
-	{runeRange{0x1E54, 0x1E54}, sbprUpper},     // L&       LATIN CAPITAL LETTER P WITH ACUTE
-	{runeRange{0x1E55, 0x1E55}, sbprLower},     // L&       LATIN SMALL LETTER P WITH ACUTE
-	{runeRange{0x1E56, 0x1E56}, sbprUpper},     // L&       LATIN CAPITAL LETTER P WITH DOT ABOVE
-	{runeRange{0x1E57, 0x1E57}, sbprLower},     // L&       LATIN SMALL LETTER P WITH DOT ABOVE
-	{runeRange{0x1E58, 0x1E58}, sbprUpper},     // L&       LATIN CAPITAL LETTER R WITH DOT ABOVE
-	{runeRange{0x1E59, 0x1E59}, sbprLower},     // L&       LATIN SMALL LETTER R WITH DOT ABOVE
-	{runeRange{0x1E5A, 0x1E5A}, sbprUpper},     // L&       LATIN CAPITAL LETTER R WITH DOT BELOW
-	{runeRange{0x1E5B, 0x1E5B}, sbprLower},     // L&       LATIN SMALL LETTER R WITH DOT BELOW
-	{runeRange{0x1E5C, 0x1E5C}, sbprUpper},     // L&       LATIN CAPITAL LETTER R WITH DOT BELOW AND MACRON
-	{runeRange{0x1E5D, 0x1E5D}, sbprLower},     // L&       LATIN SMALL LETTER R WITH DOT BELOW AND MACRON
-	{runeRange{0x1E5E, 0x1E5E}, sbprUpper},     // L&       LATIN CAPITAL LETTER R WITH LINE BELOW
-	{runeRange{0x1E5F, 0x1E5F}, sbprLower},     // L&       LATIN SMALL LETTER R WITH LINE BELOW
-	{runeRange{0x1E60, 0x1E60}, sbprUpper},     // L&       LATIN CAPITAL LETTER S WITH DOT ABOVE
-	{runeRange{0x1E61, 0x1E61}, sbprLower},     // L&       LATIN SMALL LETTER S WITH DOT ABOVE
-	{runeRange{0x1E62, 0x1E62}, sbprUpper},     // L&       LATIN CAPITAL LETTER S WITH DOT BELOW
-	{runeRange{0x1E63, 0x1E63}, sbprLower},     // L&       LATIN SMALL LETTER S WITH DOT BELOW
-	{runeRange{0x1E64, 0x1E64}, sbprUpper},     // L&       LATIN CAPITAL LETTER S WITH ACUTE AND DOT ABOVE
-	{runeRange{0x1E65, 0x1E65}, sbprLower},     // L&       LATIN SMALL LETTER S WITH ACUTE AND DOT ABOVE
-	{runeRange{0x1E66, 0x1E66}, sbprUpper},     // L&       LATIN CAPITAL LETTER S WITH CARON AND DOT ABOVE
-	{runeRange{0x1E67, 0x1E67}, sbprLower},     // L&       LATIN SMALL LETTER S WITH CARON AND DOT ABOVE
-	{runeRange{0x1E68, 0x1E68}, sbprUpper},     // L&       LATIN CAPITAL LETTER S WITH DOT BELOW AND DOT ABOVE
-	{runeRange{0x1E69, 0x1E69}, sbprLower},     // L&       LATIN SMALL LETTER S WITH DOT BELOW AND DOT ABOVE
-	{runeRange{0x1E6A, 0x1E6A}, sbprUpper},     // L&       LATIN CAPITAL LETTER T WITH DOT ABOVE
-	{runeRange{0x1E6B, 0x1E6B}, sbprLower},     // L&       LATIN SMALL LETTER T WITH DOT ABOVE
-	{runeRange{0x1E6C, 0x1E6C}, sbprUpper},     // L&       LATIN CAPITAL LETTER T WITH DOT BELOW
-	{runeRange{0x1E6D, 0x1E6D}, sbprLower},     // L&       LATIN SMALL LETTER T WITH DOT BELOW
-	{runeRange{0x1E6E, 0x1E6E}, sbprUpper},     // L&       LATIN CAPITAL LETTER T WITH LINE BELOW
-	{runeRange{0x1E6F, 0x1E6F}, sbprLower},     // L&       LATIN SMALL LETTER T WITH LINE BELOW
-	{runeRange{0x1E70, 0x1E70}, sbprUpper},     // L&       LATIN CAPITAL LETTER T WITH CIRCUMFLEX BELOW
-	{runeRange{0x1E71, 0x1E71}, sbprLower},     // L&       LATIN SMALL LETTER T WITH CIRCUMFLEX BELOW
-	{runeRange{0x1E72, 0x1E72}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH DIAERESIS BELOW
-	{runeRange{0x1E73, 0x1E73}, sbprLower},     // L&       LATIN SMALL LETTER U WITH DIAERESIS BELOW
-	{runeRange{0x1E74, 0x1E74}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH TILDE BELOW
-	{runeRange{0x1E75, 0x1E75}, sbprLower},     // L&       LATIN SMALL LETTER U WITH TILDE BELOW
-	{runeRange{0x1E76, 0x1E76}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH CIRCUMFLEX BELOW
-	{runeRange{0x1E77, 0x1E77}, sbprLower},     // L&       LATIN SMALL LETTER U WITH CIRCUMFLEX BELOW
-	{runeRange{0x1E78, 0x1E78}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH TILDE AND ACUTE
-	{runeRange{0x1E79, 0x1E79}, sbprLower},     // L&       LATIN SMALL LETTER U WITH TILDE AND ACUTE
-	{runeRange{0x1E7A, 0x1E7A}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH MACRON AND DIAERESIS
-	{runeRange{0x1E7B, 0x1E7B}, sbprLower},     // L&       LATIN SMALL LETTER U WITH MACRON AND DIAERESIS
-	{runeRange{0x1E7C, 0x1E7C}, sbprUpper},     // L&       LATIN CAPITAL LETTER V WITH TILDE
-	{runeRange{0x1E7D, 0x1E7D}, sbprLower},     // L&       LATIN SMALL LETTER V WITH TILDE
-	{runeRange{0x1E7E, 0x1E7E}, sbprUpper},     // L&       LATIN CAPITAL LETTER V WITH DOT BELOW
-	{runeRange{0x1E7F, 0x1E7F}, sbprLower},     // L&       LATIN SMALL LETTER V WITH DOT BELOW
-	{runeRange{0x1E80, 0x1E80}, sbprUpper},     // L&       LATIN CAPITAL LETTER W WITH GRAVE
-	{runeRange{0x1E81, 0x1E81}, sbprLower},     // L&       LATIN SMALL LETTER W WITH GRAVE
-	{runeRange{0x1E82, 0x1E82}, sbprUpper},     // L&       LATIN CAPITAL LETTER W WITH ACUTE
-	{runeRange{0x1E83, 0x1E83}, sbprLower},     // L&       LATIN SMALL LETTER W WITH ACUTE
-	{runeRange{0x1E84, 0x1E84}, sbprUpper},     // L&       LATIN CAPITAL LETTER W WITH DIAERESIS
-	{runeRange{0x1E85, 0x1E85}, sbprLower},     // L&       LATIN SMALL LETTER W WITH DIAERESIS
-	{runeRange{0x1E86, 0x1E86}, sbprUpper},     // L&       LATIN CAPITAL LETTER W WITH DOT ABOVE
-	{runeRange{0x1E87, 0x1E87}, sbprLower},     // L&       LATIN SMALL LETTER W WITH DOT ABOVE
-	{runeRange{0x1E88, 0x1E88}, sbprUpper},     // L&       LATIN CAPITAL LETTER W WITH DOT BELOW
-	{runeRange{0x1E89, 0x1E89}, sbprLower},     // L&       LATIN SMALL LETTER W WITH DOT BELOW
-	{runeRange{0x1E8A, 0x1E8A}, sbprUpper},     // L&       LATIN CAPITAL LETTER X WITH DOT ABOVE
-	{runeRange{0x1E8B, 0x1E8B}, sbprLower},     // L&       LATIN SMALL LETTER X WITH DOT ABOVE
-	{runeRange{0x1E8C, 0x1E8C}, sbprUpper},     // L&       LATIN CAPITAL LETTER X WITH DIAERESIS
-	{runeRange{0x1E8D, 0x1E8D}, sbprLower},     // L&       LATIN SMALL LETTER X WITH DIAERESIS
-	{runeRange{0x1E8E, 0x1E8E}, sbprUpper},     // L&       LATIN CAPITAL LETTER Y WITH DOT ABOVE
-	{runeRange{0x1E8F, 0x1E8F}, sbprLower},     // L&       LATIN SMALL LETTER Y WITH DOT ABOVE
-	{runeRange{0x1E90, 0x1E90}, sbprUpper},     // L&       LATIN CAPITAL LETTER Z WITH CIRCUMFLEX
-	{runeRange{0x1E91, 0x1E91}, sbprLower},     // L&       LATIN SMALL LETTER Z WITH CIRCUMFLEX
-	{runeRange{0x1E92, 0x1E92}, sbprUpper},     // L&       LATIN CAPITAL LETTER Z WITH DOT BELOW
-	{runeRange{0x1E93, 0x1E93}, sbprLower},     // L&       LATIN SMALL LETTER Z WITH DOT BELOW
-	{runeRange{0x1E94, 0x1E94}, sbprUpper},     // L&       LATIN CAPITAL LETTER Z WITH LINE BELOW
-	{runeRange{0x1E95, 0x1E9D}, sbprLower},     // L&   [9] LATIN SMALL LETTER Z WITH LINE BELOW..LATIN SMALL LETTER LONG S WITH HIGH STROKE
-	{runeRange{0x1E9E, 0x1E9E}, sbprUpper},     // L&       LATIN CAPITAL LETTER SHARP S
-	{runeRange{0x1E9F, 0x1E9F}, sbprLower},     // L&       LATIN SMALL LETTER DELTA
-	{runeRange{0x1EA0, 0x1EA0}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH DOT BELOW
-	{runeRange{0x1EA1, 0x1EA1}, sbprLower},     // L&       LATIN SMALL LETTER A WITH DOT BELOW
-	{runeRange{0x1EA2, 0x1EA2}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH HOOK ABOVE
-	{runeRange{0x1EA3, 0x1EA3}, sbprLower},     // L&       LATIN SMALL LETTER A WITH HOOK ABOVE
-	{runeRange{0x1EA4, 0x1EA4}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH CIRCUMFLEX AND ACUTE
-	{runeRange{0x1EA5, 0x1EA5}, sbprLower},     // L&       LATIN SMALL LETTER A WITH CIRCUMFLEX AND ACUTE
-	{runeRange{0x1EA6, 0x1EA6}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH CIRCUMFLEX AND GRAVE
-	{runeRange{0x1EA7, 0x1EA7}, sbprLower},     // L&       LATIN SMALL LETTER A WITH CIRCUMFLEX AND GRAVE
-	{runeRange{0x1EA8, 0x1EA8}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH CIRCUMFLEX AND HOOK ABOVE
-	{runeRange{0x1EA9, 0x1EA9}, sbprLower},     // L&       LATIN SMALL LETTER A WITH CIRCUMFLEX AND HOOK ABOVE
-	{runeRange{0x1EAA, 0x1EAA}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH CIRCUMFLEX AND TILDE
-	{runeRange{0x1EAB, 0x1EAB}, sbprLower},     // L&       LATIN SMALL LETTER A WITH CIRCUMFLEX AND TILDE
-	{runeRange{0x1EAC, 0x1EAC}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH CIRCUMFLEX AND DOT BELOW
-	{runeRange{0x1EAD, 0x1EAD}, sbprLower},     // L&       LATIN SMALL LETTER A WITH CIRCUMFLEX AND DOT BELOW
-	{runeRange{0x1EAE, 0x1EAE}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH BREVE AND ACUTE
-	{runeRange{0x1EAF, 0x1EAF}, sbprLower},     // L&       LATIN SMALL LETTER A WITH BREVE AND ACUTE
-	{runeRange{0x1EB0, 0x1EB0}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH BREVE AND GRAVE
-	{runeRange{0x1EB1, 0x1EB1}, sbprLower},     // L&       LATIN SMALL LETTER A WITH BREVE AND GRAVE
-	{runeRange{0x1EB2, 0x1EB2}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH BREVE AND HOOK ABOVE
-	{runeRange{0x1EB3, 0x1EB3}, sbprLower},     // L&       LATIN SMALL LETTER A WITH BREVE AND HOOK ABOVE
-	{runeRange{0x1EB4, 0x1EB4}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH BREVE AND TILDE
-	{runeRange{0x1EB5, 0x1EB5}, sbprLower},     // L&       LATIN SMALL LETTER A WITH BREVE AND TILDE
-	{runeRange{0x1EB6, 0x1EB6}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH BREVE AND DOT BELOW
-	{runeRange{0x1EB7, 0x1EB7}, sbprLower},     // L&       LATIN SMALL LETTER A WITH BREVE AND DOT BELOW
-	{runeRange{0x1EB8, 0x1EB8}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH DOT BELOW
-	{runeRange{0x1EB9, 0x1EB9}, sbprLower},     // L&       LATIN SMALL LETTER E WITH DOT BELOW
-	{runeRange{0x1EBA, 0x1EBA}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH HOOK ABOVE
-	{runeRange{0x1EBB, 0x1EBB}, sbprLower},     // L&       LATIN SMALL LETTER E WITH HOOK ABOVE
-	{runeRange{0x1EBC, 0x1EBC}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH TILDE
-	{runeRange{0x1EBD, 0x1EBD}, sbprLower},     // L&       LATIN SMALL LETTER E WITH TILDE
-	{runeRange{0x1EBE, 0x1EBE}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH CIRCUMFLEX AND ACUTE
-	{runeRange{0x1EBF, 0x1EBF}, sbprLower},     // L&       LATIN SMALL LETTER E WITH CIRCUMFLEX AND ACUTE
-	{runeRange{0x1EC0, 0x1EC0}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH CIRCUMFLEX AND GRAVE
-	{runeRange{0x1EC1, 0x1EC1}, sbprLower},     // L&       LATIN SMALL LETTER E WITH CIRCUMFLEX AND GRAVE
-	{runeRange{0x1EC2, 0x1EC2}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH CIRCUMFLEX AND HOOK ABOVE
-	{runeRange{0x1EC3, 0x1EC3}, sbprLower},     // L&       LATIN SMALL LETTER E WITH CIRCUMFLEX AND HOOK ABOVE
-	{runeRange{0x1EC4, 0x1EC4}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH CIRCUMFLEX AND TILDE
-	{runeRange{0x1EC5, 0x1EC5}, sbprLower},     // L&       LATIN SMALL LETTER E WITH CIRCUMFLEX AND TILDE
-	{runeRange{0x1EC6, 0x1EC6}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH CIRCUMFLEX AND DOT BELOW
-	{runeRange{0x1EC7, 0x1EC7}, sbprLower},     // L&       LATIN SMALL LETTER E WITH CIRCUMFLEX AND DOT BELOW
-	{runeRange{0x1EC8, 0x1EC8}, sbprUpper},     // L&       LATIN CAPITAL LETTER I WITH HOOK ABOVE
-	{runeRange{0x1EC9, 0x1EC9}, sbprLower},     // L&       LATIN SMALL LETTER I WITH HOOK ABOVE
-	{runeRange{0x1ECA, 0x1ECA}, sbprUpper},     // L&       LATIN CAPITAL LETTER I WITH DOT BELOW
-	{runeRange{0x1ECB, 0x1ECB}, sbprLower},     // L&       LATIN SMALL LETTER I WITH DOT BELOW
-	{runeRange{0x1ECC, 0x1ECC}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH DOT BELOW
-	{runeRange{0x1ECD, 0x1ECD}, sbprLower},     // L&       LATIN SMALL LETTER O WITH DOT BELOW
-	{runeRange{0x1ECE, 0x1ECE}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH HOOK ABOVE
-	{runeRange{0x1ECF, 0x1ECF}, sbprLower},     // L&       LATIN SMALL LETTER O WITH HOOK ABOVE
-	{runeRange{0x1ED0, 0x1ED0}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH CIRCUMFLEX AND ACUTE
-	{runeRange{0x1ED1, 0x1ED1}, sbprLower},     // L&       LATIN SMALL LETTER O WITH CIRCUMFLEX AND ACUTE
-	{runeRange{0x1ED2, 0x1ED2}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH CIRCUMFLEX AND GRAVE
-	{runeRange{0x1ED3, 0x1ED3}, sbprLower},     // L&       LATIN SMALL LETTER O WITH CIRCUMFLEX AND GRAVE
-	{runeRange{0x1ED4, 0x1ED4}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH CIRCUMFLEX AND HOOK ABOVE
-	{runeRange{0x1ED5, 0x1ED5}, sbprLower},     // L&       LATIN SMALL LETTER O WITH CIRCUMFLEX AND HOOK ABOVE
-	{runeRange{0x1ED6, 0x1ED6}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH CIRCUMFLEX AND TILDE
-	{runeRange{0x1ED7, 0x1ED7}, sbprLower},     // L&       LATIN SMALL LETTER O WITH CIRCUMFLEX AND TILDE
-	{runeRange{0x1ED8, 0x1ED8}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH CIRCUMFLEX AND DOT BELOW
-	{runeRange{0x1ED9, 0x1ED9}, sbprLower},     // L&       LATIN SMALL LETTER O WITH CIRCUMFLEX AND DOT BELOW
-	{runeRange{0x1EDA, 0x1EDA}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH HORN AND ACUTE
-	{runeRange{0x1EDB, 0x1EDB}, sbprLower},     // L&       LATIN SMALL LETTER O WITH HORN AND ACUTE
-	{runeRange{0x1EDC, 0x1EDC}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH HORN AND GRAVE
-	{runeRange{0x1EDD, 0x1EDD}, sbprLower},     // L&       LATIN SMALL LETTER O WITH HORN AND GRAVE
-	{runeRange{0x1EDE, 0x1EDE}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH HORN AND HOOK ABOVE
-	{runeRange{0x1EDF, 0x1EDF}, sbprLower},     // L&       LATIN SMALL LETTER O WITH HORN AND HOOK ABOVE
-	{runeRange{0x1EE0, 0x1EE0}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH HORN AND TILDE
-	{runeRange{0x1EE1, 0x1EE1}, sbprLower},     // L&       LATIN SMALL LETTER O WITH HORN AND TILDE
-	{runeRange{0x1EE2, 0x1EE2}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH HORN AND DOT BELOW
-	{runeRange{0x1EE3, 0x1EE3}, sbprLower},     // L&       LATIN SMALL LETTER O WITH HORN AND DOT BELOW
-	{runeRange{0x1EE4, 0x1EE4}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH DOT BELOW
-	{runeRange{0x1EE5, 0x1EE5}, sbprLower},     // L&       LATIN SMALL LETTER U WITH DOT BELOW
-	{runeRange{0x1EE6, 0x1EE6}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH HOOK ABOVE
-	{runeRange{0x1EE7, 0x1EE7}, sbprLower},     // L&       LATIN SMALL LETTER U WITH HOOK ABOVE
-	{runeRange{0x1EE8, 0x1EE8}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH HORN AND ACUTE
-	{runeRange{0x1EE9, 0x1EE9}, sbprLower},     // L&       LATIN SMALL LETTER U WITH HORN AND ACUTE
-	{runeRange{0x1EEA, 0x1EEA}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH HORN AND GRAVE
-	{runeRange{0x1EEB, 0x1EEB}, sbprLower},     // L&       LATIN SMALL LETTER U WITH HORN AND GRAVE
-	{runeRange{0x1EEC, 0x1EEC}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH HORN AND HOOK ABOVE
-	{runeRange{0x1EED, 0x1EED}, sbprLower},     // L&       LATIN SMALL LETTER U WITH HORN AND HOOK ABOVE
-	{runeRange{0x1EEE, 0x1EEE}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH HORN AND TILDE
-	{runeRange{0x1EEF, 0x1EEF}, sbprLower},     // L&       LATIN SMALL LETTER U WITH HORN AND TILDE
-	{runeRange{0x1EF0, 0x1EF0}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH HORN AND DOT BELOW
-	{runeRange{0x1EF1, 0x1EF1}, sbprLower},     // L&       LATIN SMALL LETTER U WITH HORN AND DOT BELOW
-	{runeRange{0x1EF2, 0x1EF2}, sbprUpper},     // L&       LATIN CAPITAL LETTER Y WITH GRAVE
-	{runeRange{0x1EF3, 0x1EF3}, sbprLower},     // L&       LATIN SMALL LETTER Y WITH GRAVE
-	{runeRange{0x1EF4, 0x1EF4}, sbprUpper},     // L&       LATIN CAPITAL LETTER Y WITH DOT BELOW
-	{runeRange{0x1EF5, 0x1EF5}, sbprLower},     // L&       LATIN SMALL LETTER Y WITH DOT BELOW
-	{runeRange{0x1EF6, 0x1EF6}, sbprUpper},     // L&       LATIN CAPITAL LETTER Y WITH HOOK ABOVE
-	{runeRange{0x1EF7, 0x1EF7}, sbprLower},     // L&       LATIN SMALL LETTER Y WITH HOOK ABOVE
-	{runeRange{0x1EF8, 0x1EF8}, sbprUpper},     // L&       LATIN CAPITAL LETTER Y WITH TILDE
-	{runeRange{0x1EF9, 0x1EF9}, sbprLower},     // L&       LATIN SMALL LETTER Y WITH TILDE
-	{runeRange{0x1EFA, 0x1EFA}, sbprUpper},     // L&       LATIN CAPITAL LETTER MIDDLE-WELSH LL
-	{runeRange{0x1EFB, 0x1EFB}, sbprLower},     // L&       LATIN SMALL LETTER MIDDLE-WELSH LL
-	{runeRange{0x1EFC, 0x1EFC}, sbprUpper},     // L&       LATIN CAPITAL LETTER MIDDLE-WELSH V
-	{runeRange{0x1EFD, 0x1EFD}, sbprLower},     // L&       LATIN SMALL LETTER MIDDLE-WELSH V
-	{runeRange{0x1EFE, 0x1EFE}, sbprUpper},     // L&       LATIN CAPITAL LETTER Y WITH LOOP
-	{runeRange{0x1EFF, 0x1F07}, sbprLower},     // L&   [9] LATIN SMALL LETTER Y WITH LOOP..GREEK SMALL LETTER ALPHA WITH DASIA AND PERISPOMENI
-	{runeRange{0x1F08, 0x1F0F}, sbprUpper},     // L&   [8] GREEK CAPITAL LETTER ALPHA WITH PSILI..GREEK CAPITAL LETTER ALPHA WITH DASIA AND PERISPOMENI
-	{runeRange{0x1F10, 0x1F15}, sbprLower},     // L&   [6] GREEK SMALL LETTER EPSILON WITH PSILI..GREEK SMALL LETTER EPSILON WITH DASIA AND OXIA
-	{runeRange{0x1F18, 0x1F1D}, sbprUpper},     // L&   [6] GREEK CAPITAL LETTER EPSILON WITH PSILI..GREEK CAPITAL LETTER EPSILON WITH DASIA AND OXIA
-	{runeRange{0x1F20, 0x1F27}, sbprLower},     // L&   [8] GREEK SMALL LETTER ETA WITH PSILI..GREEK SMALL LETTER ETA WITH DASIA AND PERISPOMENI
-	{runeRange{0x1F28, 0x1F2F}, sbprUpper},     // L&   [8] GREEK CAPITAL LETTER ETA WITH PSILI..GREEK CAPITAL LETTER ETA WITH DASIA AND PERISPOMENI
-	{runeRange{0x1F30, 0x1F37}, sbprLower},     // L&   [8] GREEK SMALL LETTER IOTA WITH PSILI..GREEK SMALL LETTER IOTA WITH DASIA AND PERISPOMENI
-	{runeRange{0x1F38, 0x1F3F}, sbprUpper},     // L&   [8] GREEK CAPITAL LETTER IOTA WITH PSILI..GREEK CAPITAL LETTER IOTA WITH DASIA AND PERISPOMENI
-	{runeRange{0x1F40, 0x1F45}, sbprLower},     // L&   [6] GREEK SMALL LETTER OMICRON WITH PSILI..GREEK SMALL LETTER OMICRON WITH DASIA AND OXIA
-	{runeRange{0x1F48, 0x1F4D}, sbprUpper},     // L&   [6] GREEK CAPITAL LETTER OMICRON WITH PSILI..GREEK CAPITAL LETTER OMICRON WITH DASIA AND OXIA
-	{runeRange{0x1F50, 0x1F57}, sbprLower},     // L&   [8] GREEK SMALL LETTER UPSILON WITH PSILI..GREEK SMALL LETTER UPSILON WITH DASIA AND PERISPOMENI
-	{runeRange{0x1F59, 0x1F59}, sbprUpper},     // L&       GREEK CAPITAL LETTER UPSILON WITH DASIA
-	{runeRange{0x1F5B, 0x1F5B}, sbprUpper},     // L&       GREEK CAPITAL LETTER UPSILON WITH DASIA AND VARIA
-	{runeRange{0x1F5D, 0x1F5D}, sbprUpper},     // L&       GREEK CAPITAL LETTER UPSILON WITH DASIA AND OXIA
-	{runeRange{0x1F5F, 0x1F5F}, sbprUpper},     // L&       GREEK CAPITAL LETTER UPSILON WITH DASIA AND PERISPOMENI
-	{runeRange{0x1F60, 0x1F67}, sbprLower},     // L&   [8] GREEK SMALL LETTER OMEGA WITH PSILI..GREEK SMALL LETTER OMEGA WITH DASIA AND PERISPOMENI
-	{runeRange{0x1F68, 0x1F6F}, sbprUpper},     // L&   [8] GREEK CAPITAL LETTER OMEGA WITH PSILI..GREEK CAPITAL LETTER OMEGA WITH DASIA AND PERISPOMENI
-	{runeRange{0x1F70, 0x1F7D}, sbprLower},     // L&  [14] GREEK SMALL LETTER ALPHA WITH VARIA..GREEK SMALL LETTER OMEGA WITH OXIA
-	{runeRange{0x1F80, 0x1F87}, sbprLower},     // L&   [8] GREEK SMALL LETTER ALPHA WITH PSILI AND YPOGEGRAMMENI..GREEK SMALL LETTER ALPHA WITH DASIA AND PERISPOMENI AND YPOGEGRAMMENI
-	{runeRange{0x1F88, 0x1F8F}, sbprUpper},     // L&   [8] GREEK CAPITAL LETTER ALPHA WITH PSILI AND PROSGEGRAMMENI..GREEK CAPITAL LETTER ALPHA WITH DASIA AND PERISPOMENI AND PROSGEGRAMMENI
-	{runeRange{0x1F90, 0x1F97}, sbprLower},     // L&   [8] GREEK SMALL LETTER ETA WITH PSILI AND YPOGEGRAMMENI..GREEK SMALL LETTER ETA WITH DASIA AND PERISPOMENI AND YPOGEGRAMMENI
-	{runeRange{0x1F98, 0x1F9F}, sbprUpper},     // L&   [8] GREEK CAPITAL LETTER ETA WITH PSILI AND PROSGEGRAMMENI..GREEK CAPITAL LETTER ETA WITH DASIA AND PERISPOMENI AND PROSGEGRAMMENI
-	{runeRange{0x1FA0, 0x1FA7}, sbprLower},     // L&   [8] GREEK SMALL LETTER OMEGA WITH PSILI AND YPOGEGRAMMENI..GREEK SMALL LETTER OMEGA WITH DASIA AND PERISPOMENI AND YPOGEGRAMMENI
-	{runeRange{0x1FA8, 0x1FAF}, sbprUpper},     // L&   [8] GREEK CAPITAL LETTER OMEGA WITH PSILI AND PROSGEGRAMMENI..GREEK CAPITAL LETTER OMEGA WITH DASIA AND PERISPOMENI AND PROSGEGRAMMENI
-	{runeRange{0x1FB0, 0x1FB4}, sbprLower},     // L&   [5] GREEK SMALL LETTER ALPHA WITH VRACHY..GREEK SMALL LETTER ALPHA WITH OXIA AND YPOGEGRAMMENI
-	{runeRange{0x1FB6, 0x1FB7}, sbprLower},     // L&   [2] GREEK SMALL LETTER ALPHA WITH PERISPOMENI..GREEK SMALL LETTER ALPHA WITH PERISPOMENI AND YPOGEGRAMMENI
-	{runeRange{0x1FB8, 0x1FBC}, sbprUpper},     // L&   [5] GREEK CAPITAL LETTER ALPHA WITH VRACHY..GREEK CAPITAL LETTER ALPHA WITH PROSGEGRAMMENI
-	{runeRange{0x1FBE, 0x1FBE}, sbprLower},     // L&       GREEK PROSGEGRAMMENI
-	{runeRange{0x1FC2, 0x1FC4}, sbprLower},     // L&   [3] GREEK SMALL LETTER ETA WITH VARIA AND YPOGEGRAMMENI..GREEK SMALL LETTER ETA WITH OXIA AND YPOGEGRAMMENI
-	{runeRange{0x1FC6, 0x1FC7}, sbprLower},     // L&   [2] GREEK SMALL LETTER ETA WITH PERISPOMENI..GREEK SMALL LETTER ETA WITH PERISPOMENI AND YPOGEGRAMMENI
-	{runeRange{0x1FC8, 0x1FCC}, sbprUpper},     // L&   [5] GREEK CAPITAL LETTER EPSILON WITH VARIA..GREEK CAPITAL LETTER ETA WITH PROSGEGRAMMENI
-	{runeRange{0x1FD0, 0x1FD3}, sbprLower},     // L&   [4] GREEK SMALL LETTER IOTA WITH VRACHY..GREEK SMALL LETTER IOTA WITH DIALYTIKA AND OXIA
-	{runeRange{0x1FD6, 0x1FD7}, sbprLower},     // L&   [2] GREEK SMALL LETTER IOTA WITH PERISPOMENI..GREEK SMALL LETTER IOTA WITH DIALYTIKA AND PERISPOMENI
-	{runeRange{0x1FD8, 0x1FDB}, sbprUpper},     // L&   [4] GREEK CAPITAL LETTER IOTA WITH VRACHY..GREEK CAPITAL LETTER IOTA WITH OXIA
-	{runeRange{0x1FE0, 0x1FE7}, sbprLower},     // L&   [8] GREEK SMALL LETTER UPSILON WITH VRACHY..GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND PERISPOMENI
-	{runeRange{0x1FE8, 0x1FEC}, sbprUpper},     // L&   [5] GREEK CAPITAL LETTER UPSILON WITH VRACHY..GREEK CAPITAL LETTER RHO WITH DASIA
-	{runeRange{0x1FF2, 0x1FF4}, sbprLower},     // L&   [3] GREEK SMALL LETTER OMEGA WITH VARIA AND YPOGEGRAMMENI..GREEK SMALL LETTER OMEGA WITH OXIA AND YPOGEGRAMMENI
-	{runeRange{0x1FF6, 0x1FF7}, sbprLower},     // L&   [2] GREEK SMALL LETTER OMEGA WITH PERISPOMENI..GREEK SMALL LETTER OMEGA WITH PERISPOMENI AND YPOGEGRAMMENI
-	{runeRange{0x1FF8, 0x1FFC}, sbprUpper},     // L&   [5] GREEK CAPITAL LETTER OMICRON WITH VARIA..GREEK CAPITAL LETTER OMEGA WITH PROSGEGRAMMENI
-	{runeRange{0x2000, 0x200A}, sbprSp},        // Zs  [11] EN QUAD..HAIR SPACE
-	{runeRange{0x200B, 0x200B}, sbprFormat},    // Cf       ZERO WIDTH SPACE
-	{runeRange{0x200C, 0x200D}, sbprExtend},    // Cf   [2] ZERO WIDTH NON-JOINER..ZERO WIDTH JOINER
-	{runeRange{0x200E, 0x200F}, sbprFormat},    // Cf   [2] LEFT-TO-RIGHT MARK..RIGHT-TO-LEFT MARK
-	{runeRange{0x2013, 0x2014}, sbprSContinue}, // Pd   [2] EN DASH..EM DASH
-	{runeRange{0x2018, 0x2018}, sbprClose},     // Pi       LEFT SINGLE QUOTATION MARK
-	{runeRange{0x2019, 0x2019}, sbprClose},     // Pf       RIGHT SINGLE QUOTATION MARK
-	{runeRange{0x201A, 0x201A}, sbprClose},     // Ps       SINGLE LOW-9 QUOTATION MARK
-	{runeRange{0x201B, 0x201C}, sbprClose},     // Pi   [2] SINGLE HIGH-REVERSED-9 QUOTATION MARK..LEFT DOUBLE QUOTATION MARK
-	{runeRange{0x201D, 0x201D}, sbprClose},     // Pf       RIGHT DOUBLE QUOTATION MARK
-	{runeRange{0x201E, 0x201E}, sbprClose},     // Ps       DOUBLE LOW-9 QUOTATION MARK
-	{runeRange{0x201F, 0x201F}, sbprClose},     // Pi       DOUBLE HIGH-REVERSED-9 QUOTATION MARK
-	{runeRange{0x2024, 0x2024}, sbprATerm},     // Po       ONE DOT LEADER
-	{runeRange{0x2028, 0x2028}, sbprSep},       // Zl       LINE SEPARATOR
-	{runeRange{0x2029, 0x2029}, sbprSep},       // Zp       PARAGRAPH SEPARATOR
-	{runeRange{0x202A, 0x202E}, sbprFormat},    // Cf   [5] LEFT-TO-RIGHT EMBEDDING..RIGHT-TO-LEFT OVERRIDE
-	{runeRange{0x202F, 0x202F}, sbprSp},        // Zs       NARROW NO-BREAK SPACE
-	{runeRange{0x2039, 0x2039}, sbprClose},     // Pi       SINGLE LEFT-POINTING ANGLE QUOTATION MARK
-	{runeRange{0x203A, 0x203A}, sbprClose},     // Pf       SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
-	{runeRange{0x203C, 0x203D}, sbprSTerm},     // Po   [2] DOUBLE EXCLAMATION MARK..INTERROBANG
-	{runeRange{0x2045, 0x2045}, sbprClose},     // Ps       LEFT SQUARE BRACKET WITH QUILL
-	{runeRange{0x2046, 0x2046}, sbprClose},     // Pe       RIGHT SQUARE BRACKET WITH QUILL
-	{runeRange{0x2047, 0x2049}, sbprSTerm},     // Po   [3] DOUBLE QUESTION MARK..EXCLAMATION QUESTION MARK
-	{runeRange{0x205F, 0x205F}, sbprSp},        // Zs       MEDIUM MATHEMATICAL SPACE
-	{runeRange{0x2060, 0x2064}, sbprFormat},    // Cf   [5] WORD JOINER..INVISIBLE PLUS
-	{runeRange{0x2066, 0x206F}, sbprFormat},    // Cf  [10] LEFT-TO-RIGHT ISOLATE..NOMINAL DIGIT SHAPES
-	{runeRange{0x2071, 0x2071}, sbprLower},     // Lm       SUPERSCRIPT LATIN SMALL LETTER I
-	{runeRange{0x207D, 0x207D}, sbprClose},     // Ps       SUPERSCRIPT LEFT PARENTHESIS
-	{runeRange{0x207E, 0x207E}, sbprClose},     // Pe       SUPERSCRIPT RIGHT PARENTHESIS
-	{runeRange{0x207F, 0x207F}, sbprLower},     // Lm       SUPERSCRIPT LATIN SMALL LETTER N
-	{runeRange{0x208D, 0x208D}, sbprClose},     // Ps       SUBSCRIPT LEFT PARENTHESIS
-	{runeRange{0x208E, 0x208E}, sbprClose},     // Pe       SUBSCRIPT RIGHT PARENTHESIS
-	{runeRange{0x2090, 0x209C}, sbprLower},     // Lm  [13] LATIN SUBSCRIPT SMALL LETTER A..LATIN SUBSCRIPT SMALL LETTER T
-	{runeRange{0x20D0, 0x20DC}, sbprExtend},    // Mn  [13] COMBINING LEFT HARPOON ABOVE..COMBINING FOUR DOTS ABOVE
-	{runeRange{0x20DD, 0x20E0}, sbprExtend},    // Me   [4] COMBINING ENCLOSING CIRCLE..COMBINING ENCLOSING CIRCLE BACKSLASH
-	{runeRange{0x20E1, 0x20E1}, sbprExtend},    // Mn       COMBINING LEFT RIGHT ARROW ABOVE
-	{runeRange{0x20E2, 0x20E4}, sbprExtend},    // Me   [3] COMBINING ENCLOSING SCREEN..COMBINING ENCLOSING UPWARD POINTING TRIANGLE
-	{runeRange{0x20E5, 0x20F0}, sbprExtend},    // Mn  [12] COMBINING REVERSE SOLIDUS OVERLAY..COMBINING ASTERISK ABOVE
-	{runeRange{0x2102, 0x2102}, sbprUpper},     // L&       DOUBLE-STRUCK CAPITAL C
-	{runeRange{0x2107, 0x2107}, sbprUpper},     // L&       EULER CONSTANT
-	{runeRange{0x210A, 0x210A}, sbprLower},     // L&       SCRIPT SMALL G
-	{runeRange{0x210B, 0x210D}, sbprUpper},     // L&   [3] SCRIPT CAPITAL H..DOUBLE-STRUCK CAPITAL H
-	{runeRange{0x210E, 0x210F}, sbprLower},     // L&   [2] PLANCK CONSTANT..PLANCK CONSTANT OVER TWO PI
-	{runeRange{0x2110, 0x2112}, sbprUpper},     // L&   [3] SCRIPT CAPITAL I..SCRIPT CAPITAL L
-	{runeRange{0x2113, 0x2113}, sbprLower},     // L&       SCRIPT SMALL L
-	{runeRange{0x2115, 0x2115}, sbprUpper},     // L&       DOUBLE-STRUCK CAPITAL N
-	{runeRange{0x2119, 0x211D}, sbprUpper},     // L&   [5] DOUBLE-STRUCK CAPITAL P..DOUBLE-STRUCK CAPITAL R
-	{runeRange{0x2124, 0x2124}, sbprUpper},     // L&       DOUBLE-STRUCK CAPITAL Z
-	{runeRange{0x2126, 0x2126}, sbprUpper},     // L&       OHM SIGN
-	{runeRange{0x2128, 0x2128}, sbprUpper},     // L&       BLACK-LETTER CAPITAL Z
-	{runeRange{0x212A, 0x212D}, sbprUpper},     // L&   [4] KELVIN SIGN..BLACK-LETTER CAPITAL C
-	{runeRange{0x212F, 0x212F}, sbprLower},     // L&       SCRIPT SMALL E
-	{runeRange{0x2130, 0x2133}, sbprUpper},     // L&   [4] SCRIPT CAPITAL E..SCRIPT CAPITAL M
-	{runeRange{0x2134, 0x2134}, sbprLower},     // L&       SCRIPT SMALL O
-	{runeRange{0x2135, 0x2138}, sbprOLetter},   // Lo   [4] ALEF SYMBOL..DALET SYMBOL
-	{runeRange{0x2139, 0x2139}, sbprLower},     // L&       INFORMATION SOURCE
-	{runeRange{0x213C, 0x213D}, sbprLower},     // L&   [2] DOUBLE-STRUCK SMALL PI..DOUBLE-STRUCK SMALL GAMMA
-	{runeRange{0x213E, 0x213F}, sbprUpper},     // L&   [2] DOUBLE-STRUCK CAPITAL GAMMA..DOUBLE-STRUCK CAPITAL PI
-	{runeRange{0x2145, 0x2145}, sbprUpper},     // L&       DOUBLE-STRUCK ITALIC CAPITAL D
-	{runeRange{0x2146, 0x2149}, sbprLower},     // L&   [4] DOUBLE-STRUCK ITALIC SMALL D..DOUBLE-STRUCK ITALIC SMALL J
-	{runeRange{0x214E, 0x214E}, sbprLower},     // L&       TURNED SMALL F
-	{runeRange{0x2160, 0x216F}, sbprUpper},     // Nl  [16] ROMAN NUMERAL ONE..ROMAN NUMERAL ONE THOUSAND
-	{runeRange{0x2170, 0x217F}, sbprLower},     // Nl  [16] SMALL ROMAN NUMERAL ONE..SMALL ROMAN NUMERAL ONE THOUSAND
-	{runeRange{0x2180, 0x2182}, sbprOLetter},   // Nl   [3] ROMAN NUMERAL ONE THOUSAND C D..ROMAN NUMERAL TEN THOUSAND
-	{runeRange{0x2183, 0x2183}, sbprUpper},     // L&       ROMAN NUMERAL REVERSED ONE HUNDRED
-	{runeRange{0x2184, 0x2184}, sbprLower},     // L&       LATIN SMALL LETTER REVERSED C
-	{runeRange{0x2185, 0x2188}, sbprOLetter},   // Nl   [4] ROMAN NUMERAL SIX LATE FORM..ROMAN NUMERAL ONE HUNDRED THOUSAND
-	{runeRange{0x2308, 0x2308}, sbprClose},     // Ps       LEFT CEILING
-	{runeRange{0x2309, 0x2309}, sbprClose},     // Pe       RIGHT CEILING
-	{runeRange{0x230A, 0x230A}, sbprClose},     // Ps       LEFT FLOOR
-	{runeRange{0x230B, 0x230B}, sbprClose},     // Pe       RIGHT FLOOR
-	{runeRange{0x2329, 0x2329}, sbprClose},     // Ps       LEFT-POINTING ANGLE BRACKET
-	{runeRange{0x232A, 0x232A}, sbprClose},     // Pe       RIGHT-POINTING ANGLE BRACKET
-	{runeRange{0x24B6, 0x24CF}, sbprUpper},     // So  [26] CIRCLED LATIN CAPITAL LETTER A..CIRCLED LATIN CAPITAL LETTER Z
-	{runeRange{0x24D0, 0x24E9}, sbprLower},     // So  [26] CIRCLED LATIN SMALL LETTER A..CIRCLED LATIN SMALL LETTER Z
-	{runeRange{0x275B, 0x2760}, sbprClose},     // So   [6] HEAVY SINGLE TURNED COMMA QUOTATION MARK ORNAMENT..HEAVY LOW DOUBLE COMMA QUOTATION MARK ORNAMENT
-	{runeRange{0x2768, 0x2768}, sbprClose},     // Ps       MEDIUM LEFT PARENTHESIS ORNAMENT
-	{runeRange{0x2769, 0x2769}, sbprClose},     // Pe       MEDIUM RIGHT PARENTHESIS ORNAMENT
-	{runeRange{0x276A, 0x276A}, sbprClose},     // Ps       MEDIUM FLATTENED LEFT PARENTHESIS ORNAMENT
-	{runeRange{0x276B, 0x276B}, sbprClose},     // Pe       MEDIUM FLATTENED RIGHT PARENTHESIS ORNAMENT
-	{runeRange{0x276C, 0x276C}, sbprClose},     // Ps       MEDIUM LEFT-POINTING ANGLE BRACKET ORNAMENT
-	{runeRange{0x276D, 0x276D}, sbprClose},     // Pe       MEDIUM RIGHT-POINTING ANGLE BRACKET ORNAMENT
-	{runeRange{0x276E, 0x276E}, sbprClose},     // Ps       HEAVY LEFT-POINTING ANGLE QUOTATION MARK ORNAMENT
-	{runeRange{0x276F, 0x276F}, sbprClose},     // Pe       HEAVY RIGHT-POINTING ANGLE QUOTATION MARK ORNAMENT
-	{runeRange{0x2770, 0x2770}, sbprClose},     // Ps       HEAVY LEFT-POINTING ANGLE BRACKET ORNAMENT
-	{runeRange{0x2771, 0x2771}, sbprClose},     // Pe       HEAVY RIGHT-POINTING ANGLE BRACKET ORNAMENT
-	{runeRange{0x2772, 0x2772}, sbprClose},     // Ps       LIGHT LEFT TORTOISE SHELL BRACKET ORNAMENT
-	{runeRange{0x2773, 0x2773}, sbprClose},     // Pe       LIGHT RIGHT TORTOISE SHELL BRACKET ORNAMENT
-	{runeRange{0x2774, 0x2774}, sbprClose},     // Ps       MEDIUM LEFT CURLY BRACKET ORNAMENT
-	{runeRange{0x2775, 0x2775}, sbprClose},     // Pe       MEDIUM RIGHT CURLY BRACKET ORNAMENT
-	{runeRange{0x27C5, 0x27C5}, sbprClose},     // Ps       LEFT S-SHAPED BAG DELIMITER
-	{runeRange{0x27C6, 0x27C6}, sbprClose},     // Pe       RIGHT S-SHAPED BAG DELIMITER
-	{runeRange{0x27E6, 0x27E6}, sbprClose},     // Ps       MATHEMATICAL LEFT WHITE SQUARE BRACKET
-	{runeRange{0x27E7, 0x27E7}, sbprClose},     // Pe       MATHEMATICAL RIGHT WHITE SQUARE BRACKET
-	{runeRange{0x27E8, 0x27E8}, sbprClose},     // Ps       MATHEMATICAL LEFT ANGLE BRACKET
-	{runeRange{0x27E9, 0x27E9}, sbprClose},     // Pe       MATHEMATICAL RIGHT ANGLE BRACKET
-	{runeRange{0x27EA, 0x27EA}, sbprClose},     // Ps       MATHEMATICAL LEFT DOUBLE ANGLE BRACKET
-	{runeRange{0x27EB, 0x27EB}, sbprClose},     // Pe       MATHEMATICAL RIGHT DOUBLE ANGLE BRACKET
-	{runeRange{0x27EC, 0x27EC}, sbprClose},     // Ps       MATHEMATICAL LEFT WHITE TORTOISE SHELL BRACKET
-	{runeRange{0x27ED, 0x27ED}, sbprClose},     // Pe       MATHEMATICAL RIGHT WHITE TORTOISE SHELL BRACKET
-	{runeRange{0x27EE, 0x27EE}, sbprClose},     // Ps       MATHEMATICAL LEFT FLATTENED PARENTHESIS
-	{runeRange{0x27EF, 0x27EF}, sbprClose},     // Pe       MATHEMATICAL RIGHT FLATTENED PARENTHESIS
-	{runeRange{0x2983, 0x2983}, sbprClose},     // Ps       LEFT WHITE CURLY BRACKET
-	{runeRange{0x2984, 0x2984}, sbprClose},     // Pe       RIGHT WHITE CURLY BRACKET
-	{runeRange{0x2985, 0x2985}, sbprClose},     // Ps       LEFT WHITE PARENTHESIS
-	{runeRange{0x2986, 0x2986}, sbprClose},     // Pe       RIGHT WHITE PARENTHESIS
-	{runeRange{0x2987, 0x2987}, sbprClose},     // Ps       Z NOTATION LEFT IMAGE BRACKET
-	{runeRange{0x2988, 0x2988}, sbprClose},     // Pe       Z NOTATION RIGHT IMAGE BRACKET
-	{runeRange{0x2989, 0x2989}, sbprClose},     // Ps       Z NOTATION LEFT BINDING BRACKET
-	{runeRange{0x298A, 0x298A}, sbprClose},     // Pe       Z NOTATION RIGHT BINDING BRACKET
-	{runeRange{0x298B, 0x298B}, sbprClose},     // Ps       LEFT SQUARE BRACKET WITH UNDERBAR
-	{runeRange{0x298C, 0x298C}, sbprClose},     // Pe       RIGHT SQUARE BRACKET WITH UNDERBAR
-	{runeRange{0x298D, 0x298D}, sbprClose},     // Ps       LEFT SQUARE BRACKET WITH TICK IN TOP CORNER
-	{runeRange{0x298E, 0x298E}, sbprClose},     // Pe       RIGHT SQUARE BRACKET WITH TICK IN BOTTOM CORNER
-	{runeRange{0x298F, 0x298F}, sbprClose},     // Ps       LEFT SQUARE BRACKET WITH TICK IN BOTTOM CORNER
-	{runeRange{0x2990, 0x2990}, sbprClose},     // Pe       RIGHT SQUARE BRACKET WITH TICK IN TOP CORNER
-	{runeRange{0x2991, 0x2991}, sbprClose},     // Ps       LEFT ANGLE BRACKET WITH DOT
-	{runeRange{0x2992, 0x2992}, sbprClose},     // Pe       RIGHT ANGLE BRACKET WITH DOT
-	{runeRange{0x2993, 0x2993}, sbprClose},     // Ps       LEFT ARC LESS-THAN BRACKET
-	{runeRange{0x2994, 0x2994}, sbprClose},     // Pe       RIGHT ARC GREATER-THAN BRACKET
-	{runeRange{0x2995, 0x2995}, sbprClose},     // Ps       DOUBLE LEFT ARC GREATER-THAN BRACKET
-	{runeRange{0x2996, 0x2996}, sbprClose},     // Pe       DOUBLE RIGHT ARC LESS-THAN BRACKET
-	{runeRange{0x2997, 0x2997}, sbprClose},     // Ps       LEFT BLACK TORTOISE SHELL BRACKET
-	{runeRange{0x2998, 0x2998}, sbprClose},     // Pe       RIGHT BLACK TORTOISE SHELL BRACKET
-	{runeRange{0x29D8, 0x29D8}, sbprClose},     // Ps       LEFT WIGGLY FENCE
-	{runeRange{0x29D9, 0x29D9}, sbprClose},     // Pe       RIGHT WIGGLY FENCE
-	{runeRange{0x29DA, 0x29DA}, sbprClose},     // Ps       LEFT DOUBLE WIGGLY FENCE
-	{runeRange{0x29DB, 0x29DB}, sbprClose},     // Pe       RIGHT DOUBLE WIGGLY FENCE
-	{runeRange{0x29FC, 0x29FC}, sbprClose},     // Ps       LEFT-POINTING CURVED ANGLE BRACKET
-	{runeRange{0x29FD, 0x29FD}, sbprClose},     // Pe       RIGHT-POINTING CURVED ANGLE BRACKET
-	{runeRange{0x2C00, 0x2C2F}, sbprUpper},     // L&  [48] GLAGOLITIC CAPITAL LETTER AZU..GLAGOLITIC CAPITAL LETTER CAUDATE CHRIVI
-	{runeRange{0x2C30, 0x2C5F}, sbprLower},     // L&  [48] GLAGOLITIC SMALL LETTER AZU..GLAGOLITIC SMALL LETTER CAUDATE CHRIVI
-	{runeRange{0x2C60, 0x2C60}, sbprUpper},     // L&       LATIN CAPITAL LETTER L WITH DOUBLE BAR
-	{runeRange{0x2C61, 0x2C61}, sbprLower},     // L&       LATIN SMALL LETTER L WITH DOUBLE BAR
-	{runeRange{0x2C62, 0x2C64}, sbprUpper},     // L&   [3] LATIN CAPITAL LETTER L WITH MIDDLE TILDE..LATIN CAPITAL LETTER R WITH TAIL
-	{runeRange{0x2C65, 0x2C66}, sbprLower},     // L&   [2] LATIN SMALL LETTER A WITH STROKE..LATIN SMALL LETTER T WITH DIAGONAL STROKE
-	{runeRange{0x2C67, 0x2C67}, sbprUpper},     // L&       LATIN CAPITAL LETTER H WITH DESCENDER
-	{runeRange{0x2C68, 0x2C68}, sbprLower},     // L&       LATIN SMALL LETTER H WITH DESCENDER
-	{runeRange{0x2C69, 0x2C69}, sbprUpper},     // L&       LATIN CAPITAL LETTER K WITH DESCENDER
-	{runeRange{0x2C6A, 0x2C6A}, sbprLower},     // L&       LATIN SMALL LETTER K WITH DESCENDER
-	{runeRange{0x2C6B, 0x2C6B}, sbprUpper},     // L&       LATIN CAPITAL LETTER Z WITH DESCENDER
-	{runeRange{0x2C6C, 0x2C6C}, sbprLower},     // L&       LATIN SMALL LETTER Z WITH DESCENDER
-	{runeRange{0x2C6D, 0x2C70}, sbprUpper},     // L&   [4] LATIN CAPITAL LETTER ALPHA..LATIN CAPITAL LETTER TURNED ALPHA
-	{runeRange{0x2C71, 0x2C71}, sbprLower},     // L&       LATIN SMALL LETTER V WITH RIGHT HOOK
-	{runeRange{0x2C72, 0x2C72}, sbprUpper},     // L&       LATIN CAPITAL LETTER W WITH HOOK
-	{runeRange{0x2C73, 0x2C74}, sbprLower},     // L&   [2] LATIN SMALL LETTER W WITH HOOK..LATIN SMALL LETTER V WITH CURL
-	{runeRange{0x2C75, 0x2C75}, sbprUpper},     // L&       LATIN CAPITAL LETTER HALF H
-	{runeRange{0x2C76, 0x2C7B}, sbprLower},     // L&   [6] LATIN SMALL LETTER HALF H..LATIN LETTER SMALL CAPITAL TURNED E
-	{runeRange{0x2C7C, 0x2C7D}, sbprLower},     // Lm   [2] LATIN SUBSCRIPT SMALL LETTER J..MODIFIER LETTER CAPITAL V
-	{runeRange{0x2C7E, 0x2C80}, sbprUpper},     // L&   [3] LATIN CAPITAL LETTER S WITH SWASH TAIL..COPTIC CAPITAL LETTER ALFA
-	{runeRange{0x2C81, 0x2C81}, sbprLower},     // L&       COPTIC SMALL LETTER ALFA
-	{runeRange{0x2C82, 0x2C82}, sbprUpper},     // L&       COPTIC CAPITAL LETTER VIDA
-	{runeRange{0x2C83, 0x2C83}, sbprLower},     // L&       COPTIC SMALL LETTER VIDA
-	{runeRange{0x2C84, 0x2C84}, sbprUpper},     // L&       COPTIC CAPITAL LETTER GAMMA
-	{runeRange{0x2C85, 0x2C85}, sbprLower},     // L&       COPTIC SMALL LETTER GAMMA
-	{runeRange{0x2C86, 0x2C86}, sbprUpper},     // L&       COPTIC CAPITAL LETTER DALDA
-	{runeRange{0x2C87, 0x2C87}, sbprLower},     // L&       COPTIC SMALL LETTER DALDA
-	{runeRange{0x2C88, 0x2C88}, sbprUpper},     // L&       COPTIC CAPITAL LETTER EIE
-	{runeRange{0x2C89, 0x2C89}, sbprLower},     // L&       COPTIC SMALL LETTER EIE
-	{runeRange{0x2C8A, 0x2C8A}, sbprUpper},     // L&       COPTIC CAPITAL LETTER SOU
-	{runeRange{0x2C8B, 0x2C8B}, sbprLower},     // L&       COPTIC SMALL LETTER SOU
-	{runeRange{0x2C8C, 0x2C8C}, sbprUpper},     // L&       COPTIC CAPITAL LETTER ZATA
-	{runeRange{0x2C8D, 0x2C8D}, sbprLower},     // L&       COPTIC SMALL LETTER ZATA
-	{runeRange{0x2C8E, 0x2C8E}, sbprUpper},     // L&       COPTIC CAPITAL LETTER HATE
-	{runeRange{0x2C8F, 0x2C8F}, sbprLower},     // L&       COPTIC SMALL LETTER HATE
-	{runeRange{0x2C90, 0x2C90}, sbprUpper},     // L&       COPTIC CAPITAL LETTER THETHE
-	{runeRange{0x2C91, 0x2C91}, sbprLower},     // L&       COPTIC SMALL LETTER THETHE
-	{runeRange{0x2C92, 0x2C92}, sbprUpper},     // L&       COPTIC CAPITAL LETTER IAUDA
-	{runeRange{0x2C93, 0x2C93}, sbprLower},     // L&       COPTIC SMALL LETTER IAUDA
-	{runeRange{0x2C94, 0x2C94}, sbprUpper},     // L&       COPTIC CAPITAL LETTER KAPA
-	{runeRange{0x2C95, 0x2C95}, sbprLower},     // L&       COPTIC SMALL LETTER KAPA
-	{runeRange{0x2C96, 0x2C96}, sbprUpper},     // L&       COPTIC CAPITAL LETTER LAULA
-	{runeRange{0x2C97, 0x2C97}, sbprLower},     // L&       COPTIC SMALL LETTER LAULA
-	{runeRange{0x2C98, 0x2C98}, sbprUpper},     // L&       COPTIC CAPITAL LETTER MI
-	{runeRange{0x2C99, 0x2C99}, sbprLower},     // L&       COPTIC SMALL LETTER MI
-	{runeRange{0x2C9A, 0x2C9A}, sbprUpper},     // L&       COPTIC CAPITAL LETTER NI
-	{runeRange{0x2C9B, 0x2C9B}, sbprLower},     // L&       COPTIC SMALL LETTER NI
-	{runeRange{0x2C9C, 0x2C9C}, sbprUpper},     // L&       COPTIC CAPITAL LETTER KSI
-	{runeRange{0x2C9D, 0x2C9D}, sbprLower},     // L&       COPTIC SMALL LETTER KSI
-	{runeRange{0x2C9E, 0x2C9E}, sbprUpper},     // L&       COPTIC CAPITAL LETTER O
-	{runeRange{0x2C9F, 0x2C9F}, sbprLower},     // L&       COPTIC SMALL LETTER O
-	{runeRange{0x2CA0, 0x2CA0}, sbprUpper},     // L&       COPTIC CAPITAL LETTER PI
-	{runeRange{0x2CA1, 0x2CA1}, sbprLower},     // L&       COPTIC SMALL LETTER PI
-	{runeRange{0x2CA2, 0x2CA2}, sbprUpper},     // L&       COPTIC CAPITAL LETTER RO
-	{runeRange{0x2CA3, 0x2CA3}, sbprLower},     // L&       COPTIC SMALL LETTER RO
-	{runeRange{0x2CA4, 0x2CA4}, sbprUpper},     // L&       COPTIC CAPITAL LETTER SIMA
-	{runeRange{0x2CA5, 0x2CA5}, sbprLower},     // L&       COPTIC SMALL LETTER SIMA
-	{runeRange{0x2CA6, 0x2CA6}, sbprUpper},     // L&       COPTIC CAPITAL LETTER TAU
-	{runeRange{0x2CA7, 0x2CA7}, sbprLower},     // L&       COPTIC SMALL LETTER TAU
-	{runeRange{0x2CA8, 0x2CA8}, sbprUpper},     // L&       COPTIC CAPITAL LETTER UA
-	{runeRange{0x2CA9, 0x2CA9}, sbprLower},     // L&       COPTIC SMALL LETTER UA
-	{runeRange{0x2CAA, 0x2CAA}, sbprUpper},     // L&       COPTIC CAPITAL LETTER FI
-	{runeRange{0x2CAB, 0x2CAB}, sbprLower},     // L&       COPTIC SMALL LETTER FI
-	{runeRange{0x2CAC, 0x2CAC}, sbprUpper},     // L&       COPTIC CAPITAL LETTER KHI
-	{runeRange{0x2CAD, 0x2CAD}, sbprLower},     // L&       COPTIC SMALL LETTER KHI
-	{runeRange{0x2CAE, 0x2CAE}, sbprUpper},     // L&       COPTIC CAPITAL LETTER PSI
-	{runeRange{0x2CAF, 0x2CAF}, sbprLower},     // L&       COPTIC SMALL LETTER PSI
-	{runeRange{0x2CB0, 0x2CB0}, sbprUpper},     // L&       COPTIC CAPITAL LETTER OOU
-	{runeRange{0x2CB1, 0x2CB1}, sbprLower},     // L&       COPTIC SMALL LETTER OOU
-	{runeRange{0x2CB2, 0x2CB2}, sbprUpper},     // L&       COPTIC CAPITAL LETTER DIALECT-P ALEF
-	{runeRange{0x2CB3, 0x2CB3}, sbprLower},     // L&       COPTIC SMALL LETTER DIALECT-P ALEF
-	{runeRange{0x2CB4, 0x2CB4}, sbprUpper},     // L&       COPTIC CAPITAL LETTER OLD COPTIC AIN
-	{runeRange{0x2CB5, 0x2CB5}, sbprLower},     // L&       COPTIC SMALL LETTER OLD COPTIC AIN
-	{runeRange{0x2CB6, 0x2CB6}, sbprUpper},     // L&       COPTIC CAPITAL LETTER CRYPTOGRAMMIC EIE
-	{runeRange{0x2CB7, 0x2CB7}, sbprLower},     // L&       COPTIC SMALL LETTER CRYPTOGRAMMIC EIE
-	{runeRange{0x2CB8, 0x2CB8}, sbprUpper},     // L&       COPTIC CAPITAL LETTER DIALECT-P KAPA
-	{runeRange{0x2CB9, 0x2CB9}, sbprLower},     // L&       COPTIC SMALL LETTER DIALECT-P KAPA
-	{runeRange{0x2CBA, 0x2CBA}, sbprUpper},     // L&       COPTIC CAPITAL LETTER DIALECT-P NI
-	{runeRange{0x2CBB, 0x2CBB}, sbprLower},     // L&       COPTIC SMALL LETTER DIALECT-P NI
-	{runeRange{0x2CBC, 0x2CBC}, sbprUpper},     // L&       COPTIC CAPITAL LETTER CRYPTOGRAMMIC NI
-	{runeRange{0x2CBD, 0x2CBD}, sbprLower},     // L&       COPTIC SMALL LETTER CRYPTOGRAMMIC NI
-	{runeRange{0x2CBE, 0x2CBE}, sbprUpper},     // L&       COPTIC CAPITAL LETTER OLD COPTIC OOU
-	{runeRange{0x2CBF, 0x2CBF}, sbprLower},     // L&       COPTIC SMALL LETTER OLD COPTIC OOU
-	{runeRange{0x2CC0, 0x2CC0}, sbprUpper},     // L&       COPTIC CAPITAL LETTER SAMPI
-	{runeRange{0x2CC1, 0x2CC1}, sbprLower},     // L&       COPTIC SMALL LETTER SAMPI
-	{runeRange{0x2CC2, 0x2CC2}, sbprUpper},     // L&       COPTIC CAPITAL LETTER CROSSED SHEI
-	{runeRange{0x2CC3, 0x2CC3}, sbprLower},     // L&       COPTIC SMALL LETTER CROSSED SHEI
-	{runeRange{0x2CC4, 0x2CC4}, sbprUpper},     // L&       COPTIC CAPITAL LETTER OLD COPTIC SHEI
-	{runeRange{0x2CC5, 0x2CC5}, sbprLower},     // L&       COPTIC SMALL LETTER OLD COPTIC SHEI
-	{runeRange{0x2CC6, 0x2CC6}, sbprUpper},     // L&       COPTIC CAPITAL LETTER OLD COPTIC ESH
-	{runeRange{0x2CC7, 0x2CC7}, sbprLower},     // L&       COPTIC SMALL LETTER OLD COPTIC ESH
-	{runeRange{0x2CC8, 0x2CC8}, sbprUpper},     // L&       COPTIC CAPITAL LETTER AKHMIMIC KHEI
-	{runeRange{0x2CC9, 0x2CC9}, sbprLower},     // L&       COPTIC SMALL LETTER AKHMIMIC KHEI
-	{runeRange{0x2CCA, 0x2CCA}, sbprUpper},     // L&       COPTIC CAPITAL LETTER DIALECT-P HORI
-	{runeRange{0x2CCB, 0x2CCB}, sbprLower},     // L&       COPTIC SMALL LETTER DIALECT-P HORI
-	{runeRange{0x2CCC, 0x2CCC}, sbprUpper},     // L&       COPTIC CAPITAL LETTER OLD COPTIC HORI
-	{runeRange{0x2CCD, 0x2CCD}, sbprLower},     // L&       COPTIC SMALL LETTER OLD COPTIC HORI
-	{runeRange{0x2CCE, 0x2CCE}, sbprUpper},     // L&       COPTIC CAPITAL LETTER OLD COPTIC HA
-	{runeRange{0x2CCF, 0x2CCF}, sbprLower},     // L&       COPTIC SMALL LETTER OLD COPTIC HA
-	{runeRange{0x2CD0, 0x2CD0}, sbprUpper},     // L&       COPTIC CAPITAL LETTER L-SHAPED HA
-	{runeRange{0x2CD1, 0x2CD1}, sbprLower},     // L&       COPTIC SMALL LETTER L-SHAPED HA
-	{runeRange{0x2CD2, 0x2CD2}, sbprUpper},     // L&       COPTIC CAPITAL LETTER OLD COPTIC HEI
-	{runeRange{0x2CD3, 0x2CD3}, sbprLower},     // L&       COPTIC SMALL LETTER OLD COPTIC HEI
-	{runeRange{0x2CD4, 0x2CD4}, sbprUpper},     // L&       COPTIC CAPITAL LETTER OLD COPTIC HAT
-	{runeRange{0x2CD5, 0x2CD5}, sbprLower},     // L&       COPTIC SMALL LETTER OLD COPTIC HAT
-	{runeRange{0x2CD6, 0x2CD6}, sbprUpper},     // L&       COPTIC CAPITAL LETTER OLD COPTIC GANGIA
-	{runeRange{0x2CD7, 0x2CD7}, sbprLower},     // L&       COPTIC SMALL LETTER OLD COPTIC GANGIA
-	{runeRange{0x2CD8, 0x2CD8}, sbprUpper},     // L&       COPTIC CAPITAL LETTER OLD COPTIC DJA
-	{runeRange{0x2CD9, 0x2CD9}, sbprLower},     // L&       COPTIC SMALL LETTER OLD COPTIC DJA
-	{runeRange{0x2CDA, 0x2CDA}, sbprUpper},     // L&       COPTIC CAPITAL LETTER OLD COPTIC SHIMA
-	{runeRange{0x2CDB, 0x2CDB}, sbprLower},     // L&       COPTIC SMALL LETTER OLD COPTIC SHIMA
-	{runeRange{0x2CDC, 0x2CDC}, sbprUpper},     // L&       COPTIC CAPITAL LETTER OLD NUBIAN SHIMA
-	{runeRange{0x2CDD, 0x2CDD}, sbprLower},     // L&       COPTIC SMALL LETTER OLD NUBIAN SHIMA
-	{runeRange{0x2CDE, 0x2CDE}, sbprUpper},     // L&       COPTIC CAPITAL LETTER OLD NUBIAN NGI
-	{runeRange{0x2CDF, 0x2CDF}, sbprLower},     // L&       COPTIC SMALL LETTER OLD NUBIAN NGI
-	{runeRange{0x2CE0, 0x2CE0}, sbprUpper},     // L&       COPTIC CAPITAL LETTER OLD NUBIAN NYI
-	{runeRange{0x2CE1, 0x2CE1}, sbprLower},     // L&       COPTIC SMALL LETTER OLD NUBIAN NYI
-	{runeRange{0x2CE2, 0x2CE2}, sbprUpper},     // L&       COPTIC CAPITAL LETTER OLD NUBIAN WAU
-	{runeRange{0x2CE3, 0x2CE4}, sbprLower},     // L&   [2] COPTIC SMALL LETTER OLD NUBIAN WAU..COPTIC SYMBOL KAI
-	{runeRange{0x2CEB, 0x2CEB}, sbprUpper},     // L&       COPTIC CAPITAL LETTER CRYPTOGRAMMIC SHEI
-	{runeRange{0x2CEC, 0x2CEC}, sbprLower},     // L&       COPTIC SMALL LETTER CRYPTOGRAMMIC SHEI
-	{runeRange{0x2CED, 0x2CED}, sbprUpper},     // L&       COPTIC CAPITAL LETTER CRYPTOGRAMMIC GANGIA
-	{runeRange{0x2CEE, 0x2CEE}, sbprLower},     // L&       COPTIC SMALL LETTER CRYPTOGRAMMIC GANGIA
-	{runeRange{0x2CEF, 0x2CF1}, sbprExtend},    // Mn   [3] COPTIC COMBINING NI ABOVE..COPTIC COMBINING SPIRITUS LENIS
-	{runeRange{0x2CF2, 0x2CF2}, sbprUpper},     // L&       COPTIC CAPITAL LETTER BOHAIRIC KHEI
-	{runeRange{0x2CF3, 0x2CF3}, sbprLower},     // L&       COPTIC SMALL LETTER BOHAIRIC KHEI
-	{runeRange{0x2D00, 0x2D25}, sbprLower},     // L&  [38] GEORGIAN SMALL LETTER AN..GEORGIAN SMALL LETTER HOE
-	{runeRange{0x2D27, 0x2D27}, sbprLower},     // L&       GEORGIAN SMALL LETTER YN
-	{runeRange{0x2D2D, 0x2D2D}, sbprLower},     // L&       GEORGIAN SMALL LETTER AEN
-	{runeRange{0x2D30, 0x2D67}, sbprOLetter},   // Lo  [56] TIFINAGH LETTER YA..TIFINAGH LETTER YO
-	{runeRange{0x2D6F, 0x2D6F}, sbprOLetter},   // Lm       TIFINAGH MODIFIER LETTER LABIALIZATION MARK
-	{runeRange{0x2D7F, 0x2D7F}, sbprExtend},    // Mn       TIFINAGH CONSONANT JOINER
-	{runeRange{0x2D80, 0x2D96}, sbprOLetter},   // Lo  [23] ETHIOPIC SYLLABLE LOA..ETHIOPIC SYLLABLE GGWE
-	{runeRange{0x2DA0, 0x2DA6}, sbprOLetter},   // Lo   [7] ETHIOPIC SYLLABLE SSA..ETHIOPIC SYLLABLE SSO
-	{runeRange{0x2DA8, 0x2DAE}, sbprOLetter},   // Lo   [7] ETHIOPIC SYLLABLE CCA..ETHIOPIC SYLLABLE CCO
-	{runeRange{0x2DB0, 0x2DB6}, sbprOLetter},   // Lo   [7] ETHIOPIC SYLLABLE ZZA..ETHIOPIC SYLLABLE ZZO
-	{runeRange{0x2DB8, 0x2DBE}, sbprOLetter},   // Lo   [7] ETHIOPIC SYLLABLE CCHA..ETHIOPIC SYLLABLE CCHO
-	{runeRange{0x2DC0, 0x2DC6}, sbprOLetter},   // Lo   [7] ETHIOPIC SYLLABLE QYA..ETHIOPIC SYLLABLE QYO
-	{runeRange{0x2DC8, 0x2DCE}, sbprOLetter},   // Lo   [7] ETHIOPIC SYLLABLE KYA..ETHIOPIC SYLLABLE KYO
-	{runeRange{0x2DD0, 0x2DD6}, sbprOLetter},   // Lo   [7] ETHIOPIC SYLLABLE XYA..ETHIOPIC SYLLABLE XYO
-	{runeRange{0x2DD8, 0x2DDE}, sbprOLetter},   // Lo   [7] ETHIOPIC SYLLABLE GYA..ETHIOPIC SYLLABLE GYO
-	{runeRange{0x2DE0, 0x2DFF}, sbprExtend},    // Mn  [32] COMBINING CYRILLIC LETTER BE..COMBINING CYRILLIC LETTER IOTIFIED BIG YUS
-	{runeRange{0x2E00, 0x2E01}, sbprClose},     // Po   [2] RIGHT ANGLE SUBSTITUTION MARKER..RIGHT ANGLE DOTTED SUBSTITUTION MARKER
-	{runeRange{0x2E02, 0x2E02}, sbprClose},     // Pi       LEFT SUBSTITUTION BRACKET
-	{runeRange{0x2E03, 0x2E03}, sbprClose},     // Pf       RIGHT SUBSTITUTION BRACKET
-	{runeRange{0x2E04, 0x2E04}, sbprClose},     // Pi       LEFT DOTTED SUBSTITUTION BRACKET
-	{runeRange{0x2E05, 0x2E05}, sbprClose},     // Pf       RIGHT DOTTED SUBSTITUTION BRACKET
-	{runeRange{0x2E06, 0x2E08}, sbprClose},     // Po   [3] RAISED INTERPOLATION MARKER..DOTTED TRANSPOSITION MARKER
-	{runeRange{0x2E09, 0x2E09}, sbprClose},     // Pi       LEFT TRANSPOSITION BRACKET
-	{runeRange{0x2E0A, 0x2E0A}, sbprClose},     // Pf       RIGHT TRANSPOSITION BRACKET
-	{runeRange{0x2E0B, 0x2E0B}, sbprClose},     // Po       RAISED SQUARE
-	{runeRange{0x2E0C, 0x2E0C}, sbprClose},     // Pi       LEFT RAISED OMISSION BRACKET
-	{runeRange{0x2E0D, 0x2E0D}, sbprClose},     // Pf       RIGHT RAISED OMISSION BRACKET
-	{runeRange{0x2E1C, 0x2E1C}, sbprClose},     // Pi       LEFT LOW PARAPHRASE BRACKET
-	{runeRange{0x2E1D, 0x2E1D}, sbprClose},     // Pf       RIGHT LOW PARAPHRASE BRACKET
-	{runeRange{0x2E20, 0x2E20}, sbprClose},     // Pi       LEFT VERTICAL BAR WITH QUILL
-	{runeRange{0x2E21, 0x2E21}, sbprClose},     // Pf       RIGHT VERTICAL BAR WITH QUILL
-	{runeRange{0x2E22, 0x2E22}, sbprClose},     // Ps       TOP LEFT HALF BRACKET
-	{runeRange{0x2E23, 0x2E23}, sbprClose},     // Pe       TOP RIGHT HALF BRACKET
-	{runeRange{0x2E24, 0x2E24}, sbprClose},     // Ps       BOTTOM LEFT HALF BRACKET
-	{runeRange{0x2E25, 0x2E25}, sbprClose},     // Pe       BOTTOM RIGHT HALF BRACKET
-	{runeRange{0x2E26, 0x2E26}, sbprClose},     // Ps       LEFT SIDEWAYS U BRACKET
-	{runeRange{0x2E27, 0x2E27}, sbprClose},     // Pe       RIGHT SIDEWAYS U BRACKET
-	{runeRange{0x2E28, 0x2E28}, sbprClose},     // Ps       LEFT DOUBLE PARENTHESIS
-	{runeRange{0x2E29, 0x2E29}, sbprClose},     // Pe       RIGHT DOUBLE PARENTHESIS
-	{runeRange{0x2E2E, 0x2E2E}, sbprSTerm},     // Po       REVERSED QUESTION MARK
-	{runeRange{0x2E2F, 0x2E2F}, sbprOLetter},   // Lm       VERTICAL TILDE
-	{runeRange{0x2E3C, 0x2E3C}, sbprSTerm},     // Po       STENOGRAPHIC FULL STOP
-	{runeRange{0x2E42, 0x2E42}, sbprClose},     // Ps       DOUBLE LOW-REVERSED-9 QUOTATION MARK
-	{runeRange{0x2E53, 0x2E54}, sbprSTerm},     // Po   [2] MEDIEVAL EXCLAMATION MARK..MEDIEVAL QUESTION MARK
-	{runeRange{0x2E55, 0x2E55}, sbprClose},     // Ps       LEFT SQUARE BRACKET WITH STROKE
-	{runeRange{0x2E56, 0x2E56}, sbprClose},     // Pe       RIGHT SQUARE BRACKET WITH STROKE
-	{runeRange{0x2E57, 0x2E57}, sbprClose},     // Ps       LEFT SQUARE BRACKET WITH DOUBLE STROKE
-	{runeRange{0x2E58, 0x2E58}, sbprClose},     // Pe       RIGHT SQUARE BRACKET WITH DOUBLE STROKE
-	{runeRange{0x2E59, 0x2E59}, sbprClose},     // Ps       TOP HALF LEFT PARENTHESIS
-	{runeRange{0x2E5A, 0x2E5A}, sbprClose},     // Pe       TOP HALF RIGHT PARENTHESIS
-	{runeRange{0x2E5B, 0x2E5B}, sbprClose},     // Ps       BOTTOM HALF LEFT PARENTHESIS
-	{runeRange{0x2E5C, 0x2E5C}, sbprClose},     // Pe       BOTTOM HALF RIGHT PARENTHESIS
-	{runeRange{0x3000, 0x3000}, sbprSp},        // Zs       IDEOGRAPHIC SPACE
-	{runeRange{0x3001, 0x3001}, sbprSContinue}, // Po       IDEOGRAPHIC COMMA
-	{runeRange{0x3002, 0x3002}, sbprSTerm},     // Po       IDEOGRAPHIC FULL STOP
-	{runeRange{0x3005, 0x3005}, sbprOLetter},   // Lm       IDEOGRAPHIC ITERATION MARK
-	{runeRange{0x3006, 0x3006}, sbprOLetter},   // Lo       IDEOGRAPHIC CLOSING MARK
-	{runeRange{0x3007, 0x3007}, sbprOLetter},   // Nl       IDEOGRAPHIC NUMBER ZERO
-	{runeRange{0x3008, 0x3008}, sbprClose},     // Ps       LEFT ANGLE BRACKET
-	{runeRange{0x3009, 0x3009}, sbprClose},     // Pe       RIGHT ANGLE BRACKET
-	{runeRange{0x300A, 0x300A}, sbprClose},     // Ps       LEFT DOUBLE ANGLE BRACKET
-	{runeRange{0x300B, 0x300B}, sbprClose},     // Pe       RIGHT DOUBLE ANGLE BRACKET
-	{runeRange{0x300C, 0x300C}, sbprClose},     // Ps       LEFT CORNER BRACKET
-	{runeRange{0x300D, 0x300D}, sbprClose},     // Pe       RIGHT CORNER BRACKET
-	{runeRange{0x300E, 0x300E}, sbprClose},     // Ps       LEFT WHITE CORNER BRACKET
-	{runeRange{0x300F, 0x300F}, sbprClose},     // Pe       RIGHT WHITE CORNER BRACKET
-	{runeRange{0x3010, 0x3010}, sbprClose},     // Ps       LEFT BLACK LENTICULAR BRACKET
-	{runeRange{0x3011, 0x3011}, sbprClose},     // Pe       RIGHT BLACK LENTICULAR BRACKET
-	{runeRange{0x3014, 0x3014}, sbprClose},     // Ps       LEFT TORTOISE SHELL BRACKET
-	{runeRange{0x3015, 0x3015}, sbprClose},     // Pe       RIGHT TORTOISE SHELL BRACKET
-	{runeRange{0x3016, 0x3016}, sbprClose},     // Ps       LEFT WHITE LENTICULAR BRACKET
-	{runeRange{0x3017, 0x3017}, sbprClose},     // Pe       RIGHT WHITE LENTICULAR BRACKET
-	{runeRange{0x3018, 0x3018}, sbprClose},     // Ps       LEFT WHITE TORTOISE SHELL BRACKET
-	{runeRange{0x3019, 0x3019}, sbprClose},     // Pe       RIGHT WHITE TORTOISE SHELL BRACKET
-	{runeRange{0x301A, 0x301A}, sbprClose},     // Ps       LEFT WHITE SQUARE BRACKET
-	{runeRange{0x301B, 0x301B}, sbprClose},     // Pe       RIGHT WHITE SQUARE BRACKET
-	{runeRange{0x301D, 0x301D}, sbprClose},     // Ps       REVERSED DOUBLE PRIME QUOTATION MARK
-	{runeRange{0x301E, 0x301F}, sbprClose},     // Pe   [2] DOUBLE PRIME QUOTATION MARK..LOW DOUBLE PRIME QUOTATION MARK
-	{runeRange{0x3021, 0x3029}, sbprOLetter},   // Nl   [9] HANGZHOU NUMERAL ONE..HANGZHOU NUMERAL NINE
-	{runeRange{0x302A, 0x302D}, sbprExtend},    // Mn   [4] IDEOGRAPHIC LEVEL TONE MARK..IDEOGRAPHIC ENTERING TONE MARK
-	{runeRange{0x302E, 0x302F}, sbprExtend},    // Mc   [2] HANGUL SINGLE DOT TONE MARK..HANGUL DOUBLE DOT TONE MARK
-	{runeRange{0x3031, 0x3035}, sbprOLetter},   // Lm   [5] VERTICAL KANA REPEAT MARK..VERTICAL KANA REPEAT MARK LOWER HALF
-	{runeRange{0x3038, 0x303A}, sbprOLetter},   // Nl   [3] HANGZHOU NUMERAL TEN..HANGZHOU NUMERAL THIRTY
-	{runeRange{0x303B, 0x303B}, sbprOLetter},   // Lm       VERTICAL IDEOGRAPHIC ITERATION MARK
-	{runeRange{0x303C, 0x303C}, sbprOLetter},   // Lo       MASU MARK
-	{runeRange{0x3041, 0x3096}, sbprOLetter},   // Lo  [86] HIRAGANA LETTER SMALL A..HIRAGANA LETTER SMALL KE
-	{runeRange{0x3099, 0x309A}, sbprExtend},    // Mn   [2] COMBINING KATAKANA-HIRAGANA VOICED SOUND MARK..COMBINING KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK
-	{runeRange{0x309D, 0x309E}, sbprOLetter},   // Lm   [2] HIRAGANA ITERATION MARK..HIRAGANA VOICED ITERATION MARK
-	{runeRange{0x309F, 0x309F}, sbprOLetter},   // Lo       HIRAGANA DIGRAPH YORI
-	{runeRange{0x30A1, 0x30FA}, sbprOLetter},   // Lo  [90] KATAKANA LETTER SMALL A..KATAKANA LETTER VO
-	{runeRange{0x30FC, 0x30FE}, sbprOLetter},   // Lm   [3] KATAKANA-HIRAGANA PROLONGED SOUND MARK..KATAKANA VOICED ITERATION MARK
-	{runeRange{0x30FF, 0x30FF}, sbprOLetter},   // Lo       KATAKANA DIGRAPH KOTO
-	{runeRange{0x3105, 0x312F}, sbprOLetter},   // Lo  [43] BOPOMOFO LETTER B..BOPOMOFO LETTER NN
-	{runeRange{0x3131, 0x318E}, sbprOLetter},   // Lo  [94] HANGUL LETTER KIYEOK..HANGUL LETTER ARAEAE
-	{runeRange{0x31A0, 0x31BF}, sbprOLetter},   // Lo  [32] BOPOMOFO LETTER BU..BOPOMOFO LETTER AH
-	{runeRange{0x31F0, 0x31FF}, sbprOLetter},   // Lo  [16] KATAKANA LETTER SMALL KU..KATAKANA LETTER SMALL RO
-	{runeRange{0x3400, 0x4DBF}, sbprOLetter},   // Lo [6592] CJK UNIFIED IDEOGRAPH-3400..CJK UNIFIED IDEOGRAPH-4DBF
-	{runeRange{0x4E00, 0xA014}, sbprOLetter},   // Lo [21013] CJK UNIFIED IDEOGRAPH-4E00..YI SYLLABLE E
-	{runeRange{0xA015, 0xA015}, sbprOLetter},   // Lm       YI SYLLABLE WU
-	{runeRange{0xA016, 0xA48C}, sbprOLetter},   // Lo [1143] YI SYLLABLE BIT..YI SYLLABLE YYR
-	{runeRange{0xA4D0, 0xA4F7}, sbprOLetter},   // Lo  [40] LISU LETTER BA..LISU LETTER OE
-	{runeRange{0xA4F8, 0xA4FD}, sbprOLetter},   // Lm   [6] LISU LETTER TONE MYA TI..LISU LETTER TONE MYA JEU
-	{runeRange{0xA4FF, 0xA4FF}, sbprSTerm},     // Po       LISU PUNCTUATION FULL STOP
-	{runeRange{0xA500, 0xA60B}, sbprOLetter},   // Lo [268] VAI SYLLABLE EE..VAI SYLLABLE NG
-	{runeRange{0xA60C, 0xA60C}, sbprOLetter},   // Lm       VAI SYLLABLE LENGTHENER
-	{runeRange{0xA60E, 0xA60F}, sbprSTerm},     // Po   [2] VAI FULL STOP..VAI QUESTION MARK
-	{runeRange{0xA610, 0xA61F}, sbprOLetter},   // Lo  [16] VAI SYLLABLE NDOLE FA..VAI SYMBOL JONG
-	{runeRange{0xA620, 0xA629}, sbprNumeric},   // Nd  [10] VAI DIGIT ZERO..VAI DIGIT NINE
-	{runeRange{0xA62A, 0xA62B}, sbprOLetter},   // Lo   [2] VAI SYLLABLE NDOLE MA..VAI SYLLABLE NDOLE DO
-	{runeRange{0xA640, 0xA640}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER ZEMLYA
-	{runeRange{0xA641, 0xA641}, sbprLower},     // L&       CYRILLIC SMALL LETTER ZEMLYA
-	{runeRange{0xA642, 0xA642}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER DZELO
-	{runeRange{0xA643, 0xA643}, sbprLower},     // L&       CYRILLIC SMALL LETTER DZELO
-	{runeRange{0xA644, 0xA644}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER REVERSED DZE
-	{runeRange{0xA645, 0xA645}, sbprLower},     // L&       CYRILLIC SMALL LETTER REVERSED DZE
-	{runeRange{0xA646, 0xA646}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER IOTA
-	{runeRange{0xA647, 0xA647}, sbprLower},     // L&       CYRILLIC SMALL LETTER IOTA
-	{runeRange{0xA648, 0xA648}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER DJERV
-	{runeRange{0xA649, 0xA649}, sbprLower},     // L&       CYRILLIC SMALL LETTER DJERV
-	{runeRange{0xA64A, 0xA64A}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER MONOGRAPH UK
-	{runeRange{0xA64B, 0xA64B}, sbprLower},     // L&       CYRILLIC SMALL LETTER MONOGRAPH UK
-	{runeRange{0xA64C, 0xA64C}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER BROAD OMEGA
-	{runeRange{0xA64D, 0xA64D}, sbprLower},     // L&       CYRILLIC SMALL LETTER BROAD OMEGA
-	{runeRange{0xA64E, 0xA64E}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER NEUTRAL YER
-	{runeRange{0xA64F, 0xA64F}, sbprLower},     // L&       CYRILLIC SMALL LETTER NEUTRAL YER
-	{runeRange{0xA650, 0xA650}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER YERU WITH BACK YER
-	{runeRange{0xA651, 0xA651}, sbprLower},     // L&       CYRILLIC SMALL LETTER YERU WITH BACK YER
-	{runeRange{0xA652, 0xA652}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER IOTIFIED YAT
-	{runeRange{0xA653, 0xA653}, sbprLower},     // L&       CYRILLIC SMALL LETTER IOTIFIED YAT
-	{runeRange{0xA654, 0xA654}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER REVERSED YU
-	{runeRange{0xA655, 0xA655}, sbprLower},     // L&       CYRILLIC SMALL LETTER REVERSED YU
 	{runeRange{0xA656, 0xA656}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER IOTIFIED A
-	{runeRange{0xA657, 0xA657}, sbprLower},     // L&       CYRILLIC SMALL LETTER IOTIFIED A
-	{runeRange{0xA658, 0xA658}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER CLOSED LITTLE YUS
-	{runeRange{0xA659, 0xA659}, sbprLower},     // L&       CYRILLIC SMALL LETTER CLOSED LITTLE YUS
-	{runeRange{0xA65A, 0xA65A}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER BLENDED YUS
-	{runeRange{0xA65B, 0xA65B}, sbprLower},     // L&       CYRILLIC SMALL LETTER BLENDED YUS
-	{runeRange{0xA65C, 0xA65C}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER IOTIFIED CLOSED LITTLE YUS
-	{runeRange{0xA65D, 0xA65D}, sbprLower},     // L&       CYRILLIC SMALL LETTER IOTIFIED CLOSED LITTLE YUS
-	{runeRange{0xA65E, 0xA65E}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER YN
-	{runeRange{0xA65F, 0xA65F}, sbprLower},     // L&       CYRILLIC SMALL LETTER YN
-	{runeRange{0xA660, 0xA660}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER REVERSED TSE
-	{runeRange{0xA661, 0xA661}, sbprLower},     // L&       CYRILLIC SMALL LETTER REVERSED TSE
-	{runeRange{0xA662, 0xA662}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER SOFT DE
-	{runeRange{0xA663, 0xA663}, sbprLower},     // L&       CYRILLIC SMALL LETTER SOFT DE
-	{runeRange{0xA664, 0xA664}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER SOFT EL
-	{runeRange{0xA665, 0xA665}, sbprLower},     // L&       CYRILLIC SMALL LETTER SOFT EL
-	{runeRange{0xA666, 0xA666}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER SOFT EM
-	{runeRange{0xA667, 0xA667}, sbprLower},     // L&       CYRILLIC SMALL LETTER SOFT EM
-	{runeRange{0xA668, 0xA668}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER MONOCULAR O
-	{runeRange{0xA669, 0xA669}, sbprLower},     // L&       CYRILLIC SMALL LETTER MONOCULAR O
-	{runeRange{0xA66A, 0xA66A}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER BINOCULAR O
-	{runeRange{0xA66B, 0xA66B}, sbprLower},     // L&       CYRILLIC SMALL LETTER BINOCULAR O
-	{runeRange{0xA66C, 0xA66C}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER DOUBLE MONOCULAR O
-	{runeRange{0xA66D, 0xA66D}, sbprLower},     // L&       CYRILLIC SMALL LETTER DOUBLE MONOCULAR O
-	{runeRange{0xA66E, 0xA66E}, sbprOLetter},   // Lo       CYRILLIC LETTER MULTIOCULAR O
-	{runeRange{0xA66F, 0xA66F}, sbprExtend},    // Mn       COMBINING CYRILLIC VZMET
-	{runeRange{0xA670, 0xA672}, sbprExtend},    // Me   [3] COMBINING CYRILLIC TEN MILLIONS SIGN..COMBINING CYRILLIC THOUSAND MILLIONS SIGN
-	{runeRange{0xA674, 0xA67D}, sbprExtend},    // Mn  [10] COMBINING CYRILLIC LETTER UKRAINIAN IE..COMBINING CYRILLIC PAYEROK
-	{runeRange{0xA67F, 0xA67F}, sbprOLetter},   // Lm       CYRILLIC PAYEROK
-	{runeRange{0xA680, 0xA680}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER DWE
-	{runeRange{0xA681, 0xA681}, sbprLower},     // L&       CYRILLIC SMALL LETTER DWE
-	{runeRange{0xA682, 0xA682}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER DZWE
-	{runeRange{0xA683, 0xA683}, sbprLower},     // L&       CYRILLIC SMALL LETTER DZWE
-	{runeRange{0xA684, 0xA684}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER ZHWE
-	{runeRange{0xA685, 0xA685}, sbprLower},     // L&       CYRILLIC SMALL LETTER ZHWE
-	{runeRange{0xA686, 0xA686}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER CCHE
-	{runeRange{0xA687, 0xA687}, sbprLower},     // L&       CYRILLIC SMALL LETTER CCHE
-	{runeRange{0xA688, 0xA688}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER DZZE
-	{runeRange{0xA689, 0xA689}, sbprLower},     // L&       CYRILLIC SMALL LETTER DZZE
-	{runeRange{0xA68A, 0xA68A}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER TE WITH MIDDLE HOOK
-	{runeRange{0xA68B, 0xA68B}, sbprLower},     // L&       CYRILLIC SMALL LETTER TE WITH MIDDLE HOOK
-	{runeRange{0xA68C, 0xA68C}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER TWE
-	{runeRange{0xA68D, 0xA68D}, sbprLower},     // L&       CYRILLIC SMALL LETTER TWE
-	{runeRange{0xA68E, 0xA68E}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER TSWE
-	{runeRange{0xA68F, 0xA68F}, sbprLower},     // L&       CYRILLIC SMALL LETTER TSWE
-	{runeRange{0xA690, 0xA690}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER TSSE
-	{runeRange{0xA691, 0xA691}, sbprLower},     // L&       CYRILLIC SMALL LETTER TSSE
-	{runeRange{0xA692, 0xA692}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER TCHE
-	{runeRange{0xA693, 0xA693}, sbprLower},     // L&       CYRILLIC SMALL LETTER TCHE
-	{runeRange{0xA694, 0xA694}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER HWE
-	{runeRange{0xA695, 0xA695}, sbprLower},     // L&       CYRILLIC SMALL LETTER HWE
-	{runeRange{0xA696, 0xA696}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER SHWE
-	{runeRange{0xA697, 0xA697}, sbprLower},     // L&       CYRILLIC SMALL LETTER SHWE
-	{runeRange{0xA698, 0xA698}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER DOUBLE O
-	{runeRange{0xA699, 0xA699}, sbprLower},     // L&       CYRILLIC SMALL LETTER DOUBLE O
-	{runeRange{0xA69A, 0xA69A}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER CROSSED O
-	{runeRange{0xA69B, 0xA69B}, sbprLower},     // L&       CYRILLIC SMALL LETTER CROSSED O
-	{runeRange{0xA69C, 0xA69D}, sbprLower},     // Lm   [2] MODIFIER LETTER CYRILLIC HARD SIGN..MODIFIER LETTER CYRILLIC SOFT SIGN
-	{runeRange{0xA69E, 0xA69F}, sbprExtend},    // Mn   [2] COMBINING CYRILLIC LETTER EF..COMBINING CYRILLIC LETTER IOTIFIED E
-	{runeRange{0xA6A0, 0xA6E5}, sbprOLetter},   // Lo  [70] BAMUM LETTER A..BAMUM LETTER KI
-	{runeRange{0xA6E6, 0xA6EF}, sbprOLetter},   // Nl  [10] BAMUM LETTER MO..BAMUM LETTER KOGHOM
-	{runeRange{0xA6F0, 0xA6F1}, sbprExtend},    // Mn   [2] BAMUM COMBINING MARK KOQNDON..BAMUM COMBINING MARK TUKWENTIS
-	{runeRange{0xA6F3, 0xA6F3}, sbprSTerm},     // Po       BAMUM FULL STOP
-	{runeRange{0xA6F7, 0xA6F7}, sbprSTerm},     // Po       BAMUM QUESTION MARK
-	{runeRange{0xA717, 0xA71F}, sbprOLetter},   // Lm   [9] MODIFIER LETTER DOT VERTICAL BAR..MODIFIER LETTER LOW INVERTED EXCLAMATION MARK
-	{runeRange{0xA722, 0xA722}, sbprUpper},     // L&       LATIN CAPITAL LETTER EGYPTOLOGICAL ALEF
-	{runeRange{0xA723, 0xA723}, sbprLower},     // L&       LATIN SMALL LETTER EGYPTOLOGICAL ALEF
-	{runeRange{0xA724, 0xA724}, sbprUpper},     // L&       LATIN CAPITAL LETTER EGYPTOLOGICAL AIN
-	{runeRange{0xA725, 0xA725}, sbprLower},     // L&       LATIN SMALL LETTER EGYPTOLOGICAL AIN
-	{runeRange{0xA726, 0xA726}, sbprUpper},     // L&       LATIN CAPITAL LETTER HENG
-	{runeRange{0xA727, 0xA727}, sbprLower},     // L&       LATIN SMALL LETTER HENG
-	{runeRange{0xA728, 0xA728}, sbprUpper},     // L&       LATIN CAPITAL LETTER TZ
-	{runeRange{0xA729, 0xA729}, sbprLower},     // L&       LATIN SMALL LETTER TZ
-	{runeRange{0xA72A, 0xA72A}, sbprUpper},     // L&       LATIN CAPITAL LETTER TRESILLO
-	{runeRange{0xA72B, 0xA72B}, sbprLower},     // L&       LATIN SMALL LETTER TRESILLO
-	{runeRange{0xA72C, 0xA72C}, sbprUpper},     // L&       LATIN CAPITAL LETTER CUATRILLO
-	{runeRange{0xA72D, 0xA72D}, sbprLower},     // L&       LATIN SMALL LETTER CUATRILLO
-	{runeRange{0xA72E, 0xA72E}, sbprUpper},     // L&       LATIN CAPITAL LETTER CUATRILLO WITH COMMA
-	{runeRange{0xA72F, 0xA731}, sbprLower},     // L&   [3] LATIN SMALL LETTER CUATRILLO WITH COMMA..LATIN LETTER SMALL CAPITAL S
-	{runeRange{0xA732, 0xA732}, sbprUpper},     // L&       LATIN CAPITAL LETTER AA
-	{runeRange{0xA733, 0xA733}, sbprLower},     // L&       LATIN SMALL LETTER AA
-	{runeRange{0xA734, 0xA734}, sbprUpper},     // L&       LATIN CAPITAL LETTER AO
-	{runeRange{0xA735, 0xA735}, sbprLower},     // L&       LATIN SMALL LETTER AO
-	{runeRange{0xA736, 0xA736}, sbprUpper},     // L&       LATIN CAPITAL LETTER AU
-	{runeRange{0xA737, 0xA737}, sbprLower},     // L&       LATIN SMALL LETTER AU
-	{runeRange{0xA738, 0xA738}, sbprUpper},     // L&       LATIN CAPITAL LETTER AV
-	{runeRange{0xA739, 0xA739}, sbprLower},     // L&       LATIN SMALL LETTER AV
-	{runeRange{0xA73A, 0xA73A}, sbprUpper},     // L&       LATIN CAPITAL LETTER AV WITH HORIZONTAL BAR
-	{runeRange{0xA73B, 0xA73B}, sbprLower},     // L&       LATIN SMALL LETTER AV WITH HORIZONTAL BAR
-	{runeRange{0xA73C, 0xA73C}, sbprUpper},     // L&       LATIN CAPITAL LETTER AY
-	{runeRange{0xA73D, 0xA73D}, sbprLower},     // L&       LATIN SMALL LETTER AY
-	{runeRange{0xA73E, 0xA73E}, sbprUpper},     // L&       LATIN CAPITAL LETTER REVERSED C WITH DOT
-	{runeRange{0xA73F, 0xA73F}, sbprLower},     // L&       LATIN SMALL LETTER REVERSED C WITH DOT
-	{runeRange{0xA740, 0xA740}, sbprUpper},     // L&       LATIN CAPITAL LETTER K WITH STROKE
-	{runeRange{0xA741, 0xA741}, sbprLower},     // L&       LATIN SMALL LETTER K WITH STROKE
-	{runeRange{0xA742, 0xA742}, sbprUpper},     // L&       LATIN CAPITAL LETTER K WITH DIAGONAL STROKE
-	{runeRange{0xA743, 0xA743}, sbprLower},     // L&       LATIN SMALL LETTER K WITH DIAGONAL STROKE
-	{runeRange{0xA744, 0xA744}, sbprUpper},     // L&       LATIN CAPITAL LETTER K WITH STROKE AND DIAGONAL STROKE
-	{runeRange{0xA745, 0xA745}, sbprLower},     // L&       LATIN SMALL LETTER K WITH STROKE AND DIAGONAL STROKE
-	{runeRange{0xA746, 0xA746}, sbprUpper},     // L&       LATIN CAPITAL LETTER BROKEN L
-	{runeRange{0xA747, 0xA747}, sbprLower},     // L&       LATIN SMALL LETTER BROKEN L
-	{runeRange{0xA748, 0xA748}, sbprUpper},     // L&       LATIN CAPITAL LETTER L WITH HIGH STROKE
-	{runeRange{0xA749, 0xA749}, sbprLower},     // L&       LATIN SMALL LETTER L WITH HIGH STROKE
-	{runeRange{0xA74A, 0xA74A}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH LONG STROKE OVERLAY
-	{runeRange{0xA74B, 0xA74B}, sbprLower},     // L&       LATIN SMALL LETTER O WITH LONG STROKE OVERLAY
-	{runeRange{0xA74C, 0xA74C}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH LOOP
-	{runeRange{0xA74D, 0xA74D}, sbprLower},     // L&       LATIN SMALL LETTER O WITH LOOP
-	{runeRange{0xA74E, 0xA74E}, sbprUpper},     // L&       LATIN CAPITAL LETTER OO
-	{runeRange{0xA74F, 0xA74F}, sbprLower},     // L&       LATIN SMALL LETTER OO
-	{runeRange{0xA750, 0xA750}, sbprUpper},     // L&       LATIN CAPITAL LETTER P WITH STROKE THROUGH DESCENDER
-	{runeRange{0xA751, 0xA751}, sbprLower},     // L&       LATIN SMALL LETTER P WITH STROKE THROUGH DESCENDER
-	{runeRange{0xA752, 0xA752}, sbprUpper},     // L&       LATIN CAPITAL LETTER P WITH FLOURISH
-	{runeRange{0xA753, 0xA753}, sbprLower},     // L&       LATIN SMALL LETTER P WITH FLOURISH
-	{runeRange{0xA754, 0xA754}, sbprUpper},     // L&       LATIN CAPITAL LETTER P WITH SQUIRREL TAIL
-	{runeRange{0xA755, 0xA755}, sbprLower},     // L&       LATIN SMALL LETTER P WITH SQUIRREL TAIL
-	{runeRange{0xA756, 0xA756}, sbprUpper},     // L&       LATIN CAPITAL LETTER Q WITH STROKE THROUGH DESCENDER
-	{runeRange{0xA757, 0xA757}, sbprLower},     // L&       LATIN SMALL LETTER Q WITH STROKE THROUGH DESCENDER
-	{runeRange{0xA758, 0xA758}, sbprUpper},     // L&       LATIN CAPITAL LETTER Q WITH DIAGONAL STROKE
-	{runeRange{0xA759, 0xA759}, sbprLower},     // L&       LATIN SMALL LETTER Q WITH DIAGONAL STROKE
-	{runeRange{0xA75A, 0xA75A}, sbprUpper},     // L&       LATIN CAPITAL LETTER R ROTUNDA
-	{runeRange{0xA75B, 0xA75B}, sbprLower},     // L&       LATIN SMALL LETTER R ROTUNDA
-	{runeRange{0xA75C, 0xA75C}, sbprUpper},     // L&       LATIN CAPITAL LETTER RUM ROTUNDA
-	{runeRange{0xA75D, 0xA75D}, sbprLower},     // L&       LATIN SMALL LETTER RUM ROTUNDA
-	{runeRange{0xA75E, 0xA75E}, sbprUpper},     // L&       LATIN CAPITAL LETTER V WITH DIAGONAL STROKE
-	{runeRange{0xA75F, 0xA75F}, sbprLower},     // L&       LATIN SMALL LETTER V WITH DIAGONAL STROKE
-	{runeRange{0xA760, 0xA760}, sbprUpper},     // L&       LATIN CAPITAL LETTER VY
-	{runeRange{0xA761, 0xA761}, sbprLower},     // L&       LATIN SMALL LETTER VY
-	{runeRange{0xA762, 0xA762}, sbprUpper},     // L&       LATIN CAPITAL LETTER VISIGOTHIC Z
-	{runeRange{0xA763, 0xA763}, sbprLower},     // L&       LATIN SMALL LETTER VISIGOTHIC Z
-	{runeRange{0xA764, 0xA764}, sbprUpper},     // L&       LATIN CAPITAL LETTER THORN WITH STROKE
-	{runeRange{0xA765, 0xA765}, sbprLower},     // L&       LATIN SMALL LETTER THORN WITH STROKE
-	{runeRange{0xA766, 0xA766}, sbprUpper},     // L&       LATIN CAPITAL LETTER THORN WITH STROKE THROUGH DESCENDER
-	{runeRange{0xA767, 0xA767}, sbprLower},     // L&       LATIN SMALL LETTER THORN WITH STROKE THROUGH DESCENDER
-	{runeRange{0xA768, 0xA768}, sbprUpper},     // L&       LATIN CAPITAL LETTER VEND
-	{runeRange{0xA769, 0xA769}, sbprLower},     // L&       LATIN SMALL LETTER VEND
-	{runeRange{0xA76A, 0xA76A}, sbprUpper},     // L&       LATIN CAPITAL LETTER ET
-	{runeRange{0xA76B, 0xA76B}, sbprLower},     // L&       LATIN SMALL LETTER ET
-	{runeRange{0xA76C, 0xA76C}, sbprUpper},     // L&       LATIN CAPITAL LETTER IS
-	{runeRange{0xA76D, 0xA76D}, sbprLower},     // L&       LATIN SMALL LETTER IS
-	{runeRange{0xA76E, 0xA76E}, sbprUpper},     // L&       LATIN CAPITAL LETTER CON
-	{runeRange{0xA76F, 0xA76F}, sbprLower},     // L&       LATIN SMALL LETTER CON
-	{runeRange{0xA770, 0xA770}, sbprLower},     // Lm       MODIFIER LETTER US
-	{runeRange{0xA771, 0xA778}, sbprLower},     // L&   [8] LATIN SMALL LETTER DUM..LATIN SMALL LETTER UM
-	{runeRange{0xA779, 0xA779}, sbprUpper},     // L&       LATIN CAPITAL LETTER INSULAR D
-	{runeRange{0xA77A, 0xA77A}, sbprLower},     // L&       LATIN SMALL LETTER INSULAR D
-	{runeRange{0xA77B, 0xA77B}, sbprUpper},     // L&       LATIN CAPITAL LETTER INSULAR F
-	{runeRange{0xA77C, 0xA77C}, sbprLower},     // L&       LATIN SMALL LETTER INSULAR F
-	{runeRange{0xA77D, 0xA77E}, sbprUpper},     // L&   [2] LATIN CAPITAL LETTER INSULAR G..LATIN CAPITAL LETTER TURNED INSULAR G
-	{runeRange{0xA77F, 0xA77F}, sbprLower},     // L&       LATIN SMALL LETTER TURNED INSULAR G
-	{runeRange{0xA780, 0xA780}, sbprUpper},     // L&       LATIN CAPITAL LETTER TURNED L
-	{runeRange{0xA781, 0xA781}, sbprLower},     // L&       LATIN SMALL LETTER TURNED L
-	{runeRange{0xA782, 0xA782}, sbprUpper},     // L&       LATIN CAPITAL LETTER INSULAR R
-	{runeRange{0xA783, 0xA783}, sbprLower},     // L&       LATIN SMALL LETTER INSULAR R
-	{runeRange{0xA784, 0xA784}, sbprUpper},     // L&       LATIN CAPITAL LETTER INSULAR S
-	{runeRange{0xA785, 0xA785}, sbprLower},     // L&       LATIN SMALL LETTER INSULAR S
-	{runeRange{0xA786, 0xA786}, sbprUpper},     // L&       LATIN CAPITAL LETTER INSULAR T
-	{runeRange{0xA787, 0xA787}, sbprLower},     // L&       LATIN SMALL LETTER INSULAR T
-	{runeRange{0xA788, 0xA788}, sbprOLetter},   // Lm       MODIFIER LETTER LOW CIRCUMFLEX ACCENT
-	{runeRange{0xA78B, 0xA78B}, sbprUpper},     // L&       LATIN CAPITAL LETTER SALTILLO
-	{runeRange{0xA78C, 0xA78C}, sbprLower},     // L&       LATIN SMALL LETTER SALTILLO
-	{runeRange{0xA78D, 0xA78D}, sbprUpper},     // L&       LATIN CAPITAL LETTER TURNED H
-	{runeRange{0xA78E, 0xA78E}, sbprLower},     // L&       LATIN SMALL LETTER L WITH RETROFLEX HOOK AND BELT
-	{runeRange{0xA78F, 0xA78F}, sbprOLetter},   // Lo       LATIN LETTER SINOLOGICAL DOT
-	{runeRange{0xA790, 0xA790}, sbprUpper},     // L&       LATIN CAPITAL LETTER N WITH DESCENDER
-	{runeRange{0xA791, 0xA791}, sbprLower},     // L&       LATIN SMALL LETTER N WITH DESCENDER
-	{runeRange{0xA792, 0xA792}, sbprUpper},     // L&       LATIN CAPITAL LETTER C WITH BAR
-	{runeRange{0xA793, 0xA795}, sbprLower},     // L&   [3] LATIN SMALL LETTER C WITH BAR..LATIN SMALL LETTER H WITH PALATAL HOOK
-	{runeRange{0xA796, 0xA796}, sbprUpper},     // L&       LATIN CAPITAL LETTER B WITH FLOURISH
-	{runeRange{0xA797, 0xA797}, sbprLower},     // L&       LATIN SMALL LETTER B WITH FLOURISH
-	{runeRange{0xA798, 0xA798}, sbprUpper},     // L&       LATIN CAPITAL LETTER F WITH STROKE
-	{runeRange{0xA799, 0xA799}, sbprLower},     // L&       LATIN SMALL LETTER F WITH STROKE
-	{runeRange{0xA79A, 0xA79A}, sbprUpper},     // L&       LATIN CAPITAL LETTER VOLAPUK AE
-	{runeRange{0xA79B, 0xA79B}, sbprLower},     // L&       LATIN SMALL LETTER VOLAPUK AE
-	{runeRange{0xA79C, 0xA79C}, sbprUpper},     // L&       LATIN CAPITAL LETTER VOLAPUK OE
-	{runeRange{0xA79D, 0xA79D}, sbprLower},     // L&       LATIN SMALL LETTER VOLAPUK OE
-	{runeRange{0xA79E, 0xA79E}, sbprUpper},     // L&       LATIN CAPITAL LETTER VOLAPUK UE
-	{runeRange{0xA79F, 0xA79F}, sbprLower},     // L&       LATIN SMALL LETTER VOLAPUK UE
-	{runeRange{0xA7A0, 0xA7A0}, sbprUpper},     // L&       LATIN CAPITAL LETTER G WITH OBLIQUE STROKE
-	{runeRange{0xA7A1, 0xA7A1}, sbprLower},     // L&       LATIN SMALL LETTER G WITH OBLIQUE STROKE
-	{runeRange{0xA7A2, 0xA7A2}, sbprUpper},     // L&       LATIN CAPITAL LETTER K WITH OBLIQUE STROKE
-	{runeRange{0xA7A3, 0xA7A3}, sbprLower},     // L&       LATIN SMALL LETTER K WITH OBLIQUE STROKE
-	{runeRange{0xA7A4, 0xA7A4}, sbprUpper},     // L&       LATIN CAPITAL LETTER N WITH OBLIQUE STROKE
-	{runeRange{0xA7A5, 0xA7A5}, sbprLower},     // L&       LATIN SMALL LETTER N WITH OBLIQUE STROKE
-	{runeRange{0xA7A6, 0xA7A6}, sbprUpper},     // L&       LATIN CAPITAL LETTER R WITH OBLIQUE STROKE
-	{runeRange{0xA7A7, 0xA7A7}, sbprLower},     // L&       LATIN SMALL LETTER R WITH OBLIQUE STROKE
-	{runeRange{0xA7A8, 0xA7A8}, sbprUpper},     // L&       LATIN CAPITAL LETTER S WITH OBLIQUE STROKE
-	{runeRange{0xA7A9, 0xA7A9}, sbprLower},     // L&       LATIN SMALL LETTER S WITH OBLIQUE STROKE
-	{runeRange{0xA7AA, 0xA7AE}, sbprUpper},     // L&   [5] LATIN CAPITAL LETTER H WITH HOOK..LATIN CAPITAL LETTER SMALL CAPITAL I
-	{runeRange{0xA7AF, 0xA7AF}, sbprLower},     // L&       LATIN LETTER SMALL CAPITAL Q
-	{runeRange{0xA7B0, 0xA7B4}, sbprUpper},     // L&   [5] LATIN CAPITAL LETTER TURNED K..LATIN CAPITAL LETTER BETA
-	{runeRange{0xA7B5, 0xA7B5}, sbprLower},     // L&       LATIN SMALL LETTER BETA
-	{runeRange{0xA7B6, 0xA7B6}, sbprUpper},     // L&       LATIN CAPITAL LETTER OMEGA
-	{runeRange{0xA7B7, 0xA7B7}, sbprLower},     // L&       LATIN SMALL LETTER OMEGA
-	{runeRange{0xA7B8, 0xA7B8}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH STROKE
-	{runeRange{0xA7B9, 0xA7B9}, sbprLower},     // L&       LATIN SMALL LETTER U WITH STROKE
-	{runeRange{0xA7BA, 0xA7BA}, sbprUpper},     // L&       LATIN CAPITAL LETTER GLOTTAL A
-	{runeRange{0xA7BB, 0xA7BB}, sbprLower},     // L&       LATIN SMALL LETTER GLOTTAL A
-	{runeRange{0xA7BC, 0xA7BC}, sbprUpper},     // L&       LATIN CAPITAL LETTER GLOTTAL I
-	{runeRange{0xA7BD, 0xA7BD}, sbprLower},     // L&       LATIN SMALL LETTER GLOTTAL I
-	{runeRange{0xA7BE, 0xA7BE}, sbprUpper},     // L&       LATIN CAPITAL LETTER GLOTTAL U
-	{runeRange{0xA7BF, 0xA7BF}, sbprLower},     // L&       LATIN SMALL LETTER GLOTTAL U
-	{runeRange{0xA7C0, 0xA7C0}, sbprUpper},     // L&       LATIN CAPITAL LETTER OLD POLISH O
-	{runeRange{0xA7C1, 0xA7C1}, sbprLower},     // L&       LATIN SMALL LETTER OLD POLISH O
-	{runeRange{0xA7C2, 0xA7C2}, sbprUpper},     // L&       LATIN CAPITAL LETTER ANGLICANA W
-	{runeRange{0xA7C3, 0xA7C3}, sbprLower},     // L&       LATIN SMALL LETTER ANGLICANA W
-	{runeRange{0xA7C4, 0xA7C7}, sbprUpper},     // L&   [4] LATIN CAPITAL LETTER C WITH PALATAL HOOK..LATIN CAPITAL LETTER D WITH SHORT STROKE OVERLAY
-	{runeRange{0xA7C8, 0xA7C8}, sbprLower},     // L&       LATIN SMALL LETTER D WITH SHORT STROKE OVERLAY
-	{runeRange{0xA7C9, 0xA7C9}, sbprUpper},     // L&       LATIN CAPITAL LETTER S WITH SHORT STROKE OVERLAY
-	{runeRange{0xA7CA, 0xA7CA}, sbprLower},     // L&       LATIN SMALL LETTER S WITH SHORT STROKE OVERLAY
-	{runeRange{0xA7D0, 0xA7D0}, sbprUpper},     // L&       LATIN CAPITAL LETTER CLOSED INSULAR G
-	{runeRange{0xA7D1, 0xA7D1}, sbprLower},     // L&       LATIN SMALL LETTER CLOSED INSULAR G
-	{runeRange{0xA7D3, 0xA7D3}, sbprLower},     // L&       LATIN SMALL LETTER DOUBLE THORN
-	{runeRange{0xA7D5, 0xA7D5}, sbprLower},     // L&       LATIN SMALL LETTER DOUBLE WYNN
-	{runeRange{0xA7D6, 0xA7D6}, sbprUpper},     // L&       LATIN CAPITAL LETTER MIDDLE SCOTS S
-	{runeRange{0xA7D7, 0xA7D7}, sbprLower},     // L&       LATIN SMALL LETTER MIDDLE SCOTS S
-	{runeRange{0xA7D8, 0xA7D8}, sbprUpper},     // L&       LATIN CAPITAL LETTER SIGMOID S
-	{runeRange{0xA7D9, 0xA7D9}, sbprLower},     // L&       LATIN SMALL LETTER SIGMOID S
-	{runeRange{0xA7F2, 0xA7F4}, sbprLower},     // Lm   [3] MODIFIER LETTER CAPITAL C..MODIFIER LETTER CAPITAL Q
-	{runeRange{0xA7F5, 0xA7F5}, sbprUpper},     // L&       LATIN CAPITAL LETTER REVERSED HALF H
-	{runeRange{0xA7F6, 0xA7F6}, sbprLower},     // L&       LATIN SMALL LETTER REVERSED HALF H
-	{runeRange{0xA7F7, 0xA7F7}, sbprOLetter},   // Lo       LATIN EPIGRAPHIC LETTER SIDEWAYS I
-	{runeRange{0xA7F8, 0xA7F9}, sbprLower},     // Lm   [2] MODIFIER LETTER CAPITAL H WITH STROKE..MODIFIER LETTER SMALL LIGATURE OE
-	{runeRange{0xA7FA, 0xA7FA}, sbprLower},     // L&       LATIN LETTER SMALL CAPITAL TURNED M
-	{runeRange{0xA7FB, 0xA801}, sbprOLetter},   // Lo   [7] LATIN EPIGRAPHIC LETTER REVERSED F..SYLOTI NAGRI LETTER I
-	{runeRange{0xA802, 0xA802}, sbprExtend},    // Mn       SYLOTI NAGRI SIGN DVISVARA
-	{runeRange{0xA803, 0xA805}, sbprOLetter},   // Lo   [3] SYLOTI NAGRI LETTER U..SYLOTI NAGRI LETTER O
-	{runeRange{0xA806, 0xA806}, sbprExtend},    // Mn       SYLOTI NAGRI SIGN HASANTA
-	{runeRange{0xA807, 0xA80A}, sbprOLetter},   // Lo   [4] SYLOTI NAGRI LETTER KO..SYLOTI NAGRI LETTER GHO
-	{runeRange{0xA80B, 0xA80B}, sbprExtend},    // Mn       SYLOTI NAGRI SIGN ANUSVARA
-	{runeRange{0xA80C, 0xA822}, sbprOLetter},   // Lo  [23] SYLOTI NAGRI LETTER CO..SYLOTI NAGRI LETTER HO
-	{runeRange{0xA823, 0xA824}, sbprExtend},    // Mc   [2] SYLOTI NAGRI VOWEL SIGN A..SYLOTI NAGRI VOWEL SIGN I
-	{runeRange{0xA825, 0xA826}, sbprExtend},    // Mn   [2] SYLOTI NAGRI VOWEL SIGN U..SYLOTI NAGRI VOWEL SIGN E
-	{runeRange{0xA827, 0xA827}, sbprExtend},    // Mc       SYLOTI NAGRI VOWEL SIGN OO
-	{runeRange{0xA82C, 0xA82C}, sbprExtend},    // Mn       SYLOTI NAGRI SIGN ALTERNATE HASANTA
-	{runeRange{0xA840, 0xA873}, sbprOLetter},   // Lo  [52] PHAGS-PA LETTER KA..PHAGS-PA LETTER CANDRABINDU
-	{runeRange{0xA876, 0xA877}, sbprSTerm},     // Po   [2] PHAGS-PA MARK SHAD..PHAGS-PA MARK DOUBLE SHAD
-	{runeRange{0xA880, 0xA881}, sbprExtend},    // Mc   [2] SAURASHTRA SIGN ANUSVARA..SAURASHTRA SIGN VISARGA
-	{runeRange{0xA882, 0xA8B3}, sbprOLetter},   // Lo  [50] SAURASHTRA LETTER A..SAURASHTRA LETTER LLA
-	{runeRange{0xA8B4, 0xA8C3}, sbprExtend},    // Mc  [16] SAURASHTRA CONSONANT SIGN HAARU..SAURASHTRA VOWEL SIGN AU
-	{runeRange{0xA8C4, 0xA8C5}, sbprExtend},    // Mn   [2] SAURASHTRA SIGN VIRAMA..SAURASHTRA SIGN CANDRABINDU
-	{runeRange{0xA8CE, 0xA8CF}, sbprSTerm},     // Po   [2] SAURASHTRA DANDA..SAURASHTRA DOUBLE DANDA
-	{runeRange{0xA8D0, 0xA8D9}, sbprNumeric},   // Nd  [10] SAURASHTRA DIGIT ZERO..SAURASHTRA DIGIT NINE
-	{runeRange{0xA8E0, 0xA8F1}, sbprExtend},    // Mn  [18] COMBINING DEVANAGARI DIGIT ZERO..COMBINING DEVANAGARI SIGN AVAGRAHA
-	{runeRange{0xA8F2, 0xA8F7}, sbprOLetter},   // Lo   [6] DEVANAGARI SIGN SPACING CANDRABINDU..DEVANAGARI SIGN CANDRABINDU AVAGRAHA
-	{runeRange{0xA8FB, 0xA8FB}, sbprOLetter},   // Lo       DEVANAGARI HEADSTROKE
-	{runeRange{0xA8FD, 0xA8FE}, sbprOLetter},   // Lo   [2] DEVANAGARI JAIN OM..DEVANAGARI LETTER AY
-	{runeRange{0xA8FF, 0xA8FF}, sbprExtend},    // Mn       DEVANAGARI VOWEL SIGN AY
-	{runeRange{0xA900, 0xA909}, sbprNumeric},   // Nd  [10] KAYAH LI DIGIT ZERO..KAYAH LI DIGIT NINE
-	{runeRange{0xA90A, 0xA925}, sbprOLetter},   // Lo  [28] KAYAH LI LETTER KA..KAYAH LI LETTER OO
-	{runeRange{0xA926, 0xA92D}, sbprExtend},    // Mn   [8] KAYAH LI VOWEL UE..KAYAH LI TONE CALYA PLOPHU
-	{runeRange{0xA92F, 0xA92F}, sbprSTerm},     // Po       KAYAH LI SIGN SHYA
-	{runeRange{0xA930, 0xA946}, sbprOLetter},   // Lo  [23] REJANG LETTER KA..REJANG LETTER A
-	{runeRange{0xA947, 0xA951}, sbprExtend},    // Mn  [11] REJANG VOWEL SIGN I..REJANG CONSONANT SIGN R
-	{runeRange{0xA952, 0xA953}, sbprExtend},    // Mc   [2] REJANG CONSONANT SIGN H..REJANG VIRAMA
-	{runeRange{0xA960, 0xA97C}, sbprOLetter},   // Lo  [29] HANGUL CHOSEONG TIKEUT-MIEUM..HANGUL CHOSEONG SSANGYEORINHIEUH
-	{runeRange{0xA980, 0xA982}, sbprExtend},    // Mn   [3] JAVANESE SIGN PANYANGGA..JAVANESE SIGN LAYAR
-	{runeRange{0xA983, 0xA983}, sbprExtend},    // Mc       JAVANESE SIGN WIGNYAN
-	{runeRange{0xA984, 0xA9B2}, sbprOLetter},   // Lo  [47] JAVANESE LETTER A..JAVANESE LETTER HA
-	{runeRange{0xA9B3, 0xA9B3}, sbprExtend},    // Mn       JAVANESE SIGN CECAK TELU
-	{runeRange{0xA9B4, 0xA9B5}, sbprExtend},    // Mc   [2] JAVANESE VOWEL SIGN TARUNG..JAVANESE VOWEL SIGN TOLONG
-	{runeRange{0xA9B6, 0xA9B9}, sbprExtend},    // Mn   [4] JAVANESE VOWEL SIGN WULU..JAVANESE VOWEL SIGN SUKU MENDUT
-	{runeRange{0xA9BA, 0xA9BB}, sbprExtend},    // Mc   [2] JAVANESE VOWEL SIGN TALING..JAVANESE VOWEL SIGN DIRGA MURE
-	{runeRange{0xA9BC, 0xA9BD}, sbprExtend},    // Mn   [2] JAVANESE VOWEL SIGN PEPET..JAVANESE CONSONANT SIGN KERET
-	{runeRange{0xA9BE, 0xA9C0}, sbprExtend},    // Mc   [3] JAVANESE CONSONANT SIGN PENGKAL..JAVANESE PANGKON
-	{runeRange{0xA9C8, 0xA9C9}, sbprSTerm},     // Po   [2] JAVANESE PADA LINGSA..JAVANESE PADA LUNGSI
-	{runeRange{0xA9CF, 0xA9CF}, sbprOLetter},   // Lm       JAVANESE PANGRANGKEP
-	{runeRange{0xA9D0, 0xA9D9}, sbprNumeric},   // Nd  [10] JAVANESE DIGIT ZERO..JAVANESE DIGIT NINE
-	{runeRange{0xA9E0, 0xA9E4}, sbprOLetter},   // Lo   [5] MYANMAR LETTER SHAN GHA..MYANMAR LETTER SHAN BHA
-	{runeRange{0xA9E5, 0xA9E5}, sbprExtend},    // Mn       MYANMAR SIGN SHAN SAW
-	{runeRange{0xA9E6, 0xA9E6}, sbprOLetter},   // Lm       MYANMAR MODIFIER LETTER SHAN REDUPLICATION
-	{runeRange{0xA9E7, 0xA9EF}, sbprOLetter},   // Lo   [9] MYANMAR LETTER TAI LAING NYA..MYANMAR LETTER TAI LAING NNA
-	{runeRange{0xA9F0, 0xA9F9}, sbprNumeric},   // Nd  [10] MYANMAR TAI LAING DIGIT ZERO..MYANMAR TAI LAING DIGIT NINE
-	{runeRange{0xA9FA, 0xA9FE}, sbprOLetter},   // Lo   [5] MYANMAR LETTER TAI LAING LLA..MYANMAR LETTER TAI LAING BHA
-	{runeRange{0xAA00, 0xAA28}, sbprOLetter},   // Lo  [41] CHAM LETTER A..CHAM LETTER HA
-	{runeRange{0xAA29, 0xAA2E}, sbprExtend},    // Mn   [6] CHAM VOWEL SIGN AA..CHAM VOWEL SIGN OE
-	{runeRange{0xAA2F, 0xAA30}, sbprExtend},    // Mc   [2] CHAM VOWEL SIGN O..CHAM VOWEL SIGN AI
-	{runeRange{0xAA31, 0xAA32}, sbprExtend},    // Mn   [2] CHAM VOWEL SIGN AU..CHAM VOWEL SIGN UE
-	{runeRange{0xAA33, 0xAA34}, sbprExtend},    // Mc   [2] CHAM CONSONANT SIGN YA..CHAM CONSONANT SIGN RA
-	{runeRange{0xAA35, 0xAA36}, sbprExtend},    // Mn   [2] CHAM CONSONANT SIGN LA..CHAM CONSONANT SIGN WA
-	{runeRange{0xAA40, 0xAA42}, sbprOLetter},   // Lo   [3] CHAM LETTER FINAL K..CHAM LETTER FINAL NG
-	{runeRange{0xAA43, 0xAA43}, sbprExtend},    // Mn       CHAM CONSONANT SIGN FINAL NG
-	{runeRange{0xAA44, 0xAA4B}, sbprOLetter},   // Lo   [8] CHAM LETTER FINAL CH..CHAM LETTER FINAL SS
-	{runeRange{0xAA4C, 0xAA4C}, sbprExtend},    // Mn       CHAM CONSONANT SIGN FINAL M
-	{runeRange{0xAA4D, 0xAA4D}, sbprExtend},    // Mc       CHAM CONSONANT SIGN FINAL H
-	{runeRange{0xAA50, 0xAA59}, sbprNumeric},   // Nd  [10] CHAM DIGIT ZERO..CHAM DIGIT NINE
-	{runeRange{0xAA5D, 0xAA5F}, sbprSTerm},     // Po   [3] CHAM PUNCTUATION DANDA..CHAM PUNCTUATION TRIPLE DANDA
-	{runeRange{0xAA60, 0xAA6F}, sbprOLetter},   // Lo  [16] MYANMAR LETTER KHAMTI GA..MYANMAR LETTER KHAMTI FA
-	{runeRange{0xAA70, 0xAA70}, sbprOLetter},   // Lm       MYANMAR MODIFIER LETTER KHAMTI REDUPLICATION
-	{runeRange{0xAA71, 0xAA76}, sbprOLetter},   // Lo   [6] MYANMAR LETTER KHAMTI XA..MYANMAR LOGOGRAM KHAMTI HM
-	{runeRange{0xAA7A, 0xAA7A}, sbprOLetter},   // Lo       MYANMAR LETTER AITON RA
-	{runeRange{0xAA7B, 0xAA7B}, sbprExtend},    // Mc       MYANMAR SIGN PAO KAREN TONE
-	{runeRange{0xAA7C, 0xAA7C}, sbprExtend},    // Mn       MYANMAR SIGN TAI LAING TONE-2
-	{runeRange{0xAA7D, 0xAA7D}, sbprExtend},    // Mc       MYANMAR SIGN TAI LAING TONE-5
-	{runeRange{0xAA7E, 0xAAAF}, sbprOLetter},   // Lo  [50] MYANMAR LETTER SHWE PALAUNG CHA..TAI VIET LETTER HIGH O
-	{runeRange{0xAAB0, 0xAAB0}, sbprExtend},    // Mn       TAI VIET MAI KANG
-	{runeRange{0xAAB1, 0xAAB1}, sbprOLetter},   // Lo       TAI VIET VOWEL AA
-	{runeRange{0xAAB2, 0xAAB4}, sbprExtend},    // Mn   [3] TAI VIET VOWEL I..TAI VIET VOWEL U
-	{runeRange{0xAAB5, 0xAAB6}, sbprOLetter},   // Lo   [2] TAI VIET VOWEL E..TAI VIET VOWEL O
-	{runeRange{0xAAB7, 0xAAB8}, sbprExtend},    // Mn   [2] TAI VIET MAI KHIT..TAI VIET VOWEL IA
-	{runeRange{0xAAB9, 0xAABD}, sbprOLetter},   // Lo   [5] TAI VIET VOWEL UEA..TAI VIET VOWEL AN
-	{runeRange{0xAABE, 0xAABF}, sbprExtend},    // Mn   [2] TAI VIET VOWEL AM..TAI VIET TONE MAI EK
-	{runeRange{0xAAC0, 0xAAC0}, sbprOLetter},   // Lo       TAI VIET TONE MAI NUENG
-	{runeRange{0xAAC1, 0xAAC1}, sbprExtend},    // Mn       TAI VIET TONE MAI THO
-	{runeRange{0xAAC2, 0xAAC2}, sbprOLetter},   // Lo       TAI VIET TONE MAI SONG
-	{runeRange{0xAADB, 0xAADC}, sbprOLetter},   // Lo   [2] TAI VIET SYMBOL KON..TAI VIET SYMBOL NUENG
-	{runeRange{0xAADD, 0xAADD}, sbprOLetter},   // Lm       TAI VIET SYMBOL SAM
-	{runeRange{0xAAE0, 0xAAEA}, sbprOLetter},   // Lo  [11] MEETEI MAYEK LETTER E..MEETEI MAYEK LETTER SSA
-	{runeRange{0xAAEB, 0xAAEB}, sbprExtend},    // Mc       MEETEI MAYEK VOWEL SIGN II
-	{runeRange{0xAAEC, 0xAAED}, sbprExtend},    // Mn   [2] MEETEI MAYEK VOWEL SIGN UU..MEETEI MAYEK VOWEL SIGN AAI
-	{runeRange{0xAAEE, 0xAAEF}, sbprExtend},    // Mc   [2] MEETEI MAYEK VOWEL SIGN AU..MEETEI MAYEK VOWEL SIGN AAU
-	{runeRange{0xAAF0, 0xAAF1}, sbprSTerm},     // Po   [2] MEETEI MAYEK CHEIKHAN..MEETEI MAYEK AHANG KHUDAM
-	{runeRange{0xAAF2, 0xAAF2}, sbprOLetter},   // Lo       MEETEI MAYEK ANJI
-	{runeRange{0xAAF3, 0xAAF4}, sbprOLetter},   // Lm   [2] MEETEI MAYEK SYLLABLE REPETITION MARK..MEETEI MAYEK WORD REPETITION MARK
-	{runeRange{0xAAF5, 0xAAF5}, sbprExtend},    // Mc       MEETEI MAYEK VOWEL SIGN VISARGA
-	{runeRange{0xAAF6, 0xAAF6}, sbprExtend},    // Mn       MEETEI MAYEK VIRAMA
-	{runeRange{0xAB01, 0xAB06}, sbprOLetter},   // Lo   [6] ETHIOPIC SYLLABLE TTHU..ETHIOPIC SYLLABLE TTHO
-	{runeRange{0xAB09, 0xAB0E}, sbprOLetter},   // Lo   [6] ETHIOPIC SYLLABLE DDHU..ETHIOPIC SYLLABLE DDHO
-	{runeRange{0xAB11, 0xAB16}, sbprOLetter},   // Lo   [6] ETHIOPIC SYLLABLE DZU..ETHIOPIC SYLLABLE DZO
-	{runeRange{0xAB20, 0xAB26}, sbprOLetter},   // Lo   [7] ETHIOPIC SYLLABLE CCHHA..ETHIOPIC SYLLABLE CCHHO
-	{runeRange{0xAB28, 0xAB2E}, sbprOLetter},   // Lo   [7] ETHIOPIC SYLLABLE BBA..ETHIOPIC SYLLABLE BBO
-	{runeRange{0xAB30, 0xAB5A}, sbprLower},     // L&  [43] LATIN SMALL LETTER BARRED ALPHA..LATIN SMALL LETTER Y WITH SHORT RIGHT LEG
-	{runeRange{0xAB5C, 0xAB5F}, sbprLower},     // Lm   [4] MODIFIER LETTER SMALL HENG..MODIFIER LETTER SMALL U WITH LEFT HOOK
-	{runeRange{0xAB60, 0xAB68}, sbprLower},     // L&   [9] LATIN SMALL LETTER SAKHA YAT..LATIN SMALL LETTER TURNED R WITH MIDDLE TILDE
-	{runeRange{0xAB69, 0xAB69}, sbprLower},     // Lm       MODIFIER LETTER SMALL TURNED W
-	{runeRange{0xAB70, 0xABBF}, sbprLower},     // L&  [80] CHEROKEE SMALL LETTER A..CHEROKEE SMALL LETTER YA
-	{runeRange{0xABC0, 0xABE2}, sbprOLetter},   // Lo  [35] MEETEI MAYEK LETTER KOK..MEETEI MAYEK LETTER I LONSUM
-	{runeRange{0xABE3, 0xABE4}, sbprExtend},    // Mc   [2] MEETEI MAYEK VOWEL SIGN ONAP..MEETEI MAYEK VOWEL SIGN INAP
-	{runeRange{0xABE5, 0xABE5}, sbprExtend},    // Mn       MEETEI MAYEK VOWEL SIGN ANAP
-	{runeRange{0xABE6, 0xABE7}, sbprExtend},    // Mc   [2] MEETEI MAYEK VOWEL SIGN YENAP..MEETEI MAYEK VOWEL SIGN SOUNAP
-	{runeRange{0xABE8, 0xABE8}, sbprExtend},    // Mn       MEETEI MAYEK VOWEL SIGN UNAP
-	{runeRange{0xABE9, 0xABEA}, sbprExtend},    // Mc   [2] MEETEI MAYEK VOWEL SIGN CHEINAP..MEETEI MAYEK VOWEL SIGN NUNG
-	{runeRange{0xABEB, 0xABEB}, sbprSTerm},     // Po       MEETEI MAYEK CHEIKHEI
-	{runeRange{0xABEC, 0xABEC}, sbprExtend},    // Mc       MEETEI MAYEK LUM IYEK
-	{runeRange{0xABED, 0xABED}, sbprExtend},    // Mn       MEETEI MAYEK APUN IYEK
-	{runeRange{0xABF0, 0xABF9}, sbprNumeric},   // Nd  [10] MEETEI MAYEK DIGIT ZERO..MEETEI MAYEK DIGIT NINE
-	{runeRange{0xAC00, 0xD7A3}, sbprOLetter},   // Lo [11172] HANGUL SYLLABLE GA..HANGUL SYLLABLE HIH
-	{runeRange{0xD7B0, 0xD7C6}, sbprOLetter},   // Lo  [23] HANGUL JUNGSEONG O-YEO..HANGUL JUNGSEONG ARAEA-E
-	{runeRange{0xD7CB, 0xD7FB}, sbprOLetter},   // Lo  [49] HANGUL JONGSEONG NIEUN-RIEUL..HANGUL JONGSEONG PHIEUPH-THIEUTH
-	{runeRange{0xF900, 0xFA6D}, sbprOLetter},   // Lo [366] CJK COMPATIBILITY IDEOGRAPH-F900..CJK COMPATIBILITY IDEOGRAPH-FA6D
-	{runeRange{0xFA70, 0xFAD9}, sbprOLetter},   // Lo [106] CJK COMPATIBILITY IDEOGRAPH-FA70..CJK COMPATIBILITY IDEOGRAPH-FAD9
-	{runeRange{0xFB00, 0xFB06}, sbprLower},     // L&   [7] LATIN SMALL LIGATURE FF..LATIN SMALL LIGATURE ST
-	{runeRange{0xFB13, 0xFB17}, sbprLower},     // L&   [5] ARMENIAN SMALL LIGATURE MEN NOW..ARMENIAN SMALL LIGATURE MEN XEH
-	{runeRange{0xFB1D, 0xFB1D}, sbprOLetter},   // Lo       HEBREW LETTER YOD WITH HIRIQ
-	{runeRange{0xFB1E, 0xFB1E}, sbprExtend},    // Mn       HEBREW POINT JUDEO-SPANISH VARIKA
-	{runeRange{0xFB1F, 0xFB28}, sbprOLetter},   // Lo  [10] HEBREW LIGATURE YIDDISH YOD YOD PATAH..HEBREW LETTER WIDE TAV
-	{runeRange{0xFB2A, 0xFB36}, sbprOLetter},   // Lo  [13] HEBREW LETTER SHIN WITH SHIN DOT..HEBREW LETTER ZAYIN WITH DAGESH
-	{runeRange{0xFB38, 0xFB3C}, sbprOLetter},   // Lo   [5] HEBREW LETTER TET WITH DAGESH..HEBREW LETTER LAMED WITH DAGESH
-	{runeRange{0xFB3E, 0xFB3E}, sbprOLetter},   // Lo       HEBREW LETTER MEM WITH DAGESH
-	{runeRange{0xFB40, 0xFB41}, sbprOLetter},   // Lo   [2] HEBREW LETTER NUN WITH DAGESH..HEBREW LETTER SAMEKH WITH DAGESH
-	{runeRange{0xFB43, 0xFB44}, sbprOLetter},   // Lo   [2] HEBREW LETTER FINAL PE WITH DAGESH..HEBREW LETTER PE WITH DAGESH
-	{runeRange{0xFB46, 0xFBB1}, sbprOLetter},   // Lo [108] HEBREW LETTER TSADI WITH DAGESH..ARABIC LETTER YEH BARREE WITH HAMZA ABOVE FINAL FORM
-	{runeRange{0xFBD3, 0xFD3D}, sbprOLetter},   // Lo [363] ARABIC LETTER NG ISOLATED FORM..ARABIC LIGATURE ALEF WITH FATHATAN ISOLATED FORM
-	{runeRange{0xFD3E, 0xFD3E}, sbprClose},     // Pe       ORNATE LEFT PARENTHESIS
-	{runeRange{0xFD3F, 0xFD3F}, sbprClose},     // Ps       ORNATE RIGHT PARENTHESIS
-	{runeRange{0xFD50, 0xFD8F}, sbprOLetter},   // Lo  [64] ARABIC LIGATURE TEH WITH JEEM WITH MEEM INITIAL FORM..ARABIC LIGATURE MEEM WITH KHAH WITH MEEM INITIAL FORM
-	{runeRange{0xFD92, 0xFDC7}, sbprOLetter},   // Lo  [54] ARABIC LIGATURE MEEM WITH JEEM WITH KHAH INITIAL FORM..ARABIC LIGATURE NOON WITH JEEM WITH YEH FINAL FORM
-	{runeRange{0xFDF0, 0xFDFB}, sbprOLetter},   // Lo  [12] ARABIC LIGATURE SALLA USED AS KORANIC STOP SIGN ISOLATED FORM..ARABIC LIGATURE JALLAJALALOUHOU
-	{runeRange{0xFE00, 0xFE0F}, sbprExtend},    // Mn  [16] VARIATION SELECTOR-1..VARIATION SELECTOR-16
-	{runeRange{0xFE10, 0xFE11}, sbprSContinue}, // Po   [2] PRESENTATION FORM FOR VERTICAL COMMA..PRESENTATION FORM FOR VERTICAL IDEOGRAPHIC COMMA
-	{runeRange{0xFE13, 0xFE13}, sbprSContinue}, // Po       PRESENTATION FORM FOR VERTICAL COLON
-	{runeRange{0xFE17, 0xFE17}, sbprClose},     // Ps       PRESENTATION FORM FOR VERTICAL LEFT WHITE LENTICULAR BRACKET
-	{runeRange{0xFE18, 0xFE18}, sbprClose},     // Pe       PRESENTATION FORM FOR VERTICAL RIGHT WHITE LENTICULAR BRAKCET
-	{runeRange{0xFE20, 0xFE2F}, sbprExtend},    // Mn  [16] COMBINING LIGATURE LEFT HALF..COMBINING CYRILLIC TITLO RIGHT HALF
-	{runeRange{0xFE31, 0xFE32}, sbprSContinue}, // Pd   [2] PRESENTATION FORM FOR VERTICAL EM DASH..PRESENTATION FORM FOR VERTICAL EN DASH
-	{runeRange{0xFE35, 0xFE35}, sbprClose},     // Ps       PRESENTATION FORM FOR VERTICAL LEFT PARENTHESIS
-	{runeRange{0xFE36, 0xFE36}, sbprClose},     // Pe       PRESENTATION FORM FOR VERTICAL RIGHT PARENTHESIS
-	{runeRange{0xFE37, 0xFE37}, sbprClose},     // Ps       PRESENTATION FORM FOR VERTICAL LEFT CURLY BRACKET
-	{runeRange{0xFE38, 0xFE38}, sbprClose},     // Pe       PRESENTATION FORM FOR VERTICAL RIGHT CURLY BRACKET
-	{runeRange{0xFE39, 0xFE39}, sbprClose},     // Ps       PRESENTATION FORM FOR VERTICAL LEFT TORTOISE SHELL BRACKET
-	{runeRange{0xFE3A, 0xFE3A}, sbprClose},     // Pe       PRESENTATION FORM FOR VERTICAL RIGHT TORTOISE SHELL BRACKET
-	{runeRange{0xFE3B, 0xFE3B}, sbprClose},     // Ps       PRESENTATION FORM FOR VERTICAL LEFT BLACK LENTICULAR BRACKET
-	{runeRange{0xFE3C, 0xFE3C}, sbprClose},     // Pe       PRESENTATION FORM FOR VERTICAL RIGHT BLACK LENTICULAR BRACKET
-	{runeRange{0xFE3D, 0xFE3D}, sbprClose},     // Ps       PRESENTATION FORM FOR VERTICAL LEFT DOUBLE ANGLE BRACKET
-	{runeRange{0xFE3E, 0xFE3E}, sbprClose},     // Pe       PRESENTATION FORM FOR VERTICAL RIGHT DOUBLE ANGLE BRACKET
-	{runeRange{0xFE3F, 0xFE3F}, sbprClose},     // Ps       PRESENTATION FORM FOR VERTICAL LEFT ANGLE BRACKET
-	{runeRange{0xFE40, 0xFE40}, sbprClose},     // Pe       PRESENTATION FORM FOR VERTICAL RIGHT ANGLE BRACKET
-	{runeRange{0xFE41, 0xFE41}, sbprClose},     // Ps       PRESENTATION FORM FOR VERTICAL LEFT CORNER BRACKET
-	{runeRange{0xFE42, 0xFE42}, sbprClose},     // Pe       PRESENTATION FORM FOR VERTICAL RIGHT CORNER BRACKET
-	{runeRange{0xFE43, 0xFE43}, sbprClose},     // Ps       PRESENTATION FORM FOR VERTICAL LEFT WHITE CORNER BRACKET
-	{runeRange{0xFE44, 0xFE44}, sbprClose},     // Pe       PRESENTATION FORM FOR VERTICAL RIGHT WHITE CORNER BRACKET
-	{runeRange{0xFE47, 0xFE47}, sbprClose},     // Ps       PRESENTATION FORM FOR VERTICAL LEFT SQUARE BRACKET
-	{runeRange{0xFE48, 0xFE48}, sbprClose},     // Pe       PRESENTATION FORM FOR VERTICAL RIGHT SQUARE BRACKET
-	{runeRange{0xFE50, 0xFE51}, sbprSContinue}, // Po   [2] SMALL COMMA..SMALL IDEOGRAPHIC COMMA
-	{runeRange{0xFE52, 0xFE52}, sbprATerm},     // Po       SMALL FULL STOP
-	{runeRange{0xFE55, 0xFE55}, sbprSContinue}, // Po       SMALL COLON
-	{runeRange{0xFE56, 0xFE57}, sbprSTerm},     // Po   [2] SMALL QUESTION MARK..SMALL EXCLAMATION MARK
-	{runeRange{0xFE58, 0xFE58}, sbprSContinue}, // Pd       SMALL EM DASH
-	{runeRange{0xFE59, 0xFE59}, sbprClose},     // Ps       SMALL LEFT PARENTHESIS
-	{runeRange{0xFE5A, 0xFE5A}, sbprClose},     // Pe       SMALL RIGHT PARENTHESIS
-	{runeRange{0xFE5B, 0xFE5B}, sbprClose},     // Ps       SMALL LEFT CURLY BRACKET
-	{runeRange{0xFE5C, 0xFE5C}, sbprClose},     // Pe       SMALL RIGHT CURLY BRACKET
-	{runeRange{0xFE5D, 0xFE5D}, sbprClose},     // Ps       SMALL LEFT TORTOISE SHELL BRACKET
-	{runeRange{0xFE5E, 0xFE5E}, sbprClose},     // Pe       SMALL RIGHT TORTOISE SHELL BRACKET
-	{runeRange{0xFE63, 0xFE63}, sbprSContinue}, // Pd       SMALL HYPHEN-MINUS
-	{runeRange{0xFE70, 0xFE74}, sbprOLetter},   // Lo   [5] ARABIC FATHATAN ISOLATED FORM..ARABIC KASRATAN ISOLATED FORM
-	{runeRange{0xFE76, 0xFEFC}, sbprOLetter},   // Lo [135] ARABIC FATHA ISOLATED FORM..ARABIC LIGATURE LAM WITH ALEF FINAL FORM
-	{runeRange{0xFEFF, 0xFEFF}, sbprFormat},    // Cf       ZERO WIDTH NO-BREAK SPACE
-	{runeRange{0xFF01, 0xFF01}, sbprSTerm},     // Po       FULLWIDTH EXCLAMATION MARK
-	{runeRange{0xFF08, 0xFF08}, sbprClose},     // Ps       FULLWIDTH LEFT PARENTHESIS
-	{runeRange{0xFF09, 0xFF09}, sbprClose},     // Pe       FULLWIDTH RIGHT PARENTHESIS
-	{runeRange{0xFF0C, 0xFF0C}, sbprSContinue}, // Po       FULLWIDTH COMMA
-	{runeRange{0xFF0D, 0xFF0D}, sbprSContinue}, // Pd       FULLWIDTH HYPHEN-MINUS
-	{runeRange{0xFF0E, 0xFF0E}, sbprATerm},     // Po       FULLWIDTH FULL STOP
-	{runeRange{0xFF10, 0xFF19}, sbprNumeric},   // Nd  [10] FULLWIDTH DIGIT ZERO..FULLWIDTH DIGIT NINE
-	{runeRange{0xFF1A, 0xFF1A}, sbprSContinue}, // Po       FULLWIDTH COLON
-	{runeRange{0xFF1F, 0xFF1F}, sbprSTerm},     // Po       FULLWIDTH QUESTION MARK
-	{runeRange{0xFF21, 0xFF3A}, sbprUpper},     // L&  [26] FULLWIDTH LATIN CAPITAL LETTER A..FULLWIDTH LATIN CAPITAL LETTER Z
-	{runeRange{0xFF3B, 0xFF3B}, sbprClose},     // Ps       FULLWIDTH LEFT SQUARE BRACKET
-	{runeRange{0xFF3D, 0xFF3D}, sbprClose},     // Pe       FULLWIDTH RIGHT SQUARE BRACKET
-	{runeRange{0xFF41, 0xFF5A}, sbprLower},     // L&  [26] FULLWIDTH LATIN SMALL LETTER A..FULLWIDTH LATIN SMALL LETTER Z
-	{runeRange{0xFF5B, 0xFF5B}, sbprClose},     // Ps       FULLWIDTH LEFT CURLY BRACKET
-	{runeRange{0xFF5D, 0xFF5D}, sbprClose},     // Pe       FULLWIDTH RIGHT CURLY BRACKET
-	{runeRange{0xFF5F, 0xFF5F}, sbprClose},     // Ps       FULLWIDTH LEFT WHITE PARENTHESIS
-	{runeRange{0xFF60, 0xFF60}, sbprClose},     // Pe       FULLWIDTH RIGHT WHITE PARENTHESIS
-	{runeRange{0xFF61, 0xFF61}, sbprSTerm},     // Po       HALFWIDTH IDEOGRAPHIC FULL STOP
-	{runeRange{0xFF62, 0xFF62}, sbprClose},     // Ps       HALFWIDTH LEFT CORNER BRACKET
-	{runeRange{0xFF63, 0xFF63}, sbprClose},     // Pe       HALFWIDTH RIGHT CORNER BRACKET
-	{runeRange{0xFF64, 0xFF64}, sbprSContinue}, // Po       HALFWIDTH IDEOGRAPHIC COMMA
-	{runeRange{0xFF66, 0xFF6F}, sbprOLetter},   // Lo  [10] HALFWIDTH KATAKANA LETTER WO..HALFWIDTH KATAKANA LETTER SMALL TU
-	{runeRange{0xFF70, 0xFF70}, sbprOLetter},   // Lm       HALFWIDTH KATAKANA-HIRAGANA PROLONGED SOUND MARK
-	{runeRange{0xFF71, 0xFF9D}, sbprOLetter},   // Lo  [45] HALFWIDTH KATAKANA LETTER A..HALFWIDTH KATAKANA LETTER N
-	{runeRange{0xFF9E, 0xFF9F}, sbprExtend},    // Lm   [2] HALFWIDTH KATAKANA VOICED SOUND MARK..HALFWIDTH KATAKANA SEMI-VOICED SOUND MARK
-	{runeRange{0xFFA0, 0xFFBE}, sbprOLetter},   // Lo  [31] HALFWIDTH HANGUL FILLER..HALFWIDTH HANGUL LETTER HIEUH
-	{runeRange{0xFFC2, 0xFFC7}, sbprOLetter},   // Lo   [6] HALFWIDTH HANGUL LETTER A..HALFWIDTH HANGUL LETTER E
-	{runeRange{0xFFCA, 0xFFCF}, sbprOLetter},   // Lo   [6] HALFWIDTH HANGUL LETTER YEO..HALFWIDTH HANGUL LETTER OE
-	{runeRange{0xFFD2, 0xFFD7}, sbprOLetter},   // Lo   [6] HALFWIDTH HANGUL LETTER YO..HALFWIDTH HANGUL LETTER YU
-	{runeRange{0xFFDA, 0xFFDC}, sbprOLetter},   // Lo   [3] HALFWIDTH HANGUL LETTER EU..HALFWIDTH HANGUL LETTER I
-	{runeRange{0xFFF9, 0xFFFB}, sbprFormat},    // Cf   [3] INTERLINEAR ANNOTATION ANCHOR..INTERLINEAR ANNOTATION TERMINATOR
-	{runeRange{0x10000, 0x1000B}, sbprOLetter}, // Lo  [12] LINEAR B SYLLABLE B008 A..LINEAR B SYLLABLE B046 JE
-	{runeRange{0x1000D, 0x10026}, sbprOLetter}, // Lo  [26] LINEAR B SYLLABLE B036 JO..LINEAR B SYLLABLE B032 QO
-	{runeRange{0x10028, 0x1003A}, sbprOLetter}, // Lo  [19] LINEAR B SYLLABLE B060 RA..LINEAR B SYLLABLE B042 WO
-	{runeRange{0x1003C, 0x1003D}, sbprOLetter}, // Lo   [2] LINEAR B SYLLABLE B017 ZA..LINEAR B SYLLABLE B074 ZE
-	{runeRange{0x1003F, 0x1004D}, sbprOLetter}, // Lo  [15] LINEAR B SYLLABLE B020 ZO..LINEAR B SYLLABLE B091 TWO
-	{runeRange{0x10050, 0x1005D}, sbprOLetter}, // Lo  [14] LINEAR B SYMBOL B018..LINEAR B SYMBOL B089
-	{runeRange{0x10080, 0x100FA}, sbprOLetter}, // Lo [123] LINEAR B IDEOGRAM B100 MAN..LINEAR B IDEOGRAM VESSEL B305
-	{runeRange{0x10140, 0x10174}, sbprOLetter}, // Nl  [53] GREEK ACROPHONIC ATTIC ONE QUARTER..GREEK ACROPHONIC STRATIAN FIFTY MNAS
-	{runeRange{0x101FD, 0x101FD}, sbprExtend},  // Mn       PHAISTOS DISC SIGN COMBINING OBLIQUE STROKE
-	{runeRange{0x10280, 0x1029C}, sbprOLetter}, // Lo  [29] LYCIAN LETTER A..LYCIAN LETTER X
-	{runeRange{0x102A0, 0x102D0}, sbprOLetter}, // Lo  [49] CARIAN LETTER A..CARIAN LETTER UUU3
-	{runeRange{0x102E0, 0x102E0}, sbprExtend},  // Mn       COPTIC EPACT THOUSANDS MARK
-	{runeRange{0x10300, 0x1031F}, sbprOLetter}, // Lo  [32] OLD ITALIC LETTER A..OLD ITALIC LETTER ESS
-	{runeRange{0x1032D, 0x10340}, sbprOLetter}, // Lo  [20] OLD ITALIC LETTER YE..GOTHIC LETTER PAIRTHRA
-	{runeRange{0x10341, 0x10341}, sbprOLetter}, // Nl       GOTHIC LETTER NINETY
-	{runeRange{0x10342, 0x10349}, sbprOLetter}, // Lo   [8] GOTHIC LETTER RAIDA..GOTHIC LETTER OTHAL
-	{runeRange{0x1034A, 0x1034A}, sbprOLetter}, // Nl       GOTHIC LETTER NINE HUNDRED
-	{runeRange{0x10350, 0x10375}, sbprOLetter}, // Lo  [38] OLD PERMIC LETTER AN..OLD PERMIC LETTER IA
-	{runeRange{0x10376, 0x1037A}, sbprExtend},  // Mn   [5] COMBINING OLD PERMIC LETTER AN..COMBINING OLD PERMIC LETTER SII
-	{runeRange{0x10380, 0x1039D}, sbprOLetter}, // Lo  [30] UGARITIC LETTER ALPA..UGARITIC LETTER SSU
-	{runeRange{0x103A0, 0x103C3}, sbprOLetter}, // Lo  [36] OLD PERSIAN SIGN A..OLD PERSIAN SIGN HA
-	{runeRange{0x103C8, 0x103CF}, sbprOLetter}, // Lo   [8] OLD PERSIAN SIGN AURAMAZDAA..OLD PERSIAN SIGN BUUMISH
-	{runeRange{0x103D1, 0x103D5}, sbprOLetter}, // Nl   [5] OLD PERSIAN NUMBER ONE..OLD PERSIAN NUMBER HUNDRED
-	{runeRange{0x10400, 0x10427}, sbprUpper},   // L&  [40] DESERET CAPITAL LETTER LONG I..DESERET CAPITAL LETTER EW
-	{runeRange{0x10428, 0x1044F}, sbprLower},   // L&  [40] DESERET SMALL LETTER LONG I..DESERET SMALL LETTER EW
-	{runeRange{0x10450, 0x1049D}, sbprOLetter}, // Lo  [78] SHAVIAN LETTER PEEP..OSMANYA LETTER OO
-	{runeRange{0x104A0, 0x104A9}, sbprNumeric}, // Nd  [10] OSMANYA DIGIT ZERO..OSMANYA DIGIT NINE
-	{runeRange{0x104B0, 0x104D3}, sbprUpper},   // L&  [36] OSAGE CAPITAL LETTER A..OSAGE CAPITAL LETTER ZHA
-	{runeRange{0x104D8, 0x104FB}, sbprLower},   // L&  [36] OSAGE SMALL LETTER A..OSAGE SMALL LETTER ZHA
-	{runeRange{0x10500, 0x10527}, sbprOLetter}, // Lo  [40] ELBASAN LETTER A..ELBASAN LETTER KHE
-	{runeRange{0x10530, 0x10563}, sbprOLetter}, // Lo  [52] CAUCASIAN ALBANIAN LETTER ALT..CAUCASIAN ALBANIAN LETTER KIW
-	{runeRange{0x10570, 0x1057A}, sbprUpper},   // L&  [11] VITHKUQI CAPITAL LETTER A..VITHKUQI CAPITAL LETTER GA
-	{runeRange{0x1057C, 0x1058A}, sbprUpper},   // L&  [15] VITHKUQI CAPITAL LETTER HA..VITHKUQI CAPITAL LETTER RE
-	{runeRange{0x1058C, 0x10592}, sbprUpper},   // L&   [7] VITHKUQI CAPITAL LETTER SE..VITHKUQI CAPITAL LETTER XE
-	{runeRange{0x10594, 0x10595}, sbprUpper},   // L&   [2] VITHKUQI CAPITAL LETTER Y..VITHKUQI CAPITAL LETTER ZE
-	{runeRange{0x10597, 0x105A1}, sbprLower},   // L&  [11] VITHKUQI SMALL LETTER A..VITHKUQI SMALL LETTER GA
-	{runeRange{0x105A3, 0x105B1}, sbprLower},   // L&  [15] VITHKUQI SMALL LETTER HA..VITHKUQI SMALL LETTER RE
-	{runeRange{0x105B3, 0x105B9}, sbprLower},   // L&   [7] VITHKUQI SMALL LETTER SE..VITHKUQI SMALL LETTER XE
-	{runeRange{0x105BB, 0x105BC}, sbprLower},   // L&   [2] VITHKUQI SMALL LETTER Y..VITHKUQI SMALL LETTER ZE
-	{runeRange{0x10600, 0x10736}, sbprOLetter}, // Lo [311] LINEAR A SIGN AB001..LINEAR A SIGN A664
-	{runeRange{0x10740, 0x10755}, sbprOLetter}, // Lo  [22] LINEAR A SIGN A701 A..LINEAR A SIGN A732 JE
-	{runeRange{0x10760, 0x10767}, sbprOLetter}, // Lo   [8] LINEAR A SIGN A800..LINEAR A SIGN A807
-	{runeRange{0x10780, 0x10780}, sbprLower},   // Lm       MODIFIER LETTER SMALL CAPITAL AA
-	{runeRange{0x10781, 0x10782}, sbprOLetter}, // Lm   [2] MODIFIER LETTER SUPERSCRIPT TRIANGULAR COLON..MODIFIER LETTER SUPERSCRIPT HALF TRIANGULAR COLON
-	{runeRange{0x10783, 0x10785}, sbprLower},   // Lm   [3] MODIFIER LETTER SMALL AE..MODIFIER LETTER SMALL B WITH HOOK
-	{runeRange{0x10787, 0x107B0}, sbprLower},   // Lm  [42] MODIFIER LETTER SMALL DZ DIGRAPH..MODIFIER LETTER SMALL V WITH RIGHT HOOK
-	{runeRange{0x107B2, 0x107BA}, sbprLower},   // Lm   [9] MODIFIER LETTER SMALL CAPITAL Y..MODIFIER LETTER SMALL S WITH CURL
-	{runeRange{0x10800, 0x10805}, sbprOLetter}, // Lo   [6] CYPRIOT SYLLABLE A..CYPRIOT SYLLABLE JA
-	{runeRange{0x10808, 0x10808}, sbprOLetter}, // Lo       CYPRIOT SYLLABLE JO
-	{runeRange{0x1080A, 0x10835}, sbprOLetter}, // Lo  [44] CYPRIOT SYLLABLE KA..CYPRIOT SYLLABLE WO
-	{runeRange{0x10837, 0x10838}, sbprOLetter}, // Lo   [2] CYPRIOT SYLLABLE XA..CYPRIOT SYLLABLE XE
-	{runeRange{0x1083C, 0x1083C}, sbprOLetter}, // Lo       CYPRIOT SYLLABLE ZA
-	{runeRange{0x1083F, 0x10855}, sbprOLetter}, // Lo  [23] CYPRIOT SYLLABLE ZO..IMPERIAL ARAMAIC LETTER TAW
-	{runeRange{0x10860, 0x10876}, sbprOLetter}, // Lo  [23] PALMYRENE LETTER ALEPH..PALMYRENE LETTER TAW
-	{runeRange{0x10880, 0x1089E}, sbprOLetter}, // Lo  [31] NABATAEAN LETTER FINAL ALEPH..NABATAEAN LETTER TAW
-	{runeRange{0x108E0, 0x108F2}, sbprOLetter}, // Lo  [19] HATRAN LETTER ALEPH..HATRAN LETTER QOPH
-	{runeRange{0x108F4, 0x108F5}, sbprOLetter}, // Lo   [2] HATRAN LETTER SHIN..HATRAN LETTER TAW
-	{runeRange{0x10900, 0x10915}, sbprOLetter}, // Lo  [22] PHOENICIAN LETTER ALF..PHOENICIAN LETTER TAU
-	{runeRange{0x10920, 0x10939}, sbprOLetter}, // Lo  [26] LYDIAN LETTER A..LYDIAN LETTER C
-	{runeRange{0x10980, 0x109B7}, sbprOLetter}, // Lo  [56] MEROITIC HIEROGLYPHIC LETTER A..MEROITIC CURSIVE LETTER DA
-	{runeRange{0x109BE, 0x109BF}, sbprOLetter}, // Lo   [2] MEROITIC CURSIVE LOGOGRAM RMT..MEROITIC CURSIVE LOGOGRAM IMN
-	{runeRange{0x10A00, 0x10A00}, sbprOLetter}, // Lo       KHAROSHTHI LETTER A
-	{runeRange{0x10A01, 0x10A03}, sbprExtend},  // Mn   [3] KHAROSHTHI VOWEL SIGN I..KHAROSHTHI VOWEL SIGN VOCALIC R
-	{runeRange{0x10A05, 0x10A06}, sbprExtend},  // Mn   [2] KHAROSHTHI VOWEL SIGN E..KHAROSHTHI VOWEL SIGN O
-	{runeRange{0x10A0C, 0x10A0F}, sbprExtend},  // Mn   [4] KHAROSHTHI VOWEL LENGTH MARK..KHAROSHTHI SIGN VISARGA
-	{runeRange{0x10A10, 0x10A13}, sbprOLetter}, // Lo   [4] KHAROSHTHI LETTER KA..KHAROSHTHI LETTER GHA
-	{runeRange{0x10A15, 0x10A17}, sbprOLetter}, // Lo   [3] KHAROSHTHI LETTER CA..KHAROSHTHI LETTER JA
-	{runeRange{0x10A19, 0x10A35}, sbprOLetter}, // Lo  [29] KHAROSHTHI LETTER NYA..KHAROSHTHI LETTER VHA
-	{runeRange{0x10A38, 0x10A3A}, sbprExtend},  // Mn   [3] KHAROSHTHI SIGN BAR ABOVE..KHAROSHTHI SIGN DOT BELOW
-	{runeRange{0x10A3F, 0x10A3F}, sbprExtend},  // Mn       KHAROSHTHI VIRAMA
-	{runeRange{0x10A56, 0x10A57}, sbprSTerm},   // Po   [2] KHAROSHTHI PUNCTUATION DANDA..KHAROSHTHI PUNCTUATION DOUBLE DANDA
-	{runeRange{0x10A60, 0x10A7C}, sbprOLetter}, // Lo  [29] OLD SOUTH ARABIAN LETTER HE..OLD SOUTH ARABIAN LETTER THETH
-	{runeRange{0x10A80, 0x10A9C}, sbprOLetter}, // Lo  [29] OLD NORTH ARABIAN LETTER HEH..OLD NORTH ARABIAN LETTER ZAH
-	{runeRange{0x10AC0, 0x10AC7}, sbprOLetter}, // Lo   [8] MANICHAEAN LETTER ALEPH..MANICHAEAN LETTER WAW
-	{runeRange{0x10AC9, 0x10AE4}, sbprOLetter}, // Lo  [28] MANICHAEAN LETTER ZAYIN..MANICHAEAN LETTER TAW
-	{runeRange{0x10AE5, 0x10AE6}, sbprExtend},  // Mn   [2] MANICHAEAN ABBREVIATION MARK ABOVE..MANICHAEAN ABBREVIATION MARK BELOW
-	{runeRange{0x10B00, 0x10B35}, sbprOLetter}, // Lo  [54] AVESTAN LETTER A..AVESTAN LETTER HE
-	{runeRange{0x10B40, 0x10B55}, sbprOLetter}, // Lo  [22] INSCRIPTIONAL PARTHIAN LETTER ALEPH..INSCRIPTIONAL PARTHIAN LETTER TAW
-	{runeRange{0x10B60, 0x10B72}, sbprOLetter}, // Lo  [19] INSCRIPTIONAL PAHLAVI LETTER ALEPH..INSCRIPTIONAL PAHLAVI LETTER TAW
-	{runeRange{0x10B80, 0x10B91}, sbprOLetter}, // Lo  [18] PSALTER PAHLAVI LETTER ALEPH..PSALTER PAHLAVI LETTER TAW
-	{runeRange{0x10C00, 0x10C48}, sbprOLetter}, // Lo  [73] OLD TURKIC LETTER ORKHON A..OLD TURKIC LETTER ORKHON BASH
-	{runeRange{0x10C80, 0x10CB2}, sbprUpper},   // L&  [51] OLD HUNGARIAN CAPITAL LETTER A..OLD HUNGARIAN CAPITAL LETTER US
-	{runeRange{0x10CC0, 0x10CF2}, sbprLower},   // L&  [51] OLD HUNGARIAN SMALL LETTER A..OLD HUNGARIAN SMALL LETTER US
-	{runeRange{0x10D00, 0x10D23}, sbprOLetter}, // Lo  [36] HANIFI ROHINGYA LETTER A..HANIFI ROHINGYA MARK NA KHONNA
+	{runeRange{0x18B0, 0x18F5}, sbprOLetter},   // Lo  [70] CANADIAN SYLLABICS OY..CANADIAN SYLLABICS CARRIER DENTAL S
 	{runeRange{0x10D24, 0x10D27}, sbprExtend},  // Mn   [4] HANIFI ROHINGYA SIGN HARBAHAY..HANIFI ROHINGYA SIGN TASSI
-	{runeRange{0x10D30, 0x10D39}, sbprNumeric}, // Nd  [10] HANIFI ROHINGYA DIGIT ZERO..HANIFI ROHINGYA DIGIT NINE
-	{runeRange{0x10E80, 0x10EA9}, sbprOLetter}, // Lo  [42] YEZIDI LETTER ELIF..YEZIDI LETTER ET
-	{runeRange{0x10EAB, 0x10EAC}, sbprExtend},  // Mn   [2] YEZIDI COMBINING HAMZA MARK..YEZIDI COMBINING MADDA MARK
-	{runeRange{0x10EB0, 0x10EB1}, sbprOLetter}, // Lo   [2] YEZIDI LETTER LAM WITH DOT ABOVE..YEZIDI LETTER YOT WITH CIRCUMFLEX ABOVE
-	{runeRange{0x10EFD, 0x10EFF}, sbprExtend},  // Mn   [3] ARABIC SMALL LOW WORD SAKTA..ARABIC SMALL LOW WORD MADDA
-	{runeRange{0x10F00, 0x10F1C}, sbprOLetter}, // Lo  [29] OLD SOGDIAN LETTER ALEPH..OLD SOGDIAN LETTER FINAL TAW WITH VERTICAL TAIL
-	{runeRange{0x10F27, 0x10F27}, sbprOLetter}, // Lo       OLD SOGDIAN LIGATURE AYIN-DALETH
-	{runeRange{0x10F30, 0x10F45}, sbprOLetter}, // Lo  [22] SOGDIAN LETTER ALEPH..SOGDIAN INDEPENDENT SHIN
-	{runeRange{0x10F46, 0x10F50}, sbprExtend},  // Mn  [11] SOGDIAN COMBINING DOT BELOW..SOGDIAN COMBINING STROKE BELOW
-	{runeRange{0x10F55, 0x10F59}, sbprSTerm},   // Po   [5] SOGDIAN PUNCTUATION TWO VERTICAL BARS..SOGDIAN PUNCTUATION HALF CIRCLE WITH DOT
-	{runeRange{0x10F70, 0x10F81}, sbprOLetter}, // Lo  [18] OLD UYGHUR LETTER ALEPH..OLD UYGHUR LETTER LESH
-	{runeRange{0x10F82, 0x10F85}, sbprExtend},  // Mn   [4] OLD UYGHUR COMBINING DOT ABOVE..OLD UYGHUR COMBINING TWO DOTS BELOW
-	{runeRange{0x10F86, 0x10F89}, sbprSTerm},   // Po   [4] OLD UYGHUR PUNCTUATION BAR..OLD UYGHUR PUNCTUATION FOUR DOTS
-	{runeRange{0x10FB0, 0x10FC4}, sbprOLetter}, // Lo  [21] CHORASMIAN LETTER ALEPH..CHORASMIAN LETTER TAW
-	{runeRange{0x10FE0, 0x10FF6}, sbprOLetter}, // Lo  [23] ELYMAIC LETTER ALEPH..ELYMAIC LIGATURE ZAYIN-YODH
-	{runeRange{0x11000, 0x11000}, sbprExtend},  // Mc       BRAHMI SIGN CANDRABINDU
-	{runeRange{0x11001, 0x11001}, sbprExtend},  // Mn       BRAHMI SIGN ANUSVARA
-	{runeRange{0x11002, 0x11002}, sbprExtend},  // Mc       BRAHMI SIGN VISARGA
-	{runeRange{0x11003, 0x11037}, sbprOLetter}, // Lo  [53] BRAHMI SIGN JIHVAMULIYA..BRAHMI LETTER OLD TAMIL NNNA
-	{runeRange{0x11038, 0x11046}, sbprExtend},  // Mn  [15] BRAHMI VOWEL SIGN AA..BRAHMI VIRAMA
-	{runeRange{0x11047, 0x11048}, sbprSTerm},   // Po   [2] BRAHMI DANDA..BRAHMI DOUBLE DANDA
-	{runeRange{0x11066, 0x1106F}, sbprNumeric}, // Nd  [10] BRAHMI DIGIT ZERO..BRAHMI DIGIT NINE
-	{runeRange{0x11070, 0x11070}, sbprExtend},  // Mn       BRAHMI SIGN OLD TAMIL VIRAMA
-	{runeRange{0x11071, 0x11072}, sbprOLetter}, // Lo   [2] BRAHMI LETTER OLD TAMIL SHORT E..BRAHMI LETTER OLD TAMIL SHORT O
-	{runeRange{0x11073, 0x11074}, sbprExtend},  // Mn   [2] BRAHMI VOWEL SIGN OLD TAMIL SHORT E..BRAHMI VOWEL SIGN OLD TAMIL SHORT O
-	{runeRange{0x11075, 0x11075}, sbprOLetter}, // Lo       BRAHMI LETTER OLD TAMIL LLA
-	{runeRange{0x1107F, 0x11081}, sbprExtend},  // Mn   [3] BRAHMI NUMBER JOINER..KAITHI SIGN ANUSVARA
-	{runeRange{0x11082, 0x11082}, sbprExtend},  // Mc       KAITHI SIGN VISARGA
-	{runeRange{0x11083, 0x110AF}, sbprOLetter}, // Lo  [45] KAITHI LETTER A..KAITHI LETTER HA
-	{runeRange{0x110B0, 0x110B2}, sbprExtend},  // Mc   [3] KAITHI VOWEL SIGN AA..KAITHI VOWEL SIGN II
-	{runeRange{0x110B3, 0x110B6}, sbprExtend},  // Mn   [4] KAITHI VOWEL SIGN U..KAITHI VOWEL SIGN AI
-	{runeRange{0x110B7, 0x110B8}, sbprExtend},  // Mc   [2] KAITHI VOWEL SIGN O..KAITHI VOWEL SIGN AU
-	{runeRange{0x110B9, 0x110BA}, sbprExtend},  // Mn   [2] KAITHI SIGN VIRAMA..KAITHI SIGN NUKTA
-	{runeRange{0x110BD, 0x110BD}, sbprFormat},  // Cf       KAITHI NUMBER SIGN
-	{runeRange{0x110BE, 0x110C1}, sbprSTerm},   // Po   [4] KAITHI SECTION MARK..KAITHI DOUBLE DANDA
-	{runeRange{0x110C2, 0x110C2}, sbprExtend},  // Mn       KAITHI VOWEL SIGN VOCALIC R
-	{runeRange{0x110CD, 0x110CD}, sbprFormat},  // Cf       KAITHI NUMBER SIGN ABOVE
-	{runeRange{0x110D0, 0x110E8}, sbprOLetter}, // Lo  [25] SORA SOMPENG LETTER SAH..SORA SOMPENG LETTER MAE
-	{runeRange{0x110F0, 0x110F9}, sbprNumeric}, // Nd  [10] SORA SOMPENG DIGIT ZERO..SORA SOMPENG DIGIT NINE
-	{runeRange{0x11100, 0x11102}, sbprExtend},  // Mn   [3] CHAKMA SIGN CANDRABINDU..CHAKMA SIGN VISARGA
-	{runeRange{0x11103, 0x11126}, sbprOLetter}, // Lo  [36] CHAKMA LETTER AA..CHAKMA LETTER HAA
-	{runeRange{0x11127, 0x1112B}, sbprExtend},  // Mn   [5] CHAKMA VOWEL SIGN A..CHAKMA VOWEL SIGN UU
-	{runeRange{0x1112C, 0x1112C}, sbprExtend},  // Mc       CHAKMA VOWEL SIGN E
-	{runeRange{0x1112D, 0x11134}, sbprExtend},  // Mn   [8] CHAKMA VOWEL SIGN AI..CHAKMA MAAYYAA
-	{runeRange{0x11136, 0x1113F}, sbprNumeric}, // Nd  [10] CHAKMA DIGIT ZERO..CHAKMA DIGIT NINE
-	{runeRange{0x11141, 0x11143}, sbprSTerm},   // Po   [3] CHAKMA DANDA..CHAKMA QUESTION MARK
-	{runeRange{0x11144, 0x11144}, sbprOLetter}, // Lo       CHAKMA LETTER LHAA
-	{runeRange{0x11145, 0x11146}, sbprExtend},  // Mc   [2] CHAKMA VOWEL SIGN AA..CHAKMA VOWEL SIGN EI
-	{runeRange{0x11147, 0x11147}, sbprOLetter}, // Lo       CHAKMA LETTER VAA
-	{runeRange{0x11150, 0x11172}, sbprOLetter}, // Lo  [35] MAHAJANI LETTER A..MAHAJANI LETTER RRA
-	{runeRange{0x11173, 0x11173}, sbprExtend},  // Mn       MAHAJANI SIGN NUKTA
-	{runeRange{0x11176, 0x11176}, sbprOLetter}, // Lo       MAHAJANI LIGATURE SHRI
-	{runeRange{0x11180, 0x11181}, sbprExtend},  // Mn   [2] SHARADA SIGN CANDRABINDU..SHARADA SIGN ANUSVARA
-	{runeRange{0x11182, 0x11182}, sbprExtend},  // Mc       SHARADA SIGN VISARGA
-	{runeRange{0x11183, 0x111B2}, sbprOLetter}, // Lo  [48] SHARADA LETTER A..SHARADA LETTER HA
-	{runeRange{0x111B3, 0x111B5}, sbprExtend},  // Mc   [3] SHARADA VOWEL SIGN AA..SHARADA VOWEL SIGN II
-	{runeRange{0x111B6, 0x111BE}, sbprExtend},  // Mn   [9] SHARADA VOWEL SIGN U..SHARADA VOWEL SIGN O
-	{runeRange{0x111BF, 0x111C0}, sbprExtend},  // Mc   [2] SHARADA VOWEL SIGN AU..SHARADA SIGN VIRAMA
-	{runeRange{0x111C1, 0x111C4}, sbprOLetter}, // Lo   [4] SHARADA SIGN AVAGRAHA..SHARADA OM
-	{runeRange{0x111C5, 0x111C6}, sbprSTerm},   // Po   [2] SHARADA DANDA..SHARADA DOUBLE DANDA
-	{runeRange{0x111C9, 0x111CC}, sbprExtend},  // Mn   [4] SHARADA SANDHI MARK..SHARADA EXTRA SHORT VOWEL MARK
-	{runeRange{0x111CD, 0x111CD}, sbprSTerm},   // Po       SHARADA SUTRA MARK
-	{runeRange{0x111CE, 0x111CE}, sbprExtend},  // Mc       SHARADA VOWEL SIGN PRISHTHAMATRA E
-	{runeRange{0x111CF, 0x111CF}, sbprExtend},  // Mn       SHARADA SIGN INVERTED CANDRABINDU
-	{runeRange{0x111D0, 0x111D9}, sbprNumeric}, // Nd  [10] SHARADA DIGIT ZERO..SHARADA DIGIT NINE
-	{runeRange{0x111DA, 0x111DA}, sbprOLetter}, // Lo       SHARADA EKAM
-	{runeRange{0x111DC, 0x111DC}, sbprOLetter}, // Lo       SHARADA HEADSTROKE
-	{runeRange{0x111DE, 0x111DF}, sbprSTerm},   // Po   [2] SHARADA SECTION MARK-1..SHARADA SECTION MARK-2
-	{runeRange{0x11200, 0x11211}, sbprOLetter}, // Lo  [18] KHOJKI LETTER A..KHOJKI LETTER JJA
-	{runeRange{0x11213, 0x1122B}, sbprOLetter}, // Lo  [25] KHOJKI LETTER NYA..KHOJKI LETTER LLA
-	{runeRange{0x1122C, 0x1122E}, sbprExtend},  // Mc   [3] KHOJKI VOWEL SIGN AA..KHOJKI VOWEL SIGN II
-	{runeRange{0x1122F, 0x11231}, sbprExtend},  // Mn   [3] KHOJKI VOWEL SIGN U..KHOJKI VOWEL SIGN AI
-	{runeRange{0x11232, 0x11233}, sbprExtend},  // Mc   [2] KHOJKI VOWEL SIGN O..KHOJKI VOWEL SIGN AU
-	{runeRange{0x11234, 0x11234}, sbprExtend},  // Mn       KHOJKI SIGN ANUSVARA
-	{runeRange{0x11235, 0x11235}, sbprExtend},  // Mc       KHOJKI SIGN VIRAMA
-	{runeRange{0x11236, 0x11237}, sbprExtend},  // Mn   [2] KHOJKI SIGN NUKTA..KHOJKI SIGN SHADDA
-	{runeRange{0x11238, 0x11239}, sbprSTerm},   // Po   [2] KHOJKI DANDA..KHOJKI DOUBLE DANDA
-	{runeRange{0x1123B, 0x1123C}, sbprSTerm},   // Po   [2] KHOJKI SECTION MARK..KHOJKI DOUBLE SECTION MARK
-	{runeRange{0x1123E, 0x1123E}, sbprExtend},  // Mn       KHOJKI SIGN SUKUN
-	{runeRange{0x1123F, 0x11240}, sbprOLetter}, // Lo   [2] KHOJKI LETTER QA..KHOJKI LETTER SHORT I
-	{runeRange{0x11241, 0x11241}, sbprExtend},  // Mn       KHOJKI VOWEL SIGN VOCALIC R
-	{runeRange{0x11280, 0x11286}, sbprOLetter}, // Lo   [7] MULTANI LETTER A..MULTANI LETTER GA
-	{runeRange{0x11288, 0x11288}, sbprOLetter}, // Lo       MULTANI LETTER GHA
-	{runeRange{0x1128A, 0x1128D}, sbprOLetter}, // Lo   [4] MULTANI LETTER CA..MULTANI LETTER JJA
-	{runeRange{0x1128F, 0x1129D}, sbprOLetter}, // Lo  [15] MULTANI LETTER NYA..MULTANI LETTER BA
-	{runeRange{0x1129F, 0x112A8}, sbprOLetter}, // Lo  [10] MULTANI LETTER BHA..MULTANI LETTER RHA
-	{runeRange{0x112A9, 0x112A9}, sbprSTerm},   // Po       MULTANI SECTION MARK
-	{runeRange{0x112B0, 0x112DE}, sbprOLetter}, // Lo  [47] KHUDAWADI LETTER A..KHUDAWADI LETTER HA
-	{runeRange{0x112DF, 0x112DF}, sbprExtend},  // Mn       KHUDAWADI SIGN ANUSVARA
-	{runeRange{0x112E0, 0x112E2}, sbprExtend},  // Mc   [3] KHUDAWADI VOWEL SIGN AA..KHUDAWADI VOWEL SIGN II
-	{runeRange{0x112E3, 0x112EA}, sbprExtend},  // Mn   [8] KHUDAWADI VOWEL SIGN U..KHUDAWADI SIGN VIRAMA
-	{runeRange{0x112F0, 0x112F9}, sbprNumeric}, // Nd  [10] KHUDAWADI DIGIT ZERO..KHUDAWADI DIGIT NINE
-	{runeRange{0x11300, 0x11301}, sbprExtend},  // Mn   [2] GRANTHA SIGN COMBINING ANUSVARA ABOVE..GRANTHA SIGN CANDRABINDU
-	{runeRange{0x11302, 0x11303}, sbprExtend},  // Mc   [2] GRANTHA SIGN ANUSVARA..GRANTHA SIGN VISARGA
-	{runeRange{0x11305, 0x1130C}, sbprOLetter}, // Lo   [8] GRANTHA LETTER A..GRANTHA LETTER VOCALIC L
-	{runeRange{0x1130F, 0x11310}, sbprOLetter}, // Lo   [2] GRANTHA LETTER EE..GRANTHA LETTER AI
-	{runeRange{0x11313, 0x11328}, sbprOLetter}, // Lo  [22] GRANTHA LETTER OO..GRANTHA LETTER NA
-	{runeRange{0x1132A, 0x11330}, sbprOLetter}, // Lo   [7] GRANTHA LETTER PA..GRANTHA LETTER RA
-	{runeRange{0x11332, 0x11333}, sbprOLetter}, // Lo   [2] GRANTHA LETTER LA..GRANTHA LETTER LLA
-	{runeRange{0x11335, 0x11339}, sbprOLetter}, // Lo   [5] GRANTHA LETTER VA..GRANTHA LETTER HA
-	{runeRange{0x1133B, 0x1133C}, sbprExtend},  // Mn   [2] COMBINING BINDU BELOW..GRANTHA SIGN NUKTA
-	{runeRange{0x1133D, 0x1133D}, sbprOLetter}, // Lo       GRANTHA SIGN AVAGRAHA
-	{runeRange{0x1133E, 0x1133F}, sbprExtend},  // Mc   [2] GRANTHA VOWEL SIGN AA..GRANTHA VOWEL SIGN I
-	{runeRange{0x11340, 0x11340}, sbprExtend},  // Mn       GRANTHA VOWEL SIGN II
-	{runeRange{0x11341, 0x11344}, sbprExtend},  // Mc   [4] GRANTHA VOWEL SIGN U..GRANTHA VOWEL SIGN VOCALIC RR
-	{runeRange{0x11347, 0x11348}, sbprExtend},  // Mc   [2] GRANTHA VOWEL SIGN EE..GRANTHA VOWEL SIGN AI
-	{runeRange{0x1134B, 0x1134D}, sbprExtend},  // Mc   [3] GRANTHA VOWEL SIGN OO..GRANTHA SIGN VIRAMA
-	{runeRange{0x11350, 0x11350}, sbprOLetter}, // Lo       GRANTHA OM
-	{runeRange{0x11357, 0x11357}, sbprExtend},  // Mc       GRANTHA AU LENGTH MARK
-	{runeRange{0x1135D, 0x11361}, sbprOLetter}, // Lo   [5] GRANTHA SIGN PLUTA..GRANTHA LETTER VOCALIC LL
-	{runeRange{0x11362, 0x11363}, sbprExtend},  // Mc   [2] GRANTHA VOWEL SIGN VOCALIC L..GRANTHA VOWEL SIGN VOCALIC LL
-	{runeRange{0x11366, 0x1136C}, sbprExtend},  // Mn   [7] COMBINING GRANTHA DIGIT ZERO..COMBINING GRANTHA DIGIT SIX
-	{runeRange{0x11370, 0x11374}, sbprExtend},  // Mn   [5] COMBINING GRANTHA LETTER A..COMBINING GRANTHA LETTER PA
-	{runeRange{0x11400, 0x11434}, sbprOLetter}, // Lo  [53] NEWA LETTER A..NEWA LETTER HA
-	{runeRange{0x11435, 0x11437}, sbprExtend},  // Mc   [3] NEWA VOWEL SIGN AA..NEWA VOWEL SIGN II
-	{runeRange{0x11438, 0x1143F}, sbprExtend},  // Mn   [8] NEWA VOWEL SIGN U..NEWA VOWEL SIGN AI
-	{runeRange{0x11440, 0x11441}, sbprExtend},  // Mc   [2] NEWA VOWEL SIGN O..NEWA VOWEL SIGN AU
-	{runeRange{0x11442, 0x11444}, sbprExtend},  // Mn   [3] NEWA SIGN VIRAMA..NEWA SIGN ANUSVARA
-	{runeRange{0x11445, 0x11445}, sbprExtend},  // Mc       NEWA SIGN VISARGA
-	{runeRange{0x11446, 0x11446}, sbprExtend},  // Mn       NEWA SIGN NUKTA
-	{runeRange{0x11447, 0x1144A}, sbprOLetter}, // Lo   [4] NEWA SIGN AVAGRAHA..NEWA SIDDHI
-	{runeRange{0x1144B, 0x1144C}, sbprSTerm},   // Po   [2] NEWA DANDA..NEWA DOUBLE DANDA
-	{runeRange{0x11450, 0x11459}, sbprNumeric}, // Nd  [10] NEWA DIGIT ZERO..NEWA DIGIT NINE
-	{runeRange{0x1145E, 0x1145E}, sbprExtend},  // Mn       NEWA SANDHI MARK
-	{runeRange{0x1145F, 0x11461}, sbprOLetter}, // Lo   [3] NEWA LETTER VEDIC ANUSVARA..NEWA SIGN UPADHMANIYA
-	{runeRange{0x11480, 0x114AF}, sbprOLetter}, // Lo  [48] TIRHUTA ANJI..TIRHUTA LETTER HA
-	{runeRange{0x114B0, 0x114B2}, sbprExtend},  // Mc   [3] TIRHUTA VOWEL SIGN AA..TIRHUTA VOWEL SIGN II
-	{runeRange{0x114B3, 0x114B8}, sbprExtend},  // Mn   [6] TIRHUTA VOWEL SIGN U..TIRHUTA VOWEL SIGN VOCALIC LL
-	{runeRange{0x114B9, 0x114B9}, sbprExtend},  // Mc       TIRHUTA VOWEL SIGN E
-	{runeRange{0x114BA, 0x114BA}, sbprExtend},  // Mn       TIRHUTA VOWEL SIGN SHORT E
-	{runeRange{0x114BB, 0x114BE}, sbprExtend},  // Mc   [4] TIRHUTA VOWEL SIGN AI..TIRHUTA VOWEL SIGN AU
-	{runeRange{0x114BF, 0x114C0}, sbprExtend},  // Mn   [2] TIRHUTA SIGN CANDRABINDU..TIRHUTA SIGN ANUSVARA
-	{runeRange{0x114C1, 0x114C1}, sbprExtend},  // Mc       TIRHUTA SIGN VISARGA
-	{runeRange{0x114C2, 0x114C3}, sbprExtend},  // Mn   [2] TIRHUTA SIGN VIRAMA..TIRHUTA SIGN NUKTA
-	{runeRange{0x114C4, 0x114C5}, sbprOLetter}, // Lo   [2] TIRHUTA SIGN AVAGRAHA..TIRHUTA GVANG
-	{runeRange{0x114C7, 0x114C7}, sbprOLetter}, // Lo       TIRHUTA OM
-	{runeRange{0x114D0, 0x114D9}, sbprNumeric}, // Nd  [10] TIRHUTA DIGIT ZERO..TIRHUTA DIGIT NINE
-	{runeRange{0x11580, 0x115AE}, sbprOLetter}, // Lo  [47] SIDDHAM LETTER A..SIDDHAM LETTER HA
-	{runeRange{0x115AF, 0x115B1}, sbprExtend},  // Mc   [3] SIDDHAM VOWEL SIGN AA..SIDDHAM VOWEL SIGN II
-	{runeRange{0x115B2, 0x115B5}, sbprExtend},  // Mn   [4] SIDDHAM VOWEL SIGN U..SIDDHAM VOWEL SIGN VOCALIC RR
-	{runeRange{0x115B8, 0x115BB}, sbprExtend},  // Mc   [4] SIDDHAM VOWEL SIGN E..SIDDHAM VOWEL SIGN AU
-	{runeRange{0x115BC, 0x115BD}, sbprExtend},  // Mn   [2] SIDDHAM SIGN CANDRABINDU..SIDDHAM SIGN ANUSVARA
-	{runeRange{0x115BE, 0x115BE}, sbprExtend},  // Mc       SIDDHAM SIGN VISARGA
-	{runeRange{0x115BF, 0x115C0}, sbprExtend},  // Mn   [2] SIDDHAM SIGN VIRAMA..SIDDHAM SIGN NUKTA
-	{runeRange{0x115C2, 0x115C3}, sbprSTerm},   // Po   [2] SIDDHAM DANDA..SIDDHAM DOUBLE DANDA
-	{runeRange{0x115C9, 0x115D7}, sbprSTerm},   // Po  [15] SIDDHAM END OF TEXT MARK..SIDDHAM SECTION MARK WITH CIRCLES AND FOUR ENCLOSURES
-	{runeRange{0x115D8, 0x115DB}, sbprOLetter}, // Lo   [4] SIDDHAM LETTER THREE-CIRCLE ALTERNATE I..SIDDHAM LETTER ALTERNATE U
-	{runeRange{0x115DC, 0x115DD}, sbprExtend},  // Mn   [2] SIDDHAM VOWEL SIGN ALTERNATE U..SIDDHAM VOWEL SIGN ALTERNATE UU
-	{runeRange{0x11600, 0x1162F}, sbprOLetter}, // Lo  [48] MODI LETTER A..MODI LETTER LLA
-	{runeRange{0x11630, 0x11632}, sbprExtend},  // Mc   [3] MODI VOWEL SIGN AA..MODI VOWEL SIGN II
-	{runeRange{0x11633, 0x1163A}, sbprExtend},  // Mn   [8] MODI VOWEL SIGN U..MODI VOWEL SIGN AI
-	{runeRange{0x1163B, 0x1163C}, sbprExtend},  // Mc   [2] MODI VOWEL SIGN O..MODI VOWEL SIGN AU
-	{runeRange{0x1163D, 0x1163D}, sbprExtend},  // Mn       MODI SIGN ANUSVARA
-	{runeRange{0x1163E, 0x1163E}, sbprExtend},  // Mc       MODI SIGN VISARGA
-	{runeRange{0x1163F, 0x11640}, sbprExtend},  // Mn   [2] MODI SIGN VIRAMA..MODI SIGN ARDHACANDRA
-	{runeRange{0x11641, 0x11642}, sbprSTerm},   // Po   [2] MODI DANDA..MODI DOUBLE DANDA
-	{runeRange{0x11644, 0x11644}, sbprOLetter}, // Lo       MODI SIGN HUVA
-	{runeRange{0x11650, 0x11659}, sbprNumeric}, // Nd  [10] MODI DIGIT ZERO..MODI DIGIT NINE
-	{runeRange{0x11680, 0x116AA}, sbprOLetter}, // Lo  [43] TAKRI LETTER A..TAKRI LETTER RRA
-	{runeRange{0x116AB, 0x116AB}, sbprExtend},  // Mn       TAKRI SIGN ANUSVARA
-	{runeRange{0x116AC, 0x116AC}, sbprExtend},  // Mc       TAKRI SIGN VISARGA
-	{runeRange{0x116AD, 0x116AD}, sbprExtend},  // Mn       TAKRI VOWEL SIGN AA
-	{runeRange{0x116AE, 0x116AF}, sbprExtend},  // Mc   [2] TAKRI VOWEL SIGN I..TAKRI VOWEL SIGN II
-	{runeRange{0x116B0, 0x116B5}, sbprExtend},  // Mn   [6] TAKRI VOWEL SIGN U..TAKRI VOWEL SIGN AU
-	{runeRange{0x116B6, 0x116B6}, sbprExtend},  // Mc       TAKRI SIGN VIRAMA
-	{runeRange{0x116B7, 0x116B7}, sbprExtend},  // Mn       TAKRI SIGN NUKTA
-	{runeRange{0x116B8, 0x116B8}, sbprOLetter}, // Lo       TAKRI LETTER ARCHAIC KHA
-	{runeRange{0x116C0, 0x116C9}, sbprNumeric}, // Nd  [10] TAKRI DIGIT ZERO..TAKRI DIGIT NINE
-	{runeRange{0x11700, 0x1171A}, sbprOLetter}, // Lo  [27] AHOM LETTER KA..AHOM LETTER ALTERNATE BA
-	{runeRange{0x1171D, 0x1171F}, sbprExtend},  // Mn   [3] AHOM CONSONANT SIGN MEDIAL LA..AHOM CONSONANT SIGN MEDIAL LIGATING RA
-	{runeRange{0x11720, 0x11721}, sbprExtend},  // Mc   [2] AHOM VOWEL SIGN A..AHOM VOWEL SIGN AA
-	{runeRange{0x11722, 0x11725}, sbprExtend},  // Mn   [4] AHOM VOWEL SIGN I..AHOM VOWEL SIGN UU
-	{runeRange{0x11726, 0x11726}, sbprExtend},  // Mc       AHOM VOWEL SIGN E
-	{runeRange{0x11727, 0x1172B}, sbprExtend},  // Mn   [5] AHOM VOWEL SIGN AW..AHOM SIGN KILLER
-	{runeRange{0x11730, 0x11739}, sbprNumeric}, // Nd  [10] AHOM DIGIT ZERO..AHOM DIGIT NINE
-	{runeRange{0x1173C, 0x1173E}, sbprSTerm},   // Po   [3] AHOM SIGN SMALL SECTION..AHOM SIGN RULAI
-	{runeRange{0x11740, 0x11746}, sbprOLetter}, // Lo   [7] AHOM LETTER CA..AHOM LETTER LLA
-	{runeRange{0x11800, 0x1182B}, sbprOLetter}, // Lo  [44] DOGRA LETTER A..DOGRA LETTER RRA
-	{runeRange{0x1182C, 0x1182E}, sbprExtend},  // Mc   [3] DOGRA VOWEL SIGN AA..DOGRA VOWEL SIGN II
-	{runeRange{0x1182F, 0x11837}, sbprExtend},  // Mn   [9] DOGRA VOWEL SIGN U..DOGRA SIGN ANUSVARA
-	{runeRange{0x11838, 0x11838}, sbprExtend},  // Mc       DOGRA SIGN VISARGA
-	{runeRange{0x11839, 0x1183A}, sbprExtend},  // Mn   [2] DOGRA SIGN VIRAMA..DOGRA SIGN NUKTA
-	{runeRange{0x118A0, 0x118BF}, sbprUpper},   // L&  [32] WARANG CITI CAPITAL LETTER NGAA..WARANG CITI CAPITAL LETTER VIYO
-	{runeRange{0x118C0, 0x118DF}, sbprLower},   // L&  [32] WARANG CITI SMALL LETTER NGAA..WARANG CITI SMALL LETTER VIYO
-	{runeRange{0x118E0, 0x118E9}, sbprNumeric}, // Nd  [10] WARANG CITI DIGIT ZERO..WARANG CITI DIGIT NINE
-	{runeRange{0x118FF, 0x11906}, sbprOLetter}, // Lo   [8] WARANG CITI OM..DIVES AKURU LETTER E
-	{runeRange{0x11909, 0x11909}, sbprOLetter}, // Lo       DIVES AKURU LETTER O
-	{runeRange{0x1190C, 0x11913}, sbprOLetter}, // Lo   [8] DIVES AKURU LETTER KA..DIVES AKURU LETTER JA
-	{runeRange{0x11915, 0x11916}, sbprOLetter}, // Lo   [2] DIVES AKURU LETTER NYA..DIVES AKURU LETTER TTA
-	{runeRange{0x11918, 0x1192F}, sbprOLetter}, // Lo  [24] DIVES AKURU LETTER DDA..DIVES AKURU LETTER ZA
-	{runeRange{0x11930, 0x11935}, sbprExtend},  // Mc   [6] DIVES AKURU VOWEL SIGN AA..DIVES AKURU VOWEL SIGN E
-	{runeRange{0x11937, 0x11938}, sbprExtend},  // Mc   [2] DIVES AKURU VOWEL SIGN AI..DIVES AKURU VOWEL SIGN O
-	{runeRange{0x1193B, 0x1193C}, sbprExtend},  // Mn   [2] DIVES AKURU SIGN ANUSVARA..DIVES AKURU SIGN CANDRABINDU
-	{runeRange{0x1193D, 0x1193D}, sbprExtend},  // Mc       DIVES AKURU SIGN HALANTA
-	{runeRange{0x1193E, 0x1193E}, sbprExtend},  // Mn       DIVES AKURU VIRAMA
-	{runeRange{0x1193F, 0x1193F}, sbprOLetter}, // Lo       DIVES AKURU PREFIXED NASAL SIGN
-	{runeRange{0x11940, 0x11940}, sbprExtend},  // Mc       DIVES AKURU MEDIAL YA
-	{runeRange{0x11941, 0x11941}, sbprOLetter}, // Lo       DIVES AKURU INITIAL RA
-	{runeRange{0x11942, 0x11942}, sbprExtend},  // Mc       DIVES AKURU MEDIAL RA
-	{runeRange{0x11943, 0x11943}, sbprExtend},  // Mn       DIVES AKURU SIGN NUKTA
-	{runeRange{0x11944, 0x11944}, sbprSTerm},   // Po       DIVES AKURU DOUBLE DANDA
-	{runeRange{0x11946, 0x11946}, sbprSTerm},   // Po       DIVES AKURU END OF TEXT MARK
-	{runeRange{0x11950, 0x11959}, sbprNumeric}, // Nd  [10] DIVES AKURU DIGIT ZERO..DIVES AKURU DIGIT NINE
-	{runeRange{0x119A0, 0x119A7}, sbprOLetter}, // Lo   [8] NANDINAGARI LETTER A..NANDINAGARI LETTER VOCALIC RR
-	{runeRange{0x119AA, 0x119D0}, sbprOLetter}, // Lo  [39] NANDINAGARI LETTER E..NANDINAGARI LETTER RRA
-	{runeRange{0x119D1, 0x119D3}, sbprExtend},  // Mc   [3] NANDINAGARI VOWEL SIGN AA..NANDINAGARI VOWEL SIGN II
-	{runeRange{0x119D4, 0x119D7}, sbprExtend},  // Mn   [4] NANDINAGARI VOWEL SIGN U..NANDINAGARI VOWEL SIGN VOCALIC RR
-	{runeRange{0x119DA, 0x119DB}, sbprExtend},  // Mn   [2] NANDINAGARI VOWEL SIGN E..NANDINAGARI VOWEL SIGN AI
-	{runeRange{0x119DC, 0x119DF}, sbprExtend},  // Mc   [4] NANDINAGARI VOWEL SIGN O..NANDINAGARI SIGN VISARGA
-	{runeRange{0x119E0, 0x119E0}, sbprExtend},  // Mn       NANDINAGARI SIGN VIRAMA
-	{runeRange{0x119E1, 0x119E1}, sbprOLetter}, // Lo       NANDINAGARI SIGN AVAGRAHA
-	{runeRange{0x119E3, 0x119E3}, sbprOLetter}, // Lo       NANDINAGARI HEADSTROKE
-	{runeRange{0x119E4, 0x119E4}, sbprExtend},  // Mc       NANDINAGARI VOWEL SIGN PRISHTHAMATRA E
-	{runeRange{0x11A00, 0x11A00}, sbprOLetter}, // Lo       ZANABAZAR SQUARE LETTER A
-	{runeRange{0x11A01, 0x11A0A}, sbprExtend},  // Mn  [10] ZANABAZAR SQUARE VOWEL SIGN I..ZANABAZAR SQUARE VOWEL LENGTH MARK
-	{runeRange{0x11A0B, 0x11A32}, sbprOLetter}, // Lo  [40] ZANABAZAR SQUARE LETTER KA..ZANABAZAR SQUARE LETTER KSSA
-	{runeRange{0x11A33, 0x11A38}, sbprExtend},  // Mn   [6] ZANABAZAR SQUARE FINAL CONSONANT MARK..ZANABAZAR SQUARE SIGN ANUSVARA
-	{runeRange{0x11A39, 0x11A39}, sbprExtend},  // Mc       ZANABAZAR SQUARE SIGN VISARGA
-	{runeRange{0x11A3A, 0x11A3A}, sbprOLetter}, // Lo       ZANABAZAR SQUARE CLUSTER-INITIAL LETTER RA
-	{runeRange{0x11A3B, 0x11A3E}, sbprExtend},  // Mn   [4] ZANABAZAR SQUARE CLUSTER-FINAL LETTER YA..ZANABAZAR SQUARE CLUSTER-FINAL LETTER VA
-	{runeRange{0x11A42, 0x11A43}, sbprSTerm},   // Po   [2] ZANABAZAR SQUARE MARK SHAD..ZANABAZAR SQUARE MARK DOUBLE SHAD
-	{runeRange{0x11A47, 0x11A47}, sbprExtend},  // Mn       ZANABAZAR SQUARE SUBJOINER
-	{runeRange{0x11A50, 0x11A50}, sbprOLetter}, // Lo       SOYOMBO LETTER A
-	{runeRange{0x11A51, 0x11A56}, sbprExtend},  // Mn   [6] SOYOMBO VOWEL SIGN I..SOYOMBO VOWEL SIGN OE
-	{runeRange{0x11A57, 0x11A58}, sbprExtend},  // Mc   [2] SOYOMBO VOWEL SIGN AI..SOYOMBO VOWEL SIGN AU
-	{runeRange{0x11A59, 0x11A5B}, sbprExtend},  // Mn   [3] SOYOMBO VOWEL SIGN VOCALIC R..SOYOMBO VOWEL LENGTH MARK
-	{runeRange{0x11A5C, 0x11A89}, sbprOLetter}, // Lo  [46] SOYOMBO LETTER KA..SOYOMBO CLUSTER-INITIAL LETTER SA
-	{runeRange{0x11A8A, 0x11A96}, sbprExtend},  // Mn  [13] SOYOMBO FINAL CONSONANT SIGN G..SOYOMBO SIGN ANUSVARA
-	{runeRange{0x11A97, 0x11A97}, sbprExtend},  // Mc       SOYOMBO SIGN VISARGA
-	{runeRange{0x11A98, 0x11A99}, sbprExtend},  // Mn   [2] SOYOMBO GEMINATION MARK..SOYOMBO SUBJOINER
-	{runeRange{0x11A9B, 0x11A9C}, sbprSTerm},   // Po   [2] SOYOMBO MARK SHAD..SOYOMBO MARK DOUBLE SHAD
-	{runeRange{0x11A9D, 0x11A9D}, sbprOLetter}, // Lo       SOYOMBO MARK PLUTA
-	{runeRange{0x11AB0, 0x11AF8}, sbprOLetter}, // Lo  [73] CANADIAN SYLLABICS NATTILIK HI..PAU CIN HAU GLOTTAL STOP FINAL
-	{runeRange{0x11C00, 0x11C08}, sbprOLetter}, // Lo   [9] BHAIKSUKI LETTER A..BHAIKSUKI LETTER VOCALIC L
-	{runeRange{0x11C0A, 0x11C2E}, sbprOLetter}, // Lo  [37] BHAIKSUKI LETTER E..BHAIKSUKI LETTER HA
-	{runeRange{0x11C2F, 0x11C2F}, sbprExtend},  // Mc       BHAIKSUKI VOWEL SIGN AA
-	{runeRange{0x11C30, 0x11C36}, sbprExtend},  // Mn   [7] BHAIKSUKI VOWEL SIGN I..BHAIKSUKI VOWEL SIGN VOCALIC L
-	{runeRange{0x11C38, 0x11C3D}, sbprExtend},  // Mn   [6] BHAIKSUKI VOWEL SIGN E..BHAIKSUKI SIGN ANUSVARA
-	{runeRange{0x11C3E, 0x11C3E}, sbprExtend},  // Mc       BHAIKSUKI SIGN VISARGA
-	{runeRange{0x11C3F, 0x11C3F}, sbprExtend},  // Mn       BHAIKSUKI SIGN VIRAMA
-	{runeRange{0x11C40, 0x11C40}, sbprOLetter}, // Lo       BHAIKSUKI SIGN AVAGRAHA
-	{runeRange{0x11C41, 0x11C42}, sbprSTerm},   // Po   [2] BHAIKSUKI DANDA..BHAIKSUKI DOUBLE DANDA
-	{runeRange{0x11C50, 0x11C59}, sbprNumeric}, // Nd  [10] BHAIKSUKI DIGIT ZERO..BHAIKSUKI DIGIT NINE
-	{runeRange{0x11C72, 0x11C8F}, sbprOLetter}, // Lo  [30] MARCHEN LETTER KA..MARCHEN LETTER A
-	{runeRange{0x11C92, 0x11CA7}, sbprExtend},  // Mn  [22] MARCHEN SUBJOINED LETTER KA..MARCHEN SUBJOINED LETTER ZA
-	{runeRange{0x11CA9, 0x11CA9}, sbprExtend},  // Mc       MARCHEN SUBJOINED LETTER YA
-	{runeRange{0x11CAA, 0x11CB0}, sbprExtend},  // Mn   [7] MARCHEN SUBJOINED LETTER RA..MARCHEN VOWEL SIGN AA
-	{runeRange{0x11CB1, 0x11CB1}, sbprExtend},  // Mc       MARCHEN VOWEL SIGN I
-	{runeRange{0x11CB2, 0x11CB3}, sbprExtend},  // Mn   [2] MARCHEN VOWEL SIGN U..MARCHEN VOWEL SIGN E
-	{runeRange{0x11CB4, 0x11CB4}, sbprExtend},  // Mc       MARCHEN VOWEL SIGN O
-	{runeRange{0x11CB5, 0x11CB6}, sbprExtend},  // Mn   [2] MARCHEN SIGN ANUSVARA..MARCHEN SIGN CANDRABINDU
-	{runeRange{0x11D00, 0x11D06}, sbprOLetter}, // Lo   [7] MASARAM GONDI LETTER A..MASARAM GONDI LETTER E
-	{runeRange{0x11D08, 0x11D09}, sbprOLetter}, // Lo   [2] MASARAM GONDI LETTER AI..MASARAM GONDI LETTER O
-	{runeRange{0x11D0B, 0x11D30}, sbprOLetter}, // Lo  [38] MASARAM GONDI LETTER AU..MASARAM GONDI LETTER TRA
-	{runeRange{0x11D31, 0x11D36}, sbprExtend},  // Mn   [6] MASARAM GONDI VOWEL SIGN AA..MASARAM GONDI VOWEL SIGN VOCALIC R
+	{runeRange{0x04E9, 0x04E9}, sbprLower},     // L&       CYRILLIC SMALL LETTER BARRED O
+	{runeRange{0x298F, 0x298F}, sbprClose},     // Ps       LEFT SQUARE BRACKET WITH TICK IN BOTTOM CORNER
+	{runeRange{0xA983, 0xA983}, sbprExtend},    // Mc       JAVANESE SIGN WIGNYAN
 	{runeRange{0x11D3A, 0x11D3A}, sbprExtend},  // Mn       MASARAM GONDI VOWEL SIGN E
-	{runeRange{0x11D3C, 0x11D3D}, sbprExtend},  // Mn   [2] MASARAM GONDI VOWEL SIGN AI..MASARAM GONDI VOWEL SIGN O
-	{runeRange{0x11D3F, 0x11D45}, sbprExtend},  // Mn   [7] MASARAM GONDI VOWEL SIGN AU..MASARAM GONDI VIRAMA
-	{runeRange{0x11D46, 0x11D46}, sbprOLetter}, // Lo       MASARAM GONDI REPHA
-	{runeRange{0x11D47, 0x11D47}, sbprExtend},  // Mn       MASARAM GONDI RA-KARA
-	{runeRange{0x11D50, 0x11D59}, sbprNumeric}, // Nd  [10] MASARAM GONDI DIGIT ZERO..MASARAM GONDI DIGIT NINE
-	{runeRange{0x11D60, 0x11D65}, sbprOLetter}, // Lo   [6] GUNJALA GONDI LETTER A..GUNJALA GONDI LETTER UU
-	{runeRange{0x11D67, 0x11D68}, sbprOLetter}, // Lo   [2] GUNJALA GONDI LETTER EE..GUNJALA GONDI LETTER AI
-	{runeRange{0x11D6A, 0x11D89}, sbprOLetter}, // Lo  [32] GUNJALA GONDI LETTER OO..GUNJALA GONDI LETTER SA
-	{runeRange{0x11D8A, 0x11D8E}, sbprExtend},  // Mc   [5] GUNJALA GONDI VOWEL SIGN AA..GUNJALA GONDI VOWEL SIGN UU
-	{runeRange{0x11D90, 0x11D91}, sbprExtend},  // Mn   [2] GUNJALA GONDI VOWEL SIGN EE..GUNJALA GONDI VOWEL SIGN AI
-	{runeRange{0x11D93, 0x11D94}, sbprExtend},  // Mc   [2] GUNJALA GONDI VOWEL SIGN OO..GUNJALA GONDI VOWEL SIGN AU
-	{runeRange{0x11D95, 0x11D95}, sbprExtend},  // Mn       GUNJALA GONDI SIGN ANUSVARA
-	{runeRange{0x11D96, 0x11D96}, sbprExtend},  // Mc       GUNJALA GONDI SIGN VISARGA
-	{runeRange{0x11D97, 0x11D97}, sbprExtend},  // Mn       GUNJALA GONDI VIRAMA
-	{runeRange{0x11D98, 0x11D98}, sbprOLetter}, // Lo       GUNJALA GONDI OM
-	{runeRange{0x11DA0, 0x11DA9}, sbprNumeric}, // Nd  [10] GUNJALA GONDI DIGIT ZERO..GUNJALA GONDI DIGIT NINE
-	{runeRange{0x11EE0, 0x11EF2}, sbprOLetter}, // Lo  [19] MAKASAR LETTER KA..MAKASAR ANGKA
-	{runeRange{0x11EF3, 0x11EF4}, sbprExtend},  // Mn   [2] MAKASAR VOWEL SIGN I..MAKASAR VOWEL SIGN U
-	{runeRange{0x11EF5, 0x11EF6}, sbprExtend},  // Mc   [2] MAKASAR VOWEL SIGN E..MAKASAR VOWEL SIGN O
-	{runeRange{0x11EF7, 0x11EF8}, sbprSTerm},   // Po   [2] MAKASAR PASSIMBANG..MAKASAR END OF SECTION
-	{runeRange{0x11F00, 0x11F01}, sbprExtend},  // Mn   [2] KAWI SIGN CANDRABINDU..KAWI SIGN ANUSVARA
-	{runeRange{0x11F02, 0x11F02}, sbprOLetter}, // Lo       KAWI SIGN REPHA
-	{runeRange{0x11F03, 0x11F03}, sbprExtend},  // Mc       KAWI SIGN VISARGA
-	{runeRange{0x11F04, 0x11F10}, sbprOLetter}, // Lo  [13] KAWI LETTER A..KAWI LETTER O
-	{runeRange{0x11F12, 0x11F33}, sbprOLetter}, // Lo  [34] KAWI LETTER KA..KAWI LETTER JNYA
-	{runeRange{0x11F34, 0x11F35}, sbprExtend},  // Mc   [2] KAWI VOWEL SIGN AA..KAWI VOWEL SIGN ALTERNATE AA
-	{runeRange{0x11F36, 0x11F3A}, sbprExtend},  // Mn   [5] KAWI VOWEL SIGN I..KAWI VOWEL SIGN VOCALIC R
-	{runeRange{0x11F3E, 0x11F3F}, sbprExtend},  // Mc   [2] KAWI VOWEL SIGN E..KAWI VOWEL SIGN AI
-	{runeRange{0x11F40, 0x11F40}, sbprExtend},  // Mn       KAWI VOWEL SIGN EU
-	{runeRange{0x11F41, 0x11F41}, sbprExtend},  // Mc       KAWI SIGN KILLER
-	{runeRange{0x11F42, 0x11F42}, sbprExtend},  // Mn       KAWI CONJOINER
-	{runeRange{0x11F43, 0x11F44}, sbprSTerm},   // Po   [2] KAWI DANDA..KAWI DOUBLE DANDA
-	{runeRange{0x11F50, 0x11F59}, sbprNumeric}, // Nd  [10] KAWI DIGIT ZERO..KAWI DIGIT NINE
-	{runeRange{0x11FB0, 0x11FB0}, sbprOLetter}, // Lo       LISU LETTER YHA
-	{runeRange{0x12000, 0x12399}, sbprOLetter}, // Lo [922] CUNEIFORM SIGN A..CUNEIFORM SIGN U U
-	{runeRange{0x12400, 0x1246E}, sbprOLetter}, // Nl [111] CUNEIFORM NUMERIC SIGN TWO ASH..CUNEIFORM NUMERIC SIGN NINE U VARIANT FORM
-	{runeRange{0x12480, 0x12543}, sbprOLetter}, // Lo [196] CUNEIFORM SIGN AB TIMES NUN TENU..CUNEIFORM SIGN ZU5 TIMES THREE DISH TENU
-	{runeRange{0x12F90, 0x12FF0}, sbprOLetter}, // Lo  [97] CYPRO-MINOAN SIGN CM001..CYPRO-MINOAN SIGN CM114
-	{runeRange{0x13000, 0x1342F}, sbprOLetter}, // Lo [1072] EGYPTIAN HIEROGLYPH A001..EGYPTIAN HIEROGLYPH V011D
-	{runeRange{0x13430, 0x1343F}, sbprFormat},  // Cf  [16] EGYPTIAN HIEROGLYPH VERTICAL JOINER..EGYPTIAN HIEROGLYPH END WALLED ENCLOSURE
-	{runeRange{0x13440, 0x13440}, sbprExtend},  // Mn       EGYPTIAN HIEROGLYPH MIRROR HORIZONTALLY
-	{runeRange{0x13441, 0x13446}, sbprOLetter}, // Lo   [6] EGYPTIAN HIEROGLYPH FULL BLANK..EGYPTIAN HIEROGLYPH WIDE LOST SIGN
-	{runeRange{0x13447, 0x13455}, sbprExtend},  // Mn  [15] EGYPTIAN HIEROGLYPH MODIFIER DAMAGED AT TOP START..EGYPTIAN HIEROGLYPH MODIFIER DAMAGED
-	{runeRange{0x14400, 0x14646}, sbprOLetter}, // Lo [583] ANATOLIAN HIEROGLYPH A001..ANATOLIAN HIEROGLYPH A530
-	{runeRange{0x16800, 0x16A38}, sbprOLetter}, // Lo [569] BAMUM LETTER PHASE-A NGKUE MFON..BAMUM LETTER PHASE-F VUEQ
-	{runeRange{0x16A40, 0x16A5E}, sbprOLetter}, // Lo  [31] MRO LETTER TA..MRO LETTER TEK
-	{runeRange{0x16A60, 0x16A69}, sbprNumeric}, // Nd  [10] MRO DIGIT ZERO..MRO DIGIT NINE
-	{runeRange{0x16A6E, 0x16A6F}, sbprSTerm},   // Po   [2] MRO DANDA..MRO DOUBLE DANDA
-	{runeRange{0x16A70, 0x16ABE}, sbprOLetter}, // Lo  [79] TANGSA LETTER OZ..TANGSA LETTER ZA
-	{runeRange{0x16AC0, 0x16AC9}, sbprNumeric}, // Nd  [10] TANGSA DIGIT ZERO..TANGSA DIGIT NINE
-	{runeRange{0x16AD0, 0x16AED}, sbprOLetter}, // Lo  [30] BASSA VAH LETTER ENNI..BASSA VAH LETTER I
-	{runeRange{0x16AF0, 0x16AF4}, sbprExtend},  // Mn   [5] BASSA VAH COMBINING HIGH TONE..BASSA VAH COMBINING HIGH-LOW TONE
-	{runeRange{0x16AF5, 0x16AF5}, sbprSTerm},   // Po       BASSA VAH FULL STOP
-	{runeRange{0x16B00, 0x16B2F}, sbprOLetter}, // Lo  [48] PAHAWH HMONG VOWEL KEEB..PAHAWH HMONG CONSONANT CAU
-	{runeRange{0x16B30, 0x16B36}, sbprExtend},  // Mn   [7] PAHAWH HMONG MARK CIM TUB..PAHAWH HMONG MARK CIM TAUM
-	{runeRange{0x16B37, 0x16B38}, sbprSTerm},   // Po   [2] PAHAWH HMONG SIGN VOS THOM..PAHAWH HMONG SIGN VOS TSHAB CEEB
-	{runeRange{0x16B40, 0x16B43}, sbprOLetter}, // Lm   [4] PAHAWH HMONG SIGN VOS SEEV..PAHAWH HMONG SIGN IB YAM
-	{runeRange{0x16B44, 0x16B44}, sbprSTerm},   // Po       PAHAWH HMONG SIGN XAUS
-	{runeRange{0x16B50, 0x16B59}, sbprNumeric}, // Nd  [10] PAHAWH HMONG DIGIT ZERO..PAHAWH HMONG DIGIT NINE
-	{runeRange{0x16B63, 0x16B77}, sbprOLetter}, // Lo  [21] PAHAWH HMONG SIGN VOS LUB..PAHAWH HMONG SIGN CIM NRES TOS
-	{runeRange{0x16B7D, 0x16B8F}, sbprOLetter}, // Lo  [19] PAHAWH HMONG CLAN SIGN TSHEEJ..PAHAWH HMONG CLAN SIGN VWJ
-	{runeRange{0x16E40, 0x16E5F}, sbprUpper},   // L&  [32] MEDEFAIDRIN CAPITAL LETTER M..MEDEFAIDRIN CAPITAL LETTER Y
-	{runeRange{0x16E60, 0x16E7F}, sbprLower},   // L&  [32] MEDEFAIDRIN SMALL LETTER M..MEDEFAIDRIN SMALL LETTER Y
-	{runeRange{0x16E98, 0x16E98}, sbprSTerm},   // Po       MEDEFAIDRIN FULL STOP
-	{runeRange{0x16F00, 0x16F4A}, sbprOLetter}, // Lo  [75] MIAO LETTER PA..MIAO LETTER RTE
-	{runeRange{0x16F4F, 0x16F4F}, sbprExtend},  // Mn       MIAO SIGN CONSONANT MODIFIER BAR
-	{runeRange{0x16F50, 0x16F50}, sbprOLetter}, // Lo       MIAO LETTER NASALIZATION
-	{runeRange{0x16F51, 0x16F87}, sbprExtend},  // Mc  [55] MIAO SIGN ASPIRATION..MIAO VOWEL SIGN UI
-	{runeRange{0x16F8F, 0x16F92}, sbprExtend},  // Mn   [4] MIAO TONE RIGHT..MIAO TONE BELOW
-	{runeRange{0x16F93, 0x16F9F}, sbprOLetter}, // Lm  [13] MIAO LETTER TONE-2..MIAO LETTER REFORMED TONE-8
-	{runeRange{0x16FE0, 0x16FE1}, sbprOLetter}, // Lm   [2] TANGUT ITERATION MARK..NUSHU ITERATION MARK
-	{runeRange{0x16FE3, 0x16FE3}, sbprOLetter}, // Lm       OLD CHINESE ITERATION MARK
-	{runeRange{0x16FE4, 0x16FE4}, sbprExtend},  // Mn       KHITAN SMALL SCRIPT FILLER
-	{runeRange{0x16FF0, 0x16FF1}, sbprExtend},  // Mc   [2] VIETNAMESE ALTERNATE READING MARK CA..VIETNAMESE ALTERNATE READING MARK NHAY
-	{runeRange{0x17000, 0x187F7}, sbprOLetter}, // Lo [6136] TANGUT IDEOGRAPH-17000..TANGUT IDEOGRAPH-187F7
-	{runeRange{0x18800, 0x18CD5}, sbprOLetter}, // Lo [1238] TANGUT COMPONENT-001..KHITAN SMALL SCRIPT CHARACTER-18CD5
-	{runeRange{0x18D00, 0x18D08}, sbprOLetter}, // Lo   [9] TANGUT IDEOGRAPH-18D00..TANGUT IDEOGRAPH-18D08
-	{runeRange{0x1AFF0, 0x1AFF3}, sbprOLetter}, // Lm   [4] KATAKANA LETTER MINNAN TONE-2..KATAKANA LETTER MINNAN TONE-5
-	{runeRange{0x1AFF5, 0x1AFFB}, sbprOLetter}, // Lm   [7] KATAKANA LETTER MINNAN TONE-7..KATAKANA LETTER MINNAN NASALIZED TONE-5
-	{runeRange{0x1AFFD, 0x1AFFE}, sbprOLetter}, // Lm   [2] KATAKANA LETTER MINNAN NASALIZED TONE-7..KATAKANA LETTER MINNAN NASALIZED TONE-8
-	{runeRange{0x1B000, 0x1B122}, sbprOLetter}, // Lo [291] KATAKANA LETTER ARCHAIC E..KATAKANA LETTER ARCHAIC WU
-	{runeRange{0x1B132, 0x1B132}, sbprOLetter}, // Lo       HIRAGANA LETTER SMALL KO
-	{runeRange{0x1B150, 0x1B152}, sbprOLetter}, // Lo   [3] HIRAGANA LETTER SMALL WI..HIRAGANA LETTER SMALL WO
-	{runeRange{0x1B155, 0x1B155}, sbprOLetter}, // Lo       KATAKANA LETTER SMALL KO
-	{runeRange{0x1B164, 0x1B167}, sbprOLetter}, // Lo   [4] KATAKANA LETTER SMALL WI..KATAKANA LETTER SMALL N
-	{runeRange{0x1B170, 0x1B2FB}, sbprOLetter}, // Lo [396] NUSHU CHARACTER-1B170..NUSHU CHARACTER-1B2FB
-	{runeRange{0x1BC00, 0x1BC6A}, sbprOLetter}, // Lo [107] DUPLOYAN LETTER H..DUPLOYAN LETTER VOCALIC M
-	{runeRange{0x1BC70, 0x1BC7C}, sbprOLetter}, // Lo  [13] DUPLOYAN AFFIX LEFT HORIZONTAL SECANT..DUPLOYAN AFFIX ATTACHED TANGENT HOOK
-	{runeRange{0x1BC80, 0x1BC88}, sbprOLetter}, // Lo   [9] DUPLOYAN AFFIX HIGH ACUTE..DUPLOYAN AFFIX HIGH VERTICAL
-	{runeRange{0x1BC90, 0x1BC99}, sbprOLetter}, // Lo  [10] DUPLOYAN AFFIX LOW ACUTE..DUPLOYAN AFFIX LOW ARROW
-	{runeRange{0x1BC9D, 0x1BC9E}, sbprExtend},  // Mn   [2] DUPLOYAN THICK LETTER SELECTOR..DUPLOYAN DOUBLE MARK
-	{runeRange{0x1BC9F, 0x1BC9F}, sbprSTerm},   // Po       DUPLOYAN PUNCTUATION CHINOOK FULL STOP
-	{runeRange{0x1BCA0, 0x1BCA3}, sbprFormat},  // Cf   [4] SHORTHAND FORMAT LETTER OVERLAP..SHORTHAND FORMAT UP STEP
-	{runeRange{0x1CF00, 0x1CF2D}, sbprExtend},  // Mn  [46] ZNAMENNY COMBINING MARK GORAZDO NIZKO S KRYZHEM ON LEFT..ZNAMENNY COMBINING MARK KRYZH ON LEFT
-	{runeRange{0x1CF30, 0x1CF46}, sbprExtend},  // Mn  [23] ZNAMENNY COMBINING TONAL RANGE MARK MRACHNO..ZNAMENNY PRIZNAK MODIFIER ROG
-	{runeRange{0x1D165, 0x1D166}, sbprExtend},  // Mc   [2] MUSICAL SYMBOL COMBINING STEM..MUSICAL SYMBOL COMBINING SPRECHGESANG STEM
-	{runeRange{0x1D167, 0x1D169}, sbprExtend},  // Mn   [3] MUSICAL SYMBOL COMBINING TREMOLO-1..MUSICAL SYMBOL COMBINING TREMOLO-3
-	{runeRange{0x1D16D, 0x1D172}, sbprExtend},  // Mc   [6] MUSICAL SYMBOL COMBINING AUGMENTATION DOT..MUSICAL SYMBOL COMBINING FLAG-5
-	{runeRange{0x1D173, 0x1D17A}, sbprFormat},  // Cf   [8] MUSICAL SYMBOL BEGIN BEAM..MUSICAL SYMBOL END PHRASE
-	{runeRange{0x1D17B, 0x1D182}, sbprExtend},  // Mn   [8] MUSICAL SYMBOL COMBINING ACCENT..MUSICAL SYMBOL COMBINING LOURE
-	{runeRange{0x1D185, 0x1D18B}, sbprExtend},  // Mn   [7] MUSICAL SYMBOL COMBINING DOIT..MUSICAL SYMBOL COMBINING TRIPLE TONGUE
-	{runeRange{0x1D1AA, 0x1D1AD}, sbprExtend},  // Mn   [4] MUSICAL SYMBOL COMBINING DOWN BOW..MUSICAL SYMBOL COMBINING SNAP PIZZICATO
-	{runeRange{0x1D242, 0x1D244}, sbprExtend},  // Mn   [3] COMBINING GREEK MUSICAL TRISEME..COMBINING GREEK MUSICAL PENTASEME
-	{runeRange{0x1D400, 0x1D419}, sbprUpper},   // L&  [26] MATHEMATICAL BOLD CAPITAL A..MATHEMATICAL BOLD CAPITAL Z
-	{runeRange{0x1D41A, 0x1D433}, sbprLower},   // L&  [26] MATHEMATICAL BOLD SMALL A..MATHEMATICAL BOLD SMALL Z
-	{runeRange{0x1D434, 0x1D44D}, sbprUpper},   // L&  [26] MATHEMATICAL ITALIC CAPITAL A..MATHEMATICAL ITALIC CAPITAL Z
-	{runeRange{0x1D44E, 0x1D454}, sbprLower},   // L&   [7] MATHEMATICAL ITALIC SMALL A..MATHEMATICAL ITALIC SMALL G
-	{runeRange{0x1D456, 0x1D467}, sbprLower},   // L&  [18] MATHEMATICAL ITALIC SMALL I..MATHEMATICAL ITALIC SMALL Z
-	{runeRange{0x1D468, 0x1D481}, sbprUpper},   // L&  [26] MATHEMATICAL BOLD ITALIC CAPITAL A..MATHEMATICAL BOLD ITALIC CAPITAL Z
-	{runeRange{0x1D482, 0x1D49B}, sbprLower},   // L&  [26] MATHEMATICAL BOLD ITALIC SMALL A..MATHEMATICAL BOLD ITALIC SMALL Z
-	{runeRange{0x1D49C, 0x1D49C}, sbprUpper},   // L&       MATHEMATICAL SCRIPT CAPITAL A
-	{runeRange{0x1D49E, 0x1D49F}, sbprUpper},   // L&   [2] MATHEMATICAL SCRIPT CAPITAL C..MATHEMATICAL SCRIPT CAPITAL D
-	{runeRange{0x1D4A2, 0x1D4A2}, sbprUpper},   // L&       MATHEMATICAL SCRIPT CAPITAL G
-	{runeRange{0x1D4A5, 0x1D4A6}, sbprUpper},   // L&   [2] MATHEMATICAL SCRIPT CAPITAL J..MATHEMATICAL SCRIPT CAPITAL K
-	{runeRange{0x1D4A9, 0x1D4AC}, sbprUpper},   // L&   [4] MATHEMATICAL SCRIPT CAPITAL N..MATHEMATICAL SCRIPT CAPITAL Q
-	{runeRange{0x1D4AE, 0x1D4B5}, sbprUpper},   // L&   [8] MATHEMATICAL SCRIPT CAPITAL S..MATHEMATICAL SCRIPT CAPITAL Z
-	{runeRange{0x1D4B6, 0x1D4B9}, sbprLower},   // L&   [4] MATHEMATICAL SCRIPT SMALL A..MATHEMATICAL SCRIPT SMALL D
-	{runeRange{0x1D4BB, 0x1D4BB}, sbprLower},   // L&       MATHEMATICAL SCRIPT SMALL F
-	{runeRange{0x1D4BD, 0x1D4C3}, sbprLower},   // L&   [7] MATHEMATICAL SCRIPT SMALL H..MATHEMATICAL SCRIPT SMALL N
-	{runeRange{0x1D4C5, 0x1D4CF}, sbprLower},   // L&  [11] MATHEMATICAL SCRIPT SMALL P..MATHEMATICAL SCRIPT SMALL Z
-	{runeRange{0x1D4D0, 0x1D4E9}, sbprUpper},   // L&  [26] MATHEMATICAL BOLD SCRIPT CAPITAL A..MATHEMATICAL BOLD SCRIPT CAPITAL Z
-	{runeRange{0x1D4EA, 0x1D503}, sbprLower},   // L&  [26] MATHEMATICAL BOLD SCRIPT SMALL A..MATHEMATICAL BOLD SCRIPT SMALL Z
-	{runeRange{0x1D504, 0x1D505}, sbprUpper},   // L&   [2] MATHEMATICAL FRAKTUR CAPITAL A..MATHEMATICAL FRAKTUR CAPITAL B
-	{runeRange{0x1D507, 0x1D50A}, sbprUpper},   // L&   [4] MATHEMATICAL FRAKTUR CAPITAL D..MATHEMATICAL FRAKTUR CAPITAL G
-	{runeRange{0x1D50D, 0x1D514}, sbprUpper},   // L&   [8] MATHEMATICAL FRAKTUR CAPITAL J..MATHEMATICAL FRAKTUR CAPITAL Q
-	{runeRange{0x1D516, 0x1D51C}, sbprUpper},   // L&   [7] MATHEMATICAL FRAKTUR CAPITAL S..MATHEMATICAL FRAKTUR CAPITAL Y
-	{runeRange{0x1D51E, 0x1D537}, sbprLower},   // L&  [26] MATHEMATICAL FRAKTUR SMALL A..MATHEMATICAL FRAKTUR SMALL Z
+	{runeRange{0x0205, 0x0205}, sbprLower},     // L&       LATIN SMALL LETTER E WITH DOUBLE GRAVE
+	{runeRange{0x0B5F, 0x0B61}, sbprOLetter},   // Lo   [3] ORIYA LETTER YYA..ORIYA LETTER VOCALIC LL
+	{runeRange{0x1E90, 0x1E90}, sbprUpper},     // L&       LATIN CAPITAL LETTER Z WITH CIRCUMFLEX
+	{runeRange{0x2D30, 0x2D67}, sbprOLetter},   // Lo  [56] TIFINAGH LETTER YA..TIFINAGH LETTER YO
+	{runeRange{0xA763, 0xA763}, sbprLower},     // L&       LATIN SMALL LETTER VISIGOTHIC Z
+	{runeRange{0xFE55, 0xFE55}, sbprSContinue}, // Po       SMALL COLON
+	{runeRange{0x114B3, 0x114B8}, sbprExtend},  // Mn   [6] TIRHUTA VOWEL SIGN U..TIRHUTA VOWEL SIGN VOCALIC LL
 	{runeRange{0x1D538, 0x1D539}, sbprUpper},   // L&   [2] MATHEMATICAL DOUBLE-STRUCK CAPITAL A..MATHEMATICAL DOUBLE-STRUCK CAPITAL B
-	{runeRange{0x1D53B, 0x1D53E}, sbprUpper},   // L&   [4] MATHEMATICAL DOUBLE-STRUCK CAPITAL D..MATHEMATICAL DOUBLE-STRUCK CAPITAL G
-	{runeRange{0x1D540, 0x1D544}, sbprUpper},   // L&   [5] MATHEMATICAL DOUBLE-STRUCK CAPITAL I..MATHEMATICAL DOUBLE-STRUCK CAPITAL M
-	{runeRange{0x1D546, 0x1D546}, sbprUpper},   // L&       MATHEMATICAL DOUBLE-STRUCK CAPITAL O
-	{runeRange{0x1D54A, 0x1D550}, sbprUpper},   // L&   [7] MATHEMATICAL DOUBLE-STRUCK CAPITAL S..MATHEMATICAL DOUBLE-STRUCK CAPITAL Y
-	{runeRange{0x1D552, 0x1D56B}, sbprLower},   // L&  [26] MATHEMATICAL DOUBLE-STRUCK SMALL A..MATHEMATICAL DOUBLE-STRUCK SMALL Z
-	{runeRange{0x1D56C, 0x1D585}, sbprUpper},   // L&  [26] MATHEMATICAL BOLD FRAKTUR CAPITAL A..MATHEMATICAL BOLD FRAKTUR CAPITAL Z
-	{runeRange{0x1D586, 0x1D59F}, sbprLower},   // L&  [26] MATHEMATICAL BOLD FRAKTUR SMALL A..MATHEMATICAL BOLD FRAKTUR SMALL Z
-	{runeRange{0x1D5A0, 0x1D5B9}, sbprUpper},   // L&  [26] MATHEMATICAL SANS-SERIF CAPITAL A..MATHEMATICAL SANS-SERIF CAPITAL Z
-	{runeRange{0x1D5BA, 0x1D5D3}, sbprLower},   // L&  [26] MATHEMATICAL SANS-SERIF SMALL A..MATHEMATICAL SANS-SERIF SMALL Z
-	{runeRange{0x1D5D4, 0x1D5ED}, sbprUpper},   // L&  [26] MATHEMATICAL SANS-SERIF BOLD CAPITAL A..MATHEMATICAL SANS-SERIF BOLD CAPITAL Z
-	{runeRange{0x1D5EE, 0x1D607}, sbprLower},   // L&  [26] MATHEMATICAL SANS-SERIF BOLD SMALL A..MATHEMATICAL SANS-SERIF BOLD SMALL Z
-	{runeRange{0x1D608, 0x1D621}, sbprUpper},   // L&  [26] MATHEMATICAL SANS-SERIF ITALIC CAPITAL A..MATHEMATICAL SANS-SERIF ITALIC CAPITAL Z
-	{runeRange{0x1D622, 0x1D63B}, sbprLower},   // L&  [26] MATHEMATICAL SANS-SERIF ITALIC SMALL A..MATHEMATICAL SANS-SERIF ITALIC SMALL Z
-	{runeRange{0x1D63C, 0x1D655}, sbprUpper},   // L&  [26] MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL A..MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL Z
-	{runeRange{0x1D656, 0x1D66F}, sbprLower},   // L&  [26] MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL A..MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL Z
-	{runeRange{0x1D670, 0x1D689}, sbprUpper},   // L&  [26] MATHEMATICAL MONOSPACE CAPITAL A..MATHEMATICAL MONOSPACE CAPITAL Z
-	{runeRange{0x1D68A, 0x1D6A5}, sbprLower},   // L&  [28] MATHEMATICAL MONOSPACE SMALL A..MATHEMATICAL ITALIC SMALL DOTLESS J
-	{runeRange{0x1D6A8, 0x1D6C0}, sbprUpper},   // L&  [25] MATHEMATICAL BOLD CAPITAL ALPHA..MATHEMATICAL BOLD CAPITAL OMEGA
-	{runeRange{0x1D6C2, 0x1D6DA}, sbprLower},   // L&  [25] MATHEMATICAL BOLD SMALL ALPHA..MATHEMATICAL BOLD SMALL OMEGA
-	{runeRange{0x1D6DC, 0x1D6E1}, sbprLower},   // L&   [6] MATHEMATICAL BOLD EPSILON SYMBOL..MATHEMATICAL BOLD PI SYMBOL
-	{runeRange{0x1D6E2, 0x1D6FA}, sbprUpper},   // L&  [25] MATHEMATICAL ITALIC CAPITAL ALPHA..MATHEMATICAL ITALIC CAPITAL OMEGA
-	{runeRange{0x1D6FC, 0x1D714}, sbprLower},   // L&  [25] MATHEMATICAL ITALIC SMALL ALPHA..MATHEMATICAL ITALIC SMALL OMEGA
-	{runeRange{0x1D716, 0x1D71B}, sbprLower},   // L&   [6] MATHEMATICAL ITALIC EPSILON SYMBOL..MATHEMATICAL ITALIC PI SYMBOL
-	{runeRange{0x1D71C, 0x1D734}, sbprUpper},   // L&  [25] MATHEMATICAL BOLD ITALIC CAPITAL ALPHA..MATHEMATICAL BOLD ITALIC CAPITAL OMEGA
-	{runeRange{0x1D736, 0x1D74E}, sbprLower},   // L&  [25] MATHEMATICAL BOLD ITALIC SMALL ALPHA..MATHEMATICAL BOLD ITALIC SMALL OMEGA
-	{runeRange{0x1D750, 0x1D755}, sbprLower},   // L&   [6] MATHEMATICAL BOLD ITALIC EPSILON SYMBOL..MATHEMATICAL BOLD ITALIC PI SYMBOL
-	{runeRange{0x1D756, 0x1D76E}, sbprUpper},   // L&  [25] MATHEMATICAL SANS-SERIF BOLD CAPITAL ALPHA..MATHEMATICAL SANS-SERIF BOLD CAPITAL OMEGA
-	{runeRange{0x1D770, 0x1D788}, sbprLower},   // L&  [25] MATHEMATICAL SANS-SERIF BOLD SMALL ALPHA..MATHEMATICAL SANS-SERIF BOLD SMALL OMEGA
-	{runeRange{0x1D78A, 0x1D78F}, sbprLower},   // L&   [6] MATHEMATICAL SANS-SERIF BOLD EPSILON SYMBOL..MATHEMATICAL SANS-SERIF BOLD PI SYMBOL
-	{runeRange{0x1D790, 0x1D7A8}, sbprUpper},   // L&  [25] MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL ALPHA..MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL OMEGA
-	{runeRange{0x1D7AA, 0x1D7C2}, sbprLower},   // L&  [25] MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL ALPHA..MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL OMEGA
-	{runeRange{0x1D7C4, 0x1D7C9}, sbprLower},   // L&   [6] MATHEMATICAL SANS-SERIF BOLD ITALIC EPSILON SYMBOL..MATHEMATICAL SANS-SERIF BOLD ITALIC PI SYMBOL
-	{runeRange{0x1D7CA, 0x1D7CA}, sbprUpper},   // L&       MATHEMATICAL BOLD CAPITAL DIGAMMA
-	{runeRange{0x1D7CB, 0x1D7CB}, sbprLower},   // L&       MATHEMATICAL BOLD SMALL DIGAMMA
-	{runeRange{0x1D7CE, 0x1D7FF}, sbprNumeric}, // Nd  [50] MATHEMATICAL BOLD DIGIT ZERO..MATHEMATICAL MONOSPACE DIGIT NINE
-	{runeRange{0x1DA00, 0x1DA36}, sbprExtend},  // Mn  [55] SIGNWRITING HEAD RIM..SIGNWRITING AIR SUCKING IN
-	{runeRange{0x1DA3B, 0x1DA6C}, sbprExtend},  // Mn  [50] SIGNWRITING MOUTH CLOSED NEUTRAL..SIGNWRITING EXCITEMENT
-	{runeRange{0x1DA75, 0x1DA75}, sbprExtend},  // Mn       SIGNWRITING UPPER BODY TILTING FROM HIP JOINTS
-	{runeRange{0x1DA84, 0x1DA84}, sbprExtend},  // Mn       SIGNWRITING LOCATION HEAD NECK
-	{runeRange{0x1DA88, 0x1DA88}, sbprSTerm},   // Po       SIGNWRITING FULL STOP
-	{runeRange{0x1DA9B, 0x1DA9F}, sbprExtend},  // Mn   [5] SIGNWRITING FILL MODIFIER-2..SIGNWRITING FILL MODIFIER-6
-	{runeRange{0x1DAA1, 0x1DAAF}, sbprExtend},  // Mn  [15] SIGNWRITING ROTATION MODIFIER-2..SIGNWRITING ROTATION MODIFIER-16
-	{runeRange{0x1DF00, 0x1DF09}, sbprLower},   // L&  [10] LATIN SMALL LETTER FENG DIGRAPH WITH TRILL..LATIN SMALL LETTER T WITH HOOK AND RETROFLEX HOOK
-	{runeRange{0x1DF0A, 0x1DF0A}, sbprOLetter}, // Lo       LATIN LETTER RETROFLEX CLICK WITH RETROFLEX HOOK
-	{runeRange{0x1DF0B, 0x1DF1E}, sbprLower},   // L&  [20] LATIN SMALL LETTER ESH WITH DOUBLE BAR..LATIN SMALL LETTER S WITH CURL
-	{runeRange{0x1DF25, 0x1DF2A}, sbprLower},   // L&   [6] LATIN SMALL LETTER D WITH MID-HEIGHT LEFT HOOK..LATIN SMALL LETTER T WITH MID-HEIGHT LEFT HOOK
-	{runeRange{0x1E000, 0x1E006}, sbprExtend},  // Mn   [7] COMBINING GLAGOLITIC LETTER AZU..COMBINING GLAGOLITIC LETTER ZHIVETE
-	{runeRange{0x1E008, 0x1E018}, sbprExtend},  // Mn  [17] COMBINING GLAGOLITIC LETTER ZEMLJA..COMBINING GLAGOLITIC LETTER HERU
-	{runeRange{0x1E01B, 0x1E021}, sbprExtend},  // Mn   [7] COMBINING GLAGOLITIC LETTER SHTA..COMBINING GLAGOLITIC LETTER YATI
-	{runeRange{0x1E023, 0x1E024}, sbprExtend},  // Mn   [2] COMBINING GLAGOLITIC LETTER YU..COMBINING GLAGOLITIC LETTER SMALL YUS
-	{runeRange{0x1E026, 0x1E02A}, sbprExtend},  // Mn   [5] COMBINING GLAGOLITIC LETTER YO..COMBINING GLAGOLITIC LETTER FITA
-	{runeRange{0x1E030, 0x1E06D}, sbprLower},   // Lm  [62] MODIFIER LETTER CYRILLIC SMALL A..MODIFIER LETTER CYRILLIC SMALL STRAIGHT U WITH STROKE
-	{runeRange{0x1E08F, 0x1E08F}, sbprExtend},  // Mn       COMBINING CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I
-	{runeRange{0x1E100, 0x1E12C}, sbprOLetter}, // Lo  [45] NYIAKENG PUACHUE HMONG LETTER MA..NYIAKENG PUACHUE HMONG LETTER W
-	{runeRange{0x1E130, 0x1E136}, sbprExtend},  // Mn   [7] NYIAKENG PUACHUE HMONG TONE-B..NYIAKENG PUACHUE HMONG TONE-D
-	{runeRange{0x1E137, 0x1E13D}, sbprOLetter}, // Lm   [7] NYIAKENG PUACHUE HMONG SIGN FOR PERSON..NYIAKENG PUACHUE HMONG SYLLABLE LENGTHENER
-	{runeRange{0x1E140, 0x1E149}, sbprNumeric}, // Nd  [10] NYIAKENG PUACHUE HMONG DIGIT ZERO..NYIAKENG PUACHUE HMONG DIGIT NINE
-	{runeRange{0x1E14E, 0x1E14E}, sbprOLetter}, // Lo       NYIAKENG PUACHUE HMONG LOGOGRAM NYAJ
-	{runeRange{0x1E290, 0x1E2AD}, sbprOLetter}, // Lo  [30] TOTO LETTER PA..TOTO LETTER A
-	{runeRange{0x1E2AE, 0x1E2AE}, sbprExtend},  // Mn       TOTO SIGN RISING TONE
-	{runeRange{0x1E2C0, 0x1E2EB}, sbprOLetter}, // Lo  [44] WANCHO LETTER AA..WANCHO LETTER YIH
-	{runeRange{0x1E2EC, 0x1E2EF}, sbprExtend},  // Mn   [4] WANCHO TONE TUP..WANCHO TONE KOINI
-	{runeRange{0x1E2F0, 0x1E2F9}, sbprNumeric}, // Nd  [10] WANCHO DIGIT ZERO..WANCHO DIGIT NINE
+	{runeRange{0x015F, 0x015F}, sbprLower},     // L&       LATIN SMALL LETTER S WITH CEDILLA
+	{runeRange{0x0461, 0x0461}, sbprLower},     // L&       CYRILLIC SMALL LETTER OMEGA
+	{runeRange{0x0816, 0x0819}, sbprExtend},    // Mn   [4] SAMARITAN MARK IN..SAMARITAN MARK DAGESH
+	{runeRange{0x0F39, 0x0F39}, sbprExtend},    // Mn       TIBETAN MARK TSA -PHRU
+	{runeRange{0x1E10, 0x1E10}, sbprUpper},     // L&       LATIN CAPITAL LETTER D WITH CEDILLA
+	{runeRange{0x1FB6, 0x1FB7}, sbprLower},     // L&   [2] GREEK SMALL LETTER ALPHA WITH PERISPOMENI..GREEK SMALL LETTER ALPHA WITH PERISPOMENI AND YPOGEGRAMMENI
+	{runeRange{0x2CAE, 0x2CAE}, sbprUpper},     // L&       COPTIC CAPITAL LETTER PSI
+	{runeRange{0x3011, 0x3011}, sbprClose},     // Pe       RIGHT BLACK LENTICULAR BRACKET
+	{runeRange{0xA717, 0xA71F}, sbprOLetter},   // Lm   [9] MODIFIER LETTER DOT VERTICAL BAR..MODIFIER LETTER LOW INVERTED EXCLAMATION MARK
+	{runeRange{0xA7B7, 0xA7B7}, sbprLower},     // L&       LATIN SMALL LETTER OMEGA
+	{runeRange{0xAB30, 0xAB5A}, sbprLower},     // L&  [43] LATIN SMALL LETTER BARRED ALPHA..LATIN SMALL LETTER Y WITH SHORT RIGHT LEG
+	{runeRange{0x103A0, 0x103C3}, sbprOLetter}, // Lo  [36] OLD PERSIAN SIGN A..OLD PERSIAN SIGN HA
+	{runeRange{0x111CF, 0x111CF}, sbprExtend},  // Mn       SHARADA SIGN INVERTED CANDRABINDU
+	{runeRange{0x11937, 0x11938}, sbprExtend},  // Mc   [2] DIVES AKURU VOWEL SIGN AI..DIVES AKURU VOWEL SIGN O
+	{runeRange{0x16E98, 0x16E98}, sbprSTerm},   // Po       MEDEFAIDRIN FULL STOP
 	{runeRange{0x1E4D0, 0x1E4EA}, sbprOLetter}, // Lo  [27] NAG MUNDARI LETTER O..NAG MUNDARI LETTER ELL
-	{runeRange{0x1E4EB, 0x1E4EB}, sbprOLetter}, // Lm       NAG MUNDARI SIGN OJOD
-	{runeRange{0x1E4EC, 0x1E4EF}, sbprExtend},  // Mn   [4] NAG MUNDARI SIGN MUHOR..NAG MUNDARI SIGN SUTUH
-	{runeRange{0x1E4F0, 0x1E4F9}, sbprNumeric}, // Nd  [10] NAG MUNDARI DIGIT ZERO..NAG MUNDARI DIGIT NINE
-	{runeRange{0x1E7E0, 0x1E7E6}, sbprOLetter}, // Lo   [7] ETHIOPIC SYLLABLE HHYA..ETHIOPIC SYLLABLE HHYO
-	{runeRange{0x1E7E8, 0x1E7EB}, sbprOLetter}, // Lo   [4] ETHIOPIC SYLLABLE GURAGE HHWA..ETHIOPIC SYLLABLE HHWE
-	{runeRange{0x1E7ED, 0x1E7EE}, sbprOLetter}, // Lo   [2] ETHIOPIC SYLLABLE GURAGE MWI..ETHIOPIC SYLLABLE GURAGE MWEE
-	{runeRange{0x1E7F0, 0x1E7FE}, sbprOLetter}, // Lo  [15] ETHIOPIC SYLLABLE GURAGE QWI..ETHIOPIC SYLLABLE GURAGE PWEE
-	{runeRange{0x1E800, 0x1E8C4}, sbprOLetter}, // Lo [197] MENDE KIKAKUI SYLLABLE M001 KI..MENDE KIKAKUI SYLLABLE M060 NYON
-	{runeRange{0x1E8D0, 0x1E8D6}, sbprExtend},  // Mn   [7] MENDE KIKAKUI COMBINING NUMBER TEENS..MENDE KIKAKUI COMBINING NUMBER MILLIONS
-	{runeRange{0x1E900, 0x1E921}, sbprUpper},   // L&  [34] ADLAM CAPITAL LETTER ALIF..ADLAM CAPITAL LETTER SHA
-	{runeRange{0x1E922, 0x1E943}, sbprLower},   // L&  [34] ADLAM SMALL LETTER ALIF..ADLAM SMALL LETTER SHA
-	{runeRange{0x1E944, 0x1E94A}, sbprExtend},  // Mn   [7] ADLAM ALIF LENGTHENER..ADLAM NUKTA
-	{runeRange{0x1E94B, 0x1E94B}, sbprOLetter}, // Lm       ADLAM NASALIZATION MARK
-	{runeRange{0x1E950, 0x1E959}, sbprNumeric}, // Nd  [10] ADLAM DIGIT ZERO..ADLAM DIGIT NINE
-	{runeRange{0x1EE00, 0x1EE03}, sbprOLetter}, // Lo   [4] ARABIC MATHEMATICAL ALEF..ARABIC MATHEMATICAL DAL
-	{runeRange{0x1EE05, 0x1EE1F}, sbprOLetter}, // Lo  [27] ARABIC MATHEMATICAL WAW..ARABIC MATHEMATICAL DOTLESS QAF
-	{runeRange{0x1EE21, 0x1EE22}, sbprOLetter}, // Lo   [2] ARABIC MATHEMATICAL INITIAL BEH..ARABIC MATHEMATICAL INITIAL JEEM
-	{runeRange{0x1EE24, 0x1EE24}, sbprOLetter}, // Lo       ARABIC MATHEMATICAL INITIAL HEH
-	{runeRange{0x1EE27, 0x1EE27}, sbprOLetter}, // Lo       ARABIC MATHEMATICAL INITIAL HAH
-	{runeRange{0x1EE29, 0x1EE32}, sbprOLetter}, // Lo  [10] ARABIC MATHEMATICAL INITIAL YEH..ARABIC MATHEMATICAL INITIAL QAF
-	{runeRange{0x1EE34, 0x1EE37}, sbprOLetter}, // Lo   [4] ARABIC MATHEMATICAL INITIAL SHEEN..ARABIC MATHEMATICAL INITIAL KHAH
-	{runeRange{0x1EE39, 0x1EE39}, sbprOLetter}, // Lo       ARABIC MATHEMATICAL INITIAL DAD
-	{runeRange{0x1EE3B, 0x1EE3B}, sbprOLetter}, // Lo       ARABIC MATHEMATICAL INITIAL GHAIN
-	{runeRange{0x1EE42, 0x1EE42}, sbprOLetter}, // Lo       ARABIC MATHEMATICAL TAILED JEEM
-	{runeRange{0x1EE47, 0x1EE47}, sbprOLetter}, // Lo       ARABIC MATHEMATICAL TAILED HAH
-	{runeRange{0x1EE49, 0x1EE49}, sbprOLetter}, // Lo       ARABIC MATHEMATICAL TAILED YEH
-	{runeRange{0x1EE4B, 0x1EE4B}, sbprOLetter}, // Lo       ARABIC MATHEMATICAL TAILED LAM
-	{runeRange{0x1EE4D, 0x1EE4F}, sbprOLetter}, // Lo   [3] ARABIC MATHEMATICAL TAILED NOON..ARABIC MATHEMATICAL TAILED AIN
-	{runeRange{0x1EE51, 0x1EE52}, sbprOLetter}, // Lo   [2] ARABIC MATHEMATICAL TAILED SAD..ARABIC MATHEMATICAL TAILED QAF
-	{runeRange{0x1EE54, 0x1EE54}, sbprOLetter}, // Lo       ARABIC MATHEMATICAL TAILED SHEEN
-	{runeRange{0x1EE57, 0x1EE57}, sbprOLetter}, // Lo       ARABIC MATHEMATICAL TAILED KHAH
+	{runeRange{0x011D, 0x011D}, sbprLower},     // L&       LATIN SMALL LETTER G WITH CIRCUMFLEX
+	{runeRange{0x01B6, 0x01B6}, sbprLower},     // L&       LATIN SMALL LETTER Z WITH STROKE
+	{runeRange{0x0295, 0x02AF}, sbprLower},     // L&  [27] LATIN LETTER PHARYNGEAL VOICED FRICATIVE..LATIN SMALL LETTER TURNED H WITH FISHHOOK AND TAIL
+	{runeRange{0x04A7, 0x04A7}, sbprLower},     // L&       CYRILLIC SMALL LETTER PE WITH MIDDLE HOOK
+	{runeRange{0x0529, 0x0529}, sbprLower},     // L&       CYRILLIC SMALL LETTER EN WITH LEFT HOOK
+	{runeRange{0x09FE, 0x09FE}, sbprExtend},    // Mn       BENGALI SANDHI MARK
+	{runeRange{0x0CE6, 0x0CEF}, sbprNumeric},   // Nd  [10] KANNADA DIGIT ZERO..KANNADA DIGIT NINE
+	{runeRange{0x12B2, 0x12B5}, sbprOLetter},   // Lo   [4] ETHIOPIC SYLLABLE KWI..ETHIOPIC SYLLABLE KWE
+	{runeRange{0x1BA8, 0x1BA9}, sbprExtend},    // Mn   [2] SUNDANESE VOWEL SIGN PAMEPET..SUNDANESE VOWEL SIGN PANEULEUNG
+	{runeRange{0x1E50, 0x1E50}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH MACRON AND GRAVE
+	{runeRange{0x1ED8, 0x1ED8}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH CIRCUMFLEX AND DOT BELOW
+	{runeRange{0x212A, 0x212D}, sbprUpper},     // L&   [4] KELVIN SIGN..BLACK-LETTER CAPITAL C
+	{runeRange{0x2C8E, 0x2C8E}, sbprUpper},     // L&       COPTIC CAPITAL LETTER HATE
+	{runeRange{0x2CCE, 0x2CCE}, sbprUpper},     // L&       COPTIC CAPITAL LETTER OLD COPTIC HA
+	{runeRange{0x2E26, 0x2E26}, sbprClose},     // Ps       LEFT SIDEWAYS U BRACKET
+	{runeRange{0xA016, 0xA48C}, sbprOLetter},   // Lo [1143] YI SYLLABLE BIT..YI SYLLABLE YYR
+	{runeRange{0xA683, 0xA683}, sbprLower},     // L&       CYRILLIC SMALL LETTER DZWE
+	{runeRange{0xA743, 0xA743}, sbprLower},     // L&       LATIN SMALL LETTER K WITH DIAGONAL STROKE
+	{runeRange{0xA78D, 0xA78D}, sbprUpper},     // L&       LATIN CAPITAL LETTER TURNED H
+	{runeRange{0xA802, 0xA802}, sbprExtend},    // Mn       SYLOTI NAGRI SIGN DVISVARA
+	{runeRange{0xAA71, 0xAA76}, sbprOLetter},   // Lo   [6] MYANMAR LETTER KHAMTI XA..MYANMAR LOGOGRAM KHAMTI HM
+	{runeRange{0xFD3E, 0xFD3E}, sbprClose},     // Pe       ORNATE LEFT PARENTHESIS
+	{runeRange{0xFF63, 0xFF63}, sbprClose},     // Pe       HALFWIDTH RIGHT CORNER BRACKET
+	{runeRange{0x1083F, 0x10855}, sbprOLetter}, // Lo  [23] CYPRIOT SYLLABLE ZO..IMPERIAL ARAMAIC LETTER TAW
+	{runeRange{0x110B7, 0x110B8}, sbprExtend},  // Mc   [2] KAITHI VOWEL SIGN O..KAITHI VOWEL SIGN AU
+	{runeRange{0x1130F, 0x11310}, sbprOLetter}, // Lo   [2] GRANTHA LETTER EE..GRANTHA LETTER AI
+	{runeRange{0x116AB, 0x116AB}, sbprExtend},  // Mn       TAKRI SIGN ANUSVARA
+	{runeRange{0x11A51, 0x11A56}, sbprExtend},  // Mn   [6] SOYOMBO VOWEL SIGN I..SOYOMBO VOWEL SIGN OE
+	{runeRange{0x11F43, 0x11F44}, sbprSTerm},   // Po   [2] KAWI DANDA..KAWI DOUBLE DANDA
+	{runeRange{0x1D165, 0x1D166}, sbprExtend},  // Mc   [2] MUSICAL SYMBOL COMBINING STEM..MUSICAL SYMBOL COMBINING SPRECHGESANG STEM
+	{runeRange{0x1D7C4, 0x1D7C9}, sbprLower},   // L&   [6] MATHEMATICAL SANS-SERIF BOLD ITALIC EPSILON SYMBOL..MATHEMATICAL SANS-SERIF BOLD ITALIC PI SYMBOL
 	{runeRange{0x1EE59, 0x1EE59}, sbprOLetter}, // Lo       ARABIC MATHEMATICAL TAILED DAD
-	{runeRange{0x1EE5B, 0x1EE5B}, sbprOLetter}, // Lo       ARABIC MATHEMATICAL TAILED GHAIN
-	{runeRange{0x1EE5D, 0x1EE5D}, sbprOLetter}, // Lo       ARABIC MATHEMATICAL TAILED DOTLESS NOON
-	{runeRange{0x1EE5F, 0x1EE5F}, sbprOLetter}, // Lo       ARABIC MATHEMATICAL TAILED DOTLESS QAF
-	{runeRange{0x1EE61, 0x1EE62}, sbprOLetter}, // Lo   [2] ARABIC MATHEMATICAL STRETCHED BEH..ARABIC MATHEMATICAL STRETCHED JEEM
-	{runeRange{0x1EE64, 0x1EE64}, sbprOLetter}, // Lo       ARABIC MATHEMATICAL STRETCHED HEH
-	{runeRange{0x1EE67, 0x1EE6A}, sbprOLetter}, // Lo   [4] ARABIC MATHEMATICAL STRETCHED HAH..ARABIC MATHEMATICAL STRETCHED KAF
-	{runeRange{0x1EE6C, 0x1EE72}, sbprOLetter}, // Lo   [7] ARABIC MATHEMATICAL STRETCHED MEEM..ARABIC MATHEMATICAL STRETCHED QAF
-	{runeRange{0x1EE74, 0x1EE77}, sbprOLetter}, // Lo   [4] ARABIC MATHEMATICAL STRETCHED SHEEN..ARABIC MATHEMATICAL STRETCHED KHAH
-	{runeRange{0x1EE79, 0x1EE7C}, sbprOLetter}, // Lo   [4] ARABIC MATHEMATICAL STRETCHED DAD..ARABIC MATHEMATICAL STRETCHED DOTLESS BEH
-	{runeRange{0x1EE7E, 0x1EE7E}, sbprOLetter}, // Lo       ARABIC MATHEMATICAL STRETCHED DOTLESS FEH
-	{runeRange{0x1EE80, 0x1EE89}, sbprOLetter}, // Lo  [10] ARABIC MATHEMATICAL LOOPED ALEF..ARABIC MATHEMATICAL LOOPED YEH
-	{runeRange{0x1EE8B, 0x1EE9B}, sbprOLetter}, // Lo  [17] ARABIC MATHEMATICAL LOOPED LAM..ARABIC MATHEMATICAL LOOPED GHAIN
-	{runeRange{0x1EEA1, 0x1EEA3}, sbprOLetter}, // Lo   [3] ARABIC MATHEMATICAL DOUBLE-STRUCK BEH..ARABIC MATHEMATICAL DOUBLE-STRUCK DAL
-	{runeRange{0x1EEA5, 0x1EEA9}, sbprOLetter}, // Lo   [5] ARABIC MATHEMATICAL DOUBLE-STRUCK WAW..ARABIC MATHEMATICAL DOUBLE-STRUCK YEH
-	{runeRange{0x1EEAB, 0x1EEBB}, sbprOLetter}, // Lo  [17] ARABIC MATHEMATICAL DOUBLE-STRUCK LAM..ARABIC MATHEMATICAL DOUBLE-STRUCK GHAIN
+	{runeRange{0x00D8, 0x00DE}, sbprUpper},     // L&   [7] LATIN CAPITAL LETTER O WITH STROKE..LATIN CAPITAL LETTER THORN
+	{runeRange{0x013E, 0x013E}, sbprLower},     // L&       LATIN SMALL LETTER L WITH CARON
+	{runeRange{0x0183, 0x0183}, sbprLower},     // L&       LATIN SMALL LETTER B WITH TOPBAR
+	{runeRange{0x01E1, 0x01E1}, sbprLower},     // L&       LATIN SMALL LETTER A WITH DOT ABOVE AND MACRON
+	{runeRange{0x0225, 0x0225}, sbprLower},     // L&       LATIN SMALL LETTER Z WITH HOOK
+	{runeRange{0x03D9, 0x03D9}, sbprLower},     // L&       GREEK SMALL LETTER ARCHAIC KOPPA
+	{runeRange{0x0481, 0x0481}, sbprLower},     // L&       CYRILLIC SMALL LETTER KOPPA
+	{runeRange{0x04C8, 0x04C8}, sbprLower},     // L&       CYRILLIC SMALL LETTER EN WITH HOOK
+	{runeRange{0x0509, 0x0509}, sbprLower},     // L&       CYRILLIC SMALL LETTER KOMI LJE
+	{runeRange{0x0670, 0x0670}, sbprExtend},    // Mn       ARABIC LETTER SUPERSCRIPT ALEF
+	{runeRange{0x094E, 0x094F}, sbprExtend},    // Mc   [2] DEVANAGARI VOWEL SIGN PRISHTHAMATRA E..DEVANAGARI VOWEL SIGN AW
+	{runeRange{0x0ABE, 0x0AC0}, sbprExtend},    // Mc   [3] GUJARATI VOWEL SIGN AA..GUJARATI VOWEL SIGN II
+	{runeRange{0x0C3D, 0x0C3D}, sbprOLetter},   // Lo       TELUGU SIGN AVAGRAHA
+	{runeRange{0x0DD6, 0x0DD6}, sbprExtend},    // Mn       SINHALA VOWEL SIGN DIGA PAA-PILLA
+	{runeRange{0x105E, 0x1060}, sbprExtend},    // Mn   [3] MYANMAR CONSONANT SIGN MON MEDIAL NA..MYANMAR CONSONANT SIGN MON MEDIAL LA
+	{runeRange{0x1752, 0x1753}, sbprExtend},    // Mn   [2] BUHID VOWEL SIGN I..BUHID VOWEL SIGN U
+	{runeRange{0x1A73, 0x1A7C}, sbprExtend},    // Mn  [10] TAI THAM VOWEL SIGN OA ABOVE..TAI THAM SIGN KHUEN-LUE KARAN
+	{runeRange{0x1CE2, 0x1CE8}, sbprExtend},    // Mn   [7] VEDIC SIGN VISARGA SVARITA..VEDIC SIGN VISARGA ANUDATTA WITH TAIL
+	{runeRange{0x1E30, 0x1E30}, sbprUpper},     // L&       LATIN CAPITAL LETTER K WITH ACUTE
+	{runeRange{0x1E70, 0x1E70}, sbprUpper},     // L&       LATIN CAPITAL LETTER T WITH CIRCUMFLEX BELOW
+	{runeRange{0x1EB8, 0x1EB8}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH DOT BELOW
+	{runeRange{0x1EF8, 0x1EF8}, sbprUpper},     // L&       LATIN CAPITAL LETTER Y WITH TILDE
+	{runeRange{0x203A, 0x203A}, sbprClose},     // Pf       SINGLE RIGHT-POINTING ANGLE QUOTATION MARK
+	{runeRange{0x276E, 0x276E}, sbprClose},     // Ps       HEAVY LEFT-POINTING ANGLE QUOTATION MARK ORNAMENT
+	{runeRange{0x2C75, 0x2C75}, sbprUpper},     // L&       LATIN CAPITAL LETTER HALF H
+	{runeRange{0x2C9E, 0x2C9E}, sbprUpper},     // L&       COPTIC CAPITAL LETTER O
+	{runeRange{0x2CBE, 0x2CBE}, sbprUpper},     // L&       COPTIC CAPITAL LETTER OLD COPTIC OOU
+	{runeRange{0x2CDE, 0x2CDE}, sbprUpper},     // L&       COPTIC CAPITAL LETTER OLD NUBIAN NGI
+	{runeRange{0x2E04, 0x2E04}, sbprClose},     // Pi       LEFT DOTTED SUBSTITUTION BRACKET
+	{runeRange{0x2E5C, 0x2E5C}, sbprClose},     // Pe       BOTTOM HALF RIGHT PARENTHESIS
+	{runeRange{0x303B, 0x303B}, sbprOLetter},   // Lm       VERTICAL IDEOGRAPHIC ITERATION MARK
+	{runeRange{0xA646, 0xA646}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER IOTA
+	{runeRange{0xA666, 0xA666}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER SOFT EM
+	{runeRange{0xA693, 0xA693}, sbprLower},     // L&       CYRILLIC SMALL LETTER TCHE
+	{runeRange{0xA733, 0xA733}, sbprLower},     // L&       LATIN SMALL LETTER AA
+	{runeRange{0xA753, 0xA753}, sbprLower},     // L&       LATIN SMALL LETTER P WITH FLOURISH
+	{runeRange{0xA77A, 0xA77A}, sbprLower},     // L&       LATIN SMALL LETTER INSULAR D
+	{runeRange{0xA79F, 0xA79F}, sbprLower},     // L&       LATIN SMALL LETTER VOLAPUK UE
+	{runeRange{0xA7CA, 0xA7CA}, sbprLower},     // L&       LATIN SMALL LETTER S WITH SHORT STROKE OVERLAY
+	{runeRange{0xA8CE, 0xA8CF}, sbprSTerm},     // Po   [2] SAURASHTRA DANDA..SAURASHTRA DOUBLE DANDA
+	{runeRange{0xA9FA, 0xA9FE}, sbprOLetter},   // Lo   [5] MYANMAR LETTER TAI LAING LLA..MYANMAR LETTER TAI LAING BHA
+	{runeRange{0xAADB, 0xAADC}, sbprOLetter},   // Lo   [2] TAI VIET SYMBOL KON..TAI VIET SYMBOL NUENG
+	{runeRange{0xD7B0, 0xD7C6}, sbprOLetter},   // Lo  [23] HANGUL JUNGSEONG O-YEO..HANGUL JUNGSEONG ARAEA-E
+	{runeRange{0xFE39, 0xFE39}, sbprClose},     // Ps       PRESENTATION FORM FOR VERTICAL LEFT TORTOISE SHELL BRACKET
+	{runeRange{0xFF0C, 0xFF0C}, sbprSContinue}, // Po       FULLWIDTH COMMA
+	{runeRange{0x1003F, 0x1004D}, sbprOLetter}, // Lo  [15] LINEAR B SYLLABLE B020 ZO..LINEAR B SYLLABLE B091 TWO
+	{runeRange{0x105A3, 0x105B1}, sbprLower},   // L&  [15] VITHKUQI SMALL LETTER HA..VITHKUQI SMALL LETTER RE
+	{runeRange{0x10A38, 0x10A3A}, sbprExtend},  // Mn   [3] KHAROSHTHI SIGN BAR ABOVE..KHAROSHTHI SIGN DOT BELOW
+	{runeRange{0x11000, 0x11000}, sbprExtend},  // Mc       BRAHMI SIGN CANDRABINDU
+	{runeRange{0x11145, 0x11146}, sbprExtend},  // Mc   [2] CHAKMA VOWEL SIGN AA..CHAKMA VOWEL SIGN EI
+	{runeRange{0x1123F, 0x11240}, sbprOLetter}, // Lo   [2] KHOJKI LETTER QA..KHOJKI LETTER SHORT I
+	{runeRange{0x11366, 0x1136C}, sbprExtend},  // Mn   [7] COMBINING GRANTHA DIGIT ZERO..COMBINING GRANTHA DIGIT SIX
+	{runeRange{0x115BF, 0x115C0}, sbprExtend},  // Mn   [2] SIDDHAM SIGN VIRAMA..SIDDHAM SIGN NUKTA
+	{runeRange{0x1173C, 0x1173E}, sbprSTerm},   // Po   [3] AHOM SIGN SMALL SECTION..AHOM SIGN RULAI
+	{runeRange{0x119DA, 0x119DB}, sbprExtend},  // Mn   [2] NANDINAGARI VOWEL SIGN E..NANDINAGARI VOWEL SIGN AI
+	{runeRange{0x11C3F, 0x11C3F}, sbprExtend},  // Mn       BHAIKSUKI SIGN VIRAMA
+	{runeRange{0x11DA0, 0x11DA9}, sbprNumeric}, // Nd  [10] GUNJALA GONDI DIGIT ZERO..GUNJALA GONDI DIGIT NINE
+	{runeRange{0x16A6E, 0x16A6F}, sbprSTerm},   // Po   [2] MRO DANDA..MRO DOUBLE DANDA
+	{runeRange{0x1AFFD, 0x1AFFE}, sbprOLetter}, // Lm   [2] KATAKANA LETTER MINNAN NASALIZED TONE-7..KATAKANA LETTER MINNAN NASALIZED TONE-8
+	{runeRange{0x1D49E, 0x1D49F}, sbprUpper},   // L&   [2] MATHEMATICAL SCRIPT CAPITAL C..MATHEMATICAL SCRIPT CAPITAL D
+	{runeRange{0x1D670, 0x1D689}, sbprUpper},   // L&  [26] MATHEMATICAL MONOSPACE CAPITAL A..MATHEMATICAL MONOSPACE CAPITAL Z
+	{runeRange{0x1E008, 0x1E018}, sbprExtend},  // Mn  [17] COMBINING GLAGOLITIC LETTER ZEMLJA..COMBINING GLAGOLITIC LETTER HERU
+	{runeRange{0x1EE05, 0x1EE1F}, sbprOLetter}, // Lo  [27] ARABIC MATHEMATICAL WAW..ARABIC MATHEMATICAL DOTLESS QAF
 	{runeRange{0x1F130, 0x1F149}, sbprUpper},   // So  [26] SQUARED LATIN CAPITAL LETTER A..SQUARED LATIN CAPITAL LETTER Z
-	{runeRange{0x1F150, 0x1F169}, sbprUpper},   // So  [26] NEGATIVE CIRCLED LATIN CAPITAL LETTER A..NEGATIVE CIRCLED LATIN CAPITAL LETTER Z
-	{runeRange{0x1F170, 0x1F189}, sbprUpper},   // So  [26] NEGATIVE SQUARED LATIN CAPITAL LETTER A..NEGATIVE SQUARED LATIN CAPITAL LETTER Z
-	{runeRange{0x1F676, 0x1F678}, sbprClose},   // So   [3] SANS-SERIF HEAVY DOUBLE TURNED COMMA QUOTATION MARK ORNAMENT..SANS-SERIF HEAVY LOW DOUBLE COMMA QUOTATION MARK ORNAMENT
-	{runeRange{0x1FBF0, 0x1FBF9}, sbprNumeric}, // Nd  [10] SEGMENTED DIGIT ZERO..SEGMENTED DIGIT NINE
-	{runeRange{0x20000, 0x2A6DF}, sbprOLetter}, // Lo [42720] CJK UNIFIED IDEOGRAPH-20000..CJK UNIFIED IDEOGRAPH-2A6DF
-	{runeRange{0x2A700, 0x2B739}, sbprOLetter}, // Lo [4154] CJK UNIFIED IDEOGRAPH-2A700..CJK UNIFIED IDEOGRAPH-2B739
-	{runeRange{0x2B740, 0x2B81D}, sbprOLetter}, // Lo [222] CJK UNIFIED IDEOGRAPH-2B740..CJK UNIFIED IDEOGRAPH-2B81D
+	{runeRange{0x003F, 0x003F}, sbprSTerm},     // Po       QUESTION MARK
+	{runeRange{0x010D, 0x010D}, sbprLower},     // L&       LATIN SMALL LETTER C WITH CARON
+	{runeRange{0x012D, 0x012D}, sbprLower},     // L&       LATIN SMALL LETTER I WITH BREVE
+	{runeRange{0x014F, 0x014F}, sbprLower},     // L&       LATIN SMALL LETTER O WITH BREVE
+	{runeRange{0x016F, 0x016F}, sbprLower},     // L&       LATIN SMALL LETTER U WITH RING ABOVE
+	{runeRange{0x01A1, 0x01A1}, sbprLower},     // L&       LATIN SMALL LETTER O WITH HORN
+	{runeRange{0x01D0, 0x01D0}, sbprLower},     // L&       LATIN SMALL LETTER I WITH CARON
+	{runeRange{0x01F3, 0x01F3}, sbprLower},     // L&       LATIN SMALL LETTER DZ
+	{runeRange{0x0215, 0x0215}, sbprLower},     // L&       LATIN SMALL LETTER U WITH DOUBLE GRAVE
+	{runeRange{0x023C, 0x023C}, sbprLower},     // L&       LATIN SMALL LETTER C WITH STROKE
+	{runeRange{0x037A, 0x037A}, sbprLower},     // Lm       GREEK YPOGEGRAMMENI
+	{runeRange{0x03E9, 0x03E9}, sbprLower},     // L&       COPTIC SMALL LETTER HORI
+	{runeRange{0x0471, 0x0471}, sbprLower},     // L&       CYRILLIC SMALL LETTER PSI
+	{runeRange{0x0497, 0x0497}, sbprLower},     // L&       CYRILLIC SMALL LETTER ZHE WITH DESCENDER
+	{runeRange{0x04B7, 0x04B7}, sbprLower},     // L&       CYRILLIC SMALL LETTER CHE WITH DESCENDER
+	{runeRange{0x04D9, 0x04D9}, sbprLower},     // L&       CYRILLIC SMALL LETTER SCHWA
+	{runeRange{0x04F9, 0x04F9}, sbprLower},     // L&       CYRILLIC SMALL LETTER YERU WITH DIAERESIS
+	{runeRange{0x0519, 0x0519}, sbprLower},     // L&       CYRILLIC SMALL LETTER YAE
+	{runeRange{0x05C7, 0x05C7}, sbprExtend},    // Mn       HEBREW POINT QAMATS QATAN
+	{runeRange{0x0710, 0x0710}, sbprOLetter},   // Lo       SYRIAC LETTER ALAPH
+	{runeRange{0x0898, 0x089F}, sbprExtend},    // Mn   [8] ARABIC SMALL HIGH WORD AL-JUZ..ARABIC HALF MADDA OVER MADDA
+	{runeRange{0x09B6, 0x09B9}, sbprOLetter},   // Lo   [4] BENGALI LETTER SHA..BENGALI LETTER HA
+	{runeRange{0x0A59, 0x0A5C}, sbprOLetter},   // Lo   [4] GURMUKHI LETTER KHHA..GURMUKHI LETTER RRA
+	{runeRange{0x0B13, 0x0B28}, sbprOLetter},   // Lo  [22] ORIYA LETTER O..ORIYA LETTER NA
+	{runeRange{0x0BC0, 0x0BC0}, sbprExtend},    // Mn       TAMIL VOWEL SIGN II
+	{runeRange{0x0C92, 0x0CA8}, sbprOLetter},   // Lo  [23] KANNADA LETTER O..KANNADA LETTER NA
+	{runeRange{0x0D54, 0x0D56}, sbprOLetter},   // Lo   [3] MALAYALAM LETTER CHILLU M..MALAYALAM LETTER CHILLU LLL
+	{runeRange{0x0EA5, 0x0EA5}, sbprOLetter},   // Lo       LAO LETTER LO LOOT
+	{runeRange{0x1000, 0x102A}, sbprOLetter},   // Lo  [43] MYANMAR LETTER KA..MYANMAR LETTER AU
+	{runeRange{0x109A, 0x109C}, sbprExtend},    // Mc   [3] MYANMAR SIGN KHAMTI TONE-1..MYANMAR VOWEL SIGN AITON A
+	{runeRange{0x166F, 0x167F}, sbprOLetter},   // Lo  [17] CANADIAN SYLLABICS QAI..CANADIAN SYLLABICS BLACKFOOT W
+	{runeRange{0x1802, 0x1802}, sbprSContinue}, // Po       MONGOLIAN COMMA
+	{runeRange{0x19D0, 0x19D9}, sbprNumeric},   // Nd  [10] NEW TAI LUE DIGIT ZERO..NEW TAI LUE DIGIT NINE
+	{runeRange{0x1B3C, 0x1B3C}, sbprExtend},    // Mn       BALINESE VOWEL SIGN LA LENGA
+	{runeRange{0x1C2C, 0x1C33}, sbprExtend},    // Mn   [8] LEPCHA VOWEL SIGN E..LEPCHA CONSONANT SIGN T
+	{runeRange{0x1E00, 0x1E00}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH RING BELOW
+	{runeRange{0x1E20, 0x1E20}, sbprUpper},     // L&       LATIN CAPITAL LETTER G WITH MACRON
+	{runeRange{0x1E40, 0x1E40}, sbprUpper},     // L&       LATIN CAPITAL LETTER M WITH DOT ABOVE
+	{runeRange{0x1E60, 0x1E60}, sbprUpper},     // L&       LATIN CAPITAL LETTER S WITH DOT ABOVE
+	{runeRange{0x1E80, 0x1E80}, sbprUpper},     // L&       LATIN CAPITAL LETTER W WITH GRAVE
+	{runeRange{0x1EA8, 0x1EA8}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH CIRCUMFLEX AND HOOK ABOVE
+	{runeRange{0x1EC8, 0x1EC8}, sbprUpper},     // L&       LATIN CAPITAL LETTER I WITH HOOK ABOVE
+	{runeRange{0x1EE8, 0x1EE8}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH HORN AND ACUTE
+	{runeRange{0x1F48, 0x1F4D}, sbprUpper},     // L&   [6] GREEK CAPITAL LETTER OMICRON WITH PSILI..GREEK CAPITAL LETTER OMICRON WITH DASIA AND OXIA
+	{runeRange{0x200C, 0x200D}, sbprExtend},    // Cf   [2] ZERO WIDTH NON-JOINER..ZERO WIDTH JOINER
+	{runeRange{0x20DD, 0x20E0}, sbprExtend},    // Me   [4] COMBINING ENCLOSING CIRCLE..COMBINING ENCLOSING CIRCLE BACKSLASH
+	{runeRange{0x2185, 0x2188}, sbprOLetter},   // Nl   [4] ROMAN NUMERAL SIX LATE FORM..ROMAN NUMERAL ONE HUNDRED THOUSAND
+	{runeRange{0x27EC, 0x27EC}, sbprClose},     // Ps       MATHEMATICAL LEFT WHITE TORTOISE SHELL BRACKET
+	{runeRange{0x2C00, 0x2C2F}, sbprUpper},     // L&  [48] GLAGOLITIC CAPITAL LETTER AZU..GLAGOLITIC CAPITAL LETTER CAUDATE CHRIVI
+	{runeRange{0x2C86, 0x2C86}, sbprUpper},     // L&       COPTIC CAPITAL LETTER DALDA
+	{runeRange{0x2C96, 0x2C96}, sbprUpper},     // L&       COPTIC CAPITAL LETTER LAULA
+	{runeRange{0x2CA6, 0x2CA6}, sbprUpper},     // L&       COPTIC CAPITAL LETTER TAU
+	{runeRange{0x2CB6, 0x2CB6}, sbprUpper},     // L&       COPTIC CAPITAL LETTER CRYPTOGRAMMIC EIE
+	{runeRange{0x2CC6, 0x2CC6}, sbprUpper},     // L&       COPTIC CAPITAL LETTER OLD COPTIC ESH
+	{runeRange{0x2CD6, 0x2CD6}, sbprUpper},     // L&       COPTIC CAPITAL LETTER OLD COPTIC GANGIA
+	{runeRange{0x2CED, 0x2CED}, sbprUpper},     // L&       COPTIC CAPITAL LETTER CRYPTOGRAMMIC GANGIA
+	{runeRange{0x2DC0, 0x2DC6}, sbprOLetter},   // Lo   [7] ETHIOPIC SYLLABLE QYA..ETHIOPIC SYLLABLE QYO
+	{runeRange{0x2E1C, 0x2E1C}, sbprClose},     // Pi       LEFT LOW PARAPHRASE BRACKET
+	{runeRange{0x2E53, 0x2E54}, sbprSTerm},     // Po   [2] MEDIEVAL EXCLAMATION MARK..MEDIEVAL QUESTION MARK
+	{runeRange{0x3009, 0x3009}, sbprClose},     // Pe       RIGHT ANGLE BRACKET
+	{runeRange{0x301B, 0x301B}, sbprClose},     // Pe       RIGHT WHITE SQUARE BRACKET
+	{runeRange{0x30FF, 0x30FF}, sbprOLetter},   // Lo       KATAKANA DIGRAPH KOTO
+	{runeRange{0xA620, 0xA629}, sbprNumeric},   // Nd  [10] VAI DIGIT ZERO..VAI DIGIT NINE
+	{runeRange{0xA64E, 0xA64E}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER NEUTRAL YER
+	{runeRange{0xA65E, 0xA65E}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER YN
+	{runeRange{0xA66E, 0xA66E}, sbprOLetter},   // Lo       CYRILLIC LETTER MULTIOCULAR O
+	{runeRange{0xA68B, 0xA68B}, sbprLower},     // L&       CYRILLIC SMALL LETTER TE WITH MIDDLE HOOK
+	{runeRange{0xA69B, 0xA69B}, sbprLower},     // L&       CYRILLIC SMALL LETTER CROSSED O
+	{runeRange{0xA729, 0xA729}, sbprLower},     // L&       LATIN SMALL LETTER TZ
+	{runeRange{0xA73B, 0xA73B}, sbprLower},     // L&       LATIN SMALL LETTER AV WITH HORIZONTAL BAR
+	{runeRange{0xA74B, 0xA74B}, sbprLower},     // L&       LATIN SMALL LETTER O WITH LONG STROKE OVERLAY
+	{runeRange{0xA75B, 0xA75B}, sbprLower},     // L&       LATIN SMALL LETTER R ROTUNDA
+	{runeRange{0xA76B, 0xA76B}, sbprLower},     // L&       LATIN SMALL LETTER ET
+	{runeRange{0xA783, 0xA783}, sbprLower},     // L&       LATIN SMALL LETTER INSULAR R
+	{runeRange{0xA797, 0xA797}, sbprLower},     // L&       LATIN SMALL LETTER B WITH FLOURISH
+	{runeRange{0xA7A7, 0xA7A7}, sbprLower},     // L&       LATIN SMALL LETTER R WITH OBLIQUE STROKE
+	{runeRange{0xA7BF, 0xA7BF}, sbprLower},     // L&       LATIN SMALL LETTER GLOTTAL U
+	{runeRange{0xA7D9, 0xA7D9}, sbprLower},     // L&       LATIN SMALL LETTER SIGMOID S
+	{runeRange{0xA827, 0xA827}, sbprExtend},    // Mc       SYLOTI NAGRI VOWEL SIGN OO
+	{runeRange{0xA90A, 0xA925}, sbprOLetter},   // Lo  [28] KAYAH LI LETTER KA..KAYAH LI LETTER OO
+	{runeRange{0xA9C8, 0xA9C9}, sbprSTerm},     // Po   [2] JAVANESE PADA LINGSA..JAVANESE PADA LUNGSI
+	{runeRange{0xAA43, 0xAA43}, sbprExtend},    // Mn       CHAM CONSONANT SIGN FINAL NG
+	{runeRange{0xAAB2, 0xAAB4}, sbprExtend},    // Mn   [3] TAI VIET VOWEL I..TAI VIET VOWEL U
+	{runeRange{0xAAF3, 0xAAF4}, sbprOLetter},   // Lm   [2] MEETEI MAYEK SYLLABLE REPETITION MARK..MEETEI MAYEK WORD REPETITION MARK
+	{runeRange{0xABE6, 0xABE7}, sbprExtend},    // Mc   [2] MEETEI MAYEK VOWEL SIGN YENAP..MEETEI MAYEK VOWEL SIGN SOUNAP
+	{runeRange{0xFB1F, 0xFB28}, sbprOLetter},   // Lo  [10] HEBREW LIGATURE YIDDISH YOD YOD PATAH..HEBREW LETTER WIDE TAV
+	{runeRange{0xFE17, 0xFE17}, sbprClose},     // Ps       PRESENTATION FORM FOR VERTICAL LEFT WHITE LENTICULAR BRACKET
+	{runeRange{0xFE41, 0xFE41}, sbprClose},     // Ps       PRESENTATION FORM FOR VERTICAL LEFT CORNER BRACKET
+	{runeRange{0xFE5E, 0xFE5E}, sbprClose},     // Pe       SMALL RIGHT TORTOISE SHELL BRACKET
+	{runeRange{0xFF3D, 0xFF3D}, sbprClose},     // Pe       FULLWIDTH RIGHT SQUARE BRACKET
+	{runeRange{0xFFCA, 0xFFCF}, sbprOLetter},   // Lo   [6] HALFWIDTH HANGUL LETTER YEO..HALFWIDTH HANGUL LETTER OE
+	{runeRange{0x10300, 0x1031F}, sbprOLetter}, // Lo  [32] OLD ITALIC LETTER A..OLD ITALIC LETTER ESS
+	{runeRange{0x104D8, 0x104FB}, sbprLower},   // L&  [36] OSAGE SMALL LETTER A..OSAGE SMALL LETTER ZHA
+	{runeRange{0x10783, 0x10785}, sbprLower},   // Lm   [3] MODIFIER LETTER SMALL AE..MODIFIER LETTER SMALL B WITH HOOK
+	{runeRange{0x109BE, 0x109BF}, sbprOLetter}, // Lo   [2] MEROITIC CURSIVE LOGOGRAM RMT..MEROITIC CURSIVE LOGOGRAM IMN
+	{runeRange{0x10B00, 0x10B35}, sbprOLetter}, // Lo  [54] AVESTAN LETTER A..AVESTAN LETTER HE
+	{runeRange{0x10F30, 0x10F45}, sbprOLetter}, // Lo  [22] SOGDIAN LETTER ALEPH..SOGDIAN INDEPENDENT SHIN
+	{runeRange{0x11071, 0x11072}, sbprOLetter}, // Lo   [2] BRAHMI LETTER OLD TAMIL SHORT E..BRAHMI LETTER OLD TAMIL SHORT O
+	{runeRange{0x11100, 0x11102}, sbprExtend},  // Mn   [3] CHAKMA SIGN CANDRABINDU..CHAKMA SIGN VISARGA
+	{runeRange{0x111B3, 0x111B5}, sbprExtend},  // Mc   [3] SHARADA VOWEL SIGN AA..SHARADA VOWEL SIGN II
+	{runeRange{0x1122F, 0x11231}, sbprExtend},  // Mn   [3] KHOJKI VOWEL SIGN U..KHOJKI VOWEL SIGN AI
+	{runeRange{0x112B0, 0x112DE}, sbprOLetter}, // Lo  [47] KHUDAWADI LETTER A..KHUDAWADI LETTER HA
+	{runeRange{0x11340, 0x11340}, sbprExtend},  // Mn       GRANTHA VOWEL SIGN II
+	{runeRange{0x11446, 0x11446}, sbprExtend},  // Mn       NEWA SIGN NUKTA
+	{runeRange{0x114C7, 0x114C7}, sbprOLetter}, // Lo       TIRHUTA OM
+	{runeRange{0x1163B, 0x1163C}, sbprExtend},  // Mc   [2] MODI VOWEL SIGN O..MODI VOWEL SIGN AU
+	{runeRange{0x116C0, 0x116C9}, sbprNumeric}, // Nd  [10] TAKRI DIGIT ZERO..TAKRI DIGIT NINE
+	{runeRange{0x118C0, 0x118DF}, sbprLower},   // L&  [32] WARANG CITI SMALL LETTER NGAA..WARANG CITI SMALL LETTER VIYO
+	{runeRange{0x11943, 0x11943}, sbprExtend},  // Mn       DIVES AKURU SIGN NUKTA
+	{runeRange{0x11A0B, 0x11A32}, sbprOLetter}, // Lo  [40] ZANABAZAR SQUARE LETTER KA..ZANABAZAR SQUARE LETTER KSSA
+	{runeRange{0x11A9D, 0x11A9D}, sbprOLetter}, // Lo       SOYOMBO MARK PLUTA
+	{runeRange{0x11CB1, 0x11CB1}, sbprExtend},  // Mc       MARCHEN VOWEL SIGN I
+	{runeRange{0x11D6A, 0x11D89}, sbprOLetter}, // Lo  [32] GUNJALA GONDI LETTER OO..GUNJALA GONDI LETTER SA
+	{runeRange{0x11F04, 0x11F10}, sbprOLetter}, // Lo  [13] KAWI LETTER A..KAWI LETTER O
+	{runeRange{0x13430, 0x1343F}, sbprFormat},  // Cf  [16] EGYPTIAN HIEROGLYPH VERTICAL JOINER..EGYPTIAN HIEROGLYPH END WALLED ENCLOSURE
+	{runeRange{0x16B37, 0x16B38}, sbprSTerm},   // Po   [2] PAHAWH HMONG SIGN VOS THOM..PAHAWH HMONG SIGN VOS TSHAB CEEB
+	{runeRange{0x16FE3, 0x16FE3}, sbprOLetter}, // Lm       OLD CHINESE ITERATION MARK
+	{runeRange{0x1BC70, 0x1BC7C}, sbprOLetter}, // Lo  [13] DUPLOYAN AFFIX LEFT HORIZONTAL SECANT..DUPLOYAN AFFIX ATTACHED TANGENT HOOK
+	{runeRange{0x1D400, 0x1D419}, sbprUpper},   // L&  [26] MATHEMATICAL BOLD CAPITAL A..MATHEMATICAL BOLD CAPITAL Z
+	{runeRange{0x1D4C5, 0x1D4CF}, sbprLower},   // L&  [11] MATHEMATICAL SCRIPT SMALL P..MATHEMATICAL SCRIPT SMALL Z
+	{runeRange{0x1D5A0, 0x1D5B9}, sbprUpper},   // L&  [26] MATHEMATICAL SANS-SERIF CAPITAL A..MATHEMATICAL SANS-SERIF CAPITAL Z
+	{runeRange{0x1D71C, 0x1D734}, sbprUpper},   // L&  [25] MATHEMATICAL BOLD ITALIC CAPITAL ALPHA..MATHEMATICAL BOLD ITALIC CAPITAL OMEGA
+	{runeRange{0x1DA88, 0x1DA88}, sbprSTerm},   // Po       SIGNWRITING FULL STOP
+	{runeRange{0x1E137, 0x1E13D}, sbprOLetter}, // Lm   [7] NYIAKENG PUACHUE HMONG SIGN FOR PERSON..NYIAKENG PUACHUE HMONG SYLLABLE LENGTHENER
+	{runeRange{0x1E800, 0x1E8C4}, sbprOLetter}, // Lo [197] MENDE KIKAKUI SYLLABLE M001 KI..MENDE KIKAKUI SYLLABLE M060 NYON
+	{runeRange{0x1EE42, 0x1EE42}, sbprOLetter}, // Lo       ARABIC MATHEMATICAL TAILED JEEM
+	{runeRange{0x1EE74, 0x1EE77}, sbprOLetter}, // Lo   [4] ARABIC MATHEMATICAL STRETCHED SHEEN..ARABIC MATHEMATICAL STRETCHED KHAH
 	{runeRange{0x2B820, 0x2CEA1}, sbprOLetter}, // Lo [5762] CJK UNIFIED IDEOGRAPH-2B820..CJK UNIFIED IDEOGRAPH-2CEA1
-	{runeRange{0x2CEB0, 0x2EBE0}, sbprOLetter}, // Lo [7473] CJK UNIFIED IDEOGRAPH-2CEB0..CJK UNIFIED IDEOGRAPH-2EBE0
-	{runeRange{0x2F800, 0x2FA1D}, sbprOLetter}, // Lo [542] CJK COMPATIBILITY IDEOGRAPH-2F800..CJK COMPATIBILITY IDEOGRAPH-2FA1D
-	{runeRange{0x30000, 0x3134A}, sbprOLetter}, // Lo [4939] CJK UNIFIED IDEOGRAPH-30000..CJK UNIFIED IDEOGRAPH-3134A
+	{runeRange{0x0027, 0x0027}, sbprClose},     // Po       APOSTROPHE
+	{runeRange{0x00A0, 0x00A0}, sbprSp},        // Zs       NO-BREAK SPACE
+	{runeRange{0x0105, 0x0105}, sbprLower},     // L&       LATIN SMALL LETTER A WITH OGONEK
+	{runeRange{0x0115, 0x0115}, sbprLower},     // L&       LATIN SMALL LETTER E WITH BREVE
+	{runeRange{0x0125, 0x0125}, sbprLower},     // L&       LATIN SMALL LETTER H WITH CIRCUMFLEX
+	{runeRange{0x0135, 0x0135}, sbprLower},     // L&       LATIN SMALL LETTER J WITH CIRCUMFLEX
+	{runeRange{0x0146, 0x0146}, sbprLower},     // L&       LATIN SMALL LETTER N WITH CEDILLA
+	{runeRange{0x0157, 0x0157}, sbprLower},     // L&       LATIN SMALL LETTER R WITH CEDILLA
+	{runeRange{0x0167, 0x0167}, sbprLower},     // L&       LATIN SMALL LETTER T WITH STROKE
+	{runeRange{0x0177, 0x0177}, sbprLower},     // L&       LATIN SMALL LETTER Y WITH CIRCUMFLEX
+	{runeRange{0x0192, 0x0192}, sbprLower},     // L&       LATIN SMALL LETTER F WITH HOOK
+	{runeRange{0x01AA, 0x01AB}, sbprLower},     // L&   [2] LATIN LETTER REVERSED ESH LOOP..LATIN SMALL LETTER T WITH PALATAL HOOK
+	{runeRange{0x01C6, 0x01C6}, sbprLower},     // L&       LATIN SMALL LETTER DZ WITH CARON
+	{runeRange{0x01D8, 0x01D8}, sbprLower},     // L&       LATIN SMALL LETTER U WITH DIAERESIS AND ACUTE
+	{runeRange{0x01E9, 0x01E9}, sbprLower},     // L&       LATIN SMALL LETTER K WITH CARON
+	{runeRange{0x01FD, 0x01FD}, sbprLower},     // L&       LATIN SMALL LETTER AE WITH ACUTE
+	{runeRange{0x020D, 0x020D}, sbprLower},     // L&       LATIN SMALL LETTER O WITH DOUBLE GRAVE
+	{runeRange{0x021D, 0x021D}, sbprLower},     // L&       LATIN SMALL LETTER YOGH
+	{runeRange{0x022D, 0x022D}, sbprLower},     // L&       LATIN SMALL LETTER O WITH TILDE AND MACRON
+	{runeRange{0x0249, 0x0249}, sbprLower},     // L&       LATIN SMALL LETTER J WITH STROKE
+	{runeRange{0x0300, 0x036F}, sbprExtend},    // Mn [112] COMBINING GRAVE ACCENT..COMBINING LATIN SMALL LETTER X
+	{runeRange{0x0391, 0x03A1}, sbprUpper},     // L&  [17] GREEK CAPITAL LETTER ALPHA..GREEK CAPITAL LETTER RHO
+	{runeRange{0x03E1, 0x03E1}, sbprLower},     // L&       GREEK SMALL LETTER SAMPI
+	{runeRange{0x03F5, 0x03F5}, sbprLower},     // L&       GREEK LUNATE EPSILON SYMBOL
+	{runeRange{0x0469, 0x0469}, sbprLower},     // L&       CYRILLIC SMALL LETTER IOTIFIED LITTLE YUS
+	{runeRange{0x0479, 0x0479}, sbprLower},     // L&       CYRILLIC SMALL LETTER UK
+	{runeRange{0x048F, 0x048F}, sbprLower},     // L&       CYRILLIC SMALL LETTER ER WITH TICK
+	{runeRange{0x049F, 0x049F}, sbprLower},     // L&       CYRILLIC SMALL LETTER KA WITH STROKE
+	{runeRange{0x04AF, 0x04AF}, sbprLower},     // L&       CYRILLIC SMALL LETTER STRAIGHT U
+	{runeRange{0x04BF, 0x04BF}, sbprLower},     // L&       CYRILLIC SMALL LETTER ABKHASIAN CHE WITH DESCENDER
+	{runeRange{0x04D1, 0x04D1}, sbprLower},     // L&       CYRILLIC SMALL LETTER A WITH BREVE
+	{runeRange{0x04E1, 0x04E1}, sbprLower},     // L&       CYRILLIC SMALL LETTER ABKHASIAN DZE
+	{runeRange{0x04F1, 0x04F1}, sbprLower},     // L&       CYRILLIC SMALL LETTER U WITH DIAERESIS
+	{runeRange{0x0501, 0x0501}, sbprLower},     // L&       CYRILLIC SMALL LETTER KOMI DE
+	{runeRange{0x0511, 0x0511}, sbprLower},     // L&       CYRILLIC SMALL LETTER REVERSED ZE
+	{runeRange{0x0521, 0x0521}, sbprLower},     // L&       CYRILLIC SMALL LETTER EL WITH MIDDLE HOOK
+	{runeRange{0x0559, 0x0559}, sbprOLetter},   // Lm       ARMENIAN MODIFIER LETTER LEFT HALF RING
+	{runeRange{0x061D, 0x061F}, sbprSTerm},     // Po   [3] ARABIC END OF TEXT MARK..ARABIC QUESTION MARK
+	{runeRange{0x06E7, 0x06E8}, sbprExtend},    // Mn   [2] ARABIC SMALL HIGH YEH..ARABIC SMALL HIGH NOON
+	{runeRange{0x07CA, 0x07EA}, sbprOLetter},   // Lo  [33] NKO LETTER A..NKO LETTER JONA RA
+	{runeRange{0x0839, 0x0839}, sbprSTerm},     // Po       SAMARITAN PUNCTUATION QITSA
+	{runeRange{0x093A, 0x093A}, sbprExtend},    // Mn       DEVANAGARI VOWEL SIGN OE
+	{runeRange{0x0972, 0x0980}, sbprOLetter},   // Lo  [15] DEVANAGARI LETTER CANDRA A..BENGALI ANJI
+	{runeRange{0x09CE, 0x09CE}, sbprOLetter},   // Lo       BENGALI LETTER KHANDA TA
+	{runeRange{0x0A35, 0x0A36}, sbprOLetter},   // Lo   [2] GURMUKHI LETTER VA..GURMUKHI LETTER SHA
+	{runeRange{0x0A85, 0x0A8D}, sbprOLetter},   // Lo   [9] GUJARATI LETTER A..GUJARATI VOWEL CANDRA E
+	{runeRange{0x0AE2, 0x0AE3}, sbprExtend},    // Mn   [2] GUJARATI VOWEL SIGN VOCALIC L..GUJARATI VOWEL SIGN VOCALIC LL
+	{runeRange{0x0B40, 0x0B40}, sbprExtend},    // Mc       ORIYA VOWEL SIGN II
+	{runeRange{0x0B92, 0x0B95}, sbprOLetter},   // Lo   [4] TAMIL LETTER O..TAMIL LETTER KA
+	{runeRange{0x0C00, 0x0C00}, sbprExtend},    // Mn       TELUGU SIGN COMBINING CANDRABINDU ABOVE
+	{runeRange{0x0C60, 0x0C61}, sbprOLetter},   // Lo   [2] TELUGU LETTER VOCALIC RR..TELUGU LETTER VOCALIC LL
+	{runeRange{0x0CC6, 0x0CC6}, sbprExtend},    // Mn       KANNADA VOWEL SIGN E
+	{runeRange{0x0D3B, 0x0D3C}, sbprExtend},    // Mn   [2] MALAYALAM SIGN VERTICAL BAR VIRAMA..MALAYALAM SIGN CIRCULAR VIRAMA
+	{runeRange{0x0D85, 0x0D96}, sbprOLetter},   // Lo  [18] SINHALA LETTER AYANNA..SINHALA LETTER AUYANNA
+	{runeRange{0x0E40, 0x0E45}, sbprOLetter},   // Lo   [6] THAI CHARACTER SARA E..THAI CHARACTER LAKKHANGYAO
+	{runeRange{0x0EC8, 0x0ECE}, sbprExtend},    // Mn   [7] LAO TONE MAI EK..LAO YAMAKKAN
+	{runeRange{0x0F71, 0x0F7E}, sbprExtend},    // Mn  [14] TIBETAN VOWEL SIGN AA..TIBETAN SIGN RJES SU NGA RO
+	{runeRange{0x103D, 0x103E}, sbprExtend},    // Mn   [2] MYANMAR CONSONANT SIGN MEDIAL WA..MYANMAR CONSONANT SIGN MEDIAL HA
+	{runeRange{0x1082, 0x1082}, sbprExtend},    // Mn       MYANMAR CONSONANT SIGN SHAN MEDIAL WA
+	{runeRange{0x1100, 0x1248}, sbprOLetter},   // Lo [329] HANGUL CHOSEONG KIYEOK..ETHIOPIC SYLLABLE QWA
+	{runeRange{0x135D, 0x135F}, sbprExtend},    // Mn   [3] ETHIOPIC COMBINING GEMINATION AND VOWEL LENGTH MARK..ETHIOPIC COMBINING GEMINATION MARK
+	{runeRange{0x1700, 0x1711}, sbprOLetter},   // Lo  [18] TAGALOG LETTER A..TAGALOG LETTER HA
+	{runeRange{0x17BE, 0x17C5}, sbprExtend},    // Mc   [8] KHMER VOWEL SIGN OE..KHMER VOWEL SIGN AU
+	{runeRange{0x1820, 0x1842}, sbprOLetter},   // Lo  [35] MONGOLIAN LETTER A..MONGOLIAN LETTER CHI
+	{runeRange{0x1933, 0x1938}, sbprExtend},    // Mc   [6] LIMBU SMALL LETTER TA..LIMBU SMALL LETTER LA
+	{runeRange{0x1A57, 0x1A57}, sbprExtend},    // Mc       TAI THAM CONSONANT SIGN LA TANG LAI
+	{runeRange{0x1ABF, 0x1ACE}, sbprExtend},    // Mn  [16] COMBINING LATIN SMALL LETTER W BELOW..COMBINING LATIN SMALL LETTER INSULAR T
+	{runeRange{0x1B6B, 0x1B73}, sbprExtend},    // Mn   [9] BALINESE MUSICAL SYMBOL COMBINING TEGEH..BALINESE MUSICAL SYMBOL COMBINING GONG
+	{runeRange{0x1BE8, 0x1BE9}, sbprExtend},    // Mn   [2] BATAK VOWEL SIGN PAKPAK E..BATAK VOWEL SIGN EE
+	{runeRange{0x1C78, 0x1C7D}, sbprOLetter},   // Lm   [6] OL CHIKI MU TTUDDAG..OL CHIKI AHAD
+	{runeRange{0x1CFA, 0x1CFA}, sbprOLetter},   // Lo       VEDIC SIGN DOUBLE ANUSVARA ANTARGOMUKHA
+	{runeRange{0x1E08, 0x1E08}, sbprUpper},     // L&       LATIN CAPITAL LETTER C WITH CEDILLA AND ACUTE
+	{runeRange{0x1E18, 0x1E18}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH CIRCUMFLEX BELOW
+	{runeRange{0x1E28, 0x1E28}, sbprUpper},     // L&       LATIN CAPITAL LETTER H WITH CEDILLA
+	{runeRange{0x1E38, 0x1E38}, sbprUpper},     // L&       LATIN CAPITAL LETTER L WITH DOT BELOW AND MACRON
+	{runeRange{0x1E48, 0x1E48}, sbprUpper},     // L&       LATIN CAPITAL LETTER N WITH LINE BELOW
+	{runeRange{0x1E58, 0x1E58}, sbprUpper},     // L&       LATIN CAPITAL LETTER R WITH DOT ABOVE
+	{runeRange{0x1E68, 0x1E68}, sbprUpper},     // L&       LATIN CAPITAL LETTER S WITH DOT BELOW AND DOT ABOVE
+	{runeRange{0x1E78, 0x1E78}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH TILDE AND ACUTE
+	{runeRange{0x1E88, 0x1E88}, sbprUpper},     // L&       LATIN CAPITAL LETTER W WITH DOT BELOW
+	{runeRange{0x1EA0, 0x1EA0}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH DOT BELOW
+	{runeRange{0x1EB0, 0x1EB0}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH BREVE AND GRAVE
+	{runeRange{0x1EC0, 0x1EC0}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH CIRCUMFLEX AND GRAVE
+	{runeRange{0x1ED0, 0x1ED0}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH CIRCUMFLEX AND ACUTE
+	{runeRange{0x1EE0, 0x1EE0}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH HORN AND TILDE
+	{runeRange{0x1EF0, 0x1EF0}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH HORN AND DOT BELOW
+	{runeRange{0x1F08, 0x1F0F}, sbprUpper},     // L&   [8] GREEK CAPITAL LETTER ALPHA WITH PSILI..GREEK CAPITAL LETTER ALPHA WITH DASIA AND PERISPOMENI
+	{runeRange{0x1F70, 0x1F7D}, sbprLower},     // L&  [14] GREEK SMALL LETTER ALPHA WITH VARIA..GREEK SMALL LETTER OMEGA WITH OXIA
+	{runeRange{0x1FD8, 0x1FDB}, sbprUpper},     // L&   [4] GREEK CAPITAL LETTER IOTA WITH VRACHY..GREEK CAPITAL LETTER IOTA WITH OXIA
+	{runeRange{0x201E, 0x201E}, sbprClose},     // Ps       DOUBLE LOW-9 QUOTATION MARK
+	{runeRange{0x2071, 0x2071}, sbprLower},     // Lm       SUPERSCRIPT LATIN SMALL LETTER I
+	{runeRange{0x210E, 0x210F}, sbprLower},     // L&   [2] PLANCK CONSTANT..PLANCK CONSTANT OVER TWO PI
+	{runeRange{0x2145, 0x2145}, sbprUpper},     // L&       DOUBLE-STRUCK ITALIC CAPITAL D
+	{runeRange{0x24D0, 0x24E9}, sbprLower},     // So  [26] CIRCLED LATIN SMALL LETTER A..CIRCLED LATIN SMALL LETTER Z
+	{runeRange{0x27C5, 0x27C5}, sbprClose},     // Ps       LEFT S-SHAPED BAG DELIMITER
+	{runeRange{0x2987, 0x2987}, sbprClose},     // Ps       Z NOTATION LEFT IMAGE BRACKET
+	{runeRange{0x2997, 0x2997}, sbprClose},     // Ps       LEFT BLACK TORTOISE SHELL BRACKET
+	{runeRange{0x2C69, 0x2C69}, sbprUpper},     // L&       LATIN CAPITAL LETTER K WITH DESCENDER
+	{runeRange{0x2C82, 0x2C82}, sbprUpper},     // L&       COPTIC CAPITAL LETTER VIDA
+	{runeRange{0x2C8A, 0x2C8A}, sbprUpper},     // L&       COPTIC CAPITAL LETTER SOU
+	{runeRange{0x2C92, 0x2C92}, sbprUpper},     // L&       COPTIC CAPITAL LETTER IAUDA
+	{runeRange{0x2C9A, 0x2C9A}, sbprUpper},     // L&       COPTIC CAPITAL LETTER NI
+	{runeRange{0x2CA2, 0x2CA2}, sbprUpper},     // L&       COPTIC CAPITAL LETTER RO
+	{runeRange{0x2CAA, 0x2CAA}, sbprUpper},     // L&       COPTIC CAPITAL LETTER FI
+	{runeRange{0x2CB2, 0x2CB2}, sbprUpper},     // L&       COPTIC CAPITAL LETTER DIALECT-P ALEF
+	{runeRange{0x2CBA, 0x2CBA}, sbprUpper},     // L&       COPTIC CAPITAL LETTER DIALECT-P NI
+	{runeRange{0x2CC2, 0x2CC2}, sbprUpper},     // L&       COPTIC CAPITAL LETTER CROSSED SHEI
+	{runeRange{0x2CCA, 0x2CCA}, sbprUpper},     // L&       COPTIC CAPITAL LETTER DIALECT-P HORI
+	{runeRange{0x2CD2, 0x2CD2}, sbprUpper},     // L&       COPTIC CAPITAL LETTER OLD COPTIC HEI
+	{runeRange{0x2CDA, 0x2CDA}, sbprUpper},     // L&       COPTIC CAPITAL LETTER OLD COPTIC SHIMA
+	{runeRange{0x2CE2, 0x2CE2}, sbprUpper},     // L&       COPTIC CAPITAL LETTER OLD NUBIAN WAU
+	{runeRange{0x2CF3, 0x2CF3}, sbprLower},     // L&       COPTIC SMALL LETTER BOHAIRIC KHEI
+	{runeRange{0x2DA0, 0x2DA6}, sbprOLetter},   // Lo   [7] ETHIOPIC SYLLABLE SSA..ETHIOPIC SYLLABLE SSO
+	{runeRange{0x2DE0, 0x2DFF}, sbprExtend},    // Mn  [32] COMBINING CYRILLIC LETTER BE..COMBINING CYRILLIC LETTER IOTIFIED BIG YUS
+	{runeRange{0x2E0A, 0x2E0A}, sbprClose},     // Pf       RIGHT TRANSPOSITION BRACKET
+	{runeRange{0x2E22, 0x2E22}, sbprClose},     // Ps       TOP LEFT HALF BRACKET
+	{runeRange{0x2E2E, 0x2E2E}, sbprSTerm},     // Po       REVERSED QUESTION MARK
+	{runeRange{0x2E58, 0x2E58}, sbprClose},     // Pe       RIGHT SQUARE BRACKET WITH DOUBLE STROKE
+	{runeRange{0x3005, 0x3005}, sbprOLetter},   // Lm       IDEOGRAPHIC ITERATION MARK
+	{runeRange{0x300D, 0x300D}, sbprClose},     // Pe       RIGHT CORNER BRACKET
+	{runeRange{0x3017, 0x3017}, sbprClose},     // Pe       RIGHT WHITE LENTICULAR BRACKET
+	{runeRange{0x302A, 0x302D}, sbprExtend},    // Mn   [4] IDEOGRAPHIC LEVEL TONE MARK..IDEOGRAPHIC ENTERING TONE MARK
+	{runeRange{0x309D, 0x309E}, sbprOLetter},   // Lm   [2] HIRAGANA ITERATION MARK..HIRAGANA VOICED ITERATION MARK
+	{runeRange{0x31F0, 0x31FF}, sbprOLetter},   // Lo  [16] KATAKANA LETTER SMALL KU..KATAKANA LETTER SMALL RO
+	{runeRange{0xA500, 0xA60B}, sbprOLetter},   // Lo [268] VAI SYLLABLE EE..VAI SYLLABLE NG
+	{runeRange{0xA642, 0xA642}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER DZELO
+	{runeRange{0xA64A, 0xA64A}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER MONOGRAPH UK
+	{runeRange{0xA652, 0xA652}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER IOTIFIED YAT
+	{runeRange{0xA65A, 0xA65A}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER BLENDED YUS
+	{runeRange{0xA662, 0xA662}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER SOFT DE
+	{runeRange{0xA66A, 0xA66A}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER BINOCULAR O
+	{runeRange{0xA67F, 0xA67F}, sbprOLetter},   // Lm       CYRILLIC PAYEROK
+	{runeRange{0xA687, 0xA687}, sbprLower},     // L&       CYRILLIC SMALL LETTER CCHE
+	{runeRange{0xA68F, 0xA68F}, sbprLower},     // L&       CYRILLIC SMALL LETTER TSWE
+	{runeRange{0xA697, 0xA697}, sbprLower},     // L&       CYRILLIC SMALL LETTER SHWE
+	{runeRange{0xA6E6, 0xA6EF}, sbprOLetter},   // Nl  [10] BAMUM LETTER MO..BAMUM LETTER KOGHOM
+	{runeRange{0xA725, 0xA725}, sbprLower},     // L&       LATIN SMALL LETTER EGYPTOLOGICAL AIN
+	{runeRange{0xA72D, 0xA72D}, sbprLower},     // L&       LATIN SMALL LETTER CUATRILLO
+	{runeRange{0xA737, 0xA737}, sbprLower},     // L&       LATIN SMALL LETTER AU
+	{runeRange{0xA73F, 0xA73F}, sbprLower},     // L&       LATIN SMALL LETTER REVERSED C WITH DOT
+	{runeRange{0xA747, 0xA747}, sbprLower},     // L&       LATIN SMALL LETTER BROKEN L
+	{runeRange{0xA74F, 0xA74F}, sbprLower},     // L&       LATIN SMALL LETTER OO
+	{runeRange{0xA757, 0xA757}, sbprLower},     // L&       LATIN SMALL LETTER Q WITH STROKE THROUGH DESCENDER
+	{runeRange{0xA75F, 0xA75F}, sbprLower},     // L&       LATIN SMALL LETTER V WITH DIAGONAL STROKE
+	{runeRange{0xA767, 0xA767}, sbprLower},     // L&       LATIN SMALL LETTER THORN WITH STROKE THROUGH DESCENDER
+	{runeRange{0xA76F, 0xA76F}, sbprLower},     // L&       LATIN SMALL LETTER CON
+	{runeRange{0xA77F, 0xA77F}, sbprLower},     // L&       LATIN SMALL LETTER TURNED INSULAR G
+	{runeRange{0xA787, 0xA787}, sbprLower},     // L&       LATIN SMALL LETTER INSULAR T
+	{runeRange{0xA791, 0xA791}, sbprLower},     // L&       LATIN SMALL LETTER N WITH DESCENDER
+	{runeRange{0xA79B, 0xA79B}, sbprLower},     // L&       LATIN SMALL LETTER VOLAPUK AE
+	{runeRange{0xA7A3, 0xA7A3}, sbprLower},     // L&       LATIN SMALL LETTER K WITH OBLIQUE STROKE
+	{runeRange{0xA7AF, 0xA7AF}, sbprLower},     // L&       LATIN LETTER SMALL CAPITAL Q
+	{runeRange{0xA7BB, 0xA7BB}, sbprLower},     // L&       LATIN SMALL LETTER GLOTTAL A
+	{runeRange{0xA7C3, 0xA7C3}, sbprLower},     // L&       LATIN SMALL LETTER ANGLICANA W
+	{runeRange{0xA7D5, 0xA7D5}, sbprLower},     // L&       LATIN SMALL LETTER DOUBLE WYNN
+	{runeRange{0xA7F7, 0xA7F7}, sbprOLetter},   // Lo       LATIN EPIGRAPHIC LETTER SIDEWAYS I
+	{runeRange{0xA80B, 0xA80B}, sbprExtend},    // Mn       SYLOTI NAGRI SIGN ANUSVARA
+	{runeRange{0xA880, 0xA881}, sbprExtend},    // Mc   [2] SAURASHTRA SIGN ANUSVARA..SAURASHTRA SIGN VISARGA
+	{runeRange{0xA8FB, 0xA8FB}, sbprOLetter},   // Lo       DEVANAGARI HEADSTROKE
+	{runeRange{0xA947, 0xA951}, sbprExtend},    // Mn  [11] REJANG VOWEL SIGN I..REJANG CONSONANT SIGN R
+	{runeRange{0xA9B6, 0xA9B9}, sbprExtend},    // Mn   [4] JAVANESE VOWEL SIGN WULU..JAVANESE VOWEL SIGN SUKU MENDUT
+	{runeRange{0xA9E5, 0xA9E5}, sbprExtend},    // Mn       MYANMAR SIGN SHAN SAW
+	{runeRange{0xAA31, 0xAA32}, sbprExtend},    // Mn   [2] CHAM VOWEL SIGN AU..CHAM VOWEL SIGN UE
+	{runeRange{0xAA50, 0xAA59}, sbprNumeric},   // Nd  [10] CHAM DIGIT ZERO..CHAM DIGIT NINE
+	{runeRange{0xAA7D, 0xAA7D}, sbprExtend},    // Mc       MYANMAR SIGN TAI LAING TONE-5
+	{runeRange{0xAABE, 0xAABF}, sbprExtend},    // Mn   [2] TAI VIET VOWEL AM..TAI VIET TONE MAI EK
+	{runeRange{0xAAEC, 0xAAED}, sbprExtend},    // Mn   [2] MEETEI MAYEK VOWEL SIGN UU..MEETEI MAYEK VOWEL SIGN AAI
+	{runeRange{0xAB09, 0xAB0E}, sbprOLetter},   // Lo   [6] ETHIOPIC SYLLABLE DDHU..ETHIOPIC SYLLABLE DDHO
+	{runeRange{0xAB70, 0xABBF}, sbprLower},     // L&  [80] CHEROKEE SMALL LETTER A..CHEROKEE SMALL LETTER YA
+	{runeRange{0xABEC, 0xABEC}, sbprExtend},    // Mc       MEETEI MAYEK LUM IYEK
+	{runeRange{0xFB00, 0xFB06}, sbprLower},     // L&   [7] LATIN SMALL LIGATURE FF..LATIN SMALL LIGATURE ST
+	{runeRange{0xFB40, 0xFB41}, sbprOLetter},   // Lo   [2] HEBREW LETTER NUN WITH DAGESH..HEBREW LETTER SAMEKH WITH DAGESH
+	{runeRange{0xFDF0, 0xFDFB}, sbprOLetter},   // Lo  [12] ARABIC LIGATURE SALLA USED AS KORANIC STOP SIGN ISOLATED FORM..ARABIC LIGATURE JALLAJALALOUHOU
+	{runeRange{0xFE35, 0xFE35}, sbprClose},     // Ps       PRESENTATION FORM FOR VERTICAL LEFT PARENTHESIS
+	{runeRange{0xFE3D, 0xFE3D}, sbprClose},     // Ps       PRESENTATION FORM FOR VERTICAL LEFT DOUBLE ANGLE BRACKET
+	{runeRange{0xFE47, 0xFE47}, sbprClose},     // Ps       PRESENTATION FORM FOR VERTICAL LEFT SQUARE BRACKET
+	{runeRange{0xFE5A, 0xFE5A}, sbprClose},     // Pe       SMALL RIGHT PARENTHESIS
+	{runeRange{0xFEFF, 0xFEFF}, sbprFormat},    // Cf       ZERO WIDTH NO-BREAK SPACE
+	{runeRange{0xFF1A, 0xFF1A}, sbprSContinue}, // Po       FULLWIDTH COLON
+	{runeRange{0xFF5F, 0xFF5F}, sbprClose},     // Ps       FULLWIDTH LEFT WHITE PARENTHESIS
+	{runeRange{0xFF71, 0xFF9D}, sbprOLetter},   // Lo  [45] HALFWIDTH KATAKANA LETTER A..HALFWIDTH KATAKANA LETTER N
+	{runeRange{0x10000, 0x1000B}, sbprOLetter}, // Lo  [12] LINEAR B SYLLABLE B008 A..LINEAR B SYLLABLE B046 JE
+	{runeRange{0x101FD, 0x101FD}, sbprExtend},  // Mn       PHAISTOS DISC SIGN COMBINING OBLIQUE STROKE
+	{runeRange{0x1034A, 0x1034A}, sbprOLetter}, // Nl       GOTHIC LETTER NINE HUNDRED
+	{runeRange{0x10428, 0x1044F}, sbprLower},   // L&  [40] DESERET SMALL LETTER LONG I..DESERET SMALL LETTER EW
+	{runeRange{0x1057C, 0x1058A}, sbprUpper},   // L&  [15] VITHKUQI CAPITAL LETTER HA..VITHKUQI CAPITAL LETTER RE
+	{runeRange{0x10740, 0x10755}, sbprOLetter}, // Lo  [22] LINEAR A SIGN A701 A..LINEAR A SIGN A732 JE
+	{runeRange{0x10808, 0x10808}, sbprOLetter}, // Lo       CYPRIOT SYLLABLE JO
+	{runeRange{0x108F4, 0x108F5}, sbprOLetter}, // Lo   [2] HATRAN LETTER SHIN..HATRAN LETTER TAW
+	{runeRange{0x10A0C, 0x10A0F}, sbprExtend},  // Mn   [4] KHAROSHTHI VOWEL LENGTH MARK..KHAROSHTHI SIGN VISARGA
+	{runeRange{0x10A80, 0x10A9C}, sbprOLetter}, // Lo  [29] OLD NORTH ARABIAN LETTER HEH..OLD NORTH ARABIAN LETTER ZAH
+	{runeRange{0x10C00, 0x10C48}, sbprOLetter}, // Lo  [73] OLD TURKIC LETTER ORKHON A..OLD TURKIC LETTER ORKHON BASH
+	{runeRange{0x10EB0, 0x10EB1}, sbprOLetter}, // Lo   [2] YEZIDI LETTER LAM WITH DOT ABOVE..YEZIDI LETTER YOT WITH CIRCUMFLEX ABOVE
+	{runeRange{0x10F82, 0x10F85}, sbprExtend},  // Mn   [4] OLD UYGHUR COMBINING DOT ABOVE..OLD UYGHUR COMBINING TWO DOTS BELOW
+	{runeRange{0x11038, 0x11046}, sbprExtend},  // Mn  [15] BRAHMI VOWEL SIGN AA..BRAHMI VIRAMA
+	{runeRange{0x11082, 0x11082}, sbprExtend},  // Mc       KAITHI SIGN VISARGA
+	{runeRange{0x110C2, 0x110C2}, sbprExtend},  // Mn       KAITHI VOWEL SIGN VOCALIC R
+	{runeRange{0x1112D, 0x11134}, sbprExtend},  // Mn   [8] CHAKMA VOWEL SIGN AI..CHAKMA MAAYYAA
+	{runeRange{0x11176, 0x11176}, sbprOLetter}, // Lo       MAHAJANI LIGATURE SHRI
+	{runeRange{0x111C5, 0x111C6}, sbprSTerm},   // Po   [2] SHARADA DANDA..SHARADA DOUBLE DANDA
+	{runeRange{0x111DE, 0x111DF}, sbprSTerm},   // Po   [2] SHARADA SECTION MARK-1..SHARADA SECTION MARK-2
+	{runeRange{0x11236, 0x11237}, sbprExtend},  // Mn   [2] KHOJKI SIGN NUKTA..KHOJKI SIGN SHADDA
+	{runeRange{0x1128A, 0x1128D}, sbprOLetter}, // Lo   [4] MULTANI LETTER CA..MULTANI LETTER JJA
+	{runeRange{0x112F0, 0x112F9}, sbprNumeric}, // Nd  [10] KHUDAWADI DIGIT ZERO..KHUDAWADI DIGIT NINE
+	{runeRange{0x11335, 0x11339}, sbprOLetter}, // Lo   [5] GRANTHA LETTER VA..GRANTHA LETTER HA
+	{runeRange{0x11350, 0x11350}, sbprOLetter}, // Lo       GRANTHA OM
+	{runeRange{0x11438, 0x1143F}, sbprExtend},  // Mn   [8] NEWA VOWEL SIGN U..NEWA VOWEL SIGN AI
+	{runeRange{0x1145E, 0x1145E}, sbprExtend},  // Mn       NEWA SANDHI MARK
+	{runeRange{0x114BF, 0x114C0}, sbprExtend},  // Mn   [2] TIRHUTA SIGN CANDRABINDU..TIRHUTA SIGN ANUSVARA
+	{runeRange{0x115B2, 0x115B5}, sbprExtend},  // Mn   [4] SIDDHAM VOWEL SIGN U..SIDDHAM VOWEL SIGN VOCALIC RR
+	{runeRange{0x115DC, 0x115DD}, sbprExtend},  // Mn   [2] SIDDHAM VOWEL SIGN ALTERNATE U..SIDDHAM VOWEL SIGN ALTERNATE UU
+	{runeRange{0x11641, 0x11642}, sbprSTerm},   // Po   [2] MODI DANDA..MODI DOUBLE DANDA
+	{runeRange{0x116B0, 0x116B5}, sbprExtend},  // Mn   [6] TAKRI VOWEL SIGN U..TAKRI VOWEL SIGN AU
+	{runeRange{0x11722, 0x11725}, sbprExtend},  // Mn   [4] AHOM VOWEL SIGN I..AHOM VOWEL SIGN UU
+	{runeRange{0x1182F, 0x11837}, sbprExtend},  // Mn   [9] DOGRA VOWEL SIGN U..DOGRA SIGN ANUSVARA
+	{runeRange{0x1190C, 0x11913}, sbprOLetter}, // Lo   [8] DIVES AKURU LETTER KA..DIVES AKURU LETTER JA
+	{runeRange{0x1193F, 0x1193F}, sbprOLetter}, // Lo       DIVES AKURU PREFIXED NASAL SIGN
+	{runeRange{0x119A0, 0x119A7}, sbprOLetter}, // Lo   [8] NANDINAGARI LETTER A..NANDINAGARI LETTER VOCALIC RR
+	{runeRange{0x119E3, 0x119E3}, sbprOLetter}, // Lo       NANDINAGARI HEADSTROKE
+	{runeRange{0x11A3B, 0x11A3E}, sbprExtend},  // Mn   [4] ZANABAZAR SQUARE CLUSTER-FINAL LETTER YA..ZANABAZAR SQUARE CLUSTER-FINAL LETTER VA
+	{runeRange{0x11A8A, 0x11A96}, sbprExtend},  // Mn  [13] SOYOMBO FINAL CONSONANT SIGN G..SOYOMBO SIGN ANUSVARA
+	{runeRange{0x11C2F, 0x11C2F}, sbprExtend},  // Mc       BHAIKSUKI VOWEL SIGN AA
+	{runeRange{0x11C72, 0x11C8F}, sbprOLetter}, // Lo  [30] MARCHEN LETTER KA..MARCHEN LETTER A
+	{runeRange{0x11D00, 0x11D06}, sbprOLetter}, // Lo   [7] MASARAM GONDI LETTER A..MASARAM GONDI LETTER E
+	{runeRange{0x11D47, 0x11D47}, sbprExtend},  // Mn       MASARAM GONDI RA-KARA
+	{runeRange{0x11D95, 0x11D95}, sbprExtend},  // Mn       GUNJALA GONDI SIGN ANUSVARA
+	{runeRange{0x11EF7, 0x11EF8}, sbprSTerm},   // Po   [2] MAKASAR PASSIMBANG..MAKASAR END OF SECTION
+	{runeRange{0x11F3E, 0x11F3F}, sbprExtend},  // Mc   [2] KAWI VOWEL SIGN E..KAWI VOWEL SIGN AI
+	{runeRange{0x12400, 0x1246E}, sbprOLetter}, // Nl [111] CUNEIFORM NUMERIC SIGN TWO ASH..CUNEIFORM NUMERIC SIGN NINE U VARIANT FORM
+	{runeRange{0x14400, 0x14646}, sbprOLetter}, // Lo [583] ANATOLIAN HIEROGLYPH A001..ANATOLIAN HIEROGLYPH A530
+	{runeRange{0x16AF0, 0x16AF4}, sbprExtend},  // Mn   [5] BASSA VAH COMBINING HIGH TONE..BASSA VAH COMBINING HIGH-LOW TONE
+	{runeRange{0x16B63, 0x16B77}, sbprOLetter}, // Lo  [21] PAHAWH HMONG SIGN VOS LUB..PAHAWH HMONG SIGN CIM NRES TOS
+	{runeRange{0x16F51, 0x16F87}, sbprExtend},  // Mc  [55] MIAO SIGN ASPIRATION..MIAO VOWEL SIGN UI
+	{runeRange{0x18800, 0x18CD5}, sbprOLetter}, // Lo [1238] TANGUT COMPONENT-001..KHITAN SMALL SCRIPT CHARACTER-18CD5
+	{runeRange{0x1B155, 0x1B155}, sbprOLetter}, // Lo       KATAKANA LETTER SMALL KO
+	{runeRange{0x1BC9F, 0x1BC9F}, sbprSTerm},   // Po       DUPLOYAN PUNCTUATION CHINOOK FULL STOP
+	{runeRange{0x1D17B, 0x1D182}, sbprExtend},  // Mn   [8] MUSICAL SYMBOL COMBINING ACCENT..MUSICAL SYMBOL COMBINING LOURE
+	{runeRange{0x1D456, 0x1D467}, sbprLower},   // L&  [18] MATHEMATICAL ITALIC SMALL I..MATHEMATICAL ITALIC SMALL Z
+	{runeRange{0x1D4AE, 0x1D4B5}, sbprUpper},   // L&   [8] MATHEMATICAL SCRIPT CAPITAL S..MATHEMATICAL SCRIPT CAPITAL Z
+	{runeRange{0x1D507, 0x1D50A}, sbprUpper},   // L&   [4] MATHEMATICAL FRAKTUR CAPITAL D..MATHEMATICAL FRAKTUR CAPITAL G
+	{runeRange{0x1D54A, 0x1D550}, sbprUpper},   // L&   [7] MATHEMATICAL DOUBLE-STRUCK CAPITAL S..MATHEMATICAL DOUBLE-STRUCK CAPITAL Y
+	{runeRange{0x1D608, 0x1D621}, sbprUpper},   // L&  [26] MATHEMATICAL SANS-SERIF ITALIC CAPITAL A..MATHEMATICAL SANS-SERIF ITALIC CAPITAL Z
+	{runeRange{0x1D6DC, 0x1D6E1}, sbprLower},   // L&   [6] MATHEMATICAL BOLD EPSILON SYMBOL..MATHEMATICAL BOLD PI SYMBOL
+	{runeRange{0x1D770, 0x1D788}, sbprLower},   // L&  [25] MATHEMATICAL SANS-SERIF BOLD SMALL ALPHA..MATHEMATICAL SANS-SERIF BOLD SMALL OMEGA
+	{runeRange{0x1DA00, 0x1DA36}, sbprExtend},  // Mn  [55] SIGNWRITING HEAD RIM..SIGNWRITING AIR SUCKING IN
+	{runeRange{0x1DF0A, 0x1DF0A}, sbprOLetter}, // Lo       LATIN LETTER RETROFLEX CLICK WITH RETROFLEX HOOK
+	{runeRange{0x1E030, 0x1E06D}, sbprLower},   // Lm  [62] MODIFIER LETTER CYRILLIC SMALL A..MODIFIER LETTER CYRILLIC SMALL STRAIGHT U WITH STROKE
+	{runeRange{0x1E2AE, 0x1E2AE}, sbprExtend},  // Mn       TOTO SIGN RISING TONE
+	{runeRange{0x1E7E0, 0x1E7E6}, sbprOLetter}, // Lo   [7] ETHIOPIC SYLLABLE HHYA..ETHIOPIC SYLLABLE HHYO
+	{runeRange{0x1E944, 0x1E94A}, sbprExtend},  // Mn   [7] ADLAM ALIF LENGTHENER..ADLAM NUKTA
+	{runeRange{0x1EE29, 0x1EE32}, sbprOLetter}, // Lo  [10] ARABIC MATHEMATICAL INITIAL YEH..ARABIC MATHEMATICAL INITIAL QAF
+	{runeRange{0x1EE4D, 0x1EE4F}, sbprOLetter}, // Lo   [3] ARABIC MATHEMATICAL TAILED NOON..ARABIC MATHEMATICAL TAILED AIN
+	{runeRange{0x1EE61, 0x1EE62}, sbprOLetter}, // Lo   [2] ARABIC MATHEMATICAL STRETCHED BEH..ARABIC MATHEMATICAL STRETCHED JEEM
+	{runeRange{0x1EE8B, 0x1EE9B}, sbprOLetter}, // Lo  [17] ARABIC MATHEMATICAL LOOPED LAM..ARABIC MATHEMATICAL LOOPED GHAIN
+	{runeRange{0x1FBF0, 0x1FBF9}, sbprNumeric}, // Nd  [10] SEGMENTED DIGIT ZERO..SEGMENTED DIGIT NINE
 	{runeRange{0x31350, 0x323AF}, sbprOLetter}, // Lo [4192] CJK UNIFIED IDEOGRAPH-31350..CJK UNIFIED IDEOGRAPH-323AF
-	{runeRange{0xE0001, 0xE0001}, sbprFormat},  // Cf       LANGUAGE TAG
+	{runeRange{0x000D, 0x000D}, sbprCR},        // Cc       <control-000D>
+	{runeRange{0x002D, 0x002D}, sbprSContinue}, // Pd       HYPHEN-MINUS
+	{runeRange{0x0061, 0x007A}, sbprLower},     // L&  [26] LATIN SMALL LETTER A..LATIN SMALL LETTER Z
+	{runeRange{0x00B5, 0x00B5}, sbprLower},     // L&       MICRO SIGN
+	{runeRange{0x0101, 0x0101}, sbprLower},     // L&       LATIN SMALL LETTER A WITH MACRON
+	{runeRange{0x0109, 0x0109}, sbprLower},     // L&       LATIN SMALL LETTER C WITH CIRCUMFLEX
+	{runeRange{0x0111, 0x0111}, sbprLower},     // L&       LATIN SMALL LETTER D WITH STROKE
+	{runeRange{0x0119, 0x0119}, sbprLower},     // L&       LATIN SMALL LETTER E WITH OGONEK
+	{runeRange{0x0121, 0x0121}, sbprLower},     // L&       LATIN SMALL LETTER G WITH DOT ABOVE
+	{runeRange{0x0129, 0x0129}, sbprLower},     // L&       LATIN SMALL LETTER I WITH TILDE
+	{runeRange{0x0131, 0x0131}, sbprLower},     // L&       LATIN SMALL LETTER DOTLESS I
+	{runeRange{0x013A, 0x013A}, sbprLower},     // L&       LATIN SMALL LETTER L WITH ACUTE
+	{runeRange{0x0142, 0x0142}, sbprLower},     // L&       LATIN SMALL LETTER L WITH STROKE
+	{runeRange{0x014B, 0x014B}, sbprLower},     // L&       LATIN SMALL LETTER ENG
+	{runeRange{0x0153, 0x0153}, sbprLower},     // L&       LATIN SMALL LIGATURE OE
+	{runeRange{0x015B, 0x015B}, sbprLower},     // L&       LATIN SMALL LETTER S WITH ACUTE
+	{runeRange{0x0163, 0x0163}, sbprLower},     // L&       LATIN SMALL LETTER T WITH CEDILLA
+	{runeRange{0x016B, 0x016B}, sbprLower},     // L&       LATIN SMALL LETTER U WITH MACRON
+	{runeRange{0x0173, 0x0173}, sbprLower},     // L&       LATIN SMALL LETTER U WITH OGONEK
+	{runeRange{0x017C, 0x017C}, sbprLower},     // L&       LATIN SMALL LETTER Z WITH DOT ABOVE
+	{runeRange{0x0188, 0x0188}, sbprLower},     // L&       LATIN SMALL LETTER C WITH HOOK
+	{runeRange{0x0199, 0x019B}, sbprLower},     // L&   [3] LATIN SMALL LETTER K WITH HOOK..LATIN SMALL LETTER LAMBDA WITH STROKE
+	{runeRange{0x01A5, 0x01A5}, sbprLower},     // L&       LATIN SMALL LETTER P WITH HOOK
+	{runeRange{0x01B0, 0x01B0}, sbprLower},     // L&       LATIN SMALL LETTER U WITH HORN
+	{runeRange{0x01BC, 0x01BC}, sbprUpper},     // L&       LATIN CAPITAL LETTER TONE FIVE
+	{runeRange{0x01CC, 0x01CC}, sbprLower},     // L&       LATIN SMALL LETTER NJ
+	{runeRange{0x01D4, 0x01D4}, sbprLower},     // L&       LATIN SMALL LETTER U WITH CARON
+	{runeRange{0x01DC, 0x01DD}, sbprLower},     // L&   [2] LATIN SMALL LETTER U WITH DIAERESIS AND GRAVE..LATIN SMALL LETTER TURNED E
+	{runeRange{0x01E5, 0x01E5}, sbprLower},     // L&       LATIN SMALL LETTER G WITH STROKE
+	{runeRange{0x01ED, 0x01ED}, sbprLower},     // L&       LATIN SMALL LETTER O WITH OGONEK AND MACRON
+	{runeRange{0x01F9, 0x01F9}, sbprLower},     // L&       LATIN SMALL LETTER N WITH GRAVE
+	{runeRange{0x0201, 0x0201}, sbprLower},     // L&       LATIN SMALL LETTER A WITH DOUBLE GRAVE
+	{runeRange{0x0209, 0x0209}, sbprLower},     // L&       LATIN SMALL LETTER I WITH DOUBLE GRAVE
+	{runeRange{0x0211, 0x0211}, sbprLower},     // L&       LATIN SMALL LETTER R WITH DOUBLE GRAVE
+	{runeRange{0x0219, 0x0219}, sbprLower},     // L&       LATIN SMALL LETTER S WITH COMMA BELOW
+	{runeRange{0x0221, 0x0221}, sbprLower},     // L&       LATIN SMALL LETTER D WITH CURL
+	{runeRange{0x0229, 0x0229}, sbprLower},     // L&       LATIN SMALL LETTER E WITH CEDILLA
+	{runeRange{0x0231, 0x0231}, sbprLower},     // L&       LATIN SMALL LETTER O WITH DOT ABOVE AND MACRON
+	{runeRange{0x0242, 0x0242}, sbprLower},     // L&       LATIN SMALL LETTER GLOTTAL STOP
+	{runeRange{0x024D, 0x024D}, sbprLower},     // L&       LATIN SMALL LETTER R WITH STROKE
+	{runeRange{0x02C6, 0x02D1}, sbprOLetter},   // Lm  [12] MODIFIER LETTER CIRCUMFLEX ACCENT..MODIFIER LETTER HALF TRIANGULAR COLON
+	{runeRange{0x0373, 0x0373}, sbprLower},     // L&       GREEK SMALL LETTER ARCHAIC SAMPI
+	{runeRange{0x0388, 0x038A}, sbprUpper},     // L&   [3] GREEK CAPITAL LETTER EPSILON WITH TONOS..GREEK CAPITAL LETTER IOTA WITH TONOS
+	{runeRange{0x03D0, 0x03D1}, sbprLower},     // L&   [2] GREEK BETA SYMBOL..GREEK THETA SYMBOL
+	{runeRange{0x03DD, 0x03DD}, sbprLower},     // L&       GREEK SMALL LETTER DIGAMMA
+	{runeRange{0x03E5, 0x03E5}, sbprLower},     // L&       COPTIC SMALL LETTER FEI
+	{runeRange{0x03ED, 0x03ED}, sbprLower},     // L&       COPTIC SMALL LETTER SHIMA
+	{runeRange{0x03FB, 0x03FC}, sbprLower},     // L&   [2] GREEK SMALL LETTER SAN..GREEK RHO WITH STROKE SYMBOL
+	{runeRange{0x0465, 0x0465}, sbprLower},     // L&       CYRILLIC SMALL LETTER IOTIFIED E
+	{runeRange{0x046D, 0x046D}, sbprLower},     // L&       CYRILLIC SMALL LETTER IOTIFIED BIG YUS
+	{runeRange{0x0475, 0x0475}, sbprLower},     // L&       CYRILLIC SMALL LETTER IZHITSA
+	{runeRange{0x047D, 0x047D}, sbprLower},     // L&       CYRILLIC SMALL LETTER OMEGA WITH TITLO
+	{runeRange{0x048B, 0x048B}, sbprLower},     // L&       CYRILLIC SMALL LETTER SHORT I WITH TAIL
+	{runeRange{0x0493, 0x0493}, sbprLower},     // L&       CYRILLIC SMALL LETTER GHE WITH STROKE
+	{runeRange{0x049B, 0x049B}, sbprLower},     // L&       CYRILLIC SMALL LETTER KA WITH DESCENDER
+	{runeRange{0x04A3, 0x04A3}, sbprLower},     // L&       CYRILLIC SMALL LETTER EN WITH DESCENDER
+	{runeRange{0x04AB, 0x04AB}, sbprLower},     // L&       CYRILLIC SMALL LETTER ES WITH DESCENDER
+	{runeRange{0x04B3, 0x04B3}, sbprLower},     // L&       CYRILLIC SMALL LETTER HA WITH DESCENDER
+	{runeRange{0x04BB, 0x04BB}, sbprLower},     // L&       CYRILLIC SMALL LETTER SHHA
+	{runeRange{0x04C4, 0x04C4}, sbprLower},     // L&       CYRILLIC SMALL LETTER KA WITH HOOK
+	{runeRange{0x04CC, 0x04CC}, sbprLower},     // L&       CYRILLIC SMALL LETTER KHAKASSIAN CHE
+	{runeRange{0x04D5, 0x04D5}, sbprLower},     // L&       CYRILLIC SMALL LIGATURE A IE
+	{runeRange{0x04DD, 0x04DD}, sbprLower},     // L&       CYRILLIC SMALL LETTER ZHE WITH DIAERESIS
+	{runeRange{0x04E5, 0x04E5}, sbprLower},     // L&       CYRILLIC SMALL LETTER I WITH DIAERESIS
+	{runeRange{0x04ED, 0x04ED}, sbprLower},     // L&       CYRILLIC SMALL LETTER E WITH DIAERESIS
+	{runeRange{0x04F5, 0x04F5}, sbprLower},     // L&       CYRILLIC SMALL LETTER CHE WITH DIAERESIS
+	{runeRange{0x04FD, 0x04FD}, sbprLower},     // L&       CYRILLIC SMALL LETTER HA WITH HOOK
+	{runeRange{0x0505, 0x0505}, sbprLower},     // L&       CYRILLIC SMALL LETTER KOMI ZJE
+	{runeRange{0x050D, 0x050D}, sbprLower},     // L&       CYRILLIC SMALL LETTER KOMI SJE
+	{runeRange{0x0515, 0x0515}, sbprLower},     // L&       CYRILLIC SMALL LETTER LHA
+	{runeRange{0x051D, 0x051D}, sbprLower},     // L&       CYRILLIC SMALL LETTER WE
+	{runeRange{0x0525, 0x0525}, sbprLower},     // L&       CYRILLIC SMALL LETTER PE WITH DESCENDER
+	{runeRange{0x052D, 0x052D}, sbprLower},     // L&       CYRILLIC SMALL LETTER DCHE
+	{runeRange{0x0591, 0x05BD}, sbprExtend},    // Mn  [45] HEBREW ACCENT ETNAHTA..HEBREW POINT METEG
+	{runeRange{0x0600, 0x0605}, sbprFormat},    // Cf   [6] ARABIC NUMBER SIGN..ARABIC NUMBER MARK ABOVE
+	{runeRange{0x064B, 0x065F}, sbprExtend},    // Mn  [21] ARABIC FATHATAN..ARABIC WAVY HAMZA BELOW
+	{runeRange{0x06D6, 0x06DC}, sbprExtend},    // Mn   [7] ARABIC SMALL HIGH LIGATURE SAD WITH LAM WITH ALEF MAKSURA..ARABIC SMALL HIGH SEEN
+	{runeRange{0x06FA, 0x06FC}, sbprOLetter},   // Lo   [3] ARABIC LETTER SHEEN WITH DOT BELOW..ARABIC LETTER GHAIN WITH DOT BELOW
+	{runeRange{0x074D, 0x07A5}, sbprOLetter},   // Lo  [89] SYRIAC LETTER SOGDIAN ZHAIN..THAANA LETTER WAAVU
+	{runeRange{0x07F9, 0x07F9}, sbprSTerm},     // Po       NKO EXCLAMATION MARK
+	{runeRange{0x0825, 0x0827}, sbprExtend},    // Mn   [3] SAMARITAN VOWEL SIGN SHORT A..SAMARITAN VOWEL SIGN U
+	{runeRange{0x0860, 0x086A}, sbprOLetter},   // Lo  [11] SYRIAC LETTER MALAYALAM NGA..SYRIAC LETTER MALAYALAM SSA
+	{runeRange{0x08E2, 0x08E2}, sbprFormat},    // Cf       ARABIC DISPUTED END OF AYAH
+	{runeRange{0x093E, 0x0940}, sbprExtend},    // Mc   [3] DEVANAGARI VOWEL SIGN AA..DEVANAGARI VOWEL SIGN II
+	{runeRange{0x0962, 0x0963}, sbprExtend},    // Mn   [2] DEVANAGARI VOWEL SIGN VOCALIC L..DEVANAGARI VOWEL SIGN VOCALIC LL
+	{runeRange{0x098F, 0x0990}, sbprOLetter},   // Lo   [2] BENGALI LETTER E..BENGALI LETTER AI
+	{runeRange{0x09C1, 0x09C4}, sbprExtend},    // Mn   [4] BENGALI VOWEL SIGN U..BENGALI VOWEL SIGN VOCALIC RR
+	{runeRange{0x09E2, 0x09E3}, sbprExtend},    // Mn   [2] BENGALI VOWEL SIGN VOCALIC L..BENGALI VOWEL SIGN VOCALIC LL
+	{runeRange{0x0A0F, 0x0A10}, sbprOLetter},   // Lo   [2] GURMUKHI LETTER EE..GURMUKHI LETTER AI
+	{runeRange{0x0A41, 0x0A42}, sbprExtend},    // Mn   [2] GURMUKHI VOWEL SIGN U..GURMUKHI VOWEL SIGN UU
+	{runeRange{0x0A72, 0x0A74}, sbprOLetter},   // Lo   [3] GURMUKHI IRI..GURMUKHI EK ONKAR
+	{runeRange{0x0AB2, 0x0AB3}, sbprOLetter},   // Lo   [2] GUJARATI LETTER LA..GUJARATI LETTER LLA
+	{runeRange{0x0ACB, 0x0ACC}, sbprExtend},    // Mc   [2] GUJARATI VOWEL SIGN O..GUJARATI VOWEL SIGN AU
+	{runeRange{0x0B01, 0x0B01}, sbprExtend},    // Mn       ORIYA SIGN CANDRABINDU
+	{runeRange{0x0B3C, 0x0B3C}, sbprExtend},    // Mn       ORIYA SIGN NUKTA
+	{runeRange{0x0B4D, 0x0B4D}, sbprExtend},    // Mn       ORIYA SIGN VIRAMA
+	{runeRange{0x0B82, 0x0B82}, sbprExtend},    // Mn       TAMIL SIGN ANUSVARA
+	{runeRange{0x0BA3, 0x0BA4}, sbprOLetter},   // Lo   [2] TAMIL LETTER NNA..TAMIL LETTER TA
+	{runeRange{0x0BCD, 0x0BCD}, sbprExtend},    // Mn       TAMIL SIGN VIRAMA
+	{runeRange{0x0C0E, 0x0C10}, sbprOLetter},   // Lo   [3] TELUGU LETTER E..TELUGU LETTER AI
+	{runeRange{0x0C4A, 0x0C4D}, sbprExtend},    // Mn   [4] TELUGU VOWEL SIGN O..TELUGU SIGN VIRAMA
+	{runeRange{0x0C81, 0x0C81}, sbprExtend},    // Mn       KANNADA SIGN CANDRABINDU
+	{runeRange{0x0CBD, 0x0CBD}, sbprOLetter},   // Lo       KANNADA SIGN AVAGRAHA
+	{runeRange{0x0CD5, 0x0CD6}, sbprExtend},    // Mc   [2] KANNADA LENGTH MARK..KANNADA AI LENGTH MARK
+	{runeRange{0x0D02, 0x0D03}, sbprExtend},    // Mc   [2] MALAYALAM SIGN ANUSVARA..MALAYALAM SIGN VISARGA
+	{runeRange{0x0D46, 0x0D48}, sbprExtend},    // Mc   [3] MALAYALAM VOWEL SIGN E..MALAYALAM VOWEL SIGN AI
+	{runeRange{0x0D66, 0x0D6F}, sbprNumeric},   // Nd  [10] MALAYALAM DIGIT ZERO..MALAYALAM DIGIT NINE
+	{runeRange{0x0DC0, 0x0DC6}, sbprOLetter},   // Lo   [7] SINHALA LETTER VAYANNA..SINHALA LETTER FAYANNA
+	{runeRange{0x0E01, 0x0E30}, sbprOLetter},   // Lo  [48] THAI CHARACTER KO KAI..THAI CHARACTER SARA A
+	{runeRange{0x0E81, 0x0E82}, sbprOLetter},   // Lo   [2] LAO LETTER KO..LAO LETTER KHO SUNG
+	{runeRange{0x0EB4, 0x0EBC}, sbprExtend},    // Mn   [9] LAO VOWEL SIGN I..LAO SEMIVOWEL SIGN LO
+	{runeRange{0x0F18, 0x0F19}, sbprExtend},    // Mn   [2] TIBETAN ASTROLOGICAL SIGN -KHYUD PA..TIBETAN ASTROLOGICAL SIGN SDONG TSHUGS
+	{runeRange{0x0F3D, 0x0F3D}, sbprClose},     // Pe       TIBETAN MARK ANG KHANG GYAS
+	{runeRange{0x0F88, 0x0F8C}, sbprOLetter},   // Lo   [5] TIBETAN SIGN LCE TSA CAN..TIBETAN SIGN INVERTED MCHU CAN
+	{runeRange{0x1032, 0x1037}, sbprExtend},    // Mn   [6] MYANMAR VOWEL SIGN AI..MYANMAR SIGN DOT BELOW
+	{runeRange{0x1050, 0x1055}, sbprOLetter},   // Lo   [6] MYANMAR LETTER SHA..MYANMAR LETTER VOCALIC LL
+	{runeRange{0x1067, 0x106D}, sbprExtend},    // Mc   [7] MYANMAR VOWEL SIGN WESTERN PWO KAREN EU..MYANMAR SIGN WESTERN PWO KAREN TONE-5
+	{runeRange{0x108D, 0x108D}, sbprExtend},    // Mn       MYANMAR SIGN SHAN COUNCIL EMPHATIC TONE
+	{runeRange{0x10CD, 0x10CD}, sbprUpper},     // L&       GEORGIAN CAPITAL LETTER AEN
+	{runeRange{0x125A, 0x125D}, sbprOLetter},   // Lo   [4] ETHIOPIC SYLLABLE QHWI..ETHIOPIC SYLLABLE QHWE
+	{runeRange{0x12C8, 0x12D6}, sbprOLetter},   // Lo  [15] ETHIOPIC SYLLABLE WA..ETHIOPIC SYLLABLE PHARYNGEAL O
+	{runeRange{0x13A0, 0x13F5}, sbprUpper},     // L&  [86] CHEROKEE LETTER A..CHEROKEE LETTER MV
+	{runeRange{0x169C, 0x169C}, sbprClose},     // Pe       OGHAM REVERSED FEATHER MARK
+	{runeRange{0x1732, 0x1733}, sbprExtend},    // Mn   [2] HANUNOO VOWEL SIGN I..HANUNOO VOWEL SIGN U
+	{runeRange{0x1780, 0x17B3}, sbprOLetter},   // Lo  [52] KHMER LETTER KA..KHMER INDEPENDENT VOWEL QAU
+	{runeRange{0x17D7, 0x17D7}, sbprOLetter},   // Lm       KHMER SIGN LEK TOO
+	{runeRange{0x180B, 0x180D}, sbprExtend},    // Mn   [3] MONGOLIAN FREE VARIATION SELECTOR ONE..MONGOLIAN FREE VARIATION SELECTOR THREE
+	{runeRange{0x1885, 0x1886}, sbprExtend},    // Mn   [2] MONGOLIAN LETTER ALI GALI BALUDA..MONGOLIAN LETTER ALI GALI THREE BALUDA
+	{runeRange{0x1927, 0x1928}, sbprExtend},    // Mn   [2] LIMBU VOWEL SIGN E..LIMBU VOWEL SIGN O
+	{runeRange{0x1950, 0x196D}, sbprOLetter},   // Lo  [30] TAI LE LETTER KA..TAI LE LETTER AI
+	{runeRange{0x1A1B, 0x1A1B}, sbprExtend},    // Mn       BUGINESE VOWEL SIGN AE
+	{runeRange{0x1A62, 0x1A62}, sbprExtend},    // Mn       TAI THAM VOWEL SIGN MAI SAT
+	{runeRange{0x1AA7, 0x1AA7}, sbprOLetter},   // Lm       TAI THAM SIGN MAI YAMOK
+	{runeRange{0x1B34, 0x1B34}, sbprExtend},    // Mn       BALINESE SIGN REREKAN
+	{runeRange{0x1B45, 0x1B4C}, sbprOLetter},   // Lo   [8] BALINESE LETTER KAF SASAK..BALINESE LETTER ARCHAIC JNYA
+	{runeRange{0x1B83, 0x1BA0}, sbprOLetter},   // Lo  [30] SUNDANESE LETTER A..SUNDANESE LETTER HA
+	{runeRange{0x1BB0, 0x1BB9}, sbprNumeric},   // Nd  [10] SUNDANESE DIGIT ZERO..SUNDANESE DIGIT NINE
+	{runeRange{0x1BEF, 0x1BF1}, sbprExtend},    // Mn   [3] BATAK VOWEL SIGN U FOR SIMALUNGUN SA..BATAK CONSONANT SIGN H
+	{runeRange{0x1C40, 0x1C49}, sbprNumeric},   // Nd  [10] LEPCHA DIGIT ZERO..LEPCHA DIGIT NINE
+	{runeRange{0x1CBD, 0x1CBF}, sbprOLetter},   // L&   [3] GEORGIAN MTAVRULI CAPITAL LETTER AEN..GEORGIAN MTAVRULI CAPITAL LETTER LABIAL SIGN
+	{runeRange{0x1CF4, 0x1CF4}, sbprExtend},    // Mn       VEDIC TONE CANDRA ABOVE
+	{runeRange{0x1D78, 0x1D78}, sbprLower},     // Lm       MODIFIER LETTER CYRILLIC EN
+	{runeRange{0x1E04, 0x1E04}, sbprUpper},     // L&       LATIN CAPITAL LETTER B WITH DOT BELOW
+	{runeRange{0x1E0C, 0x1E0C}, sbprUpper},     // L&       LATIN CAPITAL LETTER D WITH DOT BELOW
+	{runeRange{0x1E14, 0x1E14}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH MACRON AND GRAVE
+	{runeRange{0x1E1C, 0x1E1C}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH CEDILLA AND BREVE
+	{runeRange{0x1E24, 0x1E24}, sbprUpper},     // L&       LATIN CAPITAL LETTER H WITH DOT BELOW
+	{runeRange{0x1E2C, 0x1E2C}, sbprUpper},     // L&       LATIN CAPITAL LETTER I WITH TILDE BELOW
+	{runeRange{0x1E34, 0x1E34}, sbprUpper},     // L&       LATIN CAPITAL LETTER K WITH LINE BELOW
+	{runeRange{0x1E3C, 0x1E3C}, sbprUpper},     // L&       LATIN CAPITAL LETTER L WITH CIRCUMFLEX BELOW
+	{runeRange{0x1E44, 0x1E44}, sbprUpper},     // L&       LATIN CAPITAL LETTER N WITH DOT ABOVE
+	{runeRange{0x1E4C, 0x1E4C}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH TILDE AND ACUTE
+	{runeRange{0x1E54, 0x1E54}, sbprUpper},     // L&       LATIN CAPITAL LETTER P WITH ACUTE
+	{runeRange{0x1E5C, 0x1E5C}, sbprUpper},     // L&       LATIN CAPITAL LETTER R WITH DOT BELOW AND MACRON
+	{runeRange{0x1E64, 0x1E64}, sbprUpper},     // L&       LATIN CAPITAL LETTER S WITH ACUTE AND DOT ABOVE
+	{runeRange{0x1E6C, 0x1E6C}, sbprUpper},     // L&       LATIN CAPITAL LETTER T WITH DOT BELOW
+	{runeRange{0x1E74, 0x1E74}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH TILDE BELOW
+	{runeRange{0x1E7C, 0x1E7C}, sbprUpper},     // L&       LATIN CAPITAL LETTER V WITH TILDE
+	{runeRange{0x1E84, 0x1E84}, sbprUpper},     // L&       LATIN CAPITAL LETTER W WITH DIAERESIS
+	{runeRange{0x1E8C, 0x1E8C}, sbprUpper},     // L&       LATIN CAPITAL LETTER X WITH DIAERESIS
+	{runeRange{0x1E94, 0x1E94}, sbprUpper},     // L&       LATIN CAPITAL LETTER Z WITH LINE BELOW
+	{runeRange{0x1EA4, 0x1EA4}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH CIRCUMFLEX AND ACUTE
+	{runeRange{0x1EAC, 0x1EAC}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH CIRCUMFLEX AND DOT BELOW
+	{runeRange{0x1EB4, 0x1EB4}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH BREVE AND TILDE
+	{runeRange{0x1EBC, 0x1EBC}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH TILDE
+	{runeRange{0x1EC4, 0x1EC4}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH CIRCUMFLEX AND TILDE
+	{runeRange{0x1ECC, 0x1ECC}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH DOT BELOW
+	{runeRange{0x1ED4, 0x1ED4}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH CIRCUMFLEX AND HOOK ABOVE
+	{runeRange{0x1EDC, 0x1EDC}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH HORN AND GRAVE
+	{runeRange{0x1EE4, 0x1EE4}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH DOT BELOW
+	{runeRange{0x1EEC, 0x1EEC}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH HORN AND HOOK ABOVE
+	{runeRange{0x1EF4, 0x1EF4}, sbprUpper},     // L&       LATIN CAPITAL LETTER Y WITH DOT BELOW
+	{runeRange{0x1EFC, 0x1EFC}, sbprUpper},     // L&       LATIN CAPITAL LETTER MIDDLE-WELSH V
+	{runeRange{0x1F28, 0x1F2F}, sbprUpper},     // L&   [8] GREEK CAPITAL LETTER ETA WITH PSILI..GREEK CAPITAL LETTER ETA WITH DASIA AND PERISPOMENI
+	{runeRange{0x1F5D, 0x1F5D}, sbprUpper},     // L&       GREEK CAPITAL LETTER UPSILON WITH DASIA AND OXIA
+	{runeRange{0x1F98, 0x1F9F}, sbprUpper},     // L&   [8] GREEK CAPITAL LETTER ETA WITH PSILI AND PROSGEGRAMMENI..GREEK CAPITAL LETTER ETA WITH DASIA AND PERISPOMENI AND PROSGEGRAMMENI
+	{runeRange{0x1FC6, 0x1FC7}, sbprLower},     // L&   [2] GREEK SMALL LETTER ETA WITH PERISPOMENI..GREEK SMALL LETTER ETA WITH PERISPOMENI AND YPOGEGRAMMENI
+	{runeRange{0x1FF6, 0x1FF7}, sbprLower},     // L&   [2] GREEK SMALL LETTER OMEGA WITH PERISPOMENI..GREEK SMALL LETTER OMEGA WITH PERISPOMENI AND YPOGEGRAMMENI
+	{runeRange{0x2019, 0x2019}, sbprClose},     // Pf       RIGHT SINGLE QUOTATION MARK
+	{runeRange{0x2029, 0x2029}, sbprSep},       // Zp       PARAGRAPH SEPARATOR
+	{runeRange{0x2047, 0x2049}, sbprSTerm},     // Po   [3] DOUBLE QUESTION MARK..EXCLAMATION QUESTION MARK
+	{runeRange{0x208D, 0x208D}, sbprClose},     // Ps       SUBSCRIPT LEFT PARENTHESIS
+	{runeRange{0x2102, 0x2102}, sbprUpper},     // L&       DOUBLE-STRUCK CAPITAL C
+	{runeRange{0x2119, 0x211D}, sbprUpper},     // L&   [5] DOUBLE-STRUCK CAPITAL P..DOUBLE-STRUCK CAPITAL R
+	{runeRange{0x2135, 0x2138}, sbprOLetter},   // Lo   [4] ALEF SYMBOL..DALET SYMBOL
+	{runeRange{0x2170, 0x217F}, sbprLower},     // Nl  [16] SMALL ROMAN NUMERAL ONE..SMALL ROMAN NUMERAL ONE THOUSAND
+	{runeRange{0x230B, 0x230B}, sbprClose},     // Pe       RIGHT FLOOR
+	{runeRange{0x276A, 0x276A}, sbprClose},     // Ps       MEDIUM FLATTENED LEFT PARENTHESIS ORNAMENT
+	{runeRange{0x2772, 0x2772}, sbprClose},     // Ps       LIGHT LEFT TORTOISE SHELL BRACKET ORNAMENT
+	{runeRange{0x27E8, 0x27E8}, sbprClose},     // Ps       MATHEMATICAL LEFT ANGLE BRACKET
+	{runeRange{0x2983, 0x2983}, sbprClose},     // Ps       LEFT WHITE CURLY BRACKET
+	{runeRange{0x298B, 0x298B}, sbprClose},     // Ps       LEFT SQUARE BRACKET WITH UNDERBAR
+	{runeRange{0x2993, 0x2993}, sbprClose},     // Ps       LEFT ARC LESS-THAN BRACKET
+	{runeRange{0x29DA, 0x29DA}, sbprClose},     // Ps       LEFT DOUBLE WIGGLY FENCE
+	{runeRange{0x2C62, 0x2C64}, sbprUpper},     // L&   [3] LATIN CAPITAL LETTER L WITH MIDDLE TILDE..LATIN CAPITAL LETTER R WITH TAIL
+	{runeRange{0x2C6D, 0x2C70}, sbprUpper},     // L&   [4] LATIN CAPITAL LETTER ALPHA..LATIN CAPITAL LETTER TURNED ALPHA
+	{runeRange{0x2C7E, 0x2C80}, sbprUpper},     // L&   [3] LATIN CAPITAL LETTER S WITH SWASH TAIL..COPTIC CAPITAL LETTER ALFA
+	{runeRange{0x2C84, 0x2C84}, sbprUpper},     // L&       COPTIC CAPITAL LETTER GAMMA
+	{runeRange{0x2C88, 0x2C88}, sbprUpper},     // L&       COPTIC CAPITAL LETTER EIE
+	{runeRange{0x2C8C, 0x2C8C}, sbprUpper},     // L&       COPTIC CAPITAL LETTER ZATA
+	{runeRange{0x2C90, 0x2C90}, sbprUpper},     // L&       COPTIC CAPITAL LETTER THETHE
+	{runeRange{0x2C94, 0x2C94}, sbprUpper},     // L&       COPTIC CAPITAL LETTER KAPA
+	{runeRange{0x2C98, 0x2C98}, sbprUpper},     // L&       COPTIC CAPITAL LETTER MI
+	{runeRange{0x2C9C, 0x2C9C}, sbprUpper},     // L&       COPTIC CAPITAL LETTER KSI
+	{runeRange{0x2CA0, 0x2CA0}, sbprUpper},     // L&       COPTIC CAPITAL LETTER PI
+	{runeRange{0x2CA4, 0x2CA4}, sbprUpper},     // L&       COPTIC CAPITAL LETTER SIMA
+	{runeRange{0x2CA8, 0x2CA8}, sbprUpper},     // L&       COPTIC CAPITAL LETTER UA
+	{runeRange{0x2CAC, 0x2CAC}, sbprUpper},     // L&       COPTIC CAPITAL LETTER KHI
+	{runeRange{0x2CB0, 0x2CB0}, sbprUpper},     // L&       COPTIC CAPITAL LETTER OOU
+	{runeRange{0x2CB4, 0x2CB4}, sbprUpper},     // L&       COPTIC CAPITAL LETTER OLD COPTIC AIN
+	{runeRange{0x2CB8, 0x2CB8}, sbprUpper},     // L&       COPTIC CAPITAL LETTER DIALECT-P KAPA
+	{runeRange{0x2CBC, 0x2CBC}, sbprUpper},     // L&       COPTIC CAPITAL LETTER CRYPTOGRAMMIC NI
+	{runeRange{0x2CC0, 0x2CC0}, sbprUpper},     // L&       COPTIC CAPITAL LETTER SAMPI
+	{runeRange{0x2CC4, 0x2CC4}, sbprUpper},     // L&       COPTIC CAPITAL LETTER OLD COPTIC SHEI
+	{runeRange{0x2CC8, 0x2CC8}, sbprUpper},     // L&       COPTIC CAPITAL LETTER AKHMIMIC KHEI
+	{runeRange{0x2CCC, 0x2CCC}, sbprUpper},     // L&       COPTIC CAPITAL LETTER OLD COPTIC HORI
+	{runeRange{0x2CD0, 0x2CD0}, sbprUpper},     // L&       COPTIC CAPITAL LETTER L-SHAPED HA
+	{runeRange{0x2CD4, 0x2CD4}, sbprUpper},     // L&       COPTIC CAPITAL LETTER OLD COPTIC HAT
+	{runeRange{0x2CD8, 0x2CD8}, sbprUpper},     // L&       COPTIC CAPITAL LETTER OLD COPTIC DJA
+	{runeRange{0x2CDC, 0x2CDC}, sbprUpper},     // L&       COPTIC CAPITAL LETTER OLD NUBIAN SHIMA
+	{runeRange{0x2CE0, 0x2CE0}, sbprUpper},     // L&       COPTIC CAPITAL LETTER OLD NUBIAN NYI
+	{runeRange{0x2CEB, 0x2CEB}, sbprUpper},     // L&       COPTIC CAPITAL LETTER CRYPTOGRAMMIC SHEI
+	{runeRange{0x2CEF, 0x2CF1}, sbprExtend},    // Mn   [3] COPTIC COMBINING NI ABOVE..COPTIC COMBINING SPIRITUS LENIS
+	{runeRange{0x2D27, 0x2D27}, sbprLower},     // L&       GEORGIAN SMALL LETTER YN
+	{runeRange{0x2D7F, 0x2D7F}, sbprExtend},    // Mn       TIFINAGH CONSONANT JOINER
+	{runeRange{0x2DB0, 0x2DB6}, sbprOLetter},   // Lo   [7] ETHIOPIC SYLLABLE ZZA..ETHIOPIC SYLLABLE ZZO
+	{runeRange{0x2DD0, 0x2DD6}, sbprOLetter},   // Lo   [7] ETHIOPIC SYLLABLE XYA..ETHIOPIC SYLLABLE XYO
+	{runeRange{0x2E02, 0x2E02}, sbprClose},     // Pi       LEFT SUBSTITUTION BRACKET
+	{runeRange{0x2E06, 0x2E08}, sbprClose},     // Po   [3] RAISED INTERPOLATION MARKER..DOTTED TRANSPOSITION MARKER
+	{runeRange{0x2E0C, 0x2E0C}, sbprClose},     // Pi       LEFT RAISED OMISSION BRACKET
+	{runeRange{0x2E20, 0x2E20}, sbprClose},     // Pi       LEFT VERTICAL BAR WITH QUILL
+	{runeRange{0x2E24, 0x2E24}, sbprClose},     // Ps       BOTTOM LEFT HALF BRACKET
+	{runeRange{0x2E28, 0x2E28}, sbprClose},     // Ps       LEFT DOUBLE PARENTHESIS
+	{runeRange{0x2E3C, 0x2E3C}, sbprSTerm},     // Po       STENOGRAPHIC FULL STOP
+	{runeRange{0x2E56, 0x2E56}, sbprClose},     // Pe       RIGHT SQUARE BRACKET WITH STROKE
+	{runeRange{0x2E5A, 0x2E5A}, sbprClose},     // Pe       TOP HALF RIGHT PARENTHESIS
+	{runeRange{0x3001, 0x3001}, sbprSContinue}, // Po       IDEOGRAPHIC COMMA
+	{runeRange{0x3007, 0x3007}, sbprOLetter},   // Nl       IDEOGRAPHIC NUMBER ZERO
+	{runeRange{0x300B, 0x300B}, sbprClose},     // Pe       RIGHT DOUBLE ANGLE BRACKET
+	{runeRange{0x300F, 0x300F}, sbprClose},     // Pe       RIGHT WHITE CORNER BRACKET
+	{runeRange{0x3015, 0x3015}, sbprClose},     // Pe       RIGHT TORTOISE SHELL BRACKET
+	{runeRange{0x3019, 0x3019}, sbprClose},     // Pe       RIGHT WHITE TORTOISE SHELL BRACKET
+	{runeRange{0x301E, 0x301F}, sbprClose},     // Pe   [2] DOUBLE PRIME QUOTATION MARK..LOW DOUBLE PRIME QUOTATION MARK
+	{runeRange{0x3031, 0x3035}, sbprOLetter},   // Lm   [5] VERTICAL KANA REPEAT MARK..VERTICAL KANA REPEAT MARK LOWER HALF
+	{runeRange{0x3041, 0x3096}, sbprOLetter},   // Lo  [86] HIRAGANA LETTER SMALL A..HIRAGANA LETTER SMALL KE
+	{runeRange{0x30A1, 0x30FA}, sbprOLetter},   // Lo  [90] KATAKANA LETTER SMALL A..KATAKANA LETTER VO
+	{runeRange{0x3131, 0x318E}, sbprOLetter},   // Lo  [94] HANGUL LETTER KIYEOK..HANGUL LETTER ARAEAE
+	{runeRange{0x4E00, 0xA014}, sbprOLetter},   // Lo [21013] CJK UNIFIED IDEOGRAPH-4E00..YI SYLLABLE E
+	{runeRange{0xA4F8, 0xA4FD}, sbprOLetter},   // Lm   [6] LISU LETTER TONE MYA TI..LISU LETTER TONE MYA JEU
+	{runeRange{0xA60E, 0xA60F}, sbprSTerm},     // Po   [2] VAI FULL STOP..VAI QUESTION MARK
+	{runeRange{0xA640, 0xA640}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER ZEMLYA
+	{runeRange{0xA644, 0xA644}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER REVERSED DZE
+	{runeRange{0xA648, 0xA648}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER DJERV
+	{runeRange{0xA64C, 0xA64C}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER BROAD OMEGA
+	{runeRange{0xA650, 0xA650}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER YERU WITH BACK YER
+	{runeRange{0xA654, 0xA654}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER REVERSED YU
+	{runeRange{0xA658, 0xA658}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER CLOSED LITTLE YUS
+	{runeRange{0xA65C, 0xA65C}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER IOTIFIED CLOSED LITTLE YUS
+	{runeRange{0xA660, 0xA660}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER REVERSED TSE
+	{runeRange{0xA664, 0xA664}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER SOFT EL
+	{runeRange{0xA668, 0xA668}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER MONOCULAR O
+	{runeRange{0xA66C, 0xA66C}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER DOUBLE MONOCULAR O
+	{runeRange{0xA670, 0xA672}, sbprExtend},    // Me   [3] COMBINING CYRILLIC TEN MILLIONS SIGN..COMBINING CYRILLIC THOUSAND MILLIONS SIGN
+	{runeRange{0xA681, 0xA681}, sbprLower},     // L&       CYRILLIC SMALL LETTER DWE
+	{runeRange{0xA685, 0xA685}, sbprLower},     // L&       CYRILLIC SMALL LETTER ZHWE
+	{runeRange{0xA689, 0xA689}, sbprLower},     // L&       CYRILLIC SMALL LETTER DZZE
+	{runeRange{0xA68D, 0xA68D}, sbprLower},     // L&       CYRILLIC SMALL LETTER TWE
+	{runeRange{0xA691, 0xA691}, sbprLower},     // L&       CYRILLIC SMALL LETTER TSSE
+	{runeRange{0xA695, 0xA695}, sbprLower},     // L&       CYRILLIC SMALL LETTER HWE
+	{runeRange{0xA699, 0xA699}, sbprLower},     // L&       CYRILLIC SMALL LETTER DOUBLE O
+	{runeRange{0xA69E, 0xA69F}, sbprExtend},    // Mn   [2] COMBINING CYRILLIC LETTER EF..COMBINING CYRILLIC LETTER IOTIFIED E
+	{runeRange{0xA6F3, 0xA6F3}, sbprSTerm},     // Po       BAMUM FULL STOP
+	{runeRange{0xA723, 0xA723}, sbprLower},     // L&       LATIN SMALL LETTER EGYPTOLOGICAL ALEF
+	{runeRange{0xA727, 0xA727}, sbprLower},     // L&       LATIN SMALL LETTER HENG
+	{runeRange{0xA72B, 0xA72B}, sbprLower},     // L&       LATIN SMALL LETTER TRESILLO
+	{runeRange{0xA72F, 0xA731}, sbprLower},     // L&   [3] LATIN SMALL LETTER CUATRILLO WITH COMMA..LATIN LETTER SMALL CAPITAL S
+	{runeRange{0xA735, 0xA735}, sbprLower},     // L&       LATIN SMALL LETTER AO
+	{runeRange{0xA739, 0xA739}, sbprLower},     // L&       LATIN SMALL LETTER AV
+	{runeRange{0xA73D, 0xA73D}, sbprLower},     // L&       LATIN SMALL LETTER AY
+	{runeRange{0xA741, 0xA741}, sbprLower},     // L&       LATIN SMALL LETTER K WITH STROKE
+	{runeRange{0xA745, 0xA745}, sbprLower},     // L&       LATIN SMALL LETTER K WITH STROKE AND DIAGONAL STROKE
+	{runeRange{0xA749, 0xA749}, sbprLower},     // L&       LATIN SMALL LETTER L WITH HIGH STROKE
+	{runeRange{0xA74D, 0xA74D}, sbprLower},     // L&       LATIN SMALL LETTER O WITH LOOP
+	{runeRange{0xA751, 0xA751}, sbprLower},     // L&       LATIN SMALL LETTER P WITH STROKE THROUGH DESCENDER
+	{runeRange{0xA755, 0xA755}, sbprLower},     // L&       LATIN SMALL LETTER P WITH SQUIRREL TAIL
+	{runeRange{0xA759, 0xA759}, sbprLower},     // L&       LATIN SMALL LETTER Q WITH DIAGONAL STROKE
+	{runeRange{0xA75D, 0xA75D}, sbprLower},     // L&       LATIN SMALL LETTER RUM ROTUNDA
+	{runeRange{0xA761, 0xA761}, sbprLower},     // L&       LATIN SMALL LETTER VY
+	{runeRange{0xA765, 0xA765}, sbprLower},     // L&       LATIN SMALL LETTER THORN WITH STROKE
+	{runeRange{0xA769, 0xA769}, sbprLower},     // L&       LATIN SMALL LETTER VEND
+	{runeRange{0xA76D, 0xA76D}, sbprLower},     // L&       LATIN SMALL LETTER IS
+	{runeRange{0xA771, 0xA778}, sbprLower},     // L&   [8] LATIN SMALL LETTER DUM..LATIN SMALL LETTER UM
+	{runeRange{0xA77C, 0xA77C}, sbprLower},     // L&       LATIN SMALL LETTER INSULAR F
+	{runeRange{0xA781, 0xA781}, sbprLower},     // L&       LATIN SMALL LETTER TURNED L
+	{runeRange{0xA785, 0xA785}, sbprLower},     // L&       LATIN SMALL LETTER INSULAR S
+	{runeRange{0xA78B, 0xA78B}, sbprUpper},     // L&       LATIN CAPITAL LETTER SALTILLO
+	{runeRange{0xA78F, 0xA78F}, sbprOLetter},   // Lo       LATIN LETTER SINOLOGICAL DOT
+	{runeRange{0xA793, 0xA795}, sbprLower},     // L&   [3] LATIN SMALL LETTER C WITH BAR..LATIN SMALL LETTER H WITH PALATAL HOOK
+	{runeRange{0xA799, 0xA799}, sbprLower},     // L&       LATIN SMALL LETTER F WITH STROKE
+	{runeRange{0xA79D, 0xA79D}, sbprLower},     // L&       LATIN SMALL LETTER VOLAPUK OE
+	{runeRange{0xA7A1, 0xA7A1}, sbprLower},     // L&       LATIN SMALL LETTER G WITH OBLIQUE STROKE
+	{runeRange{0xA7A5, 0xA7A5}, sbprLower},     // L&       LATIN SMALL LETTER N WITH OBLIQUE STROKE
+	{runeRange{0xA7A9, 0xA7A9}, sbprLower},     // L&       LATIN SMALL LETTER S WITH OBLIQUE STROKE
+	{runeRange{0xA7B5, 0xA7B5}, sbprLower},     // L&       LATIN SMALL LETTER BETA
+	{runeRange{0xA7B9, 0xA7B9}, sbprLower},     // L&       LATIN SMALL LETTER U WITH STROKE
+	{runeRange{0xA7BD, 0xA7BD}, sbprLower},     // L&       LATIN SMALL LETTER GLOTTAL I
+	{runeRange{0xA7C1, 0xA7C1}, sbprLower},     // L&       LATIN SMALL LETTER OLD POLISH O
+	{runeRange{0xA7C8, 0xA7C8}, sbprLower},     // L&       LATIN SMALL LETTER D WITH SHORT STROKE OVERLAY
+	{runeRange{0xA7D1, 0xA7D1}, sbprLower},     // L&       LATIN SMALL LETTER CLOSED INSULAR G
+	{runeRange{0xA7D7, 0xA7D7}, sbprLower},     // L&       LATIN SMALL LETTER MIDDLE SCOTS S
+	{runeRange{0xA7F5, 0xA7F5}, sbprUpper},     // L&       LATIN CAPITAL LETTER REVERSED HALF H
+	{runeRange{0xA7FA, 0xA7FA}, sbprLower},     // L&       LATIN LETTER SMALL CAPITAL TURNED M
+	{runeRange{0xA806, 0xA806}, sbprExtend},    // Mn       SYLOTI NAGRI SIGN HASANTA
+	{runeRange{0xA823, 0xA824}, sbprExtend},    // Mc   [2] SYLOTI NAGRI VOWEL SIGN A..SYLOTI NAGRI VOWEL SIGN I
+	{runeRange{0xA840, 0xA873}, sbprOLetter},   // Lo  [52] PHAGS-PA LETTER KA..PHAGS-PA LETTER CANDRABINDU
+	{runeRange{0xA8B4, 0xA8C3}, sbprExtend},    // Mc  [16] SAURASHTRA CONSONANT SIGN HAARU..SAURASHTRA VOWEL SIGN AU
+	{runeRange{0xA8E0, 0xA8F1}, sbprExtend},    // Mn  [18] COMBINING DEVANAGARI DIGIT ZERO..COMBINING DEVANAGARI SIGN AVAGRAHA
+	{runeRange{0xA8FF, 0xA8FF}, sbprExtend},    // Mn       DEVANAGARI VOWEL SIGN AY
+	{runeRange{0xA92F, 0xA92F}, sbprSTerm},     // Po       KAYAH LI SIGN SHYA
+	{runeRange{0xA960, 0xA97C}, sbprOLetter},   // Lo  [29] HANGUL CHOSEONG TIKEUT-MIEUM..HANGUL CHOSEONG SSANGYEORINHIEUH
+	{runeRange{0xA9B3, 0xA9B3}, sbprExtend},    // Mn       JAVANESE SIGN CECAK TELU
+	{runeRange{0xA9BC, 0xA9BD}, sbprExtend},    // Mn   [2] JAVANESE VOWEL SIGN PEPET..JAVANESE CONSONANT SIGN KERET
+	{runeRange{0xA9D0, 0xA9D9}, sbprNumeric},   // Nd  [10] JAVANESE DIGIT ZERO..JAVANESE DIGIT NINE
+	{runeRange{0xA9E7, 0xA9EF}, sbprOLetter},   // Lo   [9] MYANMAR LETTER TAI LAING NYA..MYANMAR LETTER TAI LAING NNA
+	{runeRange{0xAA29, 0xAA2E}, sbprExtend},    // Mn   [6] CHAM VOWEL SIGN AA..CHAM VOWEL SIGN OE
+	{runeRange{0xAA35, 0xAA36}, sbprExtend},    // Mn   [2] CHAM CONSONANT SIGN LA..CHAM CONSONANT SIGN WA
+	{runeRange{0xAA4C, 0xAA4C}, sbprExtend},    // Mn       CHAM CONSONANT SIGN FINAL M
+	{runeRange{0xAA60, 0xAA6F}, sbprOLetter},   // Lo  [16] MYANMAR LETTER KHAMTI GA..MYANMAR LETTER KHAMTI FA
+	{runeRange{0xAA7B, 0xAA7B}, sbprExtend},    // Mc       MYANMAR SIGN PAO KAREN TONE
+	{runeRange{0xAAB0, 0xAAB0}, sbprExtend},    // Mn       TAI VIET MAI KANG
+	{runeRange{0xAAB7, 0xAAB8}, sbprExtend},    // Mn   [2] TAI VIET MAI KHIT..TAI VIET VOWEL IA
+	{runeRange{0xAAC1, 0xAAC1}, sbprExtend},    // Mn       TAI VIET TONE MAI THO
+	{runeRange{0xAAE0, 0xAAEA}, sbprOLetter},   // Lo  [11] MEETEI MAYEK LETTER E..MEETEI MAYEK LETTER SSA
+	{runeRange{0xAAF0, 0xAAF1}, sbprSTerm},     // Po   [2] MEETEI MAYEK CHEIKHAN..MEETEI MAYEK AHANG KHUDAM
+	{runeRange{0xAAF6, 0xAAF6}, sbprExtend},    // Mn       MEETEI MAYEK VIRAMA
+	{runeRange{0xAB20, 0xAB26}, sbprOLetter},   // Lo   [7] ETHIOPIC SYLLABLE CCHHA..ETHIOPIC SYLLABLE CCHHO
+	{runeRange{0xAB60, 0xAB68}, sbprLower},     // L&   [9] LATIN SMALL LETTER SAKHA YAT..LATIN SMALL LETTER TURNED R WITH MIDDLE TILDE
+	{runeRange{0xABE3, 0xABE4}, sbprExtend},    // Mc   [2] MEETEI MAYEK VOWEL SIGN ONAP..MEETEI MAYEK VOWEL SIGN INAP
+	{runeRange{0xABE9, 0xABEA}, sbprExtend},    // Mc   [2] MEETEI MAYEK VOWEL SIGN CHEINAP..MEETEI MAYEK VOWEL SIGN NUNG
+	{runeRange{0xABF0, 0xABF9}, sbprNumeric},   // Nd  [10] MEETEI MAYEK DIGIT ZERO..MEETEI MAYEK DIGIT NINE
+	{runeRange{0xF900, 0xFA6D}, sbprOLetter},   // Lo [366] CJK COMPATIBILITY IDEOGRAPH-F900..CJK COMPATIBILITY IDEOGRAPH-FA6D
+	{runeRange{0xFB1D, 0xFB1D}, sbprOLetter},   // Lo       HEBREW LETTER YOD WITH HIRIQ
+	{runeRange{0xFB38, 0xFB3C}, sbprOLetter},   // Lo   [5] HEBREW LETTER TET WITH DAGESH..HEBREW LETTER LAMED WITH DAGESH
+	{runeRange{0xFB46, 0xFBB1}, sbprOLetter},   // Lo [108] HEBREW LETTER TSADI WITH DAGESH..ARABIC LETTER YEH BARREE WITH HAMZA ABOVE FINAL FORM
+	{runeRange{0xFD50, 0xFD8F}, sbprOLetter},   // Lo  [64] ARABIC LIGATURE TEH WITH JEEM WITH MEEM INITIAL FORM..ARABIC LIGATURE MEEM WITH KHAH WITH MEEM INITIAL FORM
+	{runeRange{0xFE10, 0xFE11}, sbprSContinue}, // Po   [2] PRESENTATION FORM FOR VERTICAL COMMA..PRESENTATION FORM FOR VERTICAL IDEOGRAPHIC COMMA
+	{runeRange{0xFE20, 0xFE2F}, sbprExtend},    // Mn  [16] COMBINING LIGATURE LEFT HALF..COMBINING CYRILLIC TITLO RIGHT HALF
+	{runeRange{0xFE37, 0xFE37}, sbprClose},     // Ps       PRESENTATION FORM FOR VERTICAL LEFT CURLY BRACKET
+	{runeRange{0xFE3B, 0xFE3B}, sbprClose},     // Ps       PRESENTATION FORM FOR VERTICAL LEFT BLACK LENTICULAR BRACKET
+	{runeRange{0xFE3F, 0xFE3F}, sbprClose},     // Ps       PRESENTATION FORM FOR VERTICAL LEFT ANGLE BRACKET
+	{runeRange{0xFE43, 0xFE43}, sbprClose},     // Ps       PRESENTATION FORM FOR VERTICAL LEFT WHITE CORNER BRACKET
+	{runeRange{0xFE50, 0xFE51}, sbprSContinue}, // Po   [2] SMALL COMMA..SMALL IDEOGRAPHIC COMMA
+	{runeRange{0xFE58, 0xFE58}, sbprSContinue}, // Pd       SMALL EM DASH
+	{runeRange{0xFE5C, 0xFE5C}, sbprClose},     // Pe       SMALL RIGHT CURLY BRACKET
+	{runeRange{0xFE70, 0xFE74}, sbprOLetter},   // Lo   [5] ARABIC FATHATAN ISOLATED FORM..ARABIC KASRATAN ISOLATED FORM
+	{runeRange{0xFF08, 0xFF08}, sbprClose},     // Ps       FULLWIDTH LEFT PARENTHESIS
+	{runeRange{0xFF0E, 0xFF0E}, sbprATerm},     // Po       FULLWIDTH FULL STOP
+	{runeRange{0xFF21, 0xFF3A}, sbprUpper},     // L&  [26] FULLWIDTH LATIN CAPITAL LETTER A..FULLWIDTH LATIN CAPITAL LETTER Z
+	{runeRange{0xFF5B, 0xFF5B}, sbprClose},     // Ps       FULLWIDTH LEFT CURLY BRACKET
+	{runeRange{0xFF61, 0xFF61}, sbprSTerm},     // Po       HALFWIDTH IDEOGRAPHIC FULL STOP
+	{runeRange{0xFF66, 0xFF6F}, sbprOLetter},   // Lo  [10] HALFWIDTH KATAKANA LETTER WO..HALFWIDTH KATAKANA LETTER SMALL TU
+	{runeRange{0xFFA0, 0xFFBE}, sbprOLetter},   // Lo  [31] HALFWIDTH HANGUL FILLER..HALFWIDTH HANGUL LETTER HIEUH
+	{runeRange{0xFFDA, 0xFFDC}, sbprOLetter},   // Lo   [3] HALFWIDTH HANGUL LETTER EU..HALFWIDTH HANGUL LETTER I
+	{runeRange{0x10028, 0x1003A}, sbprOLetter}, // Lo  [19] LINEAR B SYLLABLE B060 RA..LINEAR B SYLLABLE B042 WO
+	{runeRange{0x10080, 0x100FA}, sbprOLetter}, // Lo [123] LINEAR B IDEOGRAM B100 MAN..LINEAR B IDEOGRAM VESSEL B305
+	{runeRange{0x102A0, 0x102D0}, sbprOLetter}, // Lo  [49] CARIAN LETTER A..CARIAN LETTER UUU3
+	{runeRange{0x10341, 0x10341}, sbprOLetter}, // Nl       GOTHIC LETTER NINETY
+	{runeRange{0x10376, 0x1037A}, sbprExtend},  // Mn   [5] COMBINING OLD PERMIC LETTER AN..COMBINING OLD PERMIC LETTER SII
+	{runeRange{0x103D1, 0x103D5}, sbprOLetter}, // Nl   [5] OLD PERSIAN NUMBER ONE..OLD PERSIAN NUMBER HUNDRED
+	{runeRange{0x104A0, 0x104A9}, sbprNumeric}, // Nd  [10] OSMANYA DIGIT ZERO..OSMANYA DIGIT NINE
+	{runeRange{0x10530, 0x10563}, sbprOLetter}, // Lo  [52] CAUCASIAN ALBANIAN LETTER ALT..CAUCASIAN ALBANIAN LETTER KIW
+	{runeRange{0x10594, 0x10595}, sbprUpper},   // L&   [2] VITHKUQI CAPITAL LETTER Y..VITHKUQI CAPITAL LETTER ZE
+	{runeRange{0x105BB, 0x105BC}, sbprLower},   // L&   [2] VITHKUQI SMALL LETTER Y..VITHKUQI SMALL LETTER ZE
+	{runeRange{0x10780, 0x10780}, sbprLower},   // Lm       MODIFIER LETTER SMALL CAPITAL AA
+	{runeRange{0x107B2, 0x107BA}, sbprLower},   // Lm   [9] MODIFIER LETTER SMALL CAPITAL Y..MODIFIER LETTER SMALL S WITH CURL
+	{runeRange{0x10837, 0x10838}, sbprOLetter}, // Lo   [2] CYPRIOT SYLLABLE XA..CYPRIOT SYLLABLE XE
+	{runeRange{0x10880, 0x1089E}, sbprOLetter}, // Lo  [31] NABATAEAN LETTER FINAL ALEPH..NABATAEAN LETTER TAW
+	{runeRange{0x10920, 0x10939}, sbprOLetter}, // Lo  [26] LYDIAN LETTER A..LYDIAN LETTER C
+	{runeRange{0x10A01, 0x10A03}, sbprExtend},  // Mn   [3] KHAROSHTHI VOWEL SIGN I..KHAROSHTHI VOWEL SIGN VOCALIC R
+	{runeRange{0x10A15, 0x10A17}, sbprOLetter}, // Lo   [3] KHAROSHTHI LETTER CA..KHAROSHTHI LETTER JA
+	{runeRange{0x10A56, 0x10A57}, sbprSTerm},   // Po   [2] KHAROSHTHI PUNCTUATION DANDA..KHAROSHTHI PUNCTUATION DOUBLE DANDA
+	{runeRange{0x10AC9, 0x10AE4}, sbprOLetter}, // Lo  [28] MANICHAEAN LETTER ZAYIN..MANICHAEAN LETTER TAW
+	{runeRange{0x10B60, 0x10B72}, sbprOLetter}, // Lo  [19] INSCRIPTIONAL PAHLAVI LETTER ALEPH..INSCRIPTIONAL PAHLAVI LETTER TAW
+	{runeRange{0x10CC0, 0x10CF2}, sbprLower},   // L&  [51] OLD HUNGARIAN SMALL LETTER A..OLD HUNGARIAN SMALL LETTER US
+	{runeRange{0x10E80, 0x10EA9}, sbprOLetter}, // Lo  [42] YEZIDI LETTER ELIF..YEZIDI LETTER ET
+	{runeRange{0x10F00, 0x10F1C}, sbprOLetter}, // Lo  [29] OLD SOGDIAN LETTER ALEPH..OLD SOGDIAN LETTER FINAL TAW WITH VERTICAL TAIL
+	{runeRange{0x10F55, 0x10F59}, sbprSTerm},   // Po   [5] SOGDIAN PUNCTUATION TWO VERTICAL BARS..SOGDIAN PUNCTUATION HALF CIRCLE WITH DOT
+	{runeRange{0x10FB0, 0x10FC4}, sbprOLetter}, // Lo  [21] CHORASMIAN LETTER ALEPH..CHORASMIAN LETTER TAW
+	{runeRange{0x11002, 0x11002}, sbprExtend},  // Mc       BRAHMI SIGN VISARGA
+	{runeRange{0x11066, 0x1106F}, sbprNumeric}, // Nd  [10] BRAHMI DIGIT ZERO..BRAHMI DIGIT NINE
+	{runeRange{0x11075, 0x11075}, sbprOLetter}, // Lo       BRAHMI LETTER OLD TAMIL LLA
+	{runeRange{0x110B0, 0x110B2}, sbprExtend},  // Mc   [3] KAITHI VOWEL SIGN AA..KAITHI VOWEL SIGN II
+	{runeRange{0x110BD, 0x110BD}, sbprFormat},  // Cf       KAITHI NUMBER SIGN
+	{runeRange{0x110D0, 0x110E8}, sbprOLetter}, // Lo  [25] SORA SOMPENG LETTER SAH..SORA SOMPENG LETTER MAE
+	{runeRange{0x11127, 0x1112B}, sbprExtend},  // Mn   [5] CHAKMA VOWEL SIGN A..CHAKMA VOWEL SIGN UU
+	{runeRange{0x11141, 0x11143}, sbprSTerm},   // Po   [3] CHAKMA DANDA..CHAKMA QUESTION MARK
+	{runeRange{0x11150, 0x11172}, sbprOLetter}, // Lo  [35] MAHAJANI LETTER A..MAHAJANI LETTER RRA
+	{runeRange{0x11182, 0x11182}, sbprExtend},  // Mc       SHARADA SIGN VISARGA
+	{runeRange{0x111BF, 0x111C0}, sbprExtend},  // Mc   [2] SHARADA VOWEL SIGN AU..SHARADA SIGN VIRAMA
+	{runeRange{0x111CD, 0x111CD}, sbprSTerm},   // Po       SHARADA SUTRA MARK
+	{runeRange{0x111DA, 0x111DA}, sbprOLetter}, // Lo       SHARADA EKAM
+	{runeRange{0x11213, 0x1122B}, sbprOLetter}, // Lo  [25] KHOJKI LETTER NYA..KHOJKI LETTER LLA
+	{runeRange{0x11234, 0x11234}, sbprExtend},  // Mn       KHOJKI SIGN ANUSVARA
+	{runeRange{0x1123B, 0x1123C}, sbprSTerm},   // Po   [2] KHOJKI SECTION MARK..KHOJKI DOUBLE SECTION MARK
+	{runeRange{0x11280, 0x11286}, sbprOLetter}, // Lo   [7] MULTANI LETTER A..MULTANI LETTER GA
+	{runeRange{0x1129F, 0x112A8}, sbprOLetter}, // Lo  [10] MULTANI LETTER BHA..MULTANI LETTER RHA
+	{runeRange{0x112E0, 0x112E2}, sbprExtend},  // Mc   [3] KHUDAWADI VOWEL SIGN AA..KHUDAWADI VOWEL SIGN II
+	{runeRange{0x11302, 0x11303}, sbprExtend},  // Mc   [2] GRANTHA SIGN ANUSVARA..GRANTHA SIGN VISARGA
+	{runeRange{0x1132A, 0x11330}, sbprOLetter}, // Lo   [7] GRANTHA LETTER PA..GRANTHA LETTER RA
+	{runeRange{0x1133D, 0x1133D}, sbprOLetter}, // Lo       GRANTHA SIGN AVAGRAHA
+	{runeRange{0x11347, 0x11348}, sbprExtend},  // Mc   [2] GRANTHA VOWEL SIGN EE..GRANTHA VOWEL SIGN AI
+	{runeRange{0x1135D, 0x11361}, sbprOLetter}, // Lo   [5] GRANTHA SIGN PLUTA..GRANTHA LETTER VOCALIC LL
+	{runeRange{0x11400, 0x11434}, sbprOLetter}, // Lo  [53] NEWA LETTER A..NEWA LETTER HA
+	{runeRange{0x11442, 0x11444}, sbprExtend},  // Mn   [3] NEWA SIGN VIRAMA..NEWA SIGN ANUSVARA
+	{runeRange{0x1144B, 0x1144C}, sbprSTerm},   // Po   [2] NEWA DANDA..NEWA DOUBLE DANDA
+	{runeRange{0x11480, 0x114AF}, sbprOLetter}, // Lo  [48] TIRHUTA ANJI..TIRHUTA LETTER HA
+	{runeRange{0x114BA, 0x114BA}, sbprExtend},  // Mn       TIRHUTA VOWEL SIGN SHORT E
+	{runeRange{0x114C2, 0x114C3}, sbprExtend},  // Mn   [2] TIRHUTA SIGN VIRAMA..TIRHUTA SIGN NUKTA
+	{runeRange{0x11580, 0x115AE}, sbprOLetter}, // Lo  [47] SIDDHAM LETTER A..SIDDHAM LETTER HA
+	{runeRange{0x115BC, 0x115BD}, sbprExtend},  // Mn   [2] SIDDHAM SIGN CANDRABINDU..SIDDHAM SIGN ANUSVARA
+	{runeRange{0x115C9, 0x115D7}, sbprSTerm},   // Po  [15] SIDDHAM END OF TEXT MARK..SIDDHAM SECTION MARK WITH CIRCLES AND FOUR ENCLOSURES
+	{runeRange{0x11630, 0x11632}, sbprExtend},  // Mc   [3] MODI VOWEL SIGN AA..MODI VOWEL SIGN II
+	{runeRange{0x1163E, 0x1163E}, sbprExtend},  // Mc       MODI SIGN VISARGA
+	{runeRange{0x11650, 0x11659}, sbprNumeric}, // Nd  [10] MODI DIGIT ZERO..MODI DIGIT NINE
+	{runeRange{0x116AD, 0x116AD}, sbprExtend},  // Mn       TAKRI VOWEL SIGN AA
+	{runeRange{0x116B7, 0x116B7}, sbprExtend},  // Mn       TAKRI SIGN NUKTA
+	{runeRange{0x1171D, 0x1171F}, sbprExtend},  // Mn   [3] AHOM CONSONANT SIGN MEDIAL LA..AHOM CONSONANT SIGN MEDIAL LIGATING RA
+	{runeRange{0x11727, 0x1172B}, sbprExtend},  // Mn   [5] AHOM VOWEL SIGN AW..AHOM SIGN KILLER
+	{runeRange{0x11800, 0x1182B}, sbprOLetter}, // Lo  [44] DOGRA LETTER A..DOGRA LETTER RRA
+	{runeRange{0x11839, 0x1183A}, sbprExtend},  // Mn   [2] DOGRA SIGN VIRAMA..DOGRA SIGN NUKTA
+	{runeRange{0x118FF, 0x11906}, sbprOLetter}, // Lo   [8] WARANG CITI OM..DIVES AKURU LETTER E
+	{runeRange{0x11918, 0x1192F}, sbprOLetter}, // Lo  [24] DIVES AKURU LETTER DDA..DIVES AKURU LETTER ZA
+	{runeRange{0x1193D, 0x1193D}, sbprExtend},  // Mc       DIVES AKURU SIGN HALANTA
+	{runeRange{0x11941, 0x11941}, sbprOLetter}, // Lo       DIVES AKURU INITIAL RA
+	{runeRange{0x11946, 0x11946}, sbprSTerm},   // Po       DIVES AKURU END OF TEXT MARK
+	{runeRange{0x119D1, 0x119D3}, sbprExtend},  // Mc   [3] NANDINAGARI VOWEL SIGN AA..NANDINAGARI VOWEL SIGN II
+	{runeRange{0x119E0, 0x119E0}, sbprExtend},  // Mn       NANDINAGARI SIGN VIRAMA
+	{runeRange{0x11A00, 0x11A00}, sbprOLetter}, // Lo       ZANABAZAR SQUARE LETTER A
+	{runeRange{0x11A39, 0x11A39}, sbprExtend},  // Mc       ZANABAZAR SQUARE SIGN VISARGA
+	{runeRange{0x11A47, 0x11A47}, sbprExtend},  // Mn       ZANABAZAR SQUARE SUBJOINER
+	{runeRange{0x11A59, 0x11A5B}, sbprExtend},  // Mn   [3] SOYOMBO VOWEL SIGN VOCALIC R..SOYOMBO VOWEL LENGTH MARK
+	{runeRange{0x11A98, 0x11A99}, sbprExtend},  // Mn   [2] SOYOMBO GEMINATION MARK..SOYOMBO SUBJOINER
+	{runeRange{0x11C00, 0x11C08}, sbprOLetter}, // Lo   [9] BHAIKSUKI LETTER A..BHAIKSUKI LETTER VOCALIC L
+	{runeRange{0x11C38, 0x11C3D}, sbprExtend},  // Mn   [6] BHAIKSUKI VOWEL SIGN E..BHAIKSUKI SIGN ANUSVARA
+	{runeRange{0x11C41, 0x11C42}, sbprSTerm},   // Po   [2] BHAIKSUKI DANDA..BHAIKSUKI DOUBLE DANDA
+	{runeRange{0x11CA9, 0x11CA9}, sbprExtend},  // Mc       MARCHEN SUBJOINED LETTER YA
+	{runeRange{0x11CB4, 0x11CB4}, sbprExtend},  // Mc       MARCHEN VOWEL SIGN O
+	{runeRange{0x11D0B, 0x11D30}, sbprOLetter}, // Lo  [38] MASARAM GONDI LETTER AU..MASARAM GONDI LETTER TRA
+	{runeRange{0x11D3F, 0x11D45}, sbprExtend},  // Mn   [7] MASARAM GONDI VOWEL SIGN AU..MASARAM GONDI VIRAMA
+	{runeRange{0x11D60, 0x11D65}, sbprOLetter}, // Lo   [6] GUNJALA GONDI LETTER A..GUNJALA GONDI LETTER UU
+	{runeRange{0x11D90, 0x11D91}, sbprExtend},  // Mn   [2] GUNJALA GONDI VOWEL SIGN EE..GUNJALA GONDI VOWEL SIGN AI
+	{runeRange{0x11D97, 0x11D97}, sbprExtend},  // Mn       GUNJALA GONDI VIRAMA
+	{runeRange{0x11EF3, 0x11EF4}, sbprExtend},  // Mn   [2] MAKASAR VOWEL SIGN I..MAKASAR VOWEL SIGN U
+	{runeRange{0x11F02, 0x11F02}, sbprOLetter}, // Lo       KAWI SIGN REPHA
+	{runeRange{0x11F34, 0x11F35}, sbprExtend},  // Mc   [2] KAWI VOWEL SIGN AA..KAWI VOWEL SIGN ALTERNATE AA
+	{runeRange{0x11F41, 0x11F41}, sbprExtend},  // Mc       KAWI SIGN KILLER
+	{runeRange{0x11FB0, 0x11FB0}, sbprOLetter}, // Lo       LISU LETTER YHA
+	{runeRange{0x12F90, 0x12FF0}, sbprOLetter}, // Lo  [97] CYPRO-MINOAN SIGN CM001..CYPRO-MINOAN SIGN CM114
+	{runeRange{0x13441, 0x13446}, sbprOLetter}, // Lo   [6] EGYPTIAN HIEROGLYPH FULL BLANK..EGYPTIAN HIEROGLYPH WIDE LOST SIGN
+	{runeRange{0x16A40, 0x16A5E}, sbprOLetter}, // Lo  [31] MRO LETTER TA..MRO LETTER TEK
+	{runeRange{0x16AC0, 0x16AC9}, sbprNumeric}, // Nd  [10] TANGSA DIGIT ZERO..TANGSA DIGIT NINE
+	{runeRange{0x16B00, 0x16B2F}, sbprOLetter}, // Lo  [48] PAHAWH HMONG VOWEL KEEB..PAHAWH HMONG CONSONANT CAU
+	{runeRange{0x16B44, 0x16B44}, sbprSTerm},   // Po       PAHAWH HMONG SIGN XAUS
+	{runeRange{0x16E40, 0x16E5F}, sbprUpper},   // L&  [32] MEDEFAIDRIN CAPITAL LETTER M..MEDEFAIDRIN CAPITAL LETTER Y
+	{runeRange{0x16F4F, 0x16F4F}, sbprExtend},  // Mn       MIAO SIGN CONSONANT MODIFIER BAR
+	{runeRange{0x16F93, 0x16F9F}, sbprOLetter}, // Lm  [13] MIAO LETTER TONE-2..MIAO LETTER REFORMED TONE-8
+	{runeRange{0x16FF0, 0x16FF1}, sbprExtend},  // Mc   [2] VIETNAMESE ALTERNATE READING MARK CA..VIETNAMESE ALTERNATE READING MARK NHAY
+	{runeRange{0x1AFF0, 0x1AFF3}, sbprOLetter}, // Lm   [4] KATAKANA LETTER MINNAN TONE-2..KATAKANA LETTER MINNAN TONE-5
+	{runeRange{0x1B132, 0x1B132}, sbprOLetter}, // Lo       HIRAGANA LETTER SMALL KO
+	{runeRange{0x1B170, 0x1B2FB}, sbprOLetter}, // Lo [396] NUSHU CHARACTER-1B170..NUSHU CHARACTER-1B2FB
+	{runeRange{0x1BC90, 0x1BC99}, sbprOLetter}, // Lo  [10] DUPLOYAN AFFIX LOW ACUTE..DUPLOYAN AFFIX LOW ARROW
+	{runeRange{0x1CF00, 0x1CF2D}, sbprExtend},  // Mn  [46] ZNAMENNY COMBINING MARK GORAZDO NIZKO S KRYZHEM ON LEFT..ZNAMENNY COMBINING MARK KRYZH ON LEFT
+	{runeRange{0x1D16D, 0x1D172}, sbprExtend},  // Mc   [6] MUSICAL SYMBOL COMBINING AUGMENTATION DOT..MUSICAL SYMBOL COMBINING FLAG-5
+	{runeRange{0x1D1AA, 0x1D1AD}, sbprExtend},  // Mn   [4] MUSICAL SYMBOL COMBINING DOWN BOW..MUSICAL SYMBOL COMBINING SNAP PIZZICATO
+	{runeRange{0x1D434, 0x1D44D}, sbprUpper},   // L&  [26] MATHEMATICAL ITALIC CAPITAL A..MATHEMATICAL ITALIC CAPITAL Z
+	{runeRange{0x1D482, 0x1D49B}, sbprLower},   // L&  [26] MATHEMATICAL BOLD ITALIC SMALL A..MATHEMATICAL BOLD ITALIC SMALL Z
+	{runeRange{0x1D4A5, 0x1D4A6}, sbprUpper},   // L&   [2] MATHEMATICAL SCRIPT CAPITAL J..MATHEMATICAL SCRIPT CAPITAL K
+	{runeRange{0x1D4BB, 0x1D4BB}, sbprLower},   // L&       MATHEMATICAL SCRIPT SMALL F
+	{runeRange{0x1D4EA, 0x1D503}, sbprLower},   // L&  [26] MATHEMATICAL BOLD SCRIPT SMALL A..MATHEMATICAL BOLD SCRIPT SMALL Z
+	{runeRange{0x1D516, 0x1D51C}, sbprUpper},   // L&   [7] MATHEMATICAL FRAKTUR CAPITAL S..MATHEMATICAL FRAKTUR CAPITAL Y
+	{runeRange{0x1D540, 0x1D544}, sbprUpper},   // L&   [5] MATHEMATICAL DOUBLE-STRUCK CAPITAL I..MATHEMATICAL DOUBLE-STRUCK CAPITAL M
+	{runeRange{0x1D56C, 0x1D585}, sbprUpper},   // L&  [26] MATHEMATICAL BOLD FRAKTUR CAPITAL A..MATHEMATICAL BOLD FRAKTUR CAPITAL Z
+	{runeRange{0x1D5D4, 0x1D5ED}, sbprUpper},   // L&  [26] MATHEMATICAL SANS-SERIF BOLD CAPITAL A..MATHEMATICAL SANS-SERIF BOLD CAPITAL Z
+	{runeRange{0x1D63C, 0x1D655}, sbprUpper},   // L&  [26] MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL A..MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL Z
+	{runeRange{0x1D6A8, 0x1D6C0}, sbprUpper},   // L&  [25] MATHEMATICAL BOLD CAPITAL ALPHA..MATHEMATICAL BOLD CAPITAL OMEGA
+	{runeRange{0x1D6FC, 0x1D714}, sbprLower},   // L&  [25] MATHEMATICAL ITALIC SMALL ALPHA..MATHEMATICAL ITALIC SMALL OMEGA
+	{runeRange{0x1D750, 0x1D755}, sbprLower},   // L&   [6] MATHEMATICAL BOLD ITALIC EPSILON SYMBOL..MATHEMATICAL BOLD ITALIC PI SYMBOL
+	{runeRange{0x1D790, 0x1D7A8}, sbprUpper},   // L&  [25] MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL ALPHA..MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL OMEGA
+	{runeRange{0x1D7CB, 0x1D7CB}, sbprLower},   // L&       MATHEMATICAL BOLD SMALL DIGAMMA
+	{runeRange{0x1DA75, 0x1DA75}, sbprExtend},  // Mn       SIGNWRITING UPPER BODY TILTING FROM HIP JOINTS
+	{runeRange{0x1DAA1, 0x1DAAF}, sbprExtend},  // Mn  [15] SIGNWRITING ROTATION MODIFIER-2..SIGNWRITING ROTATION MODIFIER-16
+	{runeRange{0x1DF25, 0x1DF2A}, sbprLower},   // L&   [6] LATIN SMALL LETTER D WITH MID-HEIGHT LEFT HOOK..LATIN SMALL LETTER T WITH MID-HEIGHT LEFT HOOK
+	{runeRange{0x1E023, 0x1E024}, sbprExtend},  // Mn   [2] COMBINING GLAGOLITIC LETTER YU..COMBINING GLAGOLITIC LETTER SMALL YUS
+	{runeRange{0x1E100, 0x1E12C}, sbprOLetter}, // Lo  [45] NYIAKENG PUACHUE HMONG LETTER MA..NYIAKENG PUACHUE HMONG LETTER W
+	{runeRange{0x1E14E, 0x1E14E}, sbprOLetter}, // Lo       NYIAKENG PUACHUE HMONG LOGOGRAM NYAJ
+	{runeRange{0x1E2EC, 0x1E2EF}, sbprExtend},  // Mn   [4] WANCHO TONE TUP..WANCHO TONE KOINI
+	{runeRange{0x1E4EC, 0x1E4EF}, sbprExtend},  // Mn   [4] NAG MUNDARI SIGN MUHOR..NAG MUNDARI SIGN SUTUH
+	{runeRange{0x1E7ED, 0x1E7EE}, sbprOLetter}, // Lo   [2] ETHIOPIC SYLLABLE GURAGE MWI..ETHIOPIC SYLLABLE GURAGE MWEE
+	{runeRange{0x1E900, 0x1E921}, sbprUpper},   // L&  [34] ADLAM CAPITAL LETTER ALIF..ADLAM CAPITAL LETTER SHA
+	{runeRange{0x1E950, 0x1E959}, sbprNumeric}, // Nd  [10] ADLAM DIGIT ZERO..ADLAM DIGIT NINE
+	{runeRange{0x1EE24, 0x1EE24}, sbprOLetter}, // Lo       ARABIC MATHEMATICAL INITIAL HEH
+	{runeRange{0x1EE39, 0x1EE39}, sbprOLetter}, // Lo       ARABIC MATHEMATICAL INITIAL DAD
+	{runeRange{0x1EE49, 0x1EE49}, sbprOLetter}, // Lo       ARABIC MATHEMATICAL TAILED YEH
+	{runeRange{0x1EE54, 0x1EE54}, sbprOLetter}, // Lo       ARABIC MATHEMATICAL TAILED SHEEN
+	{runeRange{0x1EE5D, 0x1EE5D}, sbprOLetter}, // Lo       ARABIC MATHEMATICAL TAILED DOTLESS NOON
+	{runeRange{0x1EE67, 0x1EE6A}, sbprOLetter}, // Lo   [4] ARABIC MATHEMATICAL STRETCHED HAH..ARABIC MATHEMATICAL STRETCHED KAF
+	{runeRange{0x1EE7E, 0x1EE7E}, sbprOLetter}, // Lo       ARABIC MATHEMATICAL STRETCHED DOTLESS FEH
+	{runeRange{0x1EEA5, 0x1EEA9}, sbprOLetter}, // Lo   [5] ARABIC MATHEMATICAL DOUBLE-STRUCK WAW..ARABIC MATHEMATICAL DOUBLE-STRUCK YEH
+	{runeRange{0x1F170, 0x1F189}, sbprUpper},   // So  [26] NEGATIVE SQUARED LATIN CAPITAL LETTER A..NEGATIVE SQUARED LATIN CAPITAL LETTER Z
+	{runeRange{0x2A700, 0x2B739}, sbprOLetter}, // Lo [4154] CJK UNIFIED IDEOGRAPH-2A700..CJK UNIFIED IDEOGRAPH-2B739
+	{runeRange{0x2F800, 0x2FA1D}, sbprOLetter}, // Lo [542] CJK COMPATIBILITY IDEOGRAPH-2F800..CJK COMPATIBILITY IDEOGRAPH-2FA1D
 	{runeRange{0xE0020, 0xE007F}, sbprExtend},  // Cf  [96] TAG SPACE..CANCEL TAG
+	{runeRange{0x000A, 0x000A}, sbprLF},        // Cc       <control-000A>
+	{runeRange{0x0021, 0x0021}, sbprSTerm},     // Po       EXCLAMATION MARK
+	{runeRange{0x0029, 0x0029}, sbprClose},     // Pe       RIGHT PARENTHESIS
+	{runeRange{0x0030, 0x0039}, sbprNumeric},   // Nd  [10] DIGIT ZERO..DIGIT NINE
+	{runeRange{0x005B, 0x005B}, sbprClose},     // Ps       LEFT SQUARE BRACKET
+	{runeRange{0x007D, 0x007D}, sbprClose},     // Pe       RIGHT CURLY BRACKET
+	{runeRange{0x00AB, 0x00AB}, sbprClose},     // Pi       LEFT-POINTING DOUBLE ANGLE QUOTATION MARK
+	{runeRange{0x00BB, 0x00BB}, sbprClose},     // Pf       RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK
+	{runeRange{0x00F8, 0x00FF}, sbprLower},     // L&   [8] LATIN SMALL LETTER O WITH STROKE..LATIN SMALL LETTER Y WITH DIAERESIS
+	{runeRange{0x0103, 0x0103}, sbprLower},     // L&       LATIN SMALL LETTER A WITH BREVE
+	{runeRange{0x0107, 0x0107}, sbprLower},     // L&       LATIN SMALL LETTER C WITH ACUTE
+	{runeRange{0x010B, 0x010B}, sbprLower},     // L&       LATIN SMALL LETTER C WITH DOT ABOVE
+	{runeRange{0x010F, 0x010F}, sbprLower},     // L&       LATIN SMALL LETTER D WITH CARON
+	{runeRange{0x0113, 0x0113}, sbprLower},     // L&       LATIN SMALL LETTER E WITH MACRON
+	{runeRange{0x0117, 0x0117}, sbprLower},     // L&       LATIN SMALL LETTER E WITH DOT ABOVE
+	{runeRange{0x011B, 0x011B}, sbprLower},     // L&       LATIN SMALL LETTER E WITH CARON
+	{runeRange{0x011F, 0x011F}, sbprLower},     // L&       LATIN SMALL LETTER G WITH BREVE
+	{runeRange{0x0123, 0x0123}, sbprLower},     // L&       LATIN SMALL LETTER G WITH CEDILLA
+	{runeRange{0x0127, 0x0127}, sbprLower},     // L&       LATIN SMALL LETTER H WITH STROKE
+	{runeRange{0x012B, 0x012B}, sbprLower},     // L&       LATIN SMALL LETTER I WITH MACRON
+	{runeRange{0x012F, 0x012F}, sbprLower},     // L&       LATIN SMALL LETTER I WITH OGONEK
+	{runeRange{0x0133, 0x0133}, sbprLower},     // L&       LATIN SMALL LIGATURE IJ
+	{runeRange{0x0137, 0x0138}, sbprLower},     // L&   [2] LATIN SMALL LETTER K WITH CEDILLA..LATIN SMALL LETTER KRA
+	{runeRange{0x013C, 0x013C}, sbprLower},     // L&       LATIN SMALL LETTER L WITH CEDILLA
+	{runeRange{0x0140, 0x0140}, sbprLower},     // L&       LATIN SMALL LETTER L WITH MIDDLE DOT
+	{runeRange{0x0144, 0x0144}, sbprLower},     // L&       LATIN SMALL LETTER N WITH ACUTE
+	{runeRange{0x0148, 0x0149}, sbprLower},     // L&   [2] LATIN SMALL LETTER N WITH CARON..LATIN SMALL LETTER N PRECEDED BY APOSTROPHE
+	{runeRange{0x014D, 0x014D}, sbprLower},     // L&       LATIN SMALL LETTER O WITH MACRON
+	{runeRange{0x0151, 0x0151}, sbprLower},     // L&       LATIN SMALL LETTER O WITH DOUBLE ACUTE
+	{runeRange{0x0155, 0x0155}, sbprLower},     // L&       LATIN SMALL LETTER R WITH ACUTE
+	{runeRange{0x0159, 0x0159}, sbprLower},     // L&       LATIN SMALL LETTER R WITH CARON
+	{runeRange{0x015D, 0x015D}, sbprLower},     // L&       LATIN SMALL LETTER S WITH CIRCUMFLEX
+	{runeRange{0x0161, 0x0161}, sbprLower},     // L&       LATIN SMALL LETTER S WITH CARON
+	{runeRange{0x0165, 0x0165}, sbprLower},     // L&       LATIN SMALL LETTER T WITH CARON
+	{runeRange{0x0169, 0x0169}, sbprLower},     // L&       LATIN SMALL LETTER U WITH TILDE
+	{runeRange{0x016D, 0x016D}, sbprLower},     // L&       LATIN SMALL LETTER U WITH BREVE
+	{runeRange{0x0171, 0x0171}, sbprLower},     // L&       LATIN SMALL LETTER U WITH DOUBLE ACUTE
+	{runeRange{0x0175, 0x0175}, sbprLower},     // L&       LATIN SMALL LETTER W WITH CIRCUMFLEX
+	{runeRange{0x017A, 0x017A}, sbprLower},     // L&       LATIN SMALL LETTER Z WITH ACUTE
+	{runeRange{0x017E, 0x0180}, sbprLower},     // L&   [3] LATIN SMALL LETTER Z WITH CARON..LATIN SMALL LETTER B WITH STROKE
+	{runeRange{0x0185, 0x0185}, sbprLower},     // L&       LATIN SMALL LETTER TONE SIX
+	{runeRange{0x018C, 0x018D}, sbprLower},     // L&   [2] LATIN SMALL LETTER D WITH TOPBAR..LATIN SMALL LETTER TURNED DELTA
+	{runeRange{0x0195, 0x0195}, sbprLower},     // L&       LATIN SMALL LETTER HV
+	{runeRange{0x019E, 0x019E}, sbprLower},     // L&       LATIN SMALL LETTER N WITH LONG RIGHT LEG
+	{runeRange{0x01A3, 0x01A3}, sbprLower},     // L&       LATIN SMALL LETTER OI
+	{runeRange{0x01A8, 0x01A8}, sbprLower},     // L&       LATIN SMALL LETTER TONE TWO
+	{runeRange{0x01AD, 0x01AD}, sbprLower},     // L&       LATIN SMALL LETTER T WITH HOOK
+	{runeRange{0x01B4, 0x01B4}, sbprLower},     // L&       LATIN SMALL LETTER Y WITH HOOK
+	{runeRange{0x01B9, 0x01BA}, sbprLower},     // L&   [2] LATIN SMALL LETTER EZH REVERSED..LATIN SMALL LETTER EZH WITH TAIL
+	{runeRange{0x01C0, 0x01C3}, sbprOLetter},   // Lo   [4] LATIN LETTER DENTAL CLICK..LATIN LETTER RETROFLEX CLICK
+	{runeRange{0x01C9, 0x01C9}, sbprLower},     // L&       LATIN SMALL LETTER LJ
+	{runeRange{0x01CE, 0x01CE}, sbprLower},     // L&       LATIN SMALL LETTER A WITH CARON
+	{runeRange{0x01D2, 0x01D2}, sbprLower},     // L&       LATIN SMALL LETTER O WITH CARON
+	{runeRange{0x01D6, 0x01D6}, sbprLower},     // L&       LATIN SMALL LETTER U WITH DIAERESIS AND MACRON
+	{runeRange{0x01DA, 0x01DA}, sbprLower},     // L&       LATIN SMALL LETTER U WITH DIAERESIS AND CARON
+	{runeRange{0x01DF, 0x01DF}, sbprLower},     // L&       LATIN SMALL LETTER A WITH DIAERESIS AND MACRON
+	{runeRange{0x01E3, 0x01E3}, sbprLower},     // L&       LATIN SMALL LETTER AE WITH MACRON
+	{runeRange{0x01E7, 0x01E7}, sbprLower},     // L&       LATIN SMALL LETTER G WITH CARON
+	{runeRange{0x01EB, 0x01EB}, sbprLower},     // L&       LATIN SMALL LETTER O WITH OGONEK
+	{runeRange{0x01EF, 0x01F0}, sbprLower},     // L&   [2] LATIN SMALL LETTER EZH WITH CARON..LATIN SMALL LETTER J WITH CARON
+	{runeRange{0x01F5, 0x01F5}, sbprLower},     // L&       LATIN SMALL LETTER G WITH ACUTE
+	{runeRange{0x01FB, 0x01FB}, sbprLower},     // L&       LATIN SMALL LETTER A WITH RING ABOVE AND ACUTE
+	{runeRange{0x01FF, 0x01FF}, sbprLower},     // L&       LATIN SMALL LETTER O WITH STROKE AND ACUTE
+	{runeRange{0x0203, 0x0203}, sbprLower},     // L&       LATIN SMALL LETTER A WITH INVERTED BREVE
+	{runeRange{0x0207, 0x0207}, sbprLower},     // L&       LATIN SMALL LETTER E WITH INVERTED BREVE
+	{runeRange{0x020B, 0x020B}, sbprLower},     // L&       LATIN SMALL LETTER I WITH INVERTED BREVE
+	{runeRange{0x020F, 0x020F}, sbprLower},     // L&       LATIN SMALL LETTER O WITH INVERTED BREVE
+	{runeRange{0x0213, 0x0213}, sbprLower},     // L&       LATIN SMALL LETTER R WITH INVERTED BREVE
+	{runeRange{0x0217, 0x0217}, sbprLower},     // L&       LATIN SMALL LETTER U WITH INVERTED BREVE
+	{runeRange{0x021B, 0x021B}, sbprLower},     // L&       LATIN SMALL LETTER T WITH COMMA BELOW
+	{runeRange{0x021F, 0x021F}, sbprLower},     // L&       LATIN SMALL LETTER H WITH CARON
+	{runeRange{0x0223, 0x0223}, sbprLower},     // L&       LATIN SMALL LETTER OU
+	{runeRange{0x0227, 0x0227}, sbprLower},     // L&       LATIN SMALL LETTER A WITH DOT ABOVE
+	{runeRange{0x022B, 0x022B}, sbprLower},     // L&       LATIN SMALL LETTER O WITH DIAERESIS AND MACRON
+	{runeRange{0x022F, 0x022F}, sbprLower},     // L&       LATIN SMALL LETTER O WITH DOT ABOVE
+	{runeRange{0x0233, 0x0239}, sbprLower},     // L&   [7] LATIN SMALL LETTER Y WITH MACRON..LATIN SMALL LETTER QP DIGRAPH
+	{runeRange{0x023F, 0x0240}, sbprLower},     // L&   [2] LATIN SMALL LETTER S WITH SWASH TAIL..LATIN SMALL LETTER Z WITH SWASH TAIL
+	{runeRange{0x0247, 0x0247}, sbprLower},     // L&       LATIN SMALL LETTER E WITH STROKE
+	{runeRange{0x024B, 0x024B}, sbprLower},     // L&       LATIN SMALL LETTER Q WITH HOOK TAIL
+	{runeRange{0x024F, 0x0293}, sbprLower},     // L&  [69] LATIN SMALL LETTER Y WITH STROKE..LATIN SMALL LETTER EZH WITH CURL
+	{runeRange{0x02B9, 0x02BF}, sbprOLetter},   // Lm   [7] MODIFIER LETTER PRIME..MODIFIER LETTER LEFT HALF RING
+	{runeRange{0x02EC, 0x02EC}, sbprOLetter},   // Lm       MODIFIER LETTER VOICING
+	{runeRange{0x0371, 0x0371}, sbprLower},     // L&       GREEK SMALL LETTER HETA
+	{runeRange{0x0376, 0x0376}, sbprUpper},     // L&       GREEK CAPITAL LETTER PAMPHYLIAN DIGAMMA
+	{runeRange{0x037F, 0x037F}, sbprUpper},     // L&       GREEK CAPITAL LETTER YOT
+	{runeRange{0x038E, 0x038F}, sbprUpper},     // L&   [2] GREEK CAPITAL LETTER UPSILON WITH TONOS..GREEK CAPITAL LETTER OMEGA WITH TONOS
+	{runeRange{0x03AC, 0x03CE}, sbprLower},     // L&  [35] GREEK SMALL LETTER ALPHA WITH TONOS..GREEK SMALL LETTER OMEGA WITH TONOS
+	{runeRange{0x03D5, 0x03D7}, sbprLower},     // L&   [3] GREEK PHI SYMBOL..GREEK KAI SYMBOL
+	{runeRange{0x03DB, 0x03DB}, sbprLower},     // L&       GREEK SMALL LETTER STIGMA
+	{runeRange{0x03DF, 0x03DF}, sbprLower},     // L&       GREEK SMALL LETTER KOPPA
+	{runeRange{0x03E3, 0x03E3}, sbprLower},     // L&       COPTIC SMALL LETTER SHEI
+	{runeRange{0x03E7, 0x03E7}, sbprLower},     // L&       COPTIC SMALL LETTER KHEI
+	{runeRange{0x03EB, 0x03EB}, sbprLower},     // L&       COPTIC SMALL LETTER GANGIA
+	{runeRange{0x03EF, 0x03F3}, sbprLower},     // L&   [5] COPTIC SMALL LETTER DEI..GREEK LETTER YOT
+	{runeRange{0x03F8, 0x03F8}, sbprLower},     // L&       GREEK SMALL LETTER SHO
+	{runeRange{0x0430, 0x045F}, sbprLower},     // L&  [48] CYRILLIC SMALL LETTER A..CYRILLIC SMALL LETTER DZHE
+	{runeRange{0x0463, 0x0463}, sbprLower},     // L&       CYRILLIC SMALL LETTER YAT
+	{runeRange{0x0467, 0x0467}, sbprLower},     // L&       CYRILLIC SMALL LETTER LITTLE YUS
+	{runeRange{0x046B, 0x046B}, sbprLower},     // L&       CYRILLIC SMALL LETTER BIG YUS
+	{runeRange{0x046F, 0x046F}, sbprLower},     // L&       CYRILLIC SMALL LETTER KSI
+	{runeRange{0x0473, 0x0473}, sbprLower},     // L&       CYRILLIC SMALL LETTER FITA
+	{runeRange{0x0477, 0x0477}, sbprLower},     // L&       CYRILLIC SMALL LETTER IZHITSA WITH DOUBLE GRAVE ACCENT
+	{runeRange{0x047B, 0x047B}, sbprLower},     // L&       CYRILLIC SMALL LETTER ROUND OMEGA
+	{runeRange{0x047F, 0x047F}, sbprLower},     // L&       CYRILLIC SMALL LETTER OT
+	{runeRange{0x0488, 0x0489}, sbprExtend},    // Me   [2] COMBINING CYRILLIC HUNDRED THOUSANDS SIGN..COMBINING CYRILLIC MILLIONS SIGN
+	{runeRange{0x048D, 0x048D}, sbprLower},     // L&       CYRILLIC SMALL LETTER SEMISOFT SIGN
+	{runeRange{0x0491, 0x0491}, sbprLower},     // L&       CYRILLIC SMALL LETTER GHE WITH UPTURN
+	{runeRange{0x0495, 0x0495}, sbprLower},     // L&       CYRILLIC SMALL LETTER GHE WITH MIDDLE HOOK
+	{runeRange{0x0499, 0x0499}, sbprLower},     // L&       CYRILLIC SMALL LETTER ZE WITH DESCENDER
+	{runeRange{0x049D, 0x049D}, sbprLower},     // L&       CYRILLIC SMALL LETTER KA WITH VERTICAL STROKE
+	{runeRange{0x04A1, 0x04A1}, sbprLower},     // L&       CYRILLIC SMALL LETTER BASHKIR KA
+	{runeRange{0x04A5, 0x04A5}, sbprLower},     // L&       CYRILLIC SMALL LIGATURE EN GHE
+	{runeRange{0x04A9, 0x04A9}, sbprLower},     // L&       CYRILLIC SMALL LETTER ABKHASIAN HA
+	{runeRange{0x04AD, 0x04AD}, sbprLower},     // L&       CYRILLIC SMALL LETTER TE WITH DESCENDER
+	{runeRange{0x04B1, 0x04B1}, sbprLower},     // L&       CYRILLIC SMALL LETTER STRAIGHT U WITH STROKE
+	{runeRange{0x04B5, 0x04B5}, sbprLower},     // L&       CYRILLIC SMALL LIGATURE TE TSE
+	{runeRange{0x04B9, 0x04B9}, sbprLower},     // L&       CYRILLIC SMALL LETTER CHE WITH VERTICAL STROKE
+	{runeRange{0x04BD, 0x04BD}, sbprLower},     // L&       CYRILLIC SMALL LETTER ABKHASIAN CHE
+	{runeRange{0x04C2, 0x04C2}, sbprLower},     // L&       CYRILLIC SMALL LETTER ZHE WITH BREVE
+	{runeRange{0x04C6, 0x04C6}, sbprLower},     // L&       CYRILLIC SMALL LETTER EL WITH TAIL
+	{runeRange{0x04CA, 0x04CA}, sbprLower},     // L&       CYRILLIC SMALL LETTER EN WITH TAIL
+	{runeRange{0x04CE, 0x04CF}, sbprLower},     // L&   [2] CYRILLIC SMALL LETTER EM WITH TAIL..CYRILLIC SMALL LETTER PALOCHKA
+	{runeRange{0x04D3, 0x04D3}, sbprLower},     // L&       CYRILLIC SMALL LETTER A WITH DIAERESIS
+	{runeRange{0x04D7, 0x04D7}, sbprLower},     // L&       CYRILLIC SMALL LETTER IE WITH BREVE
+	{runeRange{0x04DB, 0x04DB}, sbprLower},     // L&       CYRILLIC SMALL LETTER SCHWA WITH DIAERESIS
+	{runeRange{0x04DF, 0x04DF}, sbprLower},     // L&       CYRILLIC SMALL LETTER ZE WITH DIAERESIS
+	{runeRange{0x04E3, 0x04E3}, sbprLower},     // L&       CYRILLIC SMALL LETTER I WITH MACRON
+	{runeRange{0x04E7, 0x04E7}, sbprLower},     // L&       CYRILLIC SMALL LETTER O WITH DIAERESIS
+	{runeRange{0x04EB, 0x04EB}, sbprLower},     // L&       CYRILLIC SMALL LETTER BARRED O WITH DIAERESIS
+	{runeRange{0x04EF, 0x04EF}, sbprLower},     // L&       CYRILLIC SMALL LETTER U WITH MACRON
+	{runeRange{0x04F3, 0x04F3}, sbprLower},     // L&       CYRILLIC SMALL LETTER U WITH DOUBLE ACUTE
+	{runeRange{0x04F7, 0x04F7}, sbprLower},     // L&       CYRILLIC SMALL LETTER GHE WITH DESCENDER
+	{runeRange{0x04FB, 0x04FB}, sbprLower},     // L&       CYRILLIC SMALL LETTER GHE WITH STROKE AND HOOK
+	{runeRange{0x04FF, 0x04FF}, sbprLower},     // L&       CYRILLIC SMALL LETTER HA WITH STROKE
+	{runeRange{0x0503, 0x0503}, sbprLower},     // L&       CYRILLIC SMALL LETTER KOMI DJE
+	{runeRange{0x0507, 0x0507}, sbprLower},     // L&       CYRILLIC SMALL LETTER KOMI DZJE
+	{runeRange{0x050B, 0x050B}, sbprLower},     // L&       CYRILLIC SMALL LETTER KOMI NJE
+	{runeRange{0x050F, 0x050F}, sbprLower},     // L&       CYRILLIC SMALL LETTER KOMI TJE
+	{runeRange{0x0513, 0x0513}, sbprLower},     // L&       CYRILLIC SMALL LETTER EL WITH HOOK
+	{runeRange{0x0517, 0x0517}, sbprLower},     // L&       CYRILLIC SMALL LETTER RHA
+	{runeRange{0x051B, 0x051B}, sbprLower},     // L&       CYRILLIC SMALL LETTER QA
+	{runeRange{0x051F, 0x051F}, sbprLower},     // L&       CYRILLIC SMALL LETTER ALEUT KA
+	{runeRange{0x0523, 0x0523}, sbprLower},     // L&       CYRILLIC SMALL LETTER EN WITH MIDDLE HOOK
+	{runeRange{0x0527, 0x0527}, sbprLower},     // L&       CYRILLIC SMALL LETTER SHHA WITH DESCENDER
+	{runeRange{0x052B, 0x052B}, sbprLower},     // L&       CYRILLIC SMALL LETTER DZZHE
+	{runeRange{0x052F, 0x052F}, sbprLower},     // L&       CYRILLIC SMALL LETTER EL WITH DESCENDER
+	{runeRange{0x0560, 0x0588}, sbprLower},     // L&  [41] ARMENIAN SMALL LETTER TURNED AYB..ARMENIAN SMALL LETTER YI WITH STROKE
+	{runeRange{0x05C1, 0x05C2}, sbprExtend},    // Mn   [2] HEBREW POINT SHIN DOT..HEBREW POINT SIN DOT
+	{runeRange{0x05EF, 0x05F2}, sbprOLetter},   // Lo   [4] HEBREW YOD TRIANGLE..HEBREW LIGATURE YIDDISH DOUBLE YOD
+	{runeRange{0x0610, 0x061A}, sbprExtend},    // Mn  [11] ARABIC SIGN SALLALLAHOU ALAYHE WASSALLAM..ARABIC SMALL KASRA
+	{runeRange{0x0640, 0x0640}, sbprOLetter},   // Lm       ARABIC TATWEEL
+	{runeRange{0x066B, 0x066C}, sbprNumeric},   // Po   [2] ARABIC DECIMAL SEPARATOR..ARABIC THOUSANDS SEPARATOR
+	{runeRange{0x06D4, 0x06D4}, sbprSTerm},     // Po       ARABIC FULL STOP
+	{runeRange{0x06DF, 0x06E4}, sbprExtend},    // Mn   [6] ARABIC SMALL HIGH ROUNDED ZERO..ARABIC SMALL HIGH MADDA
+	{runeRange{0x06EE, 0x06EF}, sbprOLetter},   // Lo   [2] ARABIC LETTER DAL WITH INVERTED V..ARABIC LETTER REH WITH INVERTED V
+	{runeRange{0x0700, 0x0702}, sbprSTerm},     // Po   [3] SYRIAC END OF PARAGRAPH..SYRIAC SUBLINEAR FULL STOP
+	{runeRange{0x0712, 0x072F}, sbprOLetter},   // Lo  [30] SYRIAC LETTER BETH..SYRIAC LETTER PERSIAN DHALATH
+	{runeRange{0x07B1, 0x07B1}, sbprOLetter},   // Lo       THAANA LETTER NAA
+	{runeRange{0x07F4, 0x07F5}, sbprOLetter},   // Lm   [2] NKO HIGH TONE APOSTROPHE..NKO LOW TONE APOSTROPHE
+	{runeRange{0x07FD, 0x07FD}, sbprExtend},    // Mn       NKO DANTAYALAN
+	{runeRange{0x081B, 0x0823}, sbprExtend},    // Mn   [9] SAMARITAN MARK EPENTHETIC YUT..SAMARITAN VOWEL SIGN A
+	{runeRange{0x0829, 0x082D}, sbprExtend},    // Mn   [5] SAMARITAN VOWEL SIGN LONG I..SAMARITAN MARK NEQUDAA
+	{runeRange{0x0840, 0x0858}, sbprOLetter},   // Lo  [25] MANDAIC LETTER HALQA..MANDAIC LETTER AIN
+	{runeRange{0x0889, 0x088E}, sbprOLetter},   // Lo   [6] ARABIC LETTER NOON WITH INVERTED SMALL V..ARABIC VERTICAL TAIL
+	{runeRange{0x08C9, 0x08C9}, sbprOLetter},   // Lm       ARABIC SMALL FARSI YEH
+	{runeRange{0x0903, 0x0903}, sbprExtend},    // Mc       DEVANAGARI SIGN VISARGA
+	{runeRange{0x093C, 0x093C}, sbprExtend},    // Mn       DEVANAGARI SIGN NUKTA
+	{runeRange{0x0949, 0x094C}, sbprExtend},    // Mc   [4] DEVANAGARI VOWEL SIGN CANDRA O..DEVANAGARI VOWEL SIGN AU
+	{runeRange{0x0951, 0x0957}, sbprExtend},    // Mn   [7] DEVANAGARI STRESS SIGN UDATTA..DEVANAGARI VOWEL SIGN UUE
+	{runeRange{0x0966, 0x096F}, sbprNumeric},   // Nd  [10] DEVANAGARI DIGIT ZERO..DEVANAGARI DIGIT NINE
+	{runeRange{0x0982, 0x0983}, sbprExtend},    // Mc   [2] BENGALI SIGN ANUSVARA..BENGALI SIGN VISARGA
+	{runeRange{0x09AA, 0x09B0}, sbprOLetter},   // Lo   [7] BENGALI LETTER PA..BENGALI LETTER RA
+	{runeRange{0x09BD, 0x09BD}, sbprOLetter},   // Lo       BENGALI SIGN AVAGRAHA
+	{runeRange{0x09CB, 0x09CC}, sbprExtend},    // Mc   [2] BENGALI VOWEL SIGN O..BENGALI VOWEL SIGN AU
+	{runeRange{0x09DC, 0x09DD}, sbprOLetter},   // Lo   [2] BENGALI LETTER RRA..BENGALI LETTER RHA
+	{runeRange{0x09F0, 0x09F1}, sbprOLetter},   // Lo   [2] BENGALI LETTER RA WITH MIDDLE DIAGONAL..BENGALI LETTER RA WITH LOWER DIAGONAL
+	{runeRange{0x0A03, 0x0A03}, sbprExtend},    // Mc       GURMUKHI SIGN VISARGA
+	{runeRange{0x0A2A, 0x0A30}, sbprOLetter},   // Lo   [7] GURMUKHI LETTER PA..GURMUKHI LETTER RA
+	{runeRange{0x0A3C, 0x0A3C}, sbprExtend},    // Mn       GURMUKHI SIGN NUKTA
+	{runeRange{0x0A4B, 0x0A4D}, sbprExtend},    // Mn   [3] GURMUKHI VOWEL SIGN OO..GURMUKHI SIGN VIRAMA
+	{runeRange{0x0A66, 0x0A6F}, sbprNumeric},   // Nd  [10] GURMUKHI DIGIT ZERO..GURMUKHI DIGIT NINE
+	{runeRange{0x0A81, 0x0A82}, sbprExtend},    // Mn   [2] GUJARATI SIGN CANDRABINDU..GUJARATI SIGN ANUSVARA
+	{runeRange{0x0A93, 0x0AA8}, sbprOLetter},   // Lo  [22] GUJARATI LETTER O..GUJARATI LETTER NA
+	{runeRange{0x0ABC, 0x0ABC}, sbprExtend},    // Mn       GUJARATI SIGN NUKTA
+	{runeRange{0x0AC7, 0x0AC8}, sbprExtend},    // Mn   [2] GUJARATI VOWEL SIGN E..GUJARATI VOWEL SIGN AI
+	{runeRange{0x0AD0, 0x0AD0}, sbprOLetter},   // Lo       GUJARATI OM
+	{runeRange{0x0AF9, 0x0AF9}, sbprOLetter},   // Lo       GUJARATI LETTER ZHA
+	{runeRange{0x0B05, 0x0B0C}, sbprOLetter},   // Lo   [8] ORIYA LETTER A..ORIYA LETTER VOCALIC L
+	{runeRange{0x0B32, 0x0B33}, sbprOLetter},   // Lo   [2] ORIYA LETTER LA..ORIYA LETTER LLA
+	{runeRange{0x0B3E, 0x0B3E}, sbprExtend},    // Mc       ORIYA VOWEL SIGN AA
+	{runeRange{0x0B47, 0x0B48}, sbprExtend},    // Mc   [2] ORIYA VOWEL SIGN E..ORIYA VOWEL SIGN AI
+	{runeRange{0x0B57, 0x0B57}, sbprExtend},    // Mc       ORIYA AU LENGTH MARK
+	{runeRange{0x0B66, 0x0B6F}, sbprNumeric},   // Nd  [10] ORIYA DIGIT ZERO..ORIYA DIGIT NINE
+	{runeRange{0x0B85, 0x0B8A}, sbprOLetter},   // Lo   [6] TAMIL LETTER A..TAMIL LETTER UU
+	{runeRange{0x0B9C, 0x0B9C}, sbprOLetter},   // Lo       TAMIL LETTER JA
+	{runeRange{0x0BAE, 0x0BB9}, sbprOLetter},   // Lo  [12] TAMIL LETTER MA..TAMIL LETTER HA
+	{runeRange{0x0BC6, 0x0BC8}, sbprExtend},    // Mc   [3] TAMIL VOWEL SIGN E..TAMIL VOWEL SIGN AI
+	{runeRange{0x0BD7, 0x0BD7}, sbprExtend},    // Mc       TAMIL AU LENGTH MARK
+	{runeRange{0x0C04, 0x0C04}, sbprExtend},    // Mn       TELUGU SIGN COMBINING ANUSVARA ABOVE
+	{runeRange{0x0C2A, 0x0C39}, sbprOLetter},   // Lo  [16] TELUGU LETTER PA..TELUGU LETTER HA
+	{runeRange{0x0C41, 0x0C44}, sbprExtend},    // Mc   [4] TELUGU VOWEL SIGN U..TELUGU VOWEL SIGN VOCALIC RR
+	{runeRange{0x0C58, 0x0C5A}, sbprOLetter},   // Lo   [3] TELUGU LETTER TSA..TELUGU LETTER RRRA
+	{runeRange{0x0C66, 0x0C6F}, sbprNumeric},   // Nd  [10] TELUGU DIGIT ZERO..TELUGU DIGIT NINE
+	{runeRange{0x0C85, 0x0C8C}, sbprOLetter},   // Lo   [8] KANNADA LETTER A..KANNADA LETTER VOCALIC L
+	{runeRange{0x0CB5, 0x0CB9}, sbprOLetter},   // Lo   [5] KANNADA LETTER VA..KANNADA LETTER HA
+	{runeRange{0x0CBF, 0x0CBF}, sbprExtend},    // Mn       KANNADA VOWEL SIGN I
+	{runeRange{0x0CCA, 0x0CCB}, sbprExtend},    // Mc   [2] KANNADA VOWEL SIGN O..KANNADA VOWEL SIGN OO
+	{runeRange{0x0CE0, 0x0CE1}, sbprOLetter},   // Lo   [2] KANNADA LETTER VOCALIC RR..KANNADA LETTER VOCALIC LL
+	{runeRange{0x0CF3, 0x0CF3}, sbprExtend},    // Mc       KANNADA SIGN COMBINING ANUSVARA ABOVE RIGHT
+	{runeRange{0x0D0E, 0x0D10}, sbprOLetter},   // Lo   [3] MALAYALAM LETTER E..MALAYALAM LETTER AI
+	{runeRange{0x0D3E, 0x0D40}, sbprExtend},    // Mc   [3] MALAYALAM VOWEL SIGN AA..MALAYALAM VOWEL SIGN II
+	{runeRange{0x0D4D, 0x0D4D}, sbprExtend},    // Mn       MALAYALAM SIGN VIRAMA
+	{runeRange{0x0D5F, 0x0D61}, sbprOLetter},   // Lo   [3] MALAYALAM LETTER ARCHAIC II..MALAYALAM LETTER VOCALIC LL
+	{runeRange{0x0D81, 0x0D81}, sbprExtend},    // Mn       SINHALA SIGN CANDRABINDU
+	{runeRange{0x0DB3, 0x0DBB}, sbprOLetter},   // Lo   [9] SINHALA LETTER SANYAKA DAYANNA..SINHALA LETTER RAYANNA
+	{runeRange{0x0DCF, 0x0DD1}, sbprExtend},    // Mc   [3] SINHALA VOWEL SIGN AELA-PILLA..SINHALA VOWEL SIGN DIGA AEDA-PILLA
+	{runeRange{0x0DE6, 0x0DEF}, sbprNumeric},   // Nd  [10] SINHALA LITH DIGIT ZERO..SINHALA LITH DIGIT NINE
+	{runeRange{0x0E32, 0x0E33}, sbprOLetter},   // Lo   [2] THAI CHARACTER SARA AA..THAI CHARACTER SARA AM
+	{runeRange{0x0E47, 0x0E4E}, sbprExtend},    // Mn   [8] THAI CHARACTER MAITAIKHU..THAI CHARACTER YAMAKKAN
+	{runeRange{0x0E86, 0x0E8A}, sbprOLetter},   // Lo   [5] LAO LETTER PALI GHA..LAO LETTER SO TAM
+	{runeRange{0x0EB1, 0x0EB1}, sbprExtend},    // Mn       LAO VOWEL SIGN MAI KAN
+	{runeRange{0x0EC0, 0x0EC4}, sbprOLetter},   // Lo   [5] LAO VOWEL SIGN E..LAO VOWEL SIGN AI
+	{runeRange{0x0EDC, 0x0EDF}, sbprOLetter},   // Lo   [4] LAO HO NO..LAO LETTER KHMU NYO
+	{runeRange{0x0F35, 0x0F35}, sbprExtend},    // Mn       TIBETAN MARK NGAS BZUNG NYI ZLA
+	{runeRange{0x0F3B, 0x0F3B}, sbprClose},     // Pe       TIBETAN MARK GUG RTAGS GYAS
+	{runeRange{0x0F40, 0x0F47}, sbprOLetter},   // Lo   [8] TIBETAN LETTER KA..TIBETAN LETTER JA
+	{runeRange{0x0F80, 0x0F84}, sbprExtend},    // Mn   [5] TIBETAN VOWEL SIGN REVERSED I..TIBETAN MARK HALANTA
+	{runeRange{0x0F99, 0x0FBC}, sbprExtend},    // Mn  [36] TIBETAN SUBJOINED LETTER NYA..TIBETAN SUBJOINED LETTER FIXED-FORM RA
+	{runeRange{0x102D, 0x1030}, sbprExtend},    // Mn   [4] MYANMAR VOWEL SIGN I..MYANMAR VOWEL SIGN UU
+	{runeRange{0x1039, 0x103A}, sbprExtend},    // Mn   [2] MYANMAR SIGN VIRAMA..MYANMAR SIGN ASAT
+	{runeRange{0x1040, 0x1049}, sbprNumeric},   // Nd  [10] MYANMAR DIGIT ZERO..MYANMAR DIGIT NINE
+	{runeRange{0x1058, 0x1059}, sbprExtend},    // Mn   [2] MYANMAR VOWEL SIGN VOCALIC L..MYANMAR VOWEL SIGN VOCALIC LL
+	{runeRange{0x1062, 0x1064}, sbprExtend},    // Mc   [3] MYANMAR VOWEL SIGN SGAW KAREN EU..MYANMAR TONE MARK SGAW KAREN KE PHO
+	{runeRange{0x1071, 0x1074}, sbprExtend},    // Mn   [4] MYANMAR VOWEL SIGN GEBA KAREN I..MYANMAR VOWEL SIGN KAYAH EE
+	{runeRange{0x1085, 0x1086}, sbprExtend},    // Mn   [2] MYANMAR VOWEL SIGN SHAN E ABOVE..MYANMAR VOWEL SIGN SHAN FINAL Y
+	{runeRange{0x108F, 0x108F}, sbprExtend},    // Mc       MYANMAR SIGN RUMAI PALAUNG TONE-5
+	{runeRange{0x10A0, 0x10C5}, sbprUpper},     // L&  [38] GEORGIAN CAPITAL LETTER AN..GEORGIAN CAPITAL LETTER HOE
+	{runeRange{0x10FC, 0x10FC}, sbprLower},     // Lm       MODIFIER LETTER GEORGIAN NAR
+	{runeRange{0x1250, 0x1256}, sbprOLetter},   // Lo   [7] ETHIOPIC SYLLABLE QHA..ETHIOPIC SYLLABLE QHO
+	{runeRange{0x128A, 0x128D}, sbprOLetter},   // Lo   [4] ETHIOPIC SYLLABLE XWI..ETHIOPIC SYLLABLE XWE
+	{runeRange{0x12C0, 0x12C0}, sbprOLetter},   // Lo       ETHIOPIC SYLLABLE KXWA
+	{runeRange{0x1312, 0x1315}, sbprOLetter},   // Lo   [4] ETHIOPIC SYLLABLE GWI..ETHIOPIC SYLLABLE GWE
+	{runeRange{0x1367, 0x1368}, sbprSTerm},     // Po   [2] ETHIOPIC QUESTION MARK..ETHIOPIC PARAGRAPH SEPARATOR
+	{runeRange{0x1401, 0x166C}, sbprOLetter},   // Lo [620] CANADIAN SYLLABICS E..CANADIAN SYLLABICS CARRIER TTSA
+	{runeRange{0x1681, 0x169A}, sbprOLetter},   // Lo  [26] OGHAM LETTER BEITH..OGHAM LETTER PEITH
+	{runeRange{0x16EE, 0x16F0}, sbprOLetter},   // Nl   [3] RUNIC ARLAUG SYMBOL..RUNIC BELGTHOR SYMBOL
+	{runeRange{0x1715, 0x1715}, sbprExtend},    // Mc       TAGALOG SIGN PAMUDPOD
+	{runeRange{0x1735, 0x1736}, sbprSTerm},     // Po   [2] PHILIPPINE SINGLE PUNCTUATION..PHILIPPINE DOUBLE PUNCTUATION
+	{runeRange{0x176E, 0x1770}, sbprOLetter},   // Lo   [3] TAGBANWA LETTER LA..TAGBANWA LETTER SA
+	{runeRange{0x17B6, 0x17B6}, sbprExtend},    // Mc       KHMER VOWEL SIGN AA
+	{runeRange{0x17C7, 0x17C8}, sbprExtend},    // Mc   [2] KHMER SIGN REAHMUK..KHMER SIGN YUUKALEAPINTU
+	{runeRange{0x17DD, 0x17DD}, sbprExtend},    // Mn       KHMER SIGN ATTHACAN
+	{runeRange{0x1808, 0x1808}, sbprSContinue}, // Po       MONGOLIAN MANCHU COMMA
+	{runeRange{0x180F, 0x180F}, sbprExtend},    // Mn       MONGOLIAN FREE VARIATION SELECTOR FOUR
+	{runeRange{0x1844, 0x1878}, sbprOLetter},   // Lo  [53] MONGOLIAN LETTER TODO E..MONGOLIAN LETTER CHA WITH TWO DOTS
+	{runeRange{0x18A9, 0x18A9}, sbprExtend},    // Mn       MONGOLIAN LETTER ALI GALI DAGALGA
+	{runeRange{0x1920, 0x1922}, sbprExtend},    // Mn   [3] LIMBU VOWEL SIGN A..LIMBU VOWEL SIGN U
+	{runeRange{0x1930, 0x1931}, sbprExtend},    // Mc   [2] LIMBU SMALL LETTER KA..LIMBU SMALL LETTER NGA
+	{runeRange{0x1944, 0x1945}, sbprSTerm},     // Po   [2] LIMBU EXCLAMATION MARK..LIMBU QUESTION MARK
+	{runeRange{0x1980, 0x19AB}, sbprOLetter},   // Lo  [44] NEW TAI LUE LETTER HIGH QA..NEW TAI LUE LETTER LOW SUA
+	{runeRange{0x1A17, 0x1A18}, sbprExtend},    // Mn   [2] BUGINESE VOWEL SIGN I..BUGINESE VOWEL SIGN U
+	{runeRange{0x1A55, 0x1A55}, sbprExtend},    // Mc       TAI THAM CONSONANT SIGN MEDIAL RA
+	{runeRange{0x1A60, 0x1A60}, sbprExtend},    // Mn       TAI THAM SIGN SAKOT
+	{runeRange{0x1A65, 0x1A6C}, sbprExtend},    // Mn   [8] TAI THAM VOWEL SIGN I..TAI THAM VOWEL SIGN OA BELOW
+	{runeRange{0x1A80, 0x1A89}, sbprNumeric},   // Nd  [10] TAI THAM HORA DIGIT ZERO..TAI THAM HORA DIGIT NINE
+	{runeRange{0x1AB0, 0x1ABD}, sbprExtend},    // Mn  [14] COMBINING DOUBLED CIRCUMFLEX ACCENT..COMBINING PARENTHESES BELOW
+	{runeRange{0x1B04, 0x1B04}, sbprExtend},    // Mc       BALINESE SIGN BISAH
+	{runeRange{0x1B36, 0x1B3A}, sbprExtend},    // Mn   [5] BALINESE VOWEL SIGN ULU..BALINESE VOWEL SIGN RA REPA
+	{runeRange{0x1B42, 0x1B42}, sbprExtend},    // Mn       BALINESE VOWEL SIGN PEPET
+	{runeRange{0x1B5A, 0x1B5B}, sbprSTerm},     // Po   [2] BALINESE PANTI..BALINESE PAMADA
+	{runeRange{0x1B80, 0x1B81}, sbprExtend},    // Mn   [2] SUNDANESE SIGN PANYECEK..SUNDANESE SIGN PANGLAYAR
+	{runeRange{0x1BA2, 0x1BA5}, sbprExtend},    // Mn   [4] SUNDANESE CONSONANT SIGN PANYAKRA..SUNDANESE VOWEL SIGN PANYUKU
+	{runeRange{0x1BAB, 0x1BAD}, sbprExtend},    // Mn   [3] SUNDANESE SIGN VIRAMA..SUNDANESE CONSONANT SIGN PASANGAN WA
+	{runeRange{0x1BE6, 0x1BE6}, sbprExtend},    // Mn       BATAK SIGN TOMPI
+	{runeRange{0x1BED, 0x1BED}, sbprExtend},    // Mn       BATAK VOWEL SIGN KARO O
+	{runeRange{0x1C00, 0x1C23}, sbprOLetter},   // Lo  [36] LEPCHA LETTER KA..LEPCHA LETTER A
+	{runeRange{0x1C36, 0x1C37}, sbprExtend},    // Mn   [2] LEPCHA SIGN RAN..LEPCHA SIGN NUKTA
+	{runeRange{0x1C50, 0x1C59}, sbprNumeric},   // Nd  [10] OL CHIKI DIGIT ZERO..OL CHIKI DIGIT NINE
+	{runeRange{0x1C80, 0x1C88}, sbprLower},     // L&   [9] CYRILLIC SMALL LETTER ROUNDED VE..CYRILLIC SMALL LETTER UNBLENDED UK
+	{runeRange{0x1CD4, 0x1CE0}, sbprExtend},    // Mn  [13] VEDIC SIGN YAJURVEDIC MIDLINE SVARITA..VEDIC TONE RIGVEDIC KASHMIRI INDEPENDENT SVARITA
+	{runeRange{0x1CED, 0x1CED}, sbprExtend},    // Mn       VEDIC SIGN TIRYAK
+	{runeRange{0x1CF7, 0x1CF7}, sbprExtend},    // Mc       VEDIC SIGN ATIKRAMA
+	{runeRange{0x1D2C, 0x1D6A}, sbprLower},     // Lm  [63] MODIFIER LETTER CAPITAL A..GREEK SUBSCRIPT SMALL LETTER CHI
+	{runeRange{0x1D9B, 0x1DBF}, sbprLower},     // Lm  [37] MODIFIER LETTER SMALL TURNED ALPHA..MODIFIER LETTER SMALL THETA
+	{runeRange{0x1E02, 0x1E02}, sbprUpper},     // L&       LATIN CAPITAL LETTER B WITH DOT ABOVE
+	{runeRange{0x1E06, 0x1E06}, sbprUpper},     // L&       LATIN CAPITAL LETTER B WITH LINE BELOW
+	{runeRange{0x1E0A, 0x1E0A}, sbprUpper},     // L&       LATIN CAPITAL LETTER D WITH DOT ABOVE
+	{runeRange{0x1E0E, 0x1E0E}, sbprUpper},     // L&       LATIN CAPITAL LETTER D WITH LINE BELOW
+	{runeRange{0x1E12, 0x1E12}, sbprUpper},     // L&       LATIN CAPITAL LETTER D WITH CIRCUMFLEX BELOW
+	{runeRange{0x1E16, 0x1E16}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH MACRON AND ACUTE
+	{runeRange{0x1E1A, 0x1E1A}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH TILDE BELOW
+	{runeRange{0x1E1E, 0x1E1E}, sbprUpper},     // L&       LATIN CAPITAL LETTER F WITH DOT ABOVE
+	{runeRange{0x1E22, 0x1E22}, sbprUpper},     // L&       LATIN CAPITAL LETTER H WITH DOT ABOVE
+	{runeRange{0x1E26, 0x1E26}, sbprUpper},     // L&       LATIN CAPITAL LETTER H WITH DIAERESIS
+	{runeRange{0x1E2A, 0x1E2A}, sbprUpper},     // L&       LATIN CAPITAL LETTER H WITH BREVE BELOW
+	{runeRange{0x1E2E, 0x1E2E}, sbprUpper},     // L&       LATIN CAPITAL LETTER I WITH DIAERESIS AND ACUTE
+	{runeRange{0x1E32, 0x1E32}, sbprUpper},     // L&       LATIN CAPITAL LETTER K WITH DOT BELOW
+	{runeRange{0x1E36, 0x1E36}, sbprUpper},     // L&       LATIN CAPITAL LETTER L WITH DOT BELOW
+	{runeRange{0x1E3A, 0x1E3A}, sbprUpper},     // L&       LATIN CAPITAL LETTER L WITH LINE BELOW
+	{runeRange{0x1E3E, 0x1E3E}, sbprUpper},     // L&       LATIN CAPITAL LETTER M WITH ACUTE
+	{runeRange{0x1E42, 0x1E42}, sbprUpper},     // L&       LATIN CAPITAL LETTER M WITH DOT BELOW
+	{runeRange{0x1E46, 0x1E46}, sbprUpper},     // L&       LATIN CAPITAL LETTER N WITH DOT BELOW
+	{runeRange{0x1E4A, 0x1E4A}, sbprUpper},     // L&       LATIN CAPITAL LETTER N WITH CIRCUMFLEX BELOW
+	{runeRange{0x1E4E, 0x1E4E}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH TILDE AND DIAERESIS
+	{runeRange{0x1E52, 0x1E52}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH MACRON AND ACUTE
+	{runeRange{0x1E56, 0x1E56}, sbprUpper},     // L&       LATIN CAPITAL LETTER P WITH DOT ABOVE
+	{runeRange{0x1E5A, 0x1E5A}, sbprUpper},     // L&       LATIN CAPITAL LETTER R WITH DOT BELOW
+	{runeRange{0x1E5E, 0x1E5E}, sbprUpper},     // L&       LATIN CAPITAL LETTER R WITH LINE BELOW
+	{runeRange{0x1E62, 0x1E62}, sbprUpper},     // L&       LATIN CAPITAL LETTER S WITH DOT BELOW
+	{runeRange{0x1E66, 0x1E66}, sbprUpper},     // L&       LATIN CAPITAL LETTER S WITH CARON AND DOT ABOVE
+	{runeRange{0x1E6A, 0x1E6A}, sbprUpper},     // L&       LATIN CAPITAL LETTER T WITH DOT ABOVE
+	{runeRange{0x1E6E, 0x1E6E}, sbprUpper},     // L&       LATIN CAPITAL LETTER T WITH LINE BELOW
+	{runeRange{0x1E72, 0x1E72}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH DIAERESIS BELOW
+	{runeRange{0x1E76, 0x1E76}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH CIRCUMFLEX BELOW
+	{runeRange{0x1E7A, 0x1E7A}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH MACRON AND DIAERESIS
+	{runeRange{0x1E7E, 0x1E7E}, sbprUpper},     // L&       LATIN CAPITAL LETTER V WITH DOT BELOW
+	{runeRange{0x1E82, 0x1E82}, sbprUpper},     // L&       LATIN CAPITAL LETTER W WITH ACUTE
+	{runeRange{0x1E86, 0x1E86}, sbprUpper},     // L&       LATIN CAPITAL LETTER W WITH DOT ABOVE
+	{runeRange{0x1E8A, 0x1E8A}, sbprUpper},     // L&       LATIN CAPITAL LETTER X WITH DOT ABOVE
+	{runeRange{0x1E8E, 0x1E8E}, sbprUpper},     // L&       LATIN CAPITAL LETTER Y WITH DOT ABOVE
+	{runeRange{0x1E92, 0x1E92}, sbprUpper},     // L&       LATIN CAPITAL LETTER Z WITH DOT BELOW
+	{runeRange{0x1E9E, 0x1E9E}, sbprUpper},     // L&       LATIN CAPITAL LETTER SHARP S
+	{runeRange{0x1EA2, 0x1EA2}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH HOOK ABOVE
+	{runeRange{0x1EA6, 0x1EA6}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH CIRCUMFLEX AND GRAVE
+	{runeRange{0x1EAA, 0x1EAA}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH CIRCUMFLEX AND TILDE
+	{runeRange{0x1EAE, 0x1EAE}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH BREVE AND ACUTE
+	{runeRange{0x1EB2, 0x1EB2}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH BREVE AND HOOK ABOVE
+	{runeRange{0x1EB6, 0x1EB6}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH BREVE AND DOT BELOW
+	{runeRange{0x1EBA, 0x1EBA}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH HOOK ABOVE
+	{runeRange{0x1EBE, 0x1EBE}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH CIRCUMFLEX AND ACUTE
+	{runeRange{0x1EC2, 0x1EC2}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH CIRCUMFLEX AND HOOK ABOVE
+	{runeRange{0x1EC6, 0x1EC6}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH CIRCUMFLEX AND DOT BELOW
+	{runeRange{0x1ECA, 0x1ECA}, sbprUpper},     // L&       LATIN CAPITAL LETTER I WITH DOT BELOW
+	{runeRange{0x1ECE, 0x1ECE}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH HOOK ABOVE
+	{runeRange{0x1ED2, 0x1ED2}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH CIRCUMFLEX AND GRAVE
+	{runeRange{0x1ED6, 0x1ED6}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH CIRCUMFLEX AND TILDE
+	{runeRange{0x1EDA, 0x1EDA}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH HORN AND ACUTE
+	{runeRange{0x1EDE, 0x1EDE}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH HORN AND HOOK ABOVE
+	{runeRange{0x1EE2, 0x1EE2}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH HORN AND DOT BELOW
+	{runeRange{0x1EE6, 0x1EE6}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH HOOK ABOVE
+	{runeRange{0x1EEA, 0x1EEA}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH HORN AND GRAVE
+	{runeRange{0x1EEE, 0x1EEE}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH HORN AND TILDE
+	{runeRange{0x1EF2, 0x1EF2}, sbprUpper},     // L&       LATIN CAPITAL LETTER Y WITH GRAVE
+	{runeRange{0x1EF6, 0x1EF6}, sbprUpper},     // L&       LATIN CAPITAL LETTER Y WITH HOOK ABOVE
+	{runeRange{0x1EFA, 0x1EFA}, sbprUpper},     // L&       LATIN CAPITAL LETTER MIDDLE-WELSH LL
+	{runeRange{0x1EFE, 0x1EFE}, sbprUpper},     // L&       LATIN CAPITAL LETTER Y WITH LOOP
+	{runeRange{0x1F18, 0x1F1D}, sbprUpper},     // L&   [6] GREEK CAPITAL LETTER EPSILON WITH PSILI..GREEK CAPITAL LETTER EPSILON WITH DASIA AND OXIA
+	{runeRange{0x1F38, 0x1F3F}, sbprUpper},     // L&   [8] GREEK CAPITAL LETTER IOTA WITH PSILI..GREEK CAPITAL LETTER IOTA WITH DASIA AND PERISPOMENI
+	{runeRange{0x1F59, 0x1F59}, sbprUpper},     // L&       GREEK CAPITAL LETTER UPSILON WITH DASIA
+	{runeRange{0x1F60, 0x1F67}, sbprLower},     // L&   [8] GREEK SMALL LETTER OMEGA WITH PSILI..GREEK SMALL LETTER OMEGA WITH DASIA AND PERISPOMENI
+	{runeRange{0x1F88, 0x1F8F}, sbprUpper},     // L&   [8] GREEK CAPITAL LETTER ALPHA WITH PSILI AND PROSGEGRAMMENI..GREEK CAPITAL LETTER ALPHA WITH DASIA AND PERISPOMENI AND PROSGEGRAMMENI
+	{runeRange{0x1FA8, 0x1FAF}, sbprUpper},     // L&   [8] GREEK CAPITAL LETTER OMEGA WITH PSILI AND PROSGEGRAMMENI..GREEK CAPITAL LETTER OMEGA WITH DASIA AND PERISPOMENI AND PROSGEGRAMMENI
+	{runeRange{0x1FBE, 0x1FBE}, sbprLower},     // L&       GREEK PROSGEGRAMMENI
+	{runeRange{0x1FD0, 0x1FD3}, sbprLower},     // L&   [4] GREEK SMALL LETTER IOTA WITH VRACHY..GREEK SMALL LETTER IOTA WITH DIALYTIKA AND OXIA
+	{runeRange{0x1FE8, 0x1FEC}, sbprUpper},     // L&   [5] GREEK CAPITAL LETTER UPSILON WITH VRACHY..GREEK CAPITAL LETTER RHO WITH DASIA
+	{runeRange{0x2000, 0x200A}, sbprSp},        // Zs  [11] EN QUAD..HAIR SPACE
+	{runeRange{0x2013, 0x2014}, sbprSContinue}, // Pd   [2] EN DASH..EM DASH
+	{runeRange{0x201B, 0x201C}, sbprClose},     // Pi   [2] SINGLE HIGH-REVERSED-9 QUOTATION MARK..LEFT DOUBLE QUOTATION MARK
+	{runeRange{0x2024, 0x2024}, sbprATerm},     // Po       ONE DOT LEADER
+	{runeRange{0x202F, 0x202F}, sbprSp},        // Zs       NARROW NO-BREAK SPACE
+	{runeRange{0x2045, 0x2045}, sbprClose},     // Ps       LEFT SQUARE BRACKET WITH QUILL
+	{runeRange{0x2060, 0x2064}, sbprFormat},    // Cf   [5] WORD JOINER..INVISIBLE PLUS
+	{runeRange{0x207E, 0x207E}, sbprClose},     // Pe       SUPERSCRIPT RIGHT PARENTHESIS
+	{runeRange{0x2090, 0x209C}, sbprLower},     // Lm  [13] LATIN SUBSCRIPT SMALL LETTER A..LATIN SUBSCRIPT SMALL LETTER T
+	{runeRange{0x20E2, 0x20E4}, sbprExtend},    // Me   [3] COMBINING ENCLOSING SCREEN..COMBINING ENCLOSING UPWARD POINTING TRIANGLE
+	{runeRange{0x210A, 0x210A}, sbprLower},     // L&       SCRIPT SMALL G
+	{runeRange{0x2113, 0x2113}, sbprLower},     // L&       SCRIPT SMALL L
+	{runeRange{0x2126, 0x2126}, sbprUpper},     // L&       OHM SIGN
+	{runeRange{0x2130, 0x2133}, sbprUpper},     // L&   [4] SCRIPT CAPITAL E..SCRIPT CAPITAL M
+	{runeRange{0x213C, 0x213D}, sbprLower},     // L&   [2] DOUBLE-STRUCK SMALL PI..DOUBLE-STRUCK SMALL GAMMA
+	{runeRange{0x214E, 0x214E}, sbprLower},     // L&       TURNED SMALL F
+	{runeRange{0x2183, 0x2183}, sbprUpper},     // L&       ROMAN NUMERAL REVERSED ONE HUNDRED
+	{runeRange{0x2309, 0x2309}, sbprClose},     // Pe       RIGHT CEILING
+	{runeRange{0x232A, 0x232A}, sbprClose},     // Pe       RIGHT-POINTING ANGLE BRACKET
+	{runeRange{0x2768, 0x2768}, sbprClose},     // Ps       MEDIUM LEFT PARENTHESIS ORNAMENT
+	{runeRange{0x276C, 0x276C}, sbprClose},     // Ps       MEDIUM LEFT-POINTING ANGLE BRACKET ORNAMENT
+	{runeRange{0x2770, 0x2770}, sbprClose},     // Ps       HEAVY LEFT-POINTING ANGLE BRACKET ORNAMENT
+	{runeRange{0x2774, 0x2774}, sbprClose},     // Ps       MEDIUM LEFT CURLY BRACKET ORNAMENT
+	{runeRange{0x27E6, 0x27E6}, sbprClose},     // Ps       MATHEMATICAL LEFT WHITE SQUARE BRACKET
+	{runeRange{0x27EA, 0x27EA}, sbprClose},     // Ps       MATHEMATICAL LEFT DOUBLE ANGLE BRACKET
+	{runeRange{0x27EE, 0x27EE}, sbprClose},     // Ps       MATHEMATICAL LEFT FLATTENED PARENTHESIS
+	{runeRange{0x2985, 0x2985}, sbprClose},     // Ps       LEFT WHITE PARENTHESIS
+	{runeRange{0x2989, 0x2989}, sbprClose},     // Ps       Z NOTATION LEFT BINDING BRACKET
+	{runeRange{0x298D, 0x298D}, sbprClose},     // Ps       LEFT SQUARE BRACKET WITH TICK IN TOP CORNER
+	{runeRange{0x2991, 0x2991}, sbprClose},     // Ps       LEFT ANGLE BRACKET WITH DOT
+	{runeRange{0x2995, 0x2995}, sbprClose},     // Ps       DOUBLE LEFT ARC GREATER-THAN BRACKET
+	{runeRange{0x29D8, 0x29D8}, sbprClose},     // Ps       LEFT WIGGLY FENCE
+	{runeRange{0x29FC, 0x29FC}, sbprClose},     // Ps       LEFT-POINTING CURVED ANGLE BRACKET
+	{runeRange{0x2C60, 0x2C60}, sbprUpper},     // L&       LATIN CAPITAL LETTER L WITH DOUBLE BAR
+	{runeRange{0x2C67, 0x2C67}, sbprUpper},     // L&       LATIN CAPITAL LETTER H WITH DESCENDER
+	{runeRange{0x2C6B, 0x2C6B}, sbprUpper},     // L&       LATIN CAPITAL LETTER Z WITH DESCENDER
+	{runeRange{0x2C72, 0x2C72}, sbprUpper},     // L&       LATIN CAPITAL LETTER W WITH HOOK
+	{runeRange{0x2C7C, 0x2C7D}, sbprLower},     // Lm   [2] LATIN SUBSCRIPT SMALL LETTER J..MODIFIER LETTER CAPITAL V
+	{runeRange{0x2C81, 0x2C81}, sbprLower},     // L&       COPTIC SMALL LETTER ALFA
+	{runeRange{0x2C83, 0x2C83}, sbprLower},     // L&       COPTIC SMALL LETTER VIDA
+	{runeRange{0x2C85, 0x2C85}, sbprLower},     // L&       COPTIC SMALL LETTER GAMMA
+	{runeRange{0x2C87, 0x2C87}, sbprLower},     // L&       COPTIC SMALL LETTER DALDA
+	{runeRange{0x2C89, 0x2C89}, sbprLower},     // L&       COPTIC SMALL LETTER EIE
+	{runeRange{0x2C8B, 0x2C8B}, sbprLower},     // L&       COPTIC SMALL LETTER SOU
+	{runeRange{0x2C8D, 0x2C8D}, sbprLower},     // L&       COPTIC SMALL LETTER ZATA
+	{runeRange{0x2C8F, 0x2C8F}, sbprLower},     // L&       COPTIC SMALL LETTER HATE
+	{runeRange{0x2C91, 0x2C91}, sbprLower},     // L&       COPTIC SMALL LETTER THETHE
+	{runeRange{0x2C93, 0x2C93}, sbprLower},     // L&       COPTIC SMALL LETTER IAUDA
+	{runeRange{0x2C95, 0x2C95}, sbprLower},     // L&       COPTIC SMALL LETTER KAPA
+	{runeRange{0x2C97, 0x2C97}, sbprLower},     // L&       COPTIC SMALL LETTER LAULA
+	{runeRange{0x2C99, 0x2C99}, sbprLower},     // L&       COPTIC SMALL LETTER MI
+	{runeRange{0x2C9B, 0x2C9B}, sbprLower},     // L&       COPTIC SMALL LETTER NI
+	{runeRange{0x2C9D, 0x2C9D}, sbprLower},     // L&       COPTIC SMALL LETTER KSI
+	{runeRange{0x2C9F, 0x2C9F}, sbprLower},     // L&       COPTIC SMALL LETTER O
+	{runeRange{0x2CA1, 0x2CA1}, sbprLower},     // L&       COPTIC SMALL LETTER PI
+	{runeRange{0x2CA3, 0x2CA3}, sbprLower},     // L&       COPTIC SMALL LETTER RO
+	{runeRange{0x2CA5, 0x2CA5}, sbprLower},     // L&       COPTIC SMALL LETTER SIMA
+	{runeRange{0x2CA7, 0x2CA7}, sbprLower},     // L&       COPTIC SMALL LETTER TAU
+	{runeRange{0x2CA9, 0x2CA9}, sbprLower},     // L&       COPTIC SMALL LETTER UA
+	{runeRange{0x2CAB, 0x2CAB}, sbprLower},     // L&       COPTIC SMALL LETTER FI
+	{runeRange{0x2CAD, 0x2CAD}, sbprLower},     // L&       COPTIC SMALL LETTER KHI
+	{runeRange{0x2CAF, 0x2CAF}, sbprLower},     // L&       COPTIC SMALL LETTER PSI
+	{runeRange{0x2CB1, 0x2CB1}, sbprLower},     // L&       COPTIC SMALL LETTER OOU
+	{runeRange{0x2CB3, 0x2CB3}, sbprLower},     // L&       COPTIC SMALL LETTER DIALECT-P ALEF
+	{runeRange{0x2CB5, 0x2CB5}, sbprLower},     // L&       COPTIC SMALL LETTER OLD COPTIC AIN
+	{runeRange{0x2CB7, 0x2CB7}, sbprLower},     // L&       COPTIC SMALL LETTER CRYPTOGRAMMIC EIE
+	{runeRange{0x2CB9, 0x2CB9}, sbprLower},     // L&       COPTIC SMALL LETTER DIALECT-P KAPA
+	{runeRange{0x2CBB, 0x2CBB}, sbprLower},     // L&       COPTIC SMALL LETTER DIALECT-P NI
+	{runeRange{0x2CBD, 0x2CBD}, sbprLower},     // L&       COPTIC SMALL LETTER CRYPTOGRAMMIC NI
+	{runeRange{0x2CBF, 0x2CBF}, sbprLower},     // L&       COPTIC SMALL LETTER OLD COPTIC OOU
+	{runeRange{0x2CC1, 0x2CC1}, sbprLower},     // L&       COPTIC SMALL LETTER SAMPI
+	{runeRange{0x2CC3, 0x2CC3}, sbprLower},     // L&       COPTIC SMALL LETTER CROSSED SHEI
+	{runeRange{0x2CC5, 0x2CC5}, sbprLower},     // L&       COPTIC SMALL LETTER OLD COPTIC SHEI
+	{runeRange{0x2CC7, 0x2CC7}, sbprLower},     // L&       COPTIC SMALL LETTER OLD COPTIC ESH
+	{runeRange{0x2CC9, 0x2CC9}, sbprLower},     // L&       COPTIC SMALL LETTER AKHMIMIC KHEI
+	{runeRange{0x2CCB, 0x2CCB}, sbprLower},     // L&       COPTIC SMALL LETTER DIALECT-P HORI
+	{runeRange{0x2CCD, 0x2CCD}, sbprLower},     // L&       COPTIC SMALL LETTER OLD COPTIC HORI
+	{runeRange{0x2CCF, 0x2CCF}, sbprLower},     // L&       COPTIC SMALL LETTER OLD COPTIC HA
+	{runeRange{0x2CD1, 0x2CD1}, sbprLower},     // L&       COPTIC SMALL LETTER L-SHAPED HA
+	{runeRange{0x2CD3, 0x2CD3}, sbprLower},     // L&       COPTIC SMALL LETTER OLD COPTIC HEI
+	{runeRange{0x2CD5, 0x2CD5}, sbprLower},     // L&       COPTIC SMALL LETTER OLD COPTIC HAT
+	{runeRange{0x2CD7, 0x2CD7}, sbprLower},     // L&       COPTIC SMALL LETTER OLD COPTIC GANGIA
+	{runeRange{0x2CD9, 0x2CD9}, sbprLower},     // L&       COPTIC SMALL LETTER OLD COPTIC DJA
+	{runeRange{0x2CDB, 0x2CDB}, sbprLower},     // L&       COPTIC SMALL LETTER OLD COPTIC SHIMA
+	{runeRange{0x2CDD, 0x2CDD}, sbprLower},     // L&       COPTIC SMALL LETTER OLD NUBIAN SHIMA
+	{runeRange{0x2CDF, 0x2CDF}, sbprLower},     // L&       COPTIC SMALL LETTER OLD NUBIAN NGI
+	{runeRange{0x2CE1, 0x2CE1}, sbprLower},     // L&       COPTIC SMALL LETTER OLD NUBIAN NYI
+	{runeRange{0x2CE3, 0x2CE4}, sbprLower},     // L&   [2] COPTIC SMALL LETTER OLD NUBIAN WAU..COPTIC SYMBOL KAI
+	{runeRange{0x2CEC, 0x2CEC}, sbprLower},     // L&       COPTIC SMALL LETTER CRYPTOGRAMMIC SHEI
+	{runeRange{0x2CEE, 0x2CEE}, sbprLower},     // L&       COPTIC SMALL LETTER CRYPTOGRAMMIC GANGIA
+	{runeRange{0x2CF2, 0x2CF2}, sbprUpper},     // L&       COPTIC CAPITAL LETTER BOHAIRIC KHEI
+	{runeRange{0x2D00, 0x2D25}, sbprLower},     // L&  [38] GEORGIAN SMALL LETTER AN..GEORGIAN SMALL LETTER HOE
+	{runeRange{0x2D2D, 0x2D2D}, sbprLower},     // L&       GEORGIAN SMALL LETTER AEN
+	{runeRange{0x2D6F, 0x2D6F}, sbprOLetter},   // Lm       TIFINAGH MODIFIER LETTER LABIALIZATION MARK
+	{runeRange{0x2D80, 0x2D96}, sbprOLetter},   // Lo  [23] ETHIOPIC SYLLABLE LOA..ETHIOPIC SYLLABLE GGWE
+	{runeRange{0x2DA8, 0x2DAE}, sbprOLetter},   // Lo   [7] ETHIOPIC SYLLABLE CCA..ETHIOPIC SYLLABLE CCO
+	{runeRange{0x2DB8, 0x2DBE}, sbprOLetter},   // Lo   [7] ETHIOPIC SYLLABLE CCHA..ETHIOPIC SYLLABLE CCHO
+	{runeRange{0x2DC8, 0x2DCE}, sbprOLetter},   // Lo   [7] ETHIOPIC SYLLABLE KYA..ETHIOPIC SYLLABLE KYO
+	{runeRange{0x2DD8, 0x2DDE}, sbprOLetter},   // Lo   [7] ETHIOPIC SYLLABLE GYA..ETHIOPIC SYLLABLE GYO
+	{runeRange{0x2E00, 0x2E01}, sbprClose},     // Po   [2] RIGHT ANGLE SUBSTITUTION MARKER..RIGHT ANGLE DOTTED SUBSTITUTION MARKER
+	{runeRange{0x2E03, 0x2E03}, sbprClose},     // Pf       RIGHT SUBSTITUTION BRACKET
+	{runeRange{0x2E05, 0x2E05}, sbprClose},     // Pf       RIGHT DOTTED SUBSTITUTION BRACKET
+	{runeRange{0x2E09, 0x2E09}, sbprClose},     // Pi       LEFT TRANSPOSITION BRACKET
+	{runeRange{0x2E0B, 0x2E0B}, sbprClose},     // Po       RAISED SQUARE
+	{runeRange{0x2E0D, 0x2E0D}, sbprClose},     // Pf       RIGHT RAISED OMISSION BRACKET
+	{runeRange{0x2E1D, 0x2E1D}, sbprClose},     // Pf       RIGHT LOW PARAPHRASE BRACKET
+	{runeRange{0x2E21, 0x2E21}, sbprClose},     // Pf       RIGHT VERTICAL BAR WITH QUILL
+	{runeRange{0x2E23, 0x2E23}, sbprClose},     // Pe       TOP RIGHT HALF BRACKET
+	{runeRange{0x2E25, 0x2E25}, sbprClose},     // Pe       BOTTOM RIGHT HALF BRACKET
+	{runeRange{0x2E27, 0x2E27}, sbprClose},     // Pe       RIGHT SIDEWAYS U BRACKET
+	{runeRange{0x2E29, 0x2E29}, sbprClose},     // Pe       RIGHT DOUBLE PARENTHESIS
+	{runeRange{0x2E2F, 0x2E2F}, sbprOLetter},   // Lm       VERTICAL TILDE
+	{runeRange{0x2E42, 0x2E42}, sbprClose},     // Ps       DOUBLE LOW-REVERSED-9 QUOTATION MARK
+	{runeRange{0x2E55, 0x2E55}, sbprClose},     // Ps       LEFT SQUARE BRACKET WITH STROKE
+	{runeRange{0x2E57, 0x2E57}, sbprClose},     // Ps       LEFT SQUARE BRACKET WITH DOUBLE STROKE
+	{runeRange{0x2E59, 0x2E59}, sbprClose},     // Ps       TOP HALF LEFT PARENTHESIS
+	{runeRange{0x2E5B, 0x2E5B}, sbprClose},     // Ps       BOTTOM HALF LEFT PARENTHESIS
+	{runeRange{0x3000, 0x3000}, sbprSp},        // Zs       IDEOGRAPHIC SPACE
+	{runeRange{0x3002, 0x3002}, sbprSTerm},     // Po       IDEOGRAPHIC FULL STOP
+	{runeRange{0x3006, 0x3006}, sbprOLetter},   // Lo       IDEOGRAPHIC CLOSING MARK
+	{runeRange{0x3008, 0x3008}, sbprClose},     // Ps       LEFT ANGLE BRACKET
+	{runeRange{0x300A, 0x300A}, sbprClose},     // Ps       LEFT DOUBLE ANGLE BRACKET
+	{runeRange{0x300C, 0x300C}, sbprClose},     // Ps       LEFT CORNER BRACKET
+	{runeRange{0x300E, 0x300E}, sbprClose},     // Ps       LEFT WHITE CORNER BRACKET
+	{runeRange{0x3010, 0x3010}, sbprClose},     // Ps       LEFT BLACK LENTICULAR BRACKET
+	{runeRange{0x3014, 0x3014}, sbprClose},     // Ps       LEFT TORTOISE SHELL BRACKET
+	{runeRange{0x3016, 0x3016}, sbprClose},     // Ps       LEFT WHITE LENTICULAR BRACKET
+	{runeRange{0x3018, 0x3018}, sbprClose},     // Ps       LEFT WHITE TORTOISE SHELL BRACKET
+	{runeRange{0x301A, 0x301A}, sbprClose},     // Ps       LEFT WHITE SQUARE BRACKET
+	{runeRange{0x301D, 0x301D}, sbprClose},     // Ps       REVERSED DOUBLE PRIME QUOTATION MARK
+	{runeRange{0x3021, 0x3029}, sbprOLetter},   // Nl   [9] HANGZHOU NUMERAL ONE..HANGZHOU NUMERAL NINE
+	{runeRange{0x302E, 0x302F}, sbprExtend},    // Mc   [2] HANGUL SINGLE DOT TONE MARK..HANGUL DOUBLE DOT TONE MARK
+	{runeRange{0x3038, 0x303A}, sbprOLetter},   // Nl   [3] HANGZHOU NUMERAL TEN..HANGZHOU NUMERAL THIRTY
+	{runeRange{0x303C, 0x303C}, sbprOLetter},   // Lo       MASU MARK
+	{runeRange{0x3099, 0x309A}, sbprExtend},    // Mn   [2] COMBINING KATAKANA-HIRAGANA VOICED SOUND MARK..COMBINING KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK
+	{runeRange{0x309F, 0x309F}, sbprOLetter},   // Lo       HIRAGANA DIGRAPH YORI
+	{runeRange{0x30FC, 0x30FE}, sbprOLetter},   // Lm   [3] KATAKANA-HIRAGANA PROLONGED SOUND MARK..KATAKANA VOICED ITERATION MARK
+	{runeRange{0x3105, 0x312F}, sbprOLetter},   // Lo  [43] BOPOMOFO LETTER B..BOPOMOFO LETTER NN
+	{runeRange{0x31A0, 0x31BF}, sbprOLetter},   // Lo  [32] BOPOMOFO LETTER BU..BOPOMOFO LETTER AH
+	{runeRange{0x3400, 0x4DBF}, sbprOLetter},   // Lo [6592] CJK UNIFIED IDEOGRAPH-3400..CJK UNIFIED IDEOGRAPH-4DBF
+	{runeRange{0xA015, 0xA015}, sbprOLetter},   // Lm       YI SYLLABLE WU
+	{runeRange{0xA4D0, 0xA4F7}, sbprOLetter},   // Lo  [40] LISU LETTER BA..LISU LETTER OE
+	{runeRange{0xA4FF, 0xA4FF}, sbprSTerm},     // Po       LISU PUNCTUATION FULL STOP
+	{runeRange{0xA60C, 0xA60C}, sbprOLetter},   // Lm       VAI SYLLABLE LENGTHENER
+	{runeRange{0xA610, 0xA61F}, sbprOLetter},   // Lo  [16] VAI SYLLABLE NDOLE FA..VAI SYMBOL JONG
+	{runeRange{0xA62A, 0xA62B}, sbprOLetter},   // Lo   [2] VAI SYLLABLE NDOLE MA..VAI SYLLABLE NDOLE DO
+	{runeRange{0xA641, 0xA641}, sbprLower},     // L&       CYRILLIC SMALL LETTER ZEMLYA
+	{runeRange{0xA643, 0xA643}, sbprLower},     // L&       CYRILLIC SMALL LETTER DZELO
+	{runeRange{0xA645, 0xA645}, sbprLower},     // L&       CYRILLIC SMALL LETTER REVERSED DZE
+	{runeRange{0xA647, 0xA647}, sbprLower},     // L&       CYRILLIC SMALL LETTER IOTA
+	{runeRange{0xA649, 0xA649}, sbprLower},     // L&       CYRILLIC SMALL LETTER DJERV
+	{runeRange{0xA64B, 0xA64B}, sbprLower},     // L&       CYRILLIC SMALL LETTER MONOGRAPH UK
+	{runeRange{0xA64D, 0xA64D}, sbprLower},     // L&       CYRILLIC SMALL LETTER BROAD OMEGA
+	{runeRange{0xA64F, 0xA64F}, sbprLower},     // L&       CYRILLIC SMALL LETTER NEUTRAL YER
+	{runeRange{0xA651, 0xA651}, sbprLower},     // L&       CYRILLIC SMALL LETTER YERU WITH BACK YER
+	{runeRange{0xA653, 0xA653}, sbprLower},     // L&       CYRILLIC SMALL LETTER IOTIFIED YAT
+	{runeRange{0xA655, 0xA655}, sbprLower},     // L&       CYRILLIC SMALL LETTER REVERSED YU
+	{runeRange{0xA657, 0xA657}, sbprLower},     // L&       CYRILLIC SMALL LETTER IOTIFIED A
+	{runeRange{0xA659, 0xA659}, sbprLower},     // L&       CYRILLIC SMALL LETTER CLOSED LITTLE YUS
+	{runeRange{0xA65B, 0xA65B}, sbprLower},     // L&       CYRILLIC SMALL LETTER BLENDED YUS
+	{runeRange{0xA65D, 0xA65D}, sbprLower},     // L&       CYRILLIC SMALL LETTER IOTIFIED CLOSED LITTLE YUS
+	{runeRange{0xA65F, 0xA65F}, sbprLower},     // L&       CYRILLIC SMALL LETTER YN
+	{runeRange{0xA661, 0xA661}, sbprLower},     // L&       CYRILLIC SMALL LETTER REVERSED TSE
+	{runeRange{0xA663, 0xA663}, sbprLower},     // L&       CYRILLIC SMALL LETTER SOFT DE
+	{runeRange{0xA665, 0xA665}, sbprLower},     // L&       CYRILLIC SMALL LETTER SOFT EL
+	{runeRange{0xA667, 0xA667}, sbprLower},     // L&       CYRILLIC SMALL LETTER SOFT EM
+	{runeRange{0xA669, 0xA669}, sbprLower},     // L&       CYRILLIC SMALL LETTER MONOCULAR O
+	{runeRange{0xA66B, 0xA66B}, sbprLower},     // L&       CYRILLIC SMALL LETTER BINOCULAR O
+	{runeRange{0xA66D, 0xA66D}, sbprLower},     // L&       CYRILLIC SMALL LETTER DOUBLE MONOCULAR O
+	{runeRange{0xA66F, 0xA66F}, sbprExtend},    // Mn       COMBINING CYRILLIC VZMET
+	{runeRange{0xA674, 0xA67D}, sbprExtend},    // Mn  [10] COMBINING CYRILLIC LETTER UKRAINIAN IE..COMBINING CYRILLIC PAYEROK
+	{runeRange{0xA680, 0xA680}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER DWE
+	{runeRange{0xA682, 0xA682}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER DZWE
+	{runeRange{0xA684, 0xA684}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER ZHWE
+	{runeRange{0xA686, 0xA686}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER CCHE
+	{runeRange{0xA688, 0xA688}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER DZZE
+	{runeRange{0xA68A, 0xA68A}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER TE WITH MIDDLE HOOK
+	{runeRange{0xA68C, 0xA68C}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER TWE
+	{runeRange{0xA68E, 0xA68E}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER TSWE
+	{runeRange{0xA690, 0xA690}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER TSSE
+	{runeRange{0xA692, 0xA692}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER TCHE
+	{runeRange{0xA694, 0xA694}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER HWE
+	{runeRange{0xA696, 0xA696}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER SHWE
+	{runeRange{0xA698, 0xA698}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER DOUBLE O
+	{runeRange{0xA69A, 0xA69A}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER CROSSED O
+	{runeRange{0xA69C, 0xA69D}, sbprLower},     // Lm   [2] MODIFIER LETTER CYRILLIC HARD SIGN..MODIFIER LETTER CYRILLIC SOFT SIGN
+	{runeRange{0xA6A0, 0xA6E5}, sbprOLetter},   // Lo  [70] BAMUM LETTER A..BAMUM LETTER KI
+	{runeRange{0xA6F0, 0xA6F1}, sbprExtend},    // Mn   [2] BAMUM COMBINING MARK KOQNDON..BAMUM COMBINING MARK TUKWENTIS
+	{runeRange{0xA6F7, 0xA6F7}, sbprSTerm},     // Po       BAMUM QUESTION MARK
+	{runeRange{0xA722, 0xA722}, sbprUpper},     // L&       LATIN CAPITAL LETTER EGYPTOLOGICAL ALEF
+	{runeRange{0xA724, 0xA724}, sbprUpper},     // L&       LATIN CAPITAL LETTER EGYPTOLOGICAL AIN
+	{runeRange{0xA726, 0xA726}, sbprUpper},     // L&       LATIN CAPITAL LETTER HENG
+	{runeRange{0xA728, 0xA728}, sbprUpper},     // L&       LATIN CAPITAL LETTER TZ
+	{runeRange{0xA72A, 0xA72A}, sbprUpper},     // L&       LATIN CAPITAL LETTER TRESILLO
+	{runeRange{0xA72C, 0xA72C}, sbprUpper},     // L&       LATIN CAPITAL LETTER CUATRILLO
+	{runeRange{0xA72E, 0xA72E}, sbprUpper},     // L&       LATIN CAPITAL LETTER CUATRILLO WITH COMMA
+	{runeRange{0xA732, 0xA732}, sbprUpper},     // L&       LATIN CAPITAL LETTER AA
+	{runeRange{0xA734, 0xA734}, sbprUpper},     // L&       LATIN CAPITAL LETTER AO
+	{runeRange{0xA736, 0xA736}, sbprUpper},     // L&       LATIN CAPITAL LETTER AU
+	{runeRange{0xA738, 0xA738}, sbprUpper},     // L&       LATIN CAPITAL LETTER AV
+	{runeRange{0xA73A, 0xA73A}, sbprUpper},     // L&       LATIN CAPITAL LETTER AV WITH HORIZONTAL BAR
+	{runeRange{0xA73C, 0xA73C}, sbprUpper},     // L&       LATIN CAPITAL LETTER AY
+	{runeRange{0xA73E, 0xA73E}, sbprUpper},     // L&       LATIN CAPITAL LETTER REVERSED C WITH DOT
+	{runeRange{0xA740, 0xA740}, sbprUpper},     // L&       LATIN CAPITAL LETTER K WITH STROKE
+	{runeRange{0xA742, 0xA742}, sbprUpper},     // L&       LATIN CAPITAL LETTER K WITH DIAGONAL STROKE
+	{runeRange{0xA744, 0xA744}, sbprUpper},     // L&       LATIN CAPITAL LETTER K WITH STROKE AND DIAGONAL STROKE
+	{runeRange{0xA746, 0xA746}, sbprUpper},     // L&       LATIN CAPITAL LETTER BROKEN L
+	{runeRange{0xA748, 0xA748}, sbprUpper},     // L&       LATIN CAPITAL LETTER L WITH HIGH STROKE
+	{runeRange{0xA74A, 0xA74A}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH LONG STROKE OVERLAY
+	{runeRange{0xA74C, 0xA74C}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH LOOP
+	{runeRange{0xA74E, 0xA74E}, sbprUpper},     // L&       LATIN CAPITAL LETTER OO
+	{runeRange{0xA750, 0xA750}, sbprUpper},     // L&       LATIN CAPITAL LETTER P WITH STROKE THROUGH DESCENDER
+	{runeRange{0xA752, 0xA752}, sbprUpper},     // L&       LATIN CAPITAL LETTER P WITH FLOURISH
+	{runeRange{0xA754, 0xA754}, sbprUpper},     // L&       LATIN CAPITAL LETTER P WITH SQUIRREL TAIL
+	{runeRange{0xA756, 0xA756}, sbprUpper},     // L&       LATIN CAPITAL LETTER Q WITH STROKE THROUGH DESCENDER
+	{runeRange{0xA758, 0xA758}, sbprUpper},     // L&       LATIN CAPITAL LETTER Q WITH DIAGONAL STROKE
+	{runeRange{0xA75A, 0xA75A}, sbprUpper},     // L&       LATIN CAPITAL LETTER R ROTUNDA
+	{runeRange{0xA75C, 0xA75C}, sbprUpper},     // L&       LATIN CAPITAL LETTER RUM ROTUNDA
+	{runeRange{0xA75E, 0xA75E}, sbprUpper},     // L&       LATIN CAPITAL LETTER V WITH DIAGONAL STROKE
+	{runeRange{0xA760, 0xA760}, sbprUpper},     // L&       LATIN CAPITAL LETTER VY
+	{runeRange{0xA762, 0xA762}, sbprUpper},     // L&       LATIN CAPITAL LETTER VISIGOTHIC Z
+	{runeRange{0xA764, 0xA764}, sbprUpper},     // L&       LATIN CAPITAL LETTER THORN WITH STROKE
+	{runeRange{0xA766, 0xA766}, sbprUpper},     // L&       LATIN CAPITAL LETTER THORN WITH STROKE THROUGH DESCENDER
+	{runeRange{0xA768, 0xA768}, sbprUpper},     // L&       LATIN CAPITAL LETTER VEND
+	{runeRange{0xA76A, 0xA76A}, sbprUpper},     // L&       LATIN CAPITAL LETTER ET
+	{runeRange{0xA76C, 0xA76C}, sbprUpper},     // L&       LATIN CAPITAL LETTER IS
+	{runeRange{0xA76E, 0xA76E}, sbprUpper},     // L&       LATIN CAPITAL LETTER CON
+	{runeRange{0xA770, 0xA770}, sbprLower},     // Lm       MODIFIER LETTER US
+	{runeRange{0xA779, 0xA779}, sbprUpper},     // L&       LATIN CAPITAL LETTER INSULAR D
+	{runeRange{0xA77B, 0xA77B}, sbprUpper},     // L&       LATIN CAPITAL LETTER INSULAR F
+	{runeRange{0xA77D, 0xA77E}, sbprUpper},     // L&   [2] LATIN CAPITAL LETTER INSULAR G..LATIN CAPITAL LETTER TURNED INSULAR G
+	{runeRange{0xA780, 0xA780}, sbprUpper},     // L&       LATIN CAPITAL LETTER TURNED L
+	{runeRange{0xA782, 0xA782}, sbprUpper},     // L&       LATIN CAPITAL LETTER INSULAR R
+	{runeRange{0xA784, 0xA784}, sbprUpper},     // L&       LATIN CAPITAL LETTER INSULAR S
+	{runeRange{0xA786, 0xA786}, sbprUpper},     // L&       LATIN CAPITAL LETTER INSULAR T
+	{runeRange{0xA788, 0xA788}, sbprOLetter},   // Lm       MODIFIER LETTER LOW CIRCUMFLEX ACCENT
+	{runeRange{0xA78C, 0xA78C}, sbprLower},     // L&       LATIN SMALL LETTER SALTILLO
+	{runeRange{0xA78E, 0xA78E}, sbprLower},     // L&       LATIN SMALL LETTER L WITH RETROFLEX HOOK AND BELT
+	{runeRange{0xA790, 0xA790}, sbprUpper},     // L&       LATIN CAPITAL LETTER N WITH DESCENDER
+	{runeRange{0xA792, 0xA792}, sbprUpper},     // L&       LATIN CAPITAL LETTER C WITH BAR
+	{runeRange{0xA796, 0xA796}, sbprUpper},     // L&       LATIN CAPITAL LETTER B WITH FLOURISH
+	{runeRange{0xA798, 0xA798}, sbprUpper},     // L&       LATIN CAPITAL LETTER F WITH STROKE
+	{runeRange{0xA79A, 0xA79A}, sbprUpper},     // L&       LATIN CAPITAL LETTER VOLAPUK AE
+	{runeRange{0xA79C, 0xA79C}, sbprUpper},     // L&       LATIN CAPITAL LETTER VOLAPUK OE
+	{runeRange{0xA79E, 0xA79E}, sbprUpper},     // L&       LATIN CAPITAL LETTER VOLAPUK UE
+	{runeRange{0xA7A0, 0xA7A0}, sbprUpper},     // L&       LATIN CAPITAL LETTER G WITH OBLIQUE STROKE
+	{runeRange{0xA7A2, 0xA7A2}, sbprUpper},     // L&       LATIN CAPITAL LETTER K WITH OBLIQUE STROKE
+	{runeRange{0xA7A4, 0xA7A4}, sbprUpper},     // L&       LATIN CAPITAL LETTER N WITH OBLIQUE STROKE
+	{runeRange{0xA7A6, 0xA7A6}, sbprUpper},     // L&       LATIN CAPITAL LETTER R WITH OBLIQUE STROKE
+	{runeRange{0xA7A8, 0xA7A8}, sbprUpper},     // L&       LATIN CAPITAL LETTER S WITH OBLIQUE STROKE
+	{runeRange{0xA7AA, 0xA7AE}, sbprUpper},     // L&   [5] LATIN CAPITAL LETTER H WITH HOOK..LATIN CAPITAL LETTER SMALL CAPITAL I
+	{runeRange{0xA7B0, 0xA7B4}, sbprUpper},     // L&   [5] LATIN CAPITAL LETTER TURNED K..LATIN CAPITAL LETTER BETA
+	{runeRange{0xA7B6, 0xA7B6}, sbprUpper},     // L&       LATIN CAPITAL LETTER OMEGA
+	{runeRange{0xA7B8, 0xA7B8}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH STROKE
+	{runeRange{0xA7BA, 0xA7BA}, sbprUpper},     // L&       LATIN CAPITAL LETTER GLOTTAL A
+	{runeRange{0xA7BC, 0xA7BC}, sbprUpper},     // L&       LATIN CAPITAL LETTER GLOTTAL I
+	{runeRange{0xA7BE, 0xA7BE}, sbprUpper},     // L&       LATIN CAPITAL LETTER GLOTTAL U
+	{runeRange{0xA7C0, 0xA7C0}, sbprUpper},     // L&       LATIN CAPITAL LETTER OLD POLISH O
+	{runeRange{0xA7C2, 0xA7C2}, sbprUpper},     // L&       LATIN CAPITAL LETTER ANGLICANA W
+	{runeRange{0xA7C4, 0xA7C7}, sbprUpper},     // L&   [4] LATIN CAPITAL LETTER C WITH PALATAL HOOK..LATIN CAPITAL LETTER D WITH SHORT STROKE OVERLAY
+	{runeRange{0xA7C9, 0xA7C9}, sbprUpper},     // L&       LATIN CAPITAL LETTER S WITH SHORT STROKE OVERLAY
+	{runeRange{0xA7D0, 0xA7D0}, sbprUpper},     // L&       LATIN CAPITAL LETTER CLOSED INSULAR G
+	{runeRange{0xA7D3, 0xA7D3}, sbprLower},     // L&       LATIN SMALL LETTER DOUBLE THORN
+	{runeRange{0xA7D6, 0xA7D6}, sbprUpper},     // L&       LATIN CAPITAL LETTER MIDDLE SCOTS S
+	{runeRange{0xA7D8, 0xA7D8}, sbprUpper},     // L&       LATIN CAPITAL LETTER SIGMOID S
+	{runeRange{0xA7F2, 0xA7F4}, sbprLower},     // Lm   [3] MODIFIER LETTER CAPITAL C..MODIFIER LETTER CAPITAL Q
+	{runeRange{0xA7F6, 0xA7F6}, sbprLower},     // L&       LATIN SMALL LETTER REVERSED HALF H
+	{runeRange{0xA7F8, 0xA7F9}, sbprLower},     // Lm   [2] MODIFIER LETTER CAPITAL H WITH STROKE..MODIFIER LETTER SMALL LIGATURE OE
+	{runeRange{0xA7FB, 0xA801}, sbprOLetter},   // Lo   [7] LATIN EPIGRAPHIC LETTER REVERSED F..SYLOTI NAGRI LETTER I
+	{runeRange{0xA803, 0xA805}, sbprOLetter},   // Lo   [3] SYLOTI NAGRI LETTER U..SYLOTI NAGRI LETTER O
+	{runeRange{0xA807, 0xA80A}, sbprOLetter},   // Lo   [4] SYLOTI NAGRI LETTER KO..SYLOTI NAGRI LETTER GHO
+	{runeRange{0xA80C, 0xA822}, sbprOLetter},   // Lo  [23] SYLOTI NAGRI LETTER CO..SYLOTI NAGRI LETTER HO
+	{runeRange{0xA825, 0xA826}, sbprExtend},    // Mn   [2] SYLOTI NAGRI VOWEL SIGN U..SYLOTI NAGRI VOWEL SIGN E
+	{runeRange{0xA82C, 0xA82C}, sbprExtend},    // Mn       SYLOTI NAGRI SIGN ALTERNATE HASANTA
+	{runeRange{0xA876, 0xA877}, sbprSTerm},     // Po   [2] PHAGS-PA MARK SHAD..PHAGS-PA MARK DOUBLE SHAD
+	{runeRange{0xA882, 0xA8B3}, sbprOLetter},   // Lo  [50] SAURASHTRA LETTER A..SAURASHTRA LETTER LLA
+	{runeRange{0xA8C4, 0xA8C5}, sbprExtend},    // Mn   [2] SAURASHTRA SIGN VIRAMA..SAURASHTRA SIGN CANDRABINDU
+	{runeRange{0xA8D0, 0xA8D9}, sbprNumeric},   // Nd  [10] SAURASHTRA DIGIT ZERO..SAURASHTRA DIGIT NINE
+	{runeRange{0xA8F2, 0xA8F7}, sbprOLetter},   // Lo   [6] DEVANAGARI SIGN SPACING CANDRABINDU..DEVANAGARI SIGN CANDRABINDU AVAGRAHA
+	{runeRange{0xA8FD, 0xA8FE}, sbprOLetter},   // Lo   [2] DEVANAGARI JAIN OM..DEVANAGARI LETTER AY
+	{runeRange{0xA900, 0xA909}, sbprNumeric},   // Nd  [10] KAYAH LI DIGIT ZERO..KAYAH LI DIGIT NINE
+	{runeRange{0xA926, 0xA92D}, sbprExtend},    // Mn   [8] KAYAH LI VOWEL UE..KAYAH LI TONE CALYA PLOPHU
+	{runeRange{0xA930, 0xA946}, sbprOLetter},   // Lo  [23] REJANG LETTER KA..REJANG LETTER A
+	{runeRange{0xA952, 0xA953}, sbprExtend},    // Mc   [2] REJANG CONSONANT SIGN H..REJANG VIRAMA
+	{runeRange{0xA980, 0xA982}, sbprExtend},    // Mn   [3] JAVANESE SIGN PANYANGGA..JAVANESE SIGN LAYAR
+	{runeRange{0xA984, 0xA9B2}, sbprOLetter},   // Lo  [47] JAVANESE LETTER A..JAVANESE LETTER HA
+	{runeRange{0xA9B4, 0xA9B5}, sbprExtend},    // Mc   [2] JAVANESE VOWEL SIGN TARUNG..JAVANESE VOWEL SIGN TOLONG
+	{runeRange{0xA9BA, 0xA9BB}, sbprExtend},    // Mc   [2] JAVANESE VOWEL SIGN TALING..JAVANESE VOWEL SIGN DIRGA MURE
+	{runeRange{0xA9BE, 0xA9C0}, sbprExtend},    // Mc   [3] JAVANESE CONSONANT SIGN PENGKAL..JAVANESE PANGKON
+	{runeRange{0xA9CF, 0xA9CF}, sbprOLetter},   // Lm       JAVANESE PANGRANGKEP
+	{runeRange{0xA9E0, 0xA9E4}, sbprOLetter},   // Lo   [5] MYANMAR LETTER SHAN GHA..MYANMAR LETTER SHAN BHA
+	{runeRange{0xA9E6, 0xA9E6}, sbprOLetter},   // Lm       MYANMAR MODIFIER LETTER SHAN REDUPLICATION
+	{runeRange{0xA9F0, 0xA9F9}, sbprNumeric},   // Nd  [10] MYANMAR TAI LAING DIGIT ZERO..MYANMAR TAI LAING DIGIT NINE
+	{runeRange{0xAA00, 0xAA28}, sbprOLetter},   // Lo  [41] CHAM LETTER A..CHAM LETTER HA
+	{runeRange{0xAA2F, 0xAA30}, sbprExtend},    // Mc   [2] CHAM VOWEL SIGN O..CHAM VOWEL SIGN AI
+	{runeRange{0xAA33, 0xAA34}, sbprExtend},    // Mc   [2] CHAM CONSONANT SIGN YA..CHAM CONSONANT SIGN RA
+	{runeRange{0xAA40, 0xAA42}, sbprOLetter},   // Lo   [3] CHAM LETTER FINAL K..CHAM LETTER FINAL NG
+	{runeRange{0xAA44, 0xAA4B}, sbprOLetter},   // Lo   [8] CHAM LETTER FINAL CH..CHAM LETTER FINAL SS
+	{runeRange{0xAA4D, 0xAA4D}, sbprExtend},    // Mc       CHAM CONSONANT SIGN FINAL H
+	{runeRange{0xAA5D, 0xAA5F}, sbprSTerm},     // Po   [3] CHAM PUNCTUATION DANDA..CHAM PUNCTUATION TRIPLE DANDA
+	{runeRange{0xAA70, 0xAA70}, sbprOLetter},   // Lm       MYANMAR MODIFIER LETTER KHAMTI REDUPLICATION
+	{runeRange{0xAA7A, 0xAA7A}, sbprOLetter},   // Lo       MYANMAR LETTER AITON RA
+	{runeRange{0xAA7C, 0xAA7C}, sbprExtend},    // Mn       MYANMAR SIGN TAI LAING TONE-2
+	{runeRange{0xAA7E, 0xAAAF}, sbprOLetter},   // Lo  [50] MYANMAR LETTER SHWE PALAUNG CHA..TAI VIET LETTER HIGH O
+	{runeRange{0xAAB1, 0xAAB1}, sbprOLetter},   // Lo       TAI VIET VOWEL AA
+	{runeRange{0xAAB5, 0xAAB6}, sbprOLetter},   // Lo   [2] TAI VIET VOWEL E..TAI VIET VOWEL O
+	{runeRange{0xAAB9, 0xAABD}, sbprOLetter},   // Lo   [5] TAI VIET VOWEL UEA..TAI VIET VOWEL AN
+	{runeRange{0xAAC0, 0xAAC0}, sbprOLetter},   // Lo       TAI VIET TONE MAI NUENG
+	{runeRange{0xAAC2, 0xAAC2}, sbprOLetter},   // Lo       TAI VIET TONE MAI SONG
+	{runeRange{0xAADD, 0xAADD}, sbprOLetter},   // Lm       TAI VIET SYMBOL SAM
+	{runeRange{0xAAEB, 0xAAEB}, sbprExtend},    // Mc       MEETEI MAYEK VOWEL SIGN II
+	{runeRange{0xAAEE, 0xAAEF}, sbprExtend},    // Mc   [2] MEETEI MAYEK VOWEL SIGN AU..MEETEI MAYEK VOWEL SIGN AAU
+	{runeRange{0xAAF2, 0xAAF2}, sbprOLetter},   // Lo       MEETEI MAYEK ANJI
+	{runeRange{0xAAF5, 0xAAF5}, sbprExtend},    // Mc       MEETEI MAYEK VOWEL SIGN VISARGA
+	{runeRange{0xAB01, 0xAB06}, sbprOLetter},   // Lo   [6] ETHIOPIC SYLLABLE TTHU..ETHIOPIC SYLLABLE TTHO
+	{runeRange{0xAB11, 0xAB16}, sbprOLetter},   // Lo   [6] ETHIOPIC SYLLABLE DZU..ETHIOPIC SYLLABLE DZO
+	{runeRange{0xAB28, 0xAB2E}, sbprOLetter},   // Lo   [7] ETHIOPIC SYLLABLE BBA..ETHIOPIC SYLLABLE BBO
+	{runeRange{0xAB5C, 0xAB5F}, sbprLower},     // Lm   [4] MODIFIER LETTER SMALL HENG..MODIFIER LETTER SMALL U WITH LEFT HOOK
+	{runeRange{0xAB69, 0xAB69}, sbprLower},     // Lm       MODIFIER LETTER SMALL TURNED W
+	{runeRange{0xABC0, 0xABE2}, sbprOLetter},   // Lo  [35] MEETEI MAYEK LETTER KOK..MEETEI MAYEK LETTER I LONSUM
+	{runeRange{0xABE5, 0xABE5}, sbprExtend},    // Mn       MEETEI MAYEK VOWEL SIGN ANAP
+	{runeRange{0xABE8, 0xABE8}, sbprExtend},    // Mn       MEETEI MAYEK VOWEL SIGN UNAP
+	{runeRange{0xABEB, 0xABEB}, sbprSTerm},     // Po       MEETEI MAYEK CHEIKHEI
+	{runeRange{0xABED, 0xABED}, sbprExtend},    // Mn       MEETEI MAYEK APUN IYEK
+	{runeRange{0xAC00, 0xD7A3}, sbprOLetter},   // Lo [11172] HANGUL SYLLABLE GA..HANGUL SYLLABLE HIH
+	{runeRange{0xD7CB, 0xD7FB}, sbprOLetter},   // Lo  [49] HANGUL JONGSEONG NIEUN-RIEUL..HANGUL JONGSEONG PHIEUPH-THIEUTH
+	{runeRange{0xFA70, 0xFAD9}, sbprOLetter},   // Lo [106] CJK COMPATIBILITY IDEOGRAPH-FA70..CJK COMPATIBILITY IDEOGRAPH-FAD9
+	{runeRange{0xFB13, 0xFB17}, sbprLower},     // L&   [5] ARMENIAN SMALL LIGATURE MEN NOW..ARMENIAN SMALL LIGATURE MEN XEH
+	{runeRange{0xFB1E, 0xFB1E}, sbprExtend},    // Mn       HEBREW POINT JUDEO-SPANISH VARIKA
+	{runeRange{0xFB2A, 0xFB36}, sbprOLetter},   // Lo  [13] HEBREW LETTER SHIN WITH SHIN DOT..HEBREW LETTER ZAYIN WITH DAGESH
+	{runeRange{0xFB3E, 0xFB3E}, sbprOLetter},   // Lo       HEBREW LETTER MEM WITH DAGESH
+	{runeRange{0xFB43, 0xFB44}, sbprOLetter},   // Lo   [2] HEBREW LETTER FINAL PE WITH DAGESH..HEBREW LETTER PE WITH DAGESH
+	{runeRange{0xFBD3, 0xFD3D}, sbprOLetter},   // Lo [363] ARABIC LETTER NG ISOLATED FORM..ARABIC LIGATURE ALEF WITH FATHATAN ISOLATED FORM
+	{runeRange{0xFD3F, 0xFD3F}, sbprClose},     // Ps       ORNATE RIGHT PARENTHESIS
+	{runeRange{0xFD92, 0xFDC7}, sbprOLetter},   // Lo  [54] ARABIC LIGATURE MEEM WITH JEEM WITH KHAH INITIAL FORM..ARABIC LIGATURE NOON WITH JEEM WITH YEH FINAL FORM
+	{runeRange{0xFE00, 0xFE0F}, sbprExtend},    // Mn  [16] VARIATION SELECTOR-1..VARIATION SELECTOR-16
+	{runeRange{0xFE13, 0xFE13}, sbprSContinue}, // Po       PRESENTATION FORM FOR VERTICAL COLON
+	{runeRange{0xFE18, 0xFE18}, sbprClose},     // Pe       PRESENTATION FORM FOR VERTICAL RIGHT WHITE LENTICULAR BRAKCET
+	{runeRange{0xFE31, 0xFE32}, sbprSContinue}, // Pd   [2] PRESENTATION FORM FOR VERTICAL EM DASH..PRESENTATION FORM FOR VERTICAL EN DASH
+	{runeRange{0xFE36, 0xFE36}, sbprClose},     // Pe       PRESENTATION FORM FOR VERTICAL RIGHT PARENTHESIS
+	{runeRange{0xFE38, 0xFE38}, sbprClose},     // Pe       PRESENTATION FORM FOR VERTICAL RIGHT CURLY BRACKET
+	{runeRange{0xFE3A, 0xFE3A}, sbprClose},     // Pe       PRESENTATION FORM FOR VERTICAL RIGHT TORTOISE SHELL BRACKET
+	{runeRange{0xFE3C, 0xFE3C}, sbprClose},     // Pe       PRESENTATION FORM FOR VERTICAL RIGHT BLACK LENTICULAR BRACKET
+	{runeRange{0xFE3E, 0xFE3E}, sbprClose},     // Pe       PRESENTATION FORM FOR VERTICAL RIGHT DOUBLE ANGLE BRACKET
+	{runeRange{0xFE40, 0xFE40}, sbprClose},     // Pe       PRESENTATION FORM FOR VERTICAL RIGHT ANGLE BRACKET
+	{runeRange{0xFE42, 0xFE42}, sbprClose},     // Pe       PRESENTATION FORM FOR VERTICAL RIGHT CORNER BRACKET
+	{runeRange{0xFE44, 0xFE44}, sbprClose},     // Pe       PRESENTATION FORM FOR VERTICAL RIGHT WHITE CORNER BRACKET
+	{runeRange{0xFE48, 0xFE48}, sbprClose},     // Pe       PRESENTATION FORM FOR VERTICAL RIGHT SQUARE BRACKET
+	{runeRange{0xFE52, 0xFE52}, sbprATerm},     // Po       SMALL FULL STOP
+	{runeRange{0xFE56, 0xFE57}, sbprSTerm},     // Po   [2] SMALL QUESTION MARK..SMALL EXCLAMATION MARK
+	{runeRange{0xFE59, 0xFE59}, sbprClose},     // Ps       SMALL LEFT PARENTHESIS
+	{runeRange{0xFE5B, 0xFE5B}, sbprClose},     // Ps       SMALL LEFT CURLY BRACKET
+	{runeRange{0xFE5D, 0xFE5D}, sbprClose},     // Ps       SMALL LEFT TORTOISE SHELL BRACKET
+	{runeRange{0xFE63, 0xFE63}, sbprSContinue}, // Pd       SMALL HYPHEN-MINUS
+	{runeRange{0xFE76, 0xFEFC}, sbprOLetter},   // Lo [135] ARABIC FATHA ISOLATED FORM..ARABIC LIGATURE LAM WITH ALEF FINAL FORM
+	{runeRange{0xFF01, 0xFF01}, sbprSTerm},     // Po       FULLWIDTH EXCLAMATION MARK
+	{runeRange{0xFF09, 0xFF09}, sbprClose},     // Pe       FULLWIDTH RIGHT PARENTHESIS
+	{runeRange{0xFF0D, 0xFF0D}, sbprSContinue}, // Pd       FULLWIDTH HYPHEN-MINUS
+	{runeRange{0xFF10, 0xFF19}, sbprNumeric},   // Nd  [10] FULLWIDTH DIGIT ZERO..FULLWIDTH DIGIT NINE
+	{runeRange{0xFF1F, 0xFF1F}, sbprSTerm},     // Po       FULLWIDTH QUESTION MARK
+	{runeRange{0xFF3B, 0xFF3B}, sbprClose},     // Ps       FULLWIDTH LEFT SQUARE BRACKET
+	{runeRange{0xFF41, 0xFF5A}, sbprLower},     // L&  [26] FULLWIDTH LATIN SMALL LETTER A..FULLWIDTH LATIN SMALL LETTER Z
+	{runeRange{0xFF5D, 0xFF5D}, sbprClose},     // Pe       FULLWIDTH RIGHT CURLY BRACKET
+	{runeRange{0xFF60, 0xFF60}, sbprClose},     // Pe       FULLWIDTH RIGHT WHITE PARENTHESIS
+	{runeRange{0xFF62, 0xFF62}, sbprClose},     // Ps       HALFWIDTH LEFT CORNER BRACKET
+	{runeRange{0xFF64, 0xFF64}, sbprSContinue}, // Po       HALFWIDTH IDEOGRAPHIC COMMA
+	{runeRange{0xFF70, 0xFF70}, sbprOLetter},   // Lm       HALFWIDTH KATAKANA-HIRAGANA PROLONGED SOUND MARK
+	{runeRange{0xFF9E, 0xFF9F}, sbprExtend},    // Lm   [2] HALFWIDTH KATAKANA VOICED SOUND MARK..HALFWIDTH KATAKANA SEMI-VOICED SOUND MARK
+	{runeRange{0xFFC2, 0xFFC7}, sbprOLetter},   // Lo   [6] HALFWIDTH HANGUL LETTER A..HALFWIDTH HANGUL LETTER E
+	{runeRange{0xFFD2, 0xFFD7}, sbprOLetter},   // Lo   [6] HALFWIDTH HANGUL LETTER YO..HALFWIDTH HANGUL LETTER YU
+	{runeRange{0xFFF9, 0xFFFB}, sbprFormat},    // Cf   [3] INTERLINEAR ANNOTATION ANCHOR..INTERLINEAR ANNOTATION TERMINATOR
+	{runeRange{0x1000D, 0x10026}, sbprOLetter}, // Lo  [26] LINEAR B SYLLABLE B036 JO..LINEAR B SYLLABLE B032 QO
+	{runeRange{0x1003C, 0x1003D}, sbprOLetter}, // Lo   [2] LINEAR B SYLLABLE B017 ZA..LINEAR B SYLLABLE B074 ZE
+	{runeRange{0x10050, 0x1005D}, sbprOLetter}, // Lo  [14] LINEAR B SYMBOL B018..LINEAR B SYMBOL B089
+	{runeRange{0x10140, 0x10174}, sbprOLetter}, // Nl  [53] GREEK ACROPHONIC ATTIC ONE QUARTER..GREEK ACROPHONIC STRATIAN FIFTY MNAS
+	{runeRange{0x10280, 0x1029C}, sbprOLetter}, // Lo  [29] LYCIAN LETTER A..LYCIAN LETTER X
+	{runeRange{0x102E0, 0x102E0}, sbprExtend},  // Mn       COPTIC EPACT THOUSANDS MARK
+	{runeRange{0x1032D, 0x10340}, sbprOLetter}, // Lo  [20] OLD ITALIC LETTER YE..GOTHIC LETTER PAIRTHRA
+	{runeRange{0x10342, 0x10349}, sbprOLetter}, // Lo   [8] GOTHIC LETTER RAIDA..GOTHIC LETTER OTHAL
+	{runeRange{0x10350, 0x10375}, sbprOLetter}, // Lo  [38] OLD PERMIC LETTER AN..OLD PERMIC LETTER IA
+	{runeRange{0x10380, 0x1039D}, sbprOLetter}, // Lo  [30] UGARITIC LETTER ALPA..UGARITIC LETTER SSU
+	{runeRange{0x103C8, 0x103CF}, sbprOLetter}, // Lo   [8] OLD PERSIAN SIGN AURAMAZDAA..OLD PERSIAN SIGN BUUMISH
+	{runeRange{0x10400, 0x10427}, sbprUpper},   // L&  [40] DESERET CAPITAL LETTER LONG I..DESERET CAPITAL LETTER EW
+	{runeRange{0x10450, 0x1049D}, sbprOLetter}, // Lo  [78] SHAVIAN LETTER PEEP..OSMANYA LETTER OO
+	{runeRange{0x104B0, 0x104D3}, sbprUpper},   // L&  [36] OSAGE CAPITAL LETTER A..OSAGE CAPITAL LETTER ZHA
+	{runeRange{0x10500, 0x10527}, sbprOLetter}, // Lo  [40] ELBASAN LETTER A..ELBASAN LETTER KHE
+	{runeRange{0x10570, 0x1057A}, sbprUpper},   // L&  [11] VITHKUQI CAPITAL LETTER A..VITHKUQI CAPITAL LETTER GA
+	{runeRange{0x1058C, 0x10592}, sbprUpper},   // L&   [7] VITHKUQI CAPITAL LETTER SE..VITHKUQI CAPITAL LETTER XE
+	{runeRange{0x10597, 0x105A1}, sbprLower},   // L&  [11] VITHKUQI SMALL LETTER A..VITHKUQI SMALL LETTER GA
+	{runeRange{0x105B3, 0x105B9}, sbprLower},   // L&   [7] VITHKUQI SMALL LETTER SE..VITHKUQI SMALL LETTER XE
+	{runeRange{0x10600, 0x10736}, sbprOLetter}, // Lo [311] LINEAR A SIGN AB001..LINEAR A SIGN A664
+	{runeRange{0x10760, 0x10767}, sbprOLetter}, // Lo   [8] LINEAR A SIGN A800..LINEAR A SIGN A807
+	{runeRange{0x10781, 0x10782}, sbprOLetter}, // Lm   [2] MODIFIER LETTER SUPERSCRIPT TRIANGULAR COLON..MODIFIER LETTER SUPERSCRIPT HALF TRIANGULAR COLON
+	{runeRange{0x10787, 0x107B0}, sbprLower},   // Lm  [42] MODIFIER LETTER SMALL DZ DIGRAPH..MODIFIER LETTER SMALL V WITH RIGHT HOOK
+	{runeRange{0x10800, 0x10805}, sbprOLetter}, // Lo   [6] CYPRIOT SYLLABLE A..CYPRIOT SYLLABLE JA
+	{runeRange{0x1080A, 0x10835}, sbprOLetter}, // Lo  [44] CYPRIOT SYLLABLE KA..CYPRIOT SYLLABLE WO
+	{runeRange{0x1083C, 0x1083C}, sbprOLetter}, // Lo       CYPRIOT SYLLABLE ZA
+	{runeRange{0x10860, 0x10876}, sbprOLetter}, // Lo  [23] PALMYRENE LETTER ALEPH..PALMYRENE LETTER TAW
+	{runeRange{0x108E0, 0x108F2}, sbprOLetter}, // Lo  [19] HATRAN LETTER ALEPH..HATRAN LETTER QOPH
+	{runeRange{0x10900, 0x10915}, sbprOLetter}, // Lo  [22] PHOENICIAN LETTER ALF..PHOENICIAN LETTER TAU
+	{runeRange{0x10980, 0x109B7}, sbprOLetter}, // Lo  [56] MEROITIC HIEROGLYPHIC LETTER A..MEROITIC CURSIVE LETTER DA
+	{runeRange{0x10A00, 0x10A00}, sbprOLetter}, // Lo       KHAROSHTHI LETTER A
+	{runeRange{0x10A05, 0x10A06}, sbprExtend},  // Mn   [2] KHAROSHTHI VOWEL SIGN E..KHAROSHTHI VOWEL SIGN O
+	{runeRange{0x10A10, 0x10A13}, sbprOLetter}, // Lo   [4] KHAROSHTHI LETTER KA..KHAROSHTHI LETTER GHA
+	{runeRange{0x10A19, 0x10A35}, sbprOLetter}, // Lo  [29] KHAROSHTHI LETTER NYA..KHAROSHTHI LETTER VHA
+	{runeRange{0x10A3F, 0x10A3F}, sbprExtend},  // Mn       KHAROSHTHI VIRAMA
+	{runeRange{0x10A60, 0x10A7C}, sbprOLetter}, // Lo  [29] OLD SOUTH ARABIAN LETTER HE..OLD SOUTH ARABIAN LETTER THETH
+	{runeRange{0x10AC0, 0x10AC7}, sbprOLetter}, // Lo   [8] MANICHAEAN LETTER ALEPH..MANICHAEAN LETTER WAW
+	{runeRange{0x10AE5, 0x10AE6}, sbprExtend},  // Mn   [2] MANICHAEAN ABBREVIATION MARK ABOVE..MANICHAEAN ABBREVIATION MARK BELOW
+	{runeRange{0x10B40, 0x10B55}, sbprOLetter}, // Lo  [22] INSCRIPTIONAL PARTHIAN LETTER ALEPH..INSCRIPTIONAL PARTHIAN LETTER TAW
+	{runeRange{0x10B80, 0x10B91}, sbprOLetter}, // Lo  [18] PSALTER PAHLAVI LETTER ALEPH..PSALTER PAHLAVI LETTER TAW
+	{runeRange{0x10C80, 0x10CB2}, sbprUpper},   // L&  [51] OLD HUNGARIAN CAPITAL LETTER A..OLD HUNGARIAN CAPITAL LETTER US
+	{runeRange{0x10D00, 0x10D23}, sbprOLetter}, // Lo  [36] HANIFI ROHINGYA LETTER A..HANIFI ROHINGYA MARK NA KHONNA
+	{runeRange{0x10D30, 0x10D39}, sbprNumeric}, // Nd  [10] HANIFI ROHINGYA DIGIT ZERO..HANIFI ROHINGYA DIGIT NINE
+	{runeRange{0x10EAB, 0x10EAC}, sbprExtend},  // Mn   [2] YEZIDI COMBINING HAMZA MARK..YEZIDI COMBINING MADDA MARK
+	{runeRange{0x10EFD, 0x10EFF}, sbprExtend},  // Mn   [3] ARABIC SMALL LOW WORD SAKTA..ARABIC SMALL LOW WORD MADDA
+	{runeRange{0x10F27, 0x10F27}, sbprOLetter}, // Lo       OLD SOGDIAN LIGATURE AYIN-DALETH
+	{runeRange{0x10F46, 0x10F50}, sbprExtend},  // Mn  [11] SOGDIAN COMBINING DOT BELOW..SOGDIAN COMBINING STROKE BELOW
+	{runeRange{0x10F70, 0x10F81}, sbprOLetter}, // Lo  [18] OLD UYGHUR LETTER ALEPH..OLD UYGHUR LETTER LESH
+	{runeRange{0x10F86, 0x10F89}, sbprSTerm},   // Po   [4] OLD UYGHUR PUNCTUATION BAR..OLD UYGHUR PUNCTUATION FOUR DOTS
+	{runeRange{0x10FE0, 0x10FF6}, sbprOLetter}, // Lo  [23] ELYMAIC LETTER ALEPH..ELYMAIC LIGATURE ZAYIN-YODH
+	{runeRange{0x11001, 0x11001}, sbprExtend},  // Mn       BRAHMI SIGN ANUSVARA
+	{runeRange{0x11003, 0x11037}, sbprOLetter}, // Lo  [53] BRAHMI SIGN JIHVAMULIYA..BRAHMI LETTER OLD TAMIL NNNA
+	{runeRange{0x11047, 0x11048}, sbprSTerm},   // Po   [2] BRAHMI DANDA..BRAHMI DOUBLE DANDA
+	{runeRange{0x11070, 0x11070}, sbprExtend},  // Mn       BRAHMI SIGN OLD TAMIL VIRAMA
+	{runeRange{0x11073, 0x11074}, sbprExtend},  // Mn   [2] BRAHMI VOWEL SIGN OLD TAMIL SHORT E..BRAHMI VOWEL SIGN OLD TAMIL SHORT O
+	{runeRange{0x1107F, 0x11081}, sbprExtend},  // Mn   [3] BRAHMI NUMBER JOINER..KAITHI SIGN ANUSVARA
+	{runeRange{0x11083, 0x110AF}, sbprOLetter}, // Lo  [45] KAITHI LETTER A..KAITHI LETTER HA
+	{runeRange{0x110B3, 0x110B6}, sbprExtend},  // Mn   [4] KAITHI VOWEL SIGN U..KAITHI VOWEL SIGN AI
+	{runeRange{0x110B9, 0x110BA}, sbprExtend},  // Mn   [2] KAITHI SIGN VIRAMA..KAITHI SIGN NUKTA
+	{runeRange{0x110BE, 0x110C1}, sbprSTerm},   // Po   [4] KAITHI SECTION MARK..KAITHI DOUBLE DANDA
+	{runeRange{0x110CD, 0x110CD}, sbprFormat},  // Cf       KAITHI NUMBER SIGN ABOVE
+	{runeRange{0x110F0, 0x110F9}, sbprNumeric}, // Nd  [10] SORA SOMPENG DIGIT ZERO..SORA SOMPENG DIGIT NINE
+	{runeRange{0x11103, 0x11126}, sbprOLetter}, // Lo  [36] CHAKMA LETTER AA..CHAKMA LETTER HAA
+	{runeRange{0x1112C, 0x1112C}, sbprExtend},  // Mc       CHAKMA VOWEL SIGN E
+	{runeRange{0x11136, 0x1113F}, sbprNumeric}, // Nd  [10] CHAKMA DIGIT ZERO..CHAKMA DIGIT NINE
+	{runeRange{0x11144, 0x11144}, sbprOLetter}, // Lo       CHAKMA LETTER LHAA
+	{runeRange{0x11147, 0x11147}, sbprOLetter}, // Lo       CHAKMA LETTER VAA
+	{runeRange{0x11173, 0x11173}, sbprExtend},  // Mn       MAHAJANI SIGN NUKTA
+	{runeRange{0x11180, 0x11181}, sbprExtend},  // Mn   [2] SHARADA SIGN CANDRABINDU..SHARADA SIGN ANUSVARA
+	{runeRange{0x11183, 0x111B2}, sbprOLetter}, // Lo  [48] SHARADA LETTER A..SHARADA LETTER HA
+	{runeRange{0x111B6, 0x111BE}, sbprExtend},  // Mn   [9] SHARADA VOWEL SIGN U..SHARADA VOWEL SIGN O
+	{runeRange{0x111C1, 0x111C4}, sbprOLetter}, // Lo   [4] SHARADA SIGN AVAGRAHA..SHARADA OM
+	{runeRange{0x111C9, 0x111CC}, sbprExtend},  // Mn   [4] SHARADA SANDHI MARK..SHARADA EXTRA SHORT VOWEL MARK
+	{runeRange{0x111CE, 0x111CE}, sbprExtend},  // Mc       SHARADA VOWEL SIGN PRISHTHAMATRA E
+	{runeRange{0x111D0, 0x111D9}, sbprNumeric}, // Nd  [10] SHARADA DIGIT ZERO..SHARADA DIGIT NINE
+	{runeRange{0x111DC, 0x111DC}, sbprOLetter}, // Lo       SHARADA HEADSTROKE
+	{runeRange{0x11200, 0x11211}, sbprOLetter}, // Lo  [18] KHOJKI LETTER A..KHOJKI LETTER JJA
+	{runeRange{0x1122C, 0x1122E}, sbprExtend},  // Mc   [3] KHOJKI VOWEL SIGN AA..KHOJKI VOWEL SIGN II
+	{runeRange{0x11232, 0x11233}, sbprExtend},  // Mc   [2] KHOJKI VOWEL SIGN O..KHOJKI VOWEL SIGN AU
+	{runeRange{0x11235, 0x11235}, sbprExtend},  // Mc       KHOJKI SIGN VIRAMA
+	{runeRange{0x11238, 0x11239}, sbprSTerm},   // Po   [2] KHOJKI DANDA..KHOJKI DOUBLE DANDA
+	{runeRange{0x1123E, 0x1123E}, sbprExtend},  // Mn       KHOJKI SIGN SUKUN
+	{runeRange{0x11241, 0x11241}, sbprExtend},  // Mn       KHOJKI VOWEL SIGN VOCALIC R
+	{runeRange{0x11288, 0x11288}, sbprOLetter}, // Lo       MULTANI LETTER GHA
+	{runeRange{0x1128F, 0x1129D}, sbprOLetter}, // Lo  [15] MULTANI LETTER NYA..MULTANI LETTER BA
+	{runeRange{0x112A9, 0x112A9}, sbprSTerm},   // Po       MULTANI SECTION MARK
+	{runeRange{0x112DF, 0x112DF}, sbprExtend},  // Mn       KHUDAWADI SIGN ANUSVARA
+	{runeRange{0x112E3, 0x112EA}, sbprExtend},  // Mn   [8] KHUDAWADI VOWEL SIGN U..KHUDAWADI SIGN VIRAMA
+	{runeRange{0x11300, 0x11301}, sbprExtend},  // Mn   [2] GRANTHA SIGN COMBINING ANUSVARA ABOVE..GRANTHA SIGN CANDRABINDU
+	{runeRange{0x11305, 0x1130C}, sbprOLetter}, // Lo   [8] GRANTHA LETTER A..GRANTHA LETTER VOCALIC L
+	{runeRange{0x11313, 0x11328}, sbprOLetter}, // Lo  [22] GRANTHA LETTER OO..GRANTHA LETTER NA
+	{runeRange{0x11332, 0x11333}, sbprOLetter}, // Lo   [2] GRANTHA LETTER LA..GRANTHA LETTER LLA
+	{runeRange{0x1133B, 0x1133C}, sbprExtend},  // Mn   [2] COMBINING BINDU BELOW..GRANTHA SIGN NUKTA
+	{runeRange{0x1133E, 0x1133F}, sbprExtend},  // Mc   [2] GRANTHA VOWEL SIGN AA..GRANTHA VOWEL SIGN I
+	{runeRange{0x11341, 0x11344}, sbprExtend},  // Mc   [4] GRANTHA VOWEL SIGN U..GRANTHA VOWEL SIGN VOCALIC RR
+	{runeRange{0x1134B, 0x1134D}, sbprExtend},  // Mc   [3] GRANTHA VOWEL SIGN OO..GRANTHA SIGN VIRAMA
+	{runeRange{0x11357, 0x11357}, sbprExtend},  // Mc       GRANTHA AU LENGTH MARK
+	{runeRange{0x11362, 0x11363}, sbprExtend},  // Mc   [2] GRANTHA VOWEL SIGN VOCALIC L..GRANTHA VOWEL SIGN VOCALIC LL
+	{runeRange{0x11370, 0x11374}, sbprExtend},  // Mn   [5] COMBINING GRANTHA LETTER A..COMBINING GRANTHA LETTER PA
+	{runeRange{0x11435, 0x11437}, sbprExtend},  // Mc   [3] NEWA VOWEL SIGN AA..NEWA VOWEL SIGN II
+	{runeRange{0x11440, 0x11441}, sbprExtend},  // Mc   [2] NEWA VOWEL SIGN O..NEWA VOWEL SIGN AU
+	{runeRange{0x11445, 0x11445}, sbprExtend},  // Mc       NEWA SIGN VISARGA
+	{runeRange{0x11447, 0x1144A}, sbprOLetter}, // Lo   [4] NEWA SIGN AVAGRAHA..NEWA SIDDHI
+	{runeRange{0x11450, 0x11459}, sbprNumeric}, // Nd  [10] NEWA DIGIT ZERO..NEWA DIGIT NINE
+	{runeRange{0x1145F, 0x11461}, sbprOLetter}, // Lo   [3] NEWA LETTER VEDIC ANUSVARA..NEWA SIGN UPADHMANIYA
+	{runeRange{0x114B0, 0x114B2}, sbprExtend},  // Mc   [3] TIRHUTA VOWEL SIGN AA..TIRHUTA VOWEL SIGN II
+	{runeRange{0x114B9, 0x114B9}, sbprExtend},  // Mc       TIRHUTA VOWEL SIGN E
+	{runeRange{0x114BB, 0x114BE}, sbprExtend},  // Mc   [4] TIRHUTA VOWEL SIGN AI..TIRHUTA VOWEL SIGN AU
+	{runeRange{0x114C1, 0x114C1}, sbprExtend},  // Mc       TIRHUTA SIGN VISARGA
+	{runeRange{0x114C4, 0x114C5}, sbprOLetter}, // Lo   [2] TIRHUTA SIGN AVAGRAHA..TIRHUTA GVANG
+	{runeRange{0x114D0, 0x114D9}, sbprNumeric}, // Nd  [10] TIRHUTA DIGIT ZERO..TIRHUTA DIGIT NINE
+	{runeRange{0x115AF, 0x115B1}, sbprExtend},  // Mc   [3] SIDDHAM VOWEL SIGN AA..SIDDHAM VOWEL SIGN II
+	{runeRange{0x115B8, 0x115BB}, sbprExtend},  // Mc   [4] SIDDHAM VOWEL SIGN E..SIDDHAM VOWEL SIGN AU
+	{runeRange{0x115BE, 0x115BE}, sbprExtend},  // Mc       SIDDHAM SIGN VISARGA
+	{runeRange{0x115C2, 0x115C3}, sbprSTerm},   // Po   [2] SIDDHAM DANDA..SIDDHAM DOUBLE DANDA
+	{runeRange{0x115D8, 0x115DB}, sbprOLetter}, // Lo   [4] SIDDHAM LETTER THREE-CIRCLE ALTERNATE I..SIDDHAM LETTER ALTERNATE U
+	{runeRange{0x11600, 0x1162F}, sbprOLetter}, // Lo  [48] MODI LETTER A..MODI LETTER LLA
+	{runeRange{0x11633, 0x1163A}, sbprExtend},  // Mn   [8] MODI VOWEL SIGN U..MODI VOWEL SIGN AI
+	{runeRange{0x1163D, 0x1163D}, sbprExtend},  // Mn       MODI SIGN ANUSVARA
+	{runeRange{0x1163F, 0x11640}, sbprExtend},  // Mn   [2] MODI SIGN VIRAMA..MODI SIGN ARDHACANDRA
+	{runeRange{0x11644, 0x11644}, sbprOLetter}, // Lo       MODI SIGN HUVA
+	{runeRange{0x11680, 0x116AA}, sbprOLetter}, // Lo  [43] TAKRI LETTER A..TAKRI LETTER RRA
+	{runeRange{0x116AC, 0x116AC}, sbprExtend},  // Mc       TAKRI SIGN VISARGA
+	{runeRange{0x116AE, 0x116AF}, sbprExtend},  // Mc   [2] TAKRI VOWEL SIGN I..TAKRI VOWEL SIGN II
+	{runeRange{0x116B6, 0x116B6}, sbprExtend},  // Mc       TAKRI SIGN VIRAMA
+	{runeRange{0x116B8, 0x116B8}, sbprOLetter}, // Lo       TAKRI LETTER ARCHAIC KHA
+	{runeRange{0x11700, 0x1171A}, sbprOLetter}, // Lo  [27] AHOM LETTER KA..AHOM LETTER ALTERNATE BA
+	{runeRange{0x11720, 0x11721}, sbprExtend},  // Mc   [2] AHOM VOWEL SIGN A..AHOM VOWEL SIGN AA
+	{runeRange{0x11726, 0x11726}, sbprExtend},  // Mc       AHOM VOWEL SIGN E
+	{runeRange{0x11730, 0x11739}, sbprNumeric}, // Nd  [10] AHOM DIGIT ZERO..AHOM DIGIT NINE
+	{runeRange{0x11740, 0x11746}, sbprOLetter}, // Lo   [7] AHOM LETTER CA..AHOM LETTER LLA
+	{runeRange{0x1182C, 0x1182E}, sbprExtend},  // Mc   [3] DOGRA VOWEL SIGN AA..DOGRA VOWEL SIGN II
+	{runeRange{0x11838, 0x11838}, sbprExtend},  // Mc       DOGRA SIGN VISARGA
+	{runeRange{0x118A0, 0x118BF}, sbprUpper},   // L&  [32] WARANG CITI CAPITAL LETTER NGAA..WARANG CITI CAPITAL LETTER VIYO
+	{runeRange{0x118E0, 0x118E9}, sbprNumeric}, // Nd  [10] WARANG CITI DIGIT ZERO..WARANG CITI DIGIT NINE
+	{runeRange{0x11909, 0x11909}, sbprOLetter}, // Lo       DIVES AKURU LETTER O
+	{runeRange{0x11915, 0x11916}, sbprOLetter}, // Lo   [2] DIVES AKURU LETTER NYA..DIVES AKURU LETTER TTA
+	{runeRange{0x11930, 0x11935}, sbprExtend},  // Mc   [6] DIVES AKURU VOWEL SIGN AA..DIVES AKURU VOWEL SIGN E
+	{runeRange{0x1193B, 0x1193C}, sbprExtend},  // Mn   [2] DIVES AKURU SIGN ANUSVARA..DIVES AKURU SIGN CANDRABINDU
+	{runeRange{0x1193E, 0x1193E}, sbprExtend},  // Mn       DIVES AKURU VIRAMA
+	{runeRange{0x11940, 0x11940}, sbprExtend},  // Mc       DIVES AKURU MEDIAL YA
+	{runeRange{0x11942, 0x11942}, sbprExtend},  // Mc       DIVES AKURU MEDIAL RA
+	{runeRange{0x11944, 0x11944}, sbprSTerm},   // Po       DIVES AKURU DOUBLE DANDA
+	{runeRange{0x11950, 0x11959}, sbprNumeric}, // Nd  [10] DIVES AKURU DIGIT ZERO..DIVES AKURU DIGIT NINE
+	{runeRange{0x119AA, 0x119D0}, sbprOLetter}, // Lo  [39] NANDINAGARI LETTER E..NANDINAGARI LETTER RRA
+	{runeRange{0x119D4, 0x119D7}, sbprExtend},  // Mn   [4] NANDINAGARI VOWEL SIGN U..NANDINAGARI VOWEL SIGN VOCALIC RR
+	{runeRange{0x119DC, 0x119DF}, sbprExtend},  // Mc   [4] NANDINAGARI VOWEL SIGN O..NANDINAGARI SIGN VISARGA
+	{runeRange{0x119E1, 0x119E1}, sbprOLetter}, // Lo       NANDINAGARI SIGN AVAGRAHA
+	{runeRange{0x119E4, 0x119E4}, sbprExtend},  // Mc       NANDINAGARI VOWEL SIGN PRISHTHAMATRA E
+	{runeRange{0x11A01, 0x11A0A}, sbprExtend},  // Mn  [10] ZANABAZAR SQUARE VOWEL SIGN I..ZANABAZAR SQUARE VOWEL LENGTH MARK
+	{runeRange{0x11A33, 0x11A38}, sbprExtend},  // Mn   [6] ZANABAZAR SQUARE FINAL CONSONANT MARK..ZANABAZAR SQUARE SIGN ANUSVARA
+	{runeRange{0x11A3A, 0x11A3A}, sbprOLetter}, // Lo       ZANABAZAR SQUARE CLUSTER-INITIAL LETTER RA
+	{runeRange{0x11A42, 0x11A43}, sbprSTerm},   // Po   [2] ZANABAZAR SQUARE MARK SHAD..ZANABAZAR SQUARE MARK DOUBLE SHAD
+	{runeRange{0x11A50, 0x11A50}, sbprOLetter}, // Lo       SOYOMBO LETTER A
+	{runeRange{0x11A57, 0x11A58}, sbprExtend},  // Mc   [2] SOYOMBO VOWEL SIGN AI..SOYOMBO VOWEL SIGN AU
+	{runeRange{0x11A5C, 0x11A89}, sbprOLetter}, // Lo  [46] SOYOMBO LETTER KA..SOYOMBO CLUSTER-INITIAL LETTER SA
+	{runeRange{0x11A97, 0x11A97}, sbprExtend},  // Mc       SOYOMBO SIGN VISARGA
+	{runeRange{0x11A9B, 0x11A9C}, sbprSTerm},   // Po   [2] SOYOMBO MARK SHAD..SOYOMBO MARK DOUBLE SHAD
+	{runeRange{0x11AB0, 0x11AF8}, sbprOLetter}, // Lo  [73] CANADIAN SYLLABICS NATTILIK HI..PAU CIN HAU GLOTTAL STOP FINAL
+	{runeRange{0x11C0A, 0x11C2E}, sbprOLetter}, // Lo  [37] BHAIKSUKI LETTER E..BHAIKSUKI LETTER HA
+	{runeRange{0x11C30, 0x11C36}, sbprExtend},  // Mn   [7] BHAIKSUKI VOWEL SIGN I..BHAIKSUKI VOWEL SIGN VOCALIC L
+	{runeRange{0x11C3E, 0x11C3E}, sbprExtend},  // Mc       BHAIKSUKI SIGN VISARGA
+	{runeRange{0x11C40, 0x11C40}, sbprOLetter}, // Lo       BHAIKSUKI SIGN AVAGRAHA
+	{runeRange{0x11C50, 0x11C59}, sbprNumeric}, // Nd  [10] BHAIKSUKI DIGIT ZERO..BHAIKSUKI DIGIT NINE
+	{runeRange{0x11C92, 0x11CA7}, sbprExtend},  // Mn  [22] MARCHEN SUBJOINED LETTER KA..MARCHEN SUBJOINED LETTER ZA
+	{runeRange{0x11CAA, 0x11CB0}, sbprExtend},  // Mn   [7] MARCHEN SUBJOINED LETTER RA..MARCHEN VOWEL SIGN AA
+	{runeRange{0x11CB2, 0x11CB3}, sbprExtend},  // Mn   [2] MARCHEN VOWEL SIGN U..MARCHEN VOWEL SIGN E
+	{runeRange{0x11CB5, 0x11CB6}, sbprExtend},  // Mn   [2] MARCHEN SIGN ANUSVARA..MARCHEN SIGN CANDRABINDU
+	{runeRange{0x11D08, 0x11D09}, sbprOLetter}, // Lo   [2] MASARAM GONDI LETTER AI..MASARAM GONDI LETTER O
+	{runeRange{0x11D31, 0x11D36}, sbprExtend},  // Mn   [6] MASARAM GONDI VOWEL SIGN AA..MASARAM GONDI VOWEL SIGN VOCALIC R
+	{runeRange{0x11D3C, 0x11D3D}, sbprExtend},  // Mn   [2] MASARAM GONDI VOWEL SIGN AI..MASARAM GONDI VOWEL SIGN O
+	{runeRange{0x11D46, 0x11D46}, sbprOLetter}, // Lo       MASARAM GONDI REPHA
+	{runeRange{0x11D50, 0x11D59}, sbprNumeric}, // Nd  [10] MASARAM GONDI DIGIT ZERO..MASARAM GONDI DIGIT NINE
+	{runeRange{0x11D67, 0x11D68}, sbprOLetter}, // Lo   [2] GUNJALA GONDI LETTER EE..GUNJALA GONDI LETTER AI
+	{runeRange{0x11D8A, 0x11D8E}, sbprExtend},  // Mc   [5] GUNJALA GONDI VOWEL SIGN AA..GUNJALA GONDI VOWEL SIGN UU
+	{runeRange{0x11D93, 0x11D94}, sbprExtend},  // Mc   [2] GUNJALA GONDI VOWEL SIGN OO..GUNJALA GONDI VOWEL SIGN AU
+	{runeRange{0x11D96, 0x11D96}, sbprExtend},  // Mc       GUNJALA GONDI SIGN VISARGA
+	{runeRange{0x11D98, 0x11D98}, sbprOLetter}, // Lo       GUNJALA GONDI OM
+	{runeRange{0x11EE0, 0x11EF2}, sbprOLetter}, // Lo  [19] MAKASAR LETTER KA..MAKASAR ANGKA
+	{runeRange{0x11EF5, 0x11EF6}, sbprExtend},  // Mc   [2] MAKASAR VOWEL SIGN E..MAKASAR VOWEL SIGN O
+	{runeRange{0x11F00, 0x11F01}, sbprExtend},  // Mn   [2] KAWI SIGN CANDRABINDU..KAWI SIGN ANUSVARA
+	{runeRange{0x11F03, 0x11F03}, sbprExtend},  // Mc       KAWI SIGN VISARGA
+	{runeRange{0x11F12, 0x11F33}, sbprOLetter}, // Lo  [34] KAWI LETTER KA..KAWI LETTER JNYA
+	{runeRange{0x11F36, 0x11F3A}, sbprExtend},  // Mn   [5] KAWI VOWEL SIGN I..KAWI VOWEL SIGN VOCALIC R
+	{runeRange{0x11F40, 0x11F40}, sbprExtend},  // Mn       KAWI VOWEL SIGN EU
+	{runeRange{0x11F42, 0x11F42}, sbprExtend},  // Mn       KAWI CONJOINER
+	{runeRange{0x11F50, 0x11F59}, sbprNumeric}, // Nd  [10] KAWI DIGIT ZERO..KAWI DIGIT NINE
+	{runeRange{0x12000, 0x12399}, sbprOLetter}, // Lo [922] CUNEIFORM SIGN A..CUNEIFORM SIGN U U
+	{runeRange{0x12480, 0x12543}, sbprOLetter}, // Lo [196] CUNEIFORM SIGN AB TIMES NUN TENU..CUNEIFORM SIGN ZU5 TIMES THREE DISH TENU
+	{runeRange{0x13000, 0x1342F}, sbprOLetter}, // Lo [1072] EGYPTIAN HIEROGLYPH A001..EGYPTIAN HIEROGLYPH V011D
+	{runeRange{0x13440, 0x13440}, sbprExtend},  // Mn       EGYPTIAN HIEROGLYPH MIRROR HORIZONTALLY
+	{runeRange{0x13447, 0x13455}, sbprExtend},  // Mn  [15] EGYPTIAN HIEROGLYPH MODIFIER DAMAGED AT TOP START..EGYPTIAN HIEROGLYPH MODIFIER DAMAGED
+	{runeRange{0x16800, 0x16A38}, sbprOLetter}, // Lo [569] BAMUM LETTER PHASE-A NGKUE MFON..BAMUM LETTER PHASE-F VUEQ
+	{runeRange{0x16A60, 0x16A69}, sbprNumeric}, // Nd  [10] MRO DIGIT ZERO..MRO DIGIT NINE
+	{runeRange{0x16A70, 0x16ABE}, sbprOLetter}, // Lo  [79] TANGSA LETTER OZ..TANGSA LETTER ZA
+	{runeRange{0x16AD0, 0x16AED}, sbprOLetter}, // Lo  [30] BASSA VAH LETTER ENNI..BASSA VAH LETTER I
+	{runeRange{0x16AF5, 0x16AF5}, sbprSTerm},   // Po       BASSA VAH FULL STOP
+	{runeRange{0x16B30, 0x16B36}, sbprExtend},  // Mn   [7] PAHAWH HMONG MARK CIM TUB..PAHAWH HMONG MARK CIM TAUM
+	{runeRange{0x16B40, 0x16B43}, sbprOLetter}, // Lm   [4] PAHAWH HMONG SIGN VOS SEEV..PAHAWH HMONG SIGN IB YAM
+	{runeRange{0x16B50, 0x16B59}, sbprNumeric}, // Nd  [10] PAHAWH HMONG DIGIT ZERO..PAHAWH HMONG DIGIT NINE
+	{runeRange{0x16B7D, 0x16B8F}, sbprOLetter}, // Lo  [19] PAHAWH HMONG CLAN SIGN TSHEEJ..PAHAWH HMONG CLAN SIGN VWJ
+	{runeRange{0x16E60, 0x16E7F}, sbprLower},   // L&  [32] MEDEFAIDRIN SMALL LETTER M..MEDEFAIDRIN SMALL LETTER Y
+	{runeRange{0x16F00, 0x16F4A}, sbprOLetter}, // Lo  [75] MIAO LETTER PA..MIAO LETTER RTE
+	{runeRange{0x16F50, 0x16F50}, sbprOLetter}, // Lo       MIAO LETTER NASALIZATION
+	{runeRange{0x16F8F, 0x16F92}, sbprExtend},  // Mn   [4] MIAO TONE RIGHT..MIAO TONE BELOW
+	{runeRange{0x16FE0, 0x16FE1}, sbprOLetter}, // Lm   [2] TANGUT ITERATION MARK..NUSHU ITERATION MARK
+	{runeRange{0x16FE4, 0x16FE4}, sbprExtend},  // Mn       KHITAN SMALL SCRIPT FILLER
+	{runeRange{0x17000, 0x187F7}, sbprOLetter}, // Lo [6136] TANGUT IDEOGRAPH-17000..TANGUT IDEOGRAPH-187F7
+	{runeRange{0x18D00, 0x18D08}, sbprOLetter}, // Lo   [9] TANGUT IDEOGRAPH-18D00..TANGUT IDEOGRAPH-18D08
+	{runeRange{0x1AFF5, 0x1AFFB}, sbprOLetter}, // Lm   [7] KATAKANA LETTER MINNAN TONE-7..KATAKANA LETTER MINNAN NASALIZED TONE-5
+	{runeRange{0x1B000, 0x1B122}, sbprOLetter}, // Lo [291] KATAKANA LETTER ARCHAIC E..KATAKANA LETTER ARCHAIC WU
+	{runeRange{0x1B150, 0x1B152}, sbprOLetter}, // Lo   [3] HIRAGANA LETTER SMALL WI..HIRAGANA LETTER SMALL WO
+	{runeRange{0x1B164, 0x1B167}, sbprOLetter}, // Lo   [4] KATAKANA LETTER SMALL WI..KATAKANA LETTER SMALL N
+	{runeRange{0x1BC00, 0x1BC6A}, sbprOLetter}, // Lo [107] DUPLOYAN LETTER H..DUPLOYAN LETTER VOCALIC M
+	{runeRange{0x1BC80, 0x1BC88}, sbprOLetter}, // Lo   [9] DUPLOYAN AFFIX HIGH ACUTE..DUPLOYAN AFFIX HIGH VERTICAL
+	{runeRange{0x1BC9D, 0x1BC9E}, sbprExtend},  // Mn   [2] DUPLOYAN THICK LETTER SELECTOR..DUPLOYAN DOUBLE MARK
+	{runeRange{0x1BCA0, 0x1BCA3}, sbprFormat},  // Cf   [4] SHORTHAND FORMAT LETTER OVERLAP..SHORTHAND FORMAT UP STEP
+	{runeRange{0x1CF30, 0x1CF46}, sbprExtend},  // Mn  [23] ZNAMENNY COMBINING TONAL RANGE MARK MRACHNO..ZNAMENNY PRIZNAK MODIFIER ROG
+	{runeRange{0x1D167, 0x1D169}, sbprExtend},  // Mn   [3] MUSICAL SYMBOL COMBINING TREMOLO-1..MUSICAL SYMBOL COMBINING TREMOLO-3
+	{runeRange{0x1D173, 0x1D17A}, sbprFormat},  // Cf   [8] MUSICAL SYMBOL BEGIN BEAM..MUSICAL SYMBOL END PHRASE
+	{runeRange{0x1D185, 0x1D18B}, sbprExtend},  // Mn   [7] MUSICAL SYMBOL COMBINING DOIT..MUSICAL SYMBOL COMBINING TRIPLE TONGUE
+	{runeRange{0x1D242, 0x1D244}, sbprExtend},  // Mn   [3] COMBINING GREEK MUSICAL TRISEME..COMBINING GREEK MUSICAL PENTASEME
+	{runeRange{0x1D41A, 0x1D433}, sbprLower},   // L&  [26] MATHEMATICAL BOLD SMALL A..MATHEMATICAL BOLD SMALL Z
+	{runeRange{0x1D44E, 0x1D454}, sbprLower},   // L&   [7] MATHEMATICAL ITALIC SMALL A..MATHEMATICAL ITALIC SMALL G
+	{runeRange{0x1D468, 0x1D481}, sbprUpper},   // L&  [26] MATHEMATICAL BOLD ITALIC CAPITAL A..MATHEMATICAL BOLD ITALIC CAPITAL Z
+	{runeRange{0x1D49C, 0x1D49C}, sbprUpper},   // L&       MATHEMATICAL SCRIPT CAPITAL A
+	{runeRange{0x1D4A2, 0x1D4A2}, sbprUpper},   // L&       MATHEMATICAL SCRIPT CAPITAL G
+	{runeRange{0x1D4A9, 0x1D4AC}, sbprUpper},   // L&   [4] MATHEMATICAL SCRIPT CAPITAL N..MATHEMATICAL SCRIPT CAPITAL Q
+	{runeRange{0x1D4B6, 0x1D4B9}, sbprLower},   // L&   [4] MATHEMATICAL SCRIPT SMALL A..MATHEMATICAL SCRIPT SMALL D
+	{runeRange{0x1D4BD, 0x1D4C3}, sbprLower},   // L&   [7] MATHEMATICAL SCRIPT SMALL H..MATHEMATICAL SCRIPT SMALL N
+	{runeRange{0x1D4D0, 0x1D4E9}, sbprUpper},   // L&  [26] MATHEMATICAL BOLD SCRIPT CAPITAL A..MATHEMATICAL BOLD SCRIPT CAPITAL Z
+	{runeRange{0x1D504, 0x1D505}, sbprUpper},   // L&   [2] MATHEMATICAL FRAKTUR CAPITAL A..MATHEMATICAL FRAKTUR CAPITAL B
+	{runeRange{0x1D50D, 0x1D514}, sbprUpper},   // L&   [8] MATHEMATICAL FRAKTUR CAPITAL J..MATHEMATICAL FRAKTUR CAPITAL Q
+	{runeRange{0x1D51E, 0x1D537}, sbprLower},   // L&  [26] MATHEMATICAL FRAKTUR SMALL A..MATHEMATICAL FRAKTUR SMALL Z
+	{runeRange{0x1D53B, 0x1D53E}, sbprUpper},   // L&   [4] MATHEMATICAL DOUBLE-STRUCK CAPITAL D..MATHEMATICAL DOUBLE-STRUCK CAPITAL G
+	{runeRange{0x1D546, 0x1D546}, sbprUpper},   // L&       MATHEMATICAL DOUBLE-STRUCK CAPITAL O
+	{runeRange{0x1D552, 0x1D56B}, sbprLower},   // L&  [26] MATHEMATICAL DOUBLE-STRUCK SMALL A..MATHEMATICAL DOUBLE-STRUCK SMALL Z
+	{runeRange{0x1D586, 0x1D59F}, sbprLower},   // L&  [26] MATHEMATICAL BOLD FRAKTUR SMALL A..MATHEMATICAL BOLD FRAKTUR SMALL Z
+	{runeRange{0x1D5BA, 0x1D5D3}, sbprLower},   // L&  [26] MATHEMATICAL SANS-SERIF SMALL A..MATHEMATICAL SANS-SERIF SMALL Z
+	{runeRange{0x1D5EE, 0x1D607}, sbprLower},   // L&  [26] MATHEMATICAL SANS-SERIF BOLD SMALL A..MATHEMATICAL SANS-SERIF BOLD SMALL Z
+	{runeRange{0x1D622, 0x1D63B}, sbprLower},   // L&  [26] MATHEMATICAL SANS-SERIF ITALIC SMALL A..MATHEMATICAL SANS-SERIF ITALIC SMALL Z
+	{runeRange{0x1D656, 0x1D66F}, sbprLower},   // L&  [26] MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL A..MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL Z
+	{runeRange{0x1D68A, 0x1D6A5}, sbprLower},   // L&  [28] MATHEMATICAL MONOSPACE SMALL A..MATHEMATICAL ITALIC SMALL DOTLESS J
+	{runeRange{0x1D6C2, 0x1D6DA}, sbprLower},   // L&  [25] MATHEMATICAL BOLD SMALL ALPHA..MATHEMATICAL BOLD SMALL OMEGA
+	{runeRange{0x1D6E2, 0x1D6FA}, sbprUpper},   // L&  [25] MATHEMATICAL ITALIC CAPITAL ALPHA..MATHEMATICAL ITALIC CAPITAL OMEGA
+	{runeRange{0x1D716, 0x1D71B}, sbprLower},   // L&   [6] MATHEMATICAL ITALIC EPSILON SYMBOL..MATHEMATICAL ITALIC PI SYMBOL
+	{runeRange{0x1D736, 0x1D74E}, sbprLower},   // L&  [25] MATHEMATICAL BOLD ITALIC SMALL ALPHA..MATHEMATICAL BOLD ITALIC SMALL OMEGA
+	{runeRange{0x1D756, 0x1D76E}, sbprUpper},   // L&  [25] MATHEMATICAL SANS-SERIF BOLD CAPITAL ALPHA..MATHEMATICAL SANS-SERIF BOLD CAPITAL OMEGA
+	{runeRange{0x1D78A, 0x1D78F}, sbprLower},   // L&   [6] MATHEMATICAL SANS-SERIF BOLD EPSILON SYMBOL..MATHEMATICAL SANS-SERIF BOLD PI SYMBOL
+	{runeRange{0x1D7AA, 0x1D7C2}, sbprLower},   // L&  [25] MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL ALPHA..MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL OMEGA
+	{runeRange{0x1D7CA, 0x1D7CA}, sbprUpper},   // L&       MATHEMATICAL BOLD CAPITAL DIGAMMA
+	{runeRange{0x1D7CE, 0x1D7FF}, sbprNumeric}, // Nd  [50] MATHEMATICAL BOLD DIGIT ZERO..MATHEMATICAL MONOSPACE DIGIT NINE
+	{runeRange{0x1DA3B, 0x1DA6C}, sbprExtend},  // Mn  [50] SIGNWRITING MOUTH CLOSED NEUTRAL..SIGNWRITING EXCITEMENT
+	{runeRange{0x1DA84, 0x1DA84}, sbprExtend},  // Mn       SIGNWRITING LOCATION HEAD NECK
+	{runeRange{0x1DA9B, 0x1DA9F}, sbprExtend},  // Mn   [5] SIGNWRITING FILL MODIFIER-2..SIGNWRITING FILL MODIFIER-6
+	{runeRange{0x1DF00, 0x1DF09}, sbprLower},   // L&  [10] LATIN SMALL LETTER FENG DIGRAPH WITH TRILL..LATIN SMALL LETTER T WITH HOOK AND RETROFLEX HOOK
+	{runeRange{0x1DF0B, 0x1DF1E}, sbprLower},   // L&  [20] LATIN SMALL LETTER ESH WITH DOUBLE BAR..LATIN SMALL LETTER S WITH CURL
+	{runeRange{0x1E000, 0x1E006}, sbprExtend},  // Mn   [7] COMBINING GLAGOLITIC LETTER AZU..COMBINING GLAGOLITIC LETTER ZHIVETE
+	{runeRange{0x1E01B, 0x1E021}, sbprExtend},  // Mn   [7] COMBINING GLAGOLITIC LETTER SHTA..COMBINING GLAGOLITIC LETTER YATI
+	{runeRange{0x1E026, 0x1E02A}, sbprExtend},  // Mn   [5] COMBINING GLAGOLITIC LETTER YO..COMBINING GLAGOLITIC LETTER FITA
+	{runeRange{0x1E08F, 0x1E08F}, sbprExtend},  // Mn       COMBINING CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I
+	{runeRange{0x1E130, 0x1E136}, sbprExtend},  // Mn   [7] NYIAKENG PUACHUE HMONG TONE-B..NYIAKENG PUACHUE HMONG TONE-D
+	{runeRange{0x1E140, 0x1E149}, sbprNumeric}, // Nd  [10] NYIAKENG PUACHUE HMONG DIGIT ZERO..NYIAKENG PUACHUE HMONG DIGIT NINE
+	{runeRange{0x1E290, 0x1E2AD}, sbprOLetter}, // Lo  [30] TOTO LETTER PA..TOTO LETTER A
+	{runeRange{0x1E2C0, 0x1E2EB}, sbprOLetter}, // Lo  [44] WANCHO LETTER AA..WANCHO LETTER YIH
+	{runeRange{0x1E2F0, 0x1E2F9}, sbprNumeric}, // Nd  [10] WANCHO DIGIT ZERO..WANCHO DIGIT NINE
+	{runeRange{0x1E4EB, 0x1E4EB}, sbprOLetter}, // Lm       NAG MUNDARI SIGN OJOD
+	{runeRange{0x1E4F0, 0x1E4F9}, sbprNumeric}, // Nd  [10] NAG MUNDARI DIGIT ZERO..NAG MUNDARI DIGIT NINE
+	{runeRange{0x1E7E8, 0x1E7EB}, sbprOLetter}, // Lo   [4] ETHIOPIC SYLLABLE GURAGE HHWA..ETHIOPIC SYLLABLE HHWE
+	{runeRange{0x1E7F0, 0x1E7FE}, sbprOLetter}, // Lo  [15] ETHIOPIC SYLLABLE GURAGE QWI..ETHIOPIC SYLLABLE GURAGE PWEE
+	{runeRange{0x1E8D0, 0x1E8D6}, sbprExtend},  // Mn   [7] MENDE KIKAKUI COMBINING NUMBER TEENS..MENDE KIKAKUI COMBINING NUMBER MILLIONS
+	{runeRange{0x1E922, 0x1E943}, sbprLower},   // L&  [34] ADLAM SMALL LETTER ALIF..ADLAM SMALL LETTER SHA
+	{runeRange{0x1E94B, 0x1E94B}, sbprOLetter}, // Lm       ADLAM NASALIZATION MARK
+	{runeRange{0x1EE00, 0x1EE03}, sbprOLetter}, // Lo   [4] ARABIC MATHEMATICAL ALEF..ARABIC MATHEMATICAL DAL
+	{runeRange{0x1EE21, 0x1EE22}, sbprOLetter}, // Lo   [2] ARABIC MATHEMATICAL INITIAL BEH..ARABIC MATHEMATICAL INITIAL JEEM
+	{runeRange{0x1EE27, 0x1EE27}, sbprOLetter}, // Lo       ARABIC MATHEMATICAL INITIAL HAH
+	{runeRange{0x1EE34, 0x1EE37}, sbprOLetter}, // Lo   [4] ARABIC MATHEMATICAL INITIAL SHEEN..ARABIC MATHEMATICAL INITIAL KHAH
+	{runeRange{0x1EE3B, 0x1EE3B}, sbprOLetter}, // Lo       ARABIC MATHEMATICAL INITIAL GHAIN
+	{runeRange{0x1EE47, 0x1EE47}, sbprOLetter}, // Lo       ARABIC MATHEMATICAL TAILED HAH
+	{runeRange{0x1EE4B, 0x1EE4B}, sbprOLetter}, // Lo       ARABIC MATHEMATICAL TAILED LAM
+	{runeRange{0x1EE51, 0x1EE52}, sbprOLetter}, // Lo   [2] ARABIC MATHEMATICAL TAILED SAD..ARABIC MATHEMATICAL TAILED QAF
+	{runeRange{0x1EE57, 0x1EE57}, sbprOLetter}, // Lo       ARABIC MATHEMATICAL TAILED KHAH
+	{runeRange{0x1EE5B, 0x1EE5B}, sbprOLetter}, // Lo       ARABIC MATHEMATICAL TAILED GHAIN
+	{runeRange{0x1EE5F, 0x1EE5F}, sbprOLetter}, // Lo       ARABIC MATHEMATICAL TAILED DOTLESS QAF
+	{runeRange{0x1EE64, 0x1EE64}, sbprOLetter}, // Lo       ARABIC MATHEMATICAL STRETCHED HEH
+	{runeRange{0x1EE6C, 0x1EE72}, sbprOLetter}, // Lo   [7] ARABIC MATHEMATICAL STRETCHED MEEM..ARABIC MATHEMATICAL STRETCHED QAF
+	{runeRange{0x1EE79, 0x1EE7C}, sbprOLetter}, // Lo   [4] ARABIC MATHEMATICAL STRETCHED DAD..ARABIC MATHEMATICAL STRETCHED DOTLESS BEH
+	{runeRange{0x1EE80, 0x1EE89}, sbprOLetter}, // Lo  [10] ARABIC MATHEMATICAL LOOPED ALEF..ARABIC MATHEMATICAL LOOPED YEH
+	{runeRange{0x1EEA1, 0x1EEA3}, sbprOLetter}, // Lo   [3] ARABIC MATHEMATICAL DOUBLE-STRUCK BEH..ARABIC MATHEMATICAL DOUBLE-STRUCK DAL
+	{runeRange{0x1EEAB, 0x1EEBB}, sbprOLetter}, // Lo  [17] ARABIC MATHEMATICAL DOUBLE-STRUCK LAM..ARABIC MATHEMATICAL DOUBLE-STRUCK GHAIN
+	{runeRange{0x1F150, 0x1F169}, sbprUpper},   // So  [26] NEGATIVE CIRCLED LATIN CAPITAL LETTER A..NEGATIVE CIRCLED LATIN CAPITAL LETTER Z
+	{runeRange{0x1F676, 0x1F678}, sbprClose},   // So   [3] SANS-SERIF HEAVY DOUBLE TURNED COMMA QUOTATION MARK ORNAMENT..SANS-SERIF HEAVY LOW DOUBLE COMMA QUOTATION MARK ORNAMENT
+	{runeRange{0x20000, 0x2A6DF}, sbprOLetter}, // Lo [42720] CJK UNIFIED IDEOGRAPH-20000..CJK UNIFIED IDEOGRAPH-2A6DF
+	{runeRange{0x2B740, 0x2B81D}, sbprOLetter}, // Lo [222] CJK UNIFIED IDEOGRAPH-2B740..CJK UNIFIED IDEOGRAPH-2B81D
+	{runeRange{0x2CEB0, 0x2EBE0}, sbprOLetter}, // Lo [7473] CJK UNIFIED IDEOGRAPH-2CEB0..CJK UNIFIED IDEOGRAPH-2EBE0
+	{runeRange{0x30000, 0x3134A}, sbprOLetter}, // Lo [4939] CJK UNIFIED IDEOGRAPH-30000..CJK UNIFIED IDEOGRAPH-3134A
+	{runeRange{0xE0001, 0xE0001}, sbprFormat},  // Cf       LANGUAGE TAG
 	{runeRange{0xE0100, 0xE01EF}, sbprExtend},  // Mn [240] VARIATION SELECTOR-17..VARIATION SELECTOR-256
+	{runeRange{0x0009, 0x0009}, sbprSp},        // Cc       <control-0009>
+	{runeRange{0x000B, 0x000C}, sbprSp},        // Cc   [2] <control-000B>..<control-000C>
+	{runeRange{0x0020, 0x0020}, sbprSp},        // Zs       SPACE
+	{runeRange{0x0022, 0x0022}, sbprClose},     // Po       QUOTATION MARK
+	{runeRange{0x0028, 0x0028}, sbprClose},     // Ps       LEFT PARENTHESIS
+	{runeRange{0x002C, 0x002C}, sbprSContinue}, // Po       COMMA
+	{runeRange{0x002E, 0x002E}, sbprATerm},     // Po       FULL STOP
+	{runeRange{0x003A, 0x003A}, sbprSContinue}, // Po       COLON
+	{runeRange{0x0041, 0x005A}, sbprUpper},     // L&  [26] LATIN CAPITAL LETTER A..LATIN CAPITAL LETTER Z
+	{runeRange{0x005D, 0x005D}, sbprClose},     // Pe       RIGHT SQUARE BRACKET
+	{runeRange{0x007B, 0x007B}, sbprClose},     // Ps       LEFT CURLY BRACKET
+	{runeRange{0x0085, 0x0085}, sbprSep},       // Cc       <control-0085>
+	{runeRange{0x00AA, 0x00AA}, sbprLower},     // Lo       FEMININE ORDINAL INDICATOR
+	{runeRange{0x00AD, 0x00AD}, sbprFormat},    // Cf       SOFT HYPHEN
+	{runeRange{0x00BA, 0x00BA}, sbprLower},     // Lo       MASCULINE ORDINAL INDICATOR
+	{runeRange{0x00C0, 0x00D6}, sbprUpper},     // L&  [23] LATIN CAPITAL LETTER A WITH GRAVE..LATIN CAPITAL LETTER O WITH DIAERESIS
+	{runeRange{0x00DF, 0x00F6}, sbprLower},     // L&  [24] LATIN SMALL LETTER SHARP S..LATIN SMALL LETTER O WITH DIAERESIS
+	{runeRange{0x0100, 0x0100}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH MACRON
+	{runeRange{0x0102, 0x0102}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH BREVE
+	{runeRange{0x0104, 0x0104}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH OGONEK
+	{runeRange{0x0106, 0x0106}, sbprUpper},     // L&       LATIN CAPITAL LETTER C WITH ACUTE
+	{runeRange{0x0108, 0x0108}, sbprUpper},     // L&       LATIN CAPITAL LETTER C WITH CIRCUMFLEX
+	{runeRange{0x010A, 0x010A}, sbprUpper},     // L&       LATIN CAPITAL LETTER C WITH DOT ABOVE
+	{runeRange{0x010C, 0x010C}, sbprUpper},     // L&       LATIN CAPITAL LETTER C WITH CARON
+	{runeRange{0x010E, 0x010E}, sbprUpper},     // L&       LATIN CAPITAL LETTER D WITH CARON
+	{runeRange{0x0110, 0x0110}, sbprUpper},     // L&       LATIN CAPITAL LETTER D WITH STROKE
+	{runeRange{0x0112, 0x0112}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH MACRON
+	{runeRange{0x0114, 0x0114}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH BREVE
+	{runeRange{0x0116, 0x0116}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH DOT ABOVE
+	{runeRange{0x0118, 0x0118}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH OGONEK
+	{runeRange{0x011A, 0x011A}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH CARON
+	{runeRange{0x011C, 0x011C}, sbprUpper},     // L&       LATIN CAPITAL LETTER G WITH CIRCUMFLEX
+	{runeRange{0x011E, 0x011E}, sbprUpper},     // L&       LATIN CAPITAL LETTER G WITH BREVE
+	{runeRange{0x0120, 0x0120}, sbprUpper},     // L&       LATIN CAPITAL LETTER G WITH DOT ABOVE
+	{runeRange{0x0122, 0x0122}, sbprUpper},     // L&       LATIN CAPITAL LETTER G WITH CEDILLA
+	{runeRange{0x0124, 0x0124}, sbprUpper},     // L&       LATIN CAPITAL LETTER H WITH CIRCUMFLEX
+	{runeRange{0x0126, 0x0126}, sbprUpper},     // L&       LATIN CAPITAL LETTER H WITH STROKE
+	{runeRange{0x0128, 0x0128}, sbprUpper},     // L&       LATIN CAPITAL LETTER I WITH TILDE
+	{runeRange{0x012A, 0x012A}, sbprUpper},     // L&       LATIN CAPITAL LETTER I WITH MACRON
+	{runeRange{0x012C, 0x012C}, sbprUpper},     // L&       LATIN CAPITAL LETTER I WITH BREVE
+	{runeRange{0x012E, 0x012E}, sbprUpper},     // L&       LATIN CAPITAL LETTER I WITH OGONEK
+	{runeRange{0x0130, 0x0130}, sbprUpper},     // L&       LATIN CAPITAL LETTER I WITH DOT ABOVE
+	{runeRange{0x0132, 0x0132}, sbprUpper},     // L&       LATIN CAPITAL LIGATURE IJ
+	{runeRange{0x0134, 0x0134}, sbprUpper},     // L&       LATIN CAPITAL LETTER J WITH CIRCUMFLEX
+	{runeRange{0x0136, 0x0136}, sbprUpper},     // L&       LATIN CAPITAL LETTER K WITH CEDILLA
+	{runeRange{0x0139, 0x0139}, sbprUpper},     // L&       LATIN CAPITAL LETTER L WITH ACUTE
+	{runeRange{0x013B, 0x013B}, sbprUpper},     // L&       LATIN CAPITAL LETTER L WITH CEDILLA
+	{runeRange{0x013D, 0x013D}, sbprUpper},     // L&       LATIN CAPITAL LETTER L WITH CARON
+	{runeRange{0x013F, 0x013F}, sbprUpper},     // L&       LATIN CAPITAL LETTER L WITH MIDDLE DOT
+	{runeRange{0x0141, 0x0141}, sbprUpper},     // L&       LATIN CAPITAL LETTER L WITH STROKE
+	{runeRange{0x0143, 0x0143}, sbprUpper},     // L&       LATIN CAPITAL LETTER N WITH ACUTE
+	{runeRange{0x0145, 0x0145}, sbprUpper},     // L&       LATIN CAPITAL LETTER N WITH CEDILLA
+	{runeRange{0x0147, 0x0147}, sbprUpper},     // L&       LATIN CAPITAL LETTER N WITH CARON
+	{runeRange{0x014A, 0x014A}, sbprUpper},     // L&       LATIN CAPITAL LETTER ENG
+	{runeRange{0x014C, 0x014C}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH MACRON
+	{runeRange{0x014E, 0x014E}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH BREVE
+	{runeRange{0x0150, 0x0150}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH DOUBLE ACUTE
+	{runeRange{0x0152, 0x0152}, sbprUpper},     // L&       LATIN CAPITAL LIGATURE OE
+	{runeRange{0x0154, 0x0154}, sbprUpper},     // L&       LATIN CAPITAL LETTER R WITH ACUTE
+	{runeRange{0x0156, 0x0156}, sbprUpper},     // L&       LATIN CAPITAL LETTER R WITH CEDILLA
+	{runeRange{0x0158, 0x0158}, sbprUpper},     // L&       LATIN CAPITAL LETTER R WITH CARON
+	{runeRange{0x015A, 0x015A}, sbprUpper},     // L&       LATIN CAPITAL LETTER S WITH ACUTE
+	{runeRange{0x015C, 0x015C}, sbprUpper},     // L&       LATIN CAPITAL LETTER S WITH CIRCUMFLEX
+	{runeRange{0x015E, 0x015E}, sbprUpper},     // L&       LATIN CAPITAL LETTER S WITH CEDILLA
+	{runeRange{0x0160, 0x0160}, sbprUpper},     // L&       LATIN CAPITAL LETTER S WITH CARON
+	{runeRange{0x0162, 0x0162}, sbprUpper},     // L&       LATIN CAPITAL LETTER T WITH CEDILLA
+	{runeRange{0x0164, 0x0164}, sbprUpper},     // L&       LATIN CAPITAL LETTER T WITH CARON
+	{runeRange{0x0166, 0x0166}, sbprUpper},     // L&       LATIN CAPITAL LETTER T WITH STROKE
+	{runeRange{0x0168, 0x0168}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH TILDE
+	{runeRange{0x016A, 0x016A}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH MACRON
+	{runeRange{0x016C, 0x016C}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH BREVE
+	{runeRange{0x016E, 0x016E}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH RING ABOVE
+	{runeRange{0x0170, 0x0170}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH DOUBLE ACUTE
+	{runeRange{0x0172, 0x0172}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH OGONEK
+	{runeRange{0x0174, 0x0174}, sbprUpper},     // L&       LATIN CAPITAL LETTER W WITH CIRCUMFLEX
+	{runeRange{0x0176, 0x0176}, sbprUpper},     // L&       LATIN CAPITAL LETTER Y WITH CIRCUMFLEX
+	{runeRange{0x0178, 0x0179}, sbprUpper},     // L&   [2] LATIN CAPITAL LETTER Y WITH DIAERESIS..LATIN CAPITAL LETTER Z WITH ACUTE
+	{runeRange{0x017B, 0x017B}, sbprUpper},     // L&       LATIN CAPITAL LETTER Z WITH DOT ABOVE
+	{runeRange{0x017D, 0x017D}, sbprUpper},     // L&       LATIN CAPITAL LETTER Z WITH CARON
+	{runeRange{0x0181, 0x0182}, sbprUpper},     // L&   [2] LATIN CAPITAL LETTER B WITH HOOK..LATIN CAPITAL LETTER B WITH TOPBAR
+	{runeRange{0x0184, 0x0184}, sbprUpper},     // L&       LATIN CAPITAL LETTER TONE SIX
+	{runeRange{0x0186, 0x0187}, sbprUpper},     // L&   [2] LATIN CAPITAL LETTER OPEN O..LATIN CAPITAL LETTER C WITH HOOK
+	{runeRange{0x0189, 0x018B}, sbprUpper},     // L&   [3] LATIN CAPITAL LETTER AFRICAN D..LATIN CAPITAL LETTER D WITH TOPBAR
+	{runeRange{0x018E, 0x0191}, sbprUpper},     // L&   [4] LATIN CAPITAL LETTER REVERSED E..LATIN CAPITAL LETTER F WITH HOOK
+	{runeRange{0x0193, 0x0194}, sbprUpper},     // L&   [2] LATIN CAPITAL LETTER G WITH HOOK..LATIN CAPITAL LETTER GAMMA
+	{runeRange{0x0196, 0x0198}, sbprUpper},     // L&   [3] LATIN CAPITAL LETTER IOTA..LATIN CAPITAL LETTER K WITH HOOK
+	{runeRange{0x019C, 0x019D}, sbprUpper},     // L&   [2] LATIN CAPITAL LETTER TURNED M..LATIN CAPITAL LETTER N WITH LEFT HOOK
+	{runeRange{0x019F, 0x01A0}, sbprUpper},     // L&   [2] LATIN CAPITAL LETTER O WITH MIDDLE TILDE..LATIN CAPITAL LETTER O WITH HORN
+	{runeRange{0x01A2, 0x01A2}, sbprUpper},     // L&       LATIN CAPITAL LETTER OI
+	{runeRange{0x01A4, 0x01A4}, sbprUpper},     // L&       LATIN CAPITAL LETTER P WITH HOOK
+	{runeRange{0x01A6, 0x01A7}, sbprUpper},     // L&   [2] LATIN LETTER YR..LATIN CAPITAL LETTER TONE TWO
+	{runeRange{0x01A9, 0x01A9}, sbprUpper},     // L&       LATIN CAPITAL LETTER ESH
+	{runeRange{0x01AC, 0x01AC}, sbprUpper},     // L&       LATIN CAPITAL LETTER T WITH HOOK
+	{runeRange{0x01AE, 0x01AF}, sbprUpper},     // L&   [2] LATIN CAPITAL LETTER T WITH RETROFLEX HOOK..LATIN CAPITAL LETTER U WITH HORN
+	{runeRange{0x01B1, 0x01B3}, sbprUpper},     // L&   [3] LATIN CAPITAL LETTER UPSILON..LATIN CAPITAL LETTER Y WITH HOOK
+	{runeRange{0x01B5, 0x01B5}, sbprUpper},     // L&       LATIN CAPITAL LETTER Z WITH STROKE
+	{runeRange{0x01B7, 0x01B8}, sbprUpper},     // L&   [2] LATIN CAPITAL LETTER EZH..LATIN CAPITAL LETTER EZH REVERSED
+	{runeRange{0x01BB, 0x01BB}, sbprOLetter},   // Lo       LATIN LETTER TWO WITH STROKE
+	{runeRange{0x01BD, 0x01BF}, sbprLower},     // L&   [3] LATIN SMALL LETTER TONE FIVE..LATIN LETTER WYNN
+	{runeRange{0x01C4, 0x01C5}, sbprUpper},     // L&   [2] LATIN CAPITAL LETTER DZ WITH CARON..LATIN CAPITAL LETTER D WITH SMALL LETTER Z WITH CARON
+	{runeRange{0x01C7, 0x01C8}, sbprUpper},     // L&   [2] LATIN CAPITAL LETTER LJ..LATIN CAPITAL LETTER L WITH SMALL LETTER J
+	{runeRange{0x01CA, 0x01CB}, sbprUpper},     // L&   [2] LATIN CAPITAL LETTER NJ..LATIN CAPITAL LETTER N WITH SMALL LETTER J
+	{runeRange{0x01CD, 0x01CD}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH CARON
+	{runeRange{0x01CF, 0x01CF}, sbprUpper},     // L&       LATIN CAPITAL LETTER I WITH CARON
+	{runeRange{0x01D1, 0x01D1}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH CARON
+	{runeRange{0x01D3, 0x01D3}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH CARON
+	{runeRange{0x01D5, 0x01D5}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH DIAERESIS AND MACRON
+	{runeRange{0x01D7, 0x01D7}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH DIAERESIS AND ACUTE
+	{runeRange{0x01D9, 0x01D9}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH DIAERESIS AND CARON
+	{runeRange{0x01DB, 0x01DB}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH DIAERESIS AND GRAVE
+	{runeRange{0x01DE, 0x01DE}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH DIAERESIS AND MACRON
+	{runeRange{0x01E0, 0x01E0}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH DOT ABOVE AND MACRON
+	{runeRange{0x01E2, 0x01E2}, sbprUpper},     // L&       LATIN CAPITAL LETTER AE WITH MACRON
+	{runeRange{0x01E4, 0x01E4}, sbprUpper},     // L&       LATIN CAPITAL LETTER G WITH STROKE
+	{runeRange{0x01E6, 0x01E6}, sbprUpper},     // L&       LATIN CAPITAL LETTER G WITH CARON
+	{runeRange{0x01E8, 0x01E8}, sbprUpper},     // L&       LATIN CAPITAL LETTER K WITH CARON
+	{runeRange{0x01EA, 0x01EA}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH OGONEK
+	{runeRange{0x01EC, 0x01EC}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH OGONEK AND MACRON
+	{runeRange{0x01EE, 0x01EE}, sbprUpper},     // L&       LATIN CAPITAL LETTER EZH WITH CARON
+	{runeRange{0x01F1, 0x01F2}, sbprUpper},     // L&   [2] LATIN CAPITAL LETTER DZ..LATIN CAPITAL LETTER D WITH SMALL LETTER Z
+	{runeRange{0x01F4, 0x01F4}, sbprUpper},     // L&       LATIN CAPITAL LETTER G WITH ACUTE
+	{runeRange{0x01F6, 0x01F8}, sbprUpper},     // L&   [3] LATIN CAPITAL LETTER HWAIR..LATIN CAPITAL LETTER N WITH GRAVE
+	{runeRange{0x01FA, 0x01FA}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH RING ABOVE AND ACUTE
+	{runeRange{0x01FC, 0x01FC}, sbprUpper},     // L&       LATIN CAPITAL LETTER AE WITH ACUTE
+	{runeRange{0x01FE, 0x01FE}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH STROKE AND ACUTE
+	{runeRange{0x0200, 0x0200}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH DOUBLE GRAVE
+	{runeRange{0x0202, 0x0202}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH INVERTED BREVE
+	{runeRange{0x0204, 0x0204}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH DOUBLE GRAVE
+	{runeRange{0x0206, 0x0206}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH INVERTED BREVE
+	{runeRange{0x0208, 0x0208}, sbprUpper},     // L&       LATIN CAPITAL LETTER I WITH DOUBLE GRAVE
+	{runeRange{0x020A, 0x020A}, sbprUpper},     // L&       LATIN CAPITAL LETTER I WITH INVERTED BREVE
+	{runeRange{0x020C, 0x020C}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH DOUBLE GRAVE
+	{runeRange{0x020E, 0x020E}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH INVERTED BREVE
+	{runeRange{0x0210, 0x0210}, sbprUpper},     // L&       LATIN CAPITAL LETTER R WITH DOUBLE GRAVE
+	{runeRange{0x0212, 0x0212}, sbprUpper},     // L&       LATIN CAPITAL LETTER R WITH INVERTED BREVE
+	{runeRange{0x0214, 0x0214}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH DOUBLE GRAVE
+	{runeRange{0x0216, 0x0216}, sbprUpper},     // L&       LATIN CAPITAL LETTER U WITH INVERTED BREVE
+	{runeRange{0x0218, 0x0218}, sbprUpper},     // L&       LATIN CAPITAL LETTER S WITH COMMA BELOW
+	{runeRange{0x021A, 0x021A}, sbprUpper},     // L&       LATIN CAPITAL LETTER T WITH COMMA BELOW
+	{runeRange{0x021C, 0x021C}, sbprUpper},     // L&       LATIN CAPITAL LETTER YOGH
+	{runeRange{0x021E, 0x021E}, sbprUpper},     // L&       LATIN CAPITAL LETTER H WITH CARON
+	{runeRange{0x0220, 0x0220}, sbprUpper},     // L&       LATIN CAPITAL LETTER N WITH LONG RIGHT LEG
+	{runeRange{0x0222, 0x0222}, sbprUpper},     // L&       LATIN CAPITAL LETTER OU
+	{runeRange{0x0224, 0x0224}, sbprUpper},     // L&       LATIN CAPITAL LETTER Z WITH HOOK
+	{runeRange{0x0226, 0x0226}, sbprUpper},     // L&       LATIN CAPITAL LETTER A WITH DOT ABOVE
+	{runeRange{0x0228, 0x0228}, sbprUpper},     // L&       LATIN CAPITAL LETTER E WITH CEDILLA
+	{runeRange{0x022A, 0x022A}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH DIAERESIS AND MACRON
+	{runeRange{0x022C, 0x022C}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH TILDE AND MACRON
+	{runeRange{0x022E, 0x022E}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH DOT ABOVE
+	{runeRange{0x0230, 0x0230}, sbprUpper},     // L&       LATIN CAPITAL LETTER O WITH DOT ABOVE AND MACRON
+	{runeRange{0x0232, 0x0232}, sbprUpper},     // L&       LATIN CAPITAL LETTER Y WITH MACRON
+	{runeRange{0x023A, 0x023B}, sbprUpper},     // L&   [2] LATIN CAPITAL LETTER A WITH STROKE..LATIN CAPITAL LETTER C WITH STROKE
+	{runeRange{0x023D, 0x023E}, sbprUpper},     // L&   [2] LATIN CAPITAL LETTER L WITH BAR..LATIN CAPITAL LETTER T WITH DIAGONAL STROKE
+	{runeRange{0x0241, 0x0241}, sbprUpper},     // L&       LATIN CAPITAL LETTER GLOTTAL STOP
+	{runeRange{0x0243, 0x0246}, sbprUpper},     // L&   [4] LATIN CAPITAL LETTER B WITH STROKE..LATIN CAPITAL LETTER E WITH STROKE
+	{runeRange{0x0248, 0x0248}, sbprUpper},     // L&       LATIN CAPITAL LETTER J WITH STROKE
+	{runeRange{0x024A, 0x024A}, sbprUpper},     // L&       LATIN CAPITAL LETTER SMALL Q WITH HOOK TAIL
+	{runeRange{0x024C, 0x024C}, sbprUpper},     // L&       LATIN CAPITAL LETTER R WITH STROKE
+	{runeRange{0x024E, 0x024E}, sbprUpper},     // L&       LATIN CAPITAL LETTER Y WITH STROKE
+	{runeRange{0x0294, 0x0294}, sbprOLetter},   // Lo       LATIN LETTER GLOTTAL STOP
+	{runeRange{0x02B0, 0x02B8}, sbprLower},     // Lm   [9] MODIFIER LETTER SMALL H..MODIFIER LETTER SMALL Y
+	{runeRange{0x02C0, 0x02C1}, sbprLower},     // Lm   [2] MODIFIER LETTER GLOTTAL STOP..MODIFIER LETTER REVERSED GLOTTAL STOP
+	{runeRange{0x02E0, 0x02E4}, sbprLower},     // Lm   [5] MODIFIER LETTER SMALL GAMMA..MODIFIER LETTER SMALL REVERSED GLOTTAL STOP
+	{runeRange{0x02EE, 0x02EE}, sbprOLetter},   // Lm       MODIFIER LETTER DOUBLE APOSTROPHE
+	{runeRange{0x0370, 0x0370}, sbprUpper},     // L&       GREEK CAPITAL LETTER HETA
+	{runeRange{0x0372, 0x0372}, sbprUpper},     // L&       GREEK CAPITAL LETTER ARCHAIC SAMPI
+	{runeRange{0x0374, 0x0374}, sbprOLetter},   // Lm       GREEK NUMERAL SIGN
+	{runeRange{0x0377, 0x0377}, sbprLower},     // L&       GREEK SMALL LETTER PAMPHYLIAN DIGAMMA
+	{runeRange{0x037B, 0x037D}, sbprLower},     // L&   [3] GREEK SMALL REVERSED LUNATE SIGMA SYMBOL..GREEK SMALL REVERSED DOTTED LUNATE SIGMA SYMBOL
+	{runeRange{0x0386, 0x0386}, sbprUpper},     // L&       GREEK CAPITAL LETTER ALPHA WITH TONOS
+	{runeRange{0x038C, 0x038C}, sbprUpper},     // L&       GREEK CAPITAL LETTER OMICRON WITH TONOS
+	{runeRange{0x0390, 0x0390}, sbprLower},     // L&       GREEK SMALL LETTER IOTA WITH DIALYTIKA AND TONOS
+	{runeRange{0x03A3, 0x03AB}, sbprUpper},     // L&   [9] GREEK CAPITAL LETTER SIGMA..GREEK CAPITAL LETTER UPSILON WITH DIALYTIKA
+	{runeRange{0x03CF, 0x03CF}, sbprUpper},     // L&       GREEK CAPITAL KAI SYMBOL
+	{runeRange{0x03D2, 0x03D4}, sbprUpper},     // L&   [3] GREEK UPSILON WITH HOOK SYMBOL..GREEK UPSILON WITH DIAERESIS AND HOOK SYMBOL
+	{runeRange{0x03D8, 0x03D8}, sbprUpper},     // L&       GREEK LETTER ARCHAIC KOPPA
+	{runeRange{0x03DA, 0x03DA}, sbprUpper},     // L&       GREEK LETTER STIGMA
+	{runeRange{0x03DC, 0x03DC}, sbprUpper},     // L&       GREEK LETTER DIGAMMA
+	{runeRange{0x03DE, 0x03DE}, sbprUpper},     // L&       GREEK LETTER KOPPA
+	{runeRange{0x03E0, 0x03E0}, sbprUpper},     // L&       GREEK LETTER SAMPI
+	{runeRange{0x03E2, 0x03E2}, sbprUpper},     // L&       COPTIC CAPITAL LETTER SHEI
+	{runeRange{0x03E4, 0x03E4}, sbprUpper},     // L&       COPTIC CAPITAL LETTER FEI
+	{runeRange{0x03E6, 0x03E6}, sbprUpper},     // L&       COPTIC CAPITAL LETTER KHEI
+	{runeRange{0x03E8, 0x03E8}, sbprUpper},     // L&       COPTIC CAPITAL LETTER HORI
+	{runeRange{0x03EA, 0x03EA}, sbprUpper},     // L&       COPTIC CAPITAL LETTER GANGIA
+	{runeRange{0x03EC, 0x03EC}, sbprUpper},     // L&       COPTIC CAPITAL LETTER SHIMA
+	{runeRange{0x03EE, 0x03EE}, sbprUpper},     // L&       COPTIC CAPITAL LETTER DEI
+	{runeRange{0x03F4, 0x03F4}, sbprUpper},     // L&       GREEK CAPITAL THETA SYMBOL
+	{runeRange{0x03F7, 0x03F7}, sbprUpper},     // L&       GREEK CAPITAL LETTER SHO
+	{runeRange{0x03F9, 0x03FA}, sbprUpper},     // L&   [2] GREEK CAPITAL LUNATE SIGMA SYMBOL..GREEK CAPITAL LETTER SAN
+	{runeRange{0x03FD, 0x042F}, sbprUpper},     // L&  [51] GREEK CAPITAL REVERSED LUNATE SIGMA SYMBOL..CYRILLIC CAPITAL LETTER YA
+	{runeRange{0x0460, 0x0460}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER OMEGA
+	{runeRange{0x0462, 0x0462}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER YAT
+	{runeRange{0x0464, 0x0464}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER IOTIFIED E
+	{runeRange{0x0466, 0x0466}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER LITTLE YUS
+	{runeRange{0x0468, 0x0468}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER IOTIFIED LITTLE YUS
+	{runeRange{0x046A, 0x046A}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER BIG YUS
+	{runeRange{0x046C, 0x046C}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER IOTIFIED BIG YUS
+	{runeRange{0x046E, 0x046E}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER KSI
+	{runeRange{0x0470, 0x0470}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER PSI
+	{runeRange{0x0472, 0x0472}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER FITA
+	{runeRange{0x0474, 0x0474}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER IZHITSA
+	{runeRange{0x0476, 0x0476}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER IZHITSA WITH DOUBLE GRAVE ACCENT
+	{runeRange{0x0478, 0x0478}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER UK
+	{runeRange{0x047A, 0x047A}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER ROUND OMEGA
+	{runeRange{0x047C, 0x047C}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER OMEGA WITH TITLO
+	{runeRange{0x047E, 0x047E}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER OT
+	{runeRange{0x0480, 0x0480}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER KOPPA
+	{runeRange{0x0483, 0x0487}, sbprExtend},    // Mn   [5] COMBINING CYRILLIC TITLO..COMBINING CYRILLIC POKRYTIE
+	{runeRange{0x048A, 0x048A}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER SHORT I WITH TAIL
+	{runeRange{0x048C, 0x048C}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER SEMISOFT SIGN
+	{runeRange{0x048E, 0x048E}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER ER WITH TICK
+	{runeRange{0x0490, 0x0490}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER GHE WITH UPTURN
+	{runeRange{0x0492, 0x0492}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER GHE WITH STROKE
+	{runeRange{0x0494, 0x0494}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER GHE WITH MIDDLE HOOK
+	{runeRange{0x0496, 0x0496}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER ZHE WITH DESCENDER
+	{runeRange{0x0498, 0x0498}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER ZE WITH DESCENDER
+	{runeRange{0x049A, 0x049A}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER KA WITH DESCENDER
+	{runeRange{0x049C, 0x049C}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER KA WITH VERTICAL STROKE
+	{runeRange{0x049E, 0x049E}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER KA WITH STROKE
+	{runeRange{0x04A0, 0x04A0}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER BASHKIR KA
+	{runeRange{0x04A2, 0x04A2}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER EN WITH DESCENDER
+	{runeRange{0x04A4, 0x04A4}, sbprUpper},     // L&       CYRILLIC CAPITAL LIGATURE EN GHE
+	{runeRange{0x04A6, 0x04A6}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER PE WITH MIDDLE HOOK
+	{runeRange{0x04A8, 0x04A8}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER ABKHASIAN HA
+	{runeRange{0x04AA, 0x04AA}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER ES WITH DESCENDER
+	{runeRange{0x04AC, 0x04AC}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER TE WITH DESCENDER
+	{runeRange{0x04AE, 0x04AE}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER STRAIGHT U
+	{runeRange{0x04B0, 0x04B0}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER STRAIGHT U WITH STROKE
+	{runeRange{0x04B2, 0x04B2}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER HA WITH DESCENDER
+	{runeRange{0x04B4, 0x04B4}, sbprUpper},     // L&       CYRILLIC CAPITAL LIGATURE TE TSE
+	{runeRange{0x04B6, 0x04B6}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER CHE WITH DESCENDER
+	{runeRange{0x04B8, 0x04B8}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER CHE WITH VERTICAL STROKE
+	{runeRange{0x04BA, 0x04BA}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER SHHA
+	{runeRange{0x04BC, 0x04BC}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER ABKHASIAN CHE
+	{runeRange{0x04BE, 0x04BE}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER ABKHASIAN CHE WITH DESCENDER
+	{runeRange{0x04C0, 0x04C1}, sbprUpper},     // L&   [2] CYRILLIC LETTER PALOCHKA..CYRILLIC CAPITAL LETTER ZHE WITH BREVE
+	{runeRange{0x04C3, 0x04C3}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER KA WITH HOOK
+	{runeRange{0x04C5, 0x04C5}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER EL WITH TAIL
+	{runeRange{0x04C7, 0x04C7}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER EN WITH HOOK
+	{runeRange{0x04C9, 0x04C9}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER EN WITH TAIL
+	{runeRange{0x04CB, 0x04CB}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER KHAKASSIAN CHE
+	{runeRange{0x04CD, 0x04CD}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER EM WITH TAIL
+	{runeRange{0x04D0, 0x04D0}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER A WITH BREVE
+	{runeRange{0x04D2, 0x04D2}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER A WITH DIAERESIS
+	{runeRange{0x04D4, 0x04D4}, sbprUpper},     // L&       CYRILLIC CAPITAL LIGATURE A IE
+	{runeRange{0x04D6, 0x04D6}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER IE WITH BREVE
+	{runeRange{0x04D8, 0x04D8}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER SCHWA
+	{runeRange{0x04DA, 0x04DA}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER SCHWA WITH DIAERESIS
+	{runeRange{0x04DC, 0x04DC}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER ZHE WITH DIAERESIS
+	{runeRange{0x04DE, 0x04DE}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER ZE WITH DIAERESIS
+	{runeRange{0x04E0, 0x04E0}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER ABKHASIAN DZE
+	{runeRange{0x04E2, 0x04E2}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER I WITH MACRON
+	{runeRange{0x04E4, 0x04E4}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER I WITH DIAERESIS
+	{runeRange{0x04E6, 0x04E6}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER O WITH DIAERESIS
+	{runeRange{0x04E8, 0x04E8}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER BARRED O
+	{runeRange{0x04EA, 0x04EA}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER BARRED O WITH DIAERESIS
+	{runeRange{0x04EC, 0x04EC}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER E WITH DIAERESIS
+	{runeRange{0x04EE, 0x04EE}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER U WITH MACRON
+	{runeRange{0x04F0, 0x04F0}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER U WITH DIAERESIS
+	{runeRange{0x04F2, 0x04F2}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER U WITH DOUBLE ACUTE
+	{runeRange{0x04F4, 0x04F4}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER CHE WITH DIAERESIS
+	{runeRange{0x04F6, 0x04F6}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER GHE WITH DESCENDER
+	{runeRange{0x04F8, 0x04F8}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER YERU WITH DIAERESIS
+	{runeRange{0x04FA, 0x04FA}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER GHE WITH STROKE AND HOOK
+	{runeRange{0x04FC, 0x04FC}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER HA WITH HOOK
+	{runeRange{0x04FE, 0x04FE}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER HA WITH STROKE
+	{runeRange{0x0500, 0x0500}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER KOMI DE
+	{runeRange{0x0502, 0x0502}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER KOMI DJE
+	{runeRange{0x0504, 0x0504}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER KOMI ZJE
+	{runeRange{0x0506, 0x0506}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER KOMI DZJE
+	{runeRange{0x0508, 0x0508}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER KOMI LJE
+	{runeRange{0x050A, 0x050A}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER KOMI NJE
+	{runeRange{0x050C, 0x050C}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER KOMI SJE
+	{runeRange{0x050E, 0x050E}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER KOMI TJE
+	{runeRange{0x0510, 0x0510}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER REVERSED ZE
+	{runeRange{0x0512, 0x0512}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER EL WITH HOOK
+	{runeRange{0x0514, 0x0514}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER LHA
+	{runeRange{0x0516, 0x0516}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER RHA
+	{runeRange{0x0518, 0x0518}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER YAE
+	{runeRange{0x051A, 0x051A}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER QA
+	{runeRange{0x051C, 0x051C}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER WE
+	{runeRange{0x051E, 0x051E}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER ALEUT KA
+	{runeRange{0x0520, 0x0520}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER EL WITH MIDDLE HOOK
+	{runeRange{0x0522, 0x0522}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER EN WITH MIDDLE HOOK
+	{runeRange{0x0524, 0x0524}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER PE WITH DESCENDER
+	{runeRange{0x0526, 0x0526}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER SHHA WITH DESCENDER
+	{runeRange{0x0528, 0x0528}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER EN WITH LEFT HOOK
+	{runeRange{0x052A, 0x052A}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER DZZHE
+	{runeRange{0x052C, 0x052C}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER DCHE
+	{runeRange{0x052E, 0x052E}, sbprUpper},     // L&       CYRILLIC CAPITAL LETTER EL WITH DESCENDER
+	{runeRange{0x0531, 0x0556}, sbprUpper},     // L&  [38] ARMENIAN CAPITAL LETTER AYB..ARMENIAN CAPITAL LETTER FEH
+	{runeRange{0x055D, 0x055D}, sbprSContinue}, // Po       ARMENIAN COMMA
+	{runeRange{0x0589, 0x0589}, sbprSTerm},     // Po       ARMENIAN FULL STOP
+	{runeRange{0x05BF, 0x05BF}, sbprExtend},    // Mn       HEBREW POINT RAFE
+	{runeRange{0x05C4, 0x05C5}, sbprExtend},    // Mn   [2] HEBREW MARK UPPER DOT..HEBREW MARK LOWER DOT
+	{runeRange{0x05D0, 0x05EA}, sbprOLetter},   // Lo  [27] HEBREW LETTER ALEF..HEBREW LETTER TAV
+	{runeRange{0x05F3, 0x05F3}, sbprOLetter},   // Po       HEBREW PUNCTUATION GERESH
+	{runeRange{0x060C, 0x060D}, sbprSContinue}, // Po   [2] ARABIC COMMA..ARABIC DATE SEPARATOR
+	{runeRange{0x061C, 0x061C}, sbprFormat},    // Cf       ARABIC LETTER MARK
+	{runeRange{0x0620, 0x063F}, sbprOLetter},   // Lo  [32] ARABIC LETTER KASHMIRI YEH..ARABIC LETTER FARSI YEH WITH THREE DOTS ABOVE
+	{runeRange{0x0641, 0x064A}, sbprOLetter},   // Lo  [10] ARABIC LETTER FEH..ARABIC LETTER YEH
+	{runeRange{0x0660, 0x0669}, sbprNumeric},   // Nd  [10] ARABIC-INDIC DIGIT ZERO..ARABIC-INDIC DIGIT NINE
+	{runeRange{0x066E, 0x066F}, sbprOLetter},   // Lo   [2] ARABIC LETTER DOTLESS BEH..ARABIC LETTER DOTLESS QAF
+	{runeRange{0x0671, 0x06D3}, sbprOLetter},   // Lo  [99] ARABIC LETTER ALEF WASLA..ARABIC LETTER YEH BARREE WITH HAMZA ABOVE
+	{runeRange{0x06D5, 0x06D5}, sbprOLetter},   // Lo       ARABIC LETTER AE
+	{runeRange{0x06DD, 0x06DD}, sbprFormat},    // Cf       ARABIC END OF AYAH
+	{runeRange{0x06E5, 0x06E6}, sbprOLetter},   // Lm   [2] ARABIC SMALL WAW..ARABIC SMALL YEH
+	{runeRange{0x06EA, 0x06ED}, sbprExtend},    // Mn   [4] ARABIC EMPTY CENTRE LOW STOP..ARABIC SMALL LOW MEEM
+	{runeRange{0x06F0, 0x06F9}, sbprNumeric},   // Nd  [10] EXTENDED ARABIC-INDIC DIGIT ZERO..EXTENDED ARABIC-INDIC DIGIT NINE
+	{runeRange{0x06FF, 0x06FF}, sbprOLetter},   // Lo       ARABIC LETTER HEH WITH INVERTED V
+	{runeRange{0x070F, 0x070F}, sbprFormat},    // Cf       SYRIAC ABBREVIATION MARK
+	{runeRange{0x0711, 0x0711}, sbprExtend},    // Mn       SYRIAC LETTER SUPERSCRIPT ALAPH
+	{runeRange{0x0730, 0x074A}, sbprExtend},    // Mn  [27] SYRIAC PTHAHA ABOVE..SYRIAC BARREKH
+	{runeRange{0x07A6, 0x07B0}, sbprExtend},    // Mn  [11] THAANA ABAFILI..THAANA SUKUN
+	{runeRange{0x07C0, 0x07C9}, sbprNumeric},   // Nd  [10] NKO DIGIT ZERO..NKO DIGIT NINE
+	{runeRange{0x07EB, 0x07F3}, sbprExtend},    // Mn   [9] NKO COMBINING SHORT HIGH TONE..NKO COMBINING DOUBLE DOT ABOVE
+	{runeRange{0x07F8, 0x07F8}, sbprSContinue}, // Po       NKO COMMA
+	{runeRange{0x07FA, 0x07FA}, sbprOLetter},   // Lm       NKO LAJANYALAN
+	{runeRange{0x0800, 0x0815}, sbprOLetter},   // Lo  [22] SAMARITAN LETTER ALAF..SAMARITAN LETTER TAAF
+	{runeRange{0x081A, 0x081A}, sbprOLetter},   // Lm       SAMARITAN MODIFIER LETTER EPENTHETIC YUT
+	{runeRange{0x0824, 0x0824}, sbprOLetter},   // Lm       SAMARITAN MODIFIER LETTER SHORT A
+	{runeRange{0x0828, 0x0828}, sbprOLetter},   // Lm       SAMARITAN MODIFIER LETTER I
+	{runeRange{0x0837, 0x0837}, sbprSTerm},     // Po       SAMARITAN PUNCTUATION MELODIC QITSA
+	{runeRange{0x083D, 0x083E}, sbprSTerm},     // Po   [2] SAMARITAN PUNCTUATION SOF MASHFAAT..SAMARITAN PUNCTUATION ANNAAU
+	{runeRange{0x0859, 0x085B}, sbprExtend},    // Mn   [3] MANDAIC AFFRICATION MARK..MANDAIC GEMINATION MARK
+	{runeRange{0x0870, 0x0887}, sbprOLetter},   // Lo  [24] ARABIC LETTER ALEF WITH ATTACHED FATHA..ARABIC BASELINE ROUND DOT
+	{runeRange{0x0890, 0x0891}, sbprFormat},    // Cf   [2] ARABIC POUND MARK ABOVE..ARABIC PIASTRE MARK ABOVE
+	{runeRange{0x08A0, 0x08C8}, sbprOLetter},   // Lo  [41] ARABIC LETTER BEH WITH SMALL V BELOW..ARABIC LETTER GRAF
+	{runeRange{0x08CA, 0x08E1}, sbprExtend},    // Mn  [24] ARABIC SMALL HIGH FARSI YEH..ARABIC SMALL HIGH SIGN SAFHA
+	{runeRange{0x08E3, 0x0902}, sbprExtend},    // Mn  [32] ARABIC TURNED DAMMA BELOW..DEVANAGARI SIGN ANUSVARA
+	{runeRange{0x0904, 0x0939}, sbprOLetter},   // Lo  [54] DEVANAGARI LETTER SHORT A..DEVANAGARI LETTER HA
+	{runeRange{0x093B, 0x093B}, sbprExtend},    // Mc       DEVANAGARI VOWEL SIGN OOE
+	{runeRange{0x093D, 0x093D}, sbprOLetter},   // Lo       DEVANAGARI SIGN AVAGRAHA
+	{runeRange{0x0941, 0x0948}, sbprExtend},    // Mn   [8] DEVANAGARI VOWEL SIGN U..DEVANAGARI VOWEL SIGN AI
+	{runeRange{0x094D, 0x094D}, sbprExtend},    // Mn       DEVANAGARI SIGN VIRAMA
+	{runeRange{0x0950, 0x0950}, sbprOLetter},   // Lo       DEVANAGARI OM
+	{runeRange{0x0958, 0x0961}, sbprOLetter},   // Lo  [10] DEVANAGARI LETTER QA..DEVANAGARI LETTER VOCALIC LL
+	{runeRange{0x0964, 0x0965}, sbprSTerm},     // Po   [2] DEVANAGARI DANDA..DEVANAGARI DOUBLE DANDA
+	{runeRange{0x0971, 0x0971}, sbprOLetter},   // Lm       DEVANAGARI SIGN HIGH SPACING DOT
+	{runeRange{0x0981, 0x0981}, sbprExtend},    // Mn       BENGALI SIGN CANDRABINDU
+	{runeRange{0x0985, 0x098C}, sbprOLetter},   // Lo   [8] BENGALI LETTER A..BENGALI LETTER VOCALIC L
+	{runeRange{0x0993, 0x09A8}, sbprOLetter},   // Lo  [22] BENGALI LETTER O..BENGALI LETTER NA
+	{runeRange{0x09B2, 0x09B2}, sbprOLetter},   // Lo       BENGALI LETTER LA
+	{runeRange{0x09BC, 0x09BC}, sbprExtend},    // Mn       BENGALI SIGN NUKTA
+	{runeRange{0x09BE, 0x09C0}, sbprExtend},    // Mc   [3] BENGALI VOWEL SIGN AA..BENGALI VOWEL SIGN II
+	{runeRange{0x09C7, 0x09C8}, sbprExtend},    // Mc   [2] BENGALI VOWEL SIGN E..BENGALI VOWEL SIGN AI
+	{runeRange{0x09CD, 0x09CD}, sbprExtend},    // Mn       BENGALI SIGN VIRAMA
+	{runeRange{0x09D7, 0x09D7}, sbprExtend},    // Mc       BENGALI AU LENGTH MARK
+	{runeRange{0x09DF, 0x09E1}, sbprOLetter},   // Lo   [3] BENGALI LETTER YYA..BENGALI LETTER VOCALIC LL
+	{runeRange{0x09E6, 0x09EF}, sbprNumeric},   // Nd  [10] BENGALI DIGIT ZERO..BENGALI DIGIT NINE
+	{runeRange{0x09FC, 0x09FC}, sbprOLetter},   // Lo       BENGALI LETTER VEDIC ANUSVARA
+	{runeRange{0x0A01, 0x0A02}, sbprExtend},    // Mn   [2] GURMUKHI SIGN ADAK BINDI..GURMUKHI SIGN BINDI
+	{runeRange{0x0A05, 0x0A0A}, sbprOLetter},   // Lo   [6] GURMUKHI LETTER A..GURMUKHI LETTER UU
+	{runeRange{0x0A13, 0x0A28}, sbprOLetter},   // Lo  [22] GURMUKHI LETTER OO..GURMUKHI LETTER NA
+	{runeRange{0x0A32, 0x0A33}, sbprOLetter},   // Lo   [2] GURMUKHI LETTER LA..GURMUKHI LETTER LLA
+	{runeRange{0x0A38, 0x0A39}, sbprOLetter},   // Lo   [2] GURMUKHI LETTER SA..GURMUKHI LETTER HA
+	{runeRange{0x0A3E, 0x0A40}, sbprExtend},    // Mc   [3] GURMUKHI VOWEL SIGN AA..GURMUKHI VOWEL SIGN II
+	{runeRange{0x0A47, 0x0A48}, sbprExtend},    // Mn   [2] GURMUKHI VOWEL SIGN EE..GURMUKHI VOWEL SIGN AI
+	{runeRange{0x0A51, 0x0A51}, sbprExtend},    // Mn       GURMUKHI SIGN UDAAT
+	{runeRange{0x0A5E, 0x0A5E}, sbprOLetter},   // Lo       GURMUKHI LETTER FA
+	{runeRange{0x0A70, 0x0A71}, sbprExtend},    // Mn   [2] GURMUKHI TIPPI..GURMUKHI ADDAK
+	{runeRange{0x0A75, 0x0A75}, sbprExtend},    // Mn       GURMUKHI SIGN YAKASH
+	{runeRange{0x0A83, 0x0A83}, sbprExtend},    // Mc       GUJARATI SIGN VISARGA
+	{runeRange{0x0A8F, 0x0A91}, sbprOLetter},   // Lo   [3] GUJARATI LETTER E..GUJARATI VOWEL CANDRA O
+	{runeRange{0x0AAA, 0x0AB0}, sbprOLetter},   // Lo   [7] GUJARATI LETTER PA..GUJARATI LETTER RA
+	{runeRange{0x0AB5, 0x0AB9}, sbprOLetter},   // Lo   [5] GUJARATI LETTER VA..GUJARATI LETTER HA
+	{runeRange{0x0ABD, 0x0ABD}, sbprOLetter},   // Lo       GUJARATI SIGN AVAGRAHA
+	{runeRange{0x0AC1, 0x0AC5}, sbprExtend},    // Mn   [5] GUJARATI VOWEL SIGN U..GUJARATI VOWEL SIGN CANDRA E
+	{runeRange{0x0AC9, 0x0AC9}, sbprExtend},    // Mc       GUJARATI VOWEL SIGN CANDRA O
+	{runeRange{0x0ACD, 0x0ACD}, sbprExtend},    // Mn       GUJARATI SIGN VIRAMA
+	{runeRange{0x0AE0, 0x0AE1}, sbprOLetter},   // Lo   [2] GUJARATI LETTER VOCALIC RR..GUJARATI LETTER VOCALIC LL
+	{runeRange{0x0AE6, 0x0AEF}, sbprNumeric},   // Nd  [10] GUJARATI DIGIT ZERO..GUJARATI DIGIT NINE
+	{runeRange{0x0AFA, 0x0AFF}, sbprExtend},    // Mn   [6] GUJARATI SIGN SUKUN..GUJARATI SIGN TWO-CIRCLE NUKTA ABOVE
+	{runeRange{0x0B02, 0x0B03}, sbprExtend},    // Mc   [2] ORIYA SIGN ANUSVARA..ORIYA SIGN VISARGA
+	{runeRange{0x0B0F, 0x0B10}, sbprOLetter},   // Lo   [2] ORIYA LETTER E..ORIYA LETTER AI
+	{runeRange{0x0B2A, 0x0B30}, sbprOLetter},   // Lo   [7] ORIYA LETTER PA..ORIYA LETTER RA
+	{runeRange{0x0B35, 0x0B39}, sbprOLetter},   // Lo   [5] ORIYA LETTER VA..ORIYA LETTER HA
+	{runeRange{0x0B3D, 0x0B3D}, sbprOLetter},   // Lo       ORIYA SIGN AVAGRAHA
+	{runeRange{0x0B3F, 0x0B3F}, sbprExtend},    // Mn       ORIYA VOWEL SIGN I
+	{runeRange{0x0B41, 0x0B44}, sbprExtend},    // Mn   [4] ORIYA VOWEL SIGN U..ORIYA VOWEL SIGN VOCALIC RR
+	{runeRange{0x0B4B, 0x0B4C}, sbprExtend},    // Mc   [2] ORIYA VOWEL SIGN O..ORIYA VOWEL SIGN AU
+	{runeRange{0x0B55, 0x0B56}, sbprExtend},    // Mn   [2] ORIYA SIGN OVERLINE..ORIYA AI LENGTH MARK
+	{runeRange{0x0B5C, 0x0B5D}, sbprOLetter},   // Lo   [2] ORIYA LETTER RRA..ORIYA LETTER RHA
+	{runeRange{0x0B62, 0x0B63}, sbprExtend},    // Mn   [2] ORIYA VOWEL SIGN VOCALIC L..ORIYA VOWEL SIGN VOCALIC LL
+	{runeRange{0x0B71, 0x0B71}, sbprOLetter},   // Lo       ORIYA LETTER WA
+	{runeRange{0x0B83, 0x0B83}, sbprOLetter},   // Lo       TAMIL SIGN VISARGA
+	{runeRange{0x0B8E, 0x0B90}, sbprOLetter},   // Lo   [3] TAMIL LETTER E..TAMIL LETTER AI
+	{runeRange{0x0B99, 0x0B9A}, sbprOLetter},   // Lo   [2] TAMIL LETTER NGA..TAMIL LETTER CA
+	{runeRange{0x0B9E, 0x0B9F}, sbprOLetter},   // Lo   [2] TAMIL LETTER NYA..TAMIL LETTER TTA
+	{runeRange{0x0BA8, 0x0BAA}, sbprOLetter},   // Lo   [3] TAMIL LETTER NA..TAMIL LETTER PA
+	{runeRange{0x0BBE, 0x0BBF}, sbprExtend},    // Mc   [2] TAMIL VOWEL SIGN AA..TAMIL VOWEL SIGN I
+	{runeRange{0x0BC1, 0x0BC2}, sbprExtend},    // Mc   [2] TAMIL VOWEL SIGN U..TAMIL VOWEL SIGN UU
+	{runeRange{0x0BCA, 0x0BCC}, sbprExtend},    // Mc   [3] TAMIL VOWEL SIGN O..TAMIL VOWEL SIGN AU
+	{runeRange{0x0BD0, 0x0BD0}, sbprOLetter},   // Lo       TAMIL OM
+	{runeRange{0x0BE6, 0x0BEF}, sbprNumeric},   // Nd  [10] TAMIL DIGIT ZERO..TAMIL DIGIT NINE
+	{runeRange{0x0C01, 0x0C03}, sbprExtend},    // Mc   [3] TELUGU SIGN CANDRABINDU..TELUGU SIGN VISARGA
+	{runeRange{0x0C05, 0x0C0C}, sbprOLetter},   // Lo   [8] TELUGU LETTER A..TELUGU LETTER VOCALIC L
+	{runeRange{0x0C12, 0x0C28}, sbprOLetter},   // Lo  [23] TELUGU LETTER O..TELUGU LETTER NA
+	{runeRange{0x0C3C, 0x0C3C}, sbprExtend},    // Mn       TELUGU SIGN NUKTA
+	{runeRange{0x0C3E, 0x0C40}, sbprExtend},    // Mn   [3] TELUGU VOWEL SIGN AA..TELUGU VOWEL SIGN II
+	{runeRange{0x0C46, 0x0C48}, sbprExtend},    // Mn   [3] TELUGU VOWEL SIGN E..TELUGU VOWEL SIGN AI
+	{runeRange{0x0C55, 0x0C56}, sbprExtend},    // Mn   [2] TELUGU LENGTH MARK..TELUGU AI LENGTH MARK
+	{runeRange{0x0C5D, 0x0C5D}, sbprOLetter},   // Lo       TELUGU LETTER NAKAARA POLLU
+	{runeRange{0x0C62, 0x0C63}, sbprExtend},    // Mn   [2] TELUGU VOWEL SIGN VOCALIC L..TELUGU VOWEL SIGN VOCALIC LL
+	{runeRange{0x0C80, 0x0C80}, sbprOLetter},   // Lo       KANNADA SIGN SPACING CANDRABINDU
+	{runeRange{0x0C82, 0x0C83}, sbprExtend},    // Mc   [2] KANNADA SIGN ANUSVARA..KANNADA SIGN VISARGA
+	{runeRange{0x0C8E, 0x0C90}, sbprOLetter},   // Lo   [3] KANNADA LETTER E..KANNADA LETTER AI
+	{runeRange{0x0CAA, 0x0CB3}, sbprOLetter},   // Lo  [10] KANNADA LETTER PA..KANNADA LETTER LLA
+	{runeRange{0x0CBC, 0x0CBC}, sbprExtend},    // Mn       KANNADA SIGN NUKTA
+	{runeRange{0x0CBE, 0x0CBE}, sbprExtend},    // Mc       KANNADA VOWEL SIGN AA
+	{runeRange{0x0CC0, 0x0CC4}, sbprExtend},    // Mc   [5] KANNADA VOWEL SIGN II..KANNADA VOWEL SIGN VOCALIC RR
+	{runeRange{0x0CC7, 0x0CC8}, sbprExtend},    // Mc   [2] KANNADA VOWEL SIGN EE..KANNADA VOWEL SIGN AI
+	{runeRange{0x0CCC, 0x0CCD}, sbprExtend},    // Mn   [2] KANNADA VOWEL SIGN AU..KANNADA SIGN VIRAMA
+	{runeRange{0x0CDD, 0x0CDE}, sbprOLetter},   // Lo   [2] KANNADA LETTER NAKAARA POLLU..KANNADA LETTER FA
+	{runeRange{0x0CE2, 0x0CE3}, sbprExtend},    // Mn   [2] KANNADA VOWEL SIGN VOCALIC L..KANNADA VOWEL SIGN VOCALIC LL
+	{runeRange{0x0CF1, 0x0CF2}, sbprOLetter},   // Lo   [2] KANNADA SIGN JIHVAMULIYA..KANNADA SIGN UPADHMANIYA
+	{runeRange{0x0D00, 0x0D01}, sbprExtend},    // Mn   [2] MALAYALAM SIGN COMBINING ANUSVARA ABOVE..MALAYALAM SIGN CANDRABINDU
+	{runeRange{0x0D04, 0x0D0C}, sbprOLetter},   // Lo   [9] MALAYALAM LETTER VEDIC ANUSVARA..MALAYALAM LETTER VOCALIC L
+	{runeRange{0x0D12, 0x0D3A}, sbprOLetter},   // Lo  [41] MALAYALAM LETTER O..MALAYALAM LETTER TTTA
+	{runeRange{0x0D3D, 0x0D3D}, sbprOLetter},   // Lo       MALAYALAM SIGN AVAGRAHA
+	{runeRange{0x0D41, 0x0D44}, sbprExtend},    // Mn   [4] MALAYALAM VOWEL SIGN U..MALAYALAM VOWEL SIGN VOCALIC RR
+	{runeRange{0x0D4A, 0x0D4C}, sbprExtend},    // Mc   [3] MALAYALAM VOWEL SIGN O..MALAYALAM VOWEL SIGN AU
+	{runeRange{0x0D4E, 0x0D4E}, sbprOLetter},   // Lo       MALAYALAM LETTER DOT REPH
+	{runeRange{0x0D57, 0x0D57}, sbprExtend},    // Mc       MALAYALAM AU LENGTH MARK
+	{runeRange{0x0D62, 0x0D63}, sbprExtend},    // Mn   [2] MALAYALAM VOWEL SIGN VOCALIC L..MALAYALAM VOWEL SIGN VOCALIC LL
+	{runeRange{0x0D7A, 0x0D7F}, sbprOLetter},   // Lo   [6] MALAYALAM LETTER CHILLU NN..MALAYALAM LETTER CHILLU K
+	{runeRange{0x0D82, 0x0D83}, sbprExtend},    // Mc   [2] SINHALA SIGN ANUSVARAYA..SINHALA SIGN VISARGAYA
+	{runeRange{0x0D9A, 0x0DB1}, sbprOLetter},   // Lo  [24] SINHALA LETTER ALPAPRAANA KAYANNA..SINHALA LETTER DANTAJA NAYANNA
+	{runeRange{0x0DBD, 0x0DBD}, sbprOLetter},   // Lo       SINHALA LETTER DANTAJA LAYANNA
+	{runeRange{0x0DCA, 0x0DCA}, sbprExtend},    // Mn       SINHALA SIGN AL-LAKUNA
+	{runeRange{0x0DD2, 0x0DD4}, sbprExtend},    // Mn   [3] SINHALA VOWEL SIGN KETTI IS-PILLA..SINHALA VOWEL SIGN KETTI PAA-PILLA
+	{runeRange{0x0DD8, 0x0DDF}, sbprExtend},    // Mc   [8] SINHALA VOWEL SIGN GAETTA-PILLA..SINHALA VOWEL SIGN GAYANUKITTA
+	{runeRange{0x0DF2, 0x0DF3}, sbprExtend},    // Mc   [2] SINHALA VOWEL SIGN DIGA GAETTA-PILLA..SINHALA VOWEL SIGN DIGA GAYANUKITTA
+	{runeRange{0x0E31, 0x0E31}, sbprExtend},    // Mn       THAI CHARACTER MAI HAN-AKAT
+	{runeRange{0x0E34, 0x0E3A}, sbprExtend},    // Mn   [7] THAI CHARACTER SARA I..THAI CHARACTER PHINTHU
+	{runeRange{0x0E46, 0x0E46}, sbprOLetter},   // Lm       THAI CHARACTER MAIYAMOK
+	{runeRange{0x0E50, 0x0E59}, sbprNumeric},   // Nd  [10] THAI DIGIT ZERO..THAI DIGIT NINE
+	{runeRange{0x0E84, 0x0E84}, sbprOLetter},   // Lo       LAO LETTER KHO TAM
+	{runeRange{0x0E8C, 0x0EA3}, sbprOLetter},   // Lo  [24] LAO LETTER PALI JHA..LAO LETTER LO LING
+	{runeRange{0x0EA7, 0x0EB0}, sbprOLetter},   // Lo  [10] LAO LETTER WO..LAO VOWEL SIGN A
+	{runeRange{0x0EB2, 0x0EB3}, sbprOLetter},   // Lo   [2] LAO VOWEL SIGN AA..LAO VOWEL SIGN AM
+	{runeRange{0x0EBD, 0x0EBD}, sbprOLetter},   // Lo       LAO SEMIVOWEL SIGN NYO
+	{runeRange{0x0EC6, 0x0EC6}, sbprOLetter},   // Lm       LAO KO LA
+	{runeRange{0x0ED0, 0x0ED9}, sbprNumeric},   // Nd  [10] LAO DIGIT ZERO..LAO DIGIT NINE
+	{runeRange{0x0F00, 0x0F00}, sbprOLetter},   // Lo       TIBETAN SYLLABLE OM
+	{runeRange{0x0F20, 0x0F29}, sbprNumeric},   // Nd  [10] TIBETAN DIGIT ZERO..TIBETAN DIGIT NINE
+	{runeRange{0x0F37, 0x0F37}, sbprExtend},    // Mn       TIBETAN MARK NGAS BZUNG SGOR RTAGS
+	{runeRange{0x0F3A, 0x0F3A}, sbprClose},     // Ps       TIBETAN MARK GUG RTAGS GYON
+	{runeRange{0x0F3C, 0x0F3C}, sbprClose},     // Ps       TIBETAN MARK ANG KHANG GYON
+	{runeRange{0x0F3E, 0x0F3F}, sbprExtend},    // Mc   [2] TIBETAN SIGN YAR TSHES..TIBETAN SIGN MAR TSHES
+	{runeRange{0x0F49, 0x0F6C}, sbprOLetter},   // Lo  [36] TIBETAN LETTER NYA..TIBETAN LETTER RRA
+	{runeRange{0x0F7F, 0x0F7F}, sbprExtend},    // Mc       TIBETAN SIGN RNAM BCAD
+	{runeRange{0x0F86, 0x0F87}, sbprExtend},    // Mn   [2] TIBETAN SIGN LCI RTAGS..TIBETAN SIGN YANG RTAGS
+	{runeRange{0x0F8D, 0x0F97}, sbprExtend},    // Mn  [11] TIBETAN SUBJOINED SIGN LCE TSA CAN..TIBETAN SUBJOINED LETTER JA
+	{runeRange{0x0FC6, 0x0FC6}, sbprExtend},    // Mn       TIBETAN SYMBOL PADMA GDAN
+	{runeRange{0x102B, 0x102C}, sbprExtend},    // Mc   [2] MYANMAR VOWEL SIGN TALL AA..MYANMAR VOWEL SIGN AA
+	{runeRange{0x1031, 0x1031}, sbprExtend},    // Mc       MYANMAR VOWEL SIGN E
+	{runeRange{0x1038, 0x1038}, sbprExtend},    // Mc       MYANMAR SIGN VISARGA
+	{runeRange{0x103B, 0x103C}, sbprExtend},    // Mc   [2] MYANMAR CONSONANT SIGN MEDIAL YA..MYANMAR CONSONANT SIGN MEDIAL RA
+	{runeRange{0x103F, 0x103F}, sbprOLetter},   // Lo       MYANMAR LETTER GREAT SA
+	{runeRange{0x104A, 0x104B}, sbprSTerm},     // Po   [2] MYANMAR SIGN LITTLE SECTION..MYANMAR SIGN SECTION
+	{runeRange{0x1056, 0x1057}, sbprExtend},    // Mc   [2] MYANMAR VOWEL SIGN VOCALIC R..MYANMAR VOWEL SIGN VOCALIC RR
+	{runeRange{0x105A, 0x105D}, sbprOLetter},   // Lo   [4] MYANMAR LETTER MON NGA..MYANMAR LETTER MON BBE
+	{runeRange{0x1061, 0x1061}, sbprOLetter},   // Lo       MYANMAR LETTER SGAW KAREN SHA
+	{runeRange{0x1065, 0x1066}, sbprOLetter},   // Lo   [2] MYANMAR LETTER WESTERN PWO KAREN THA..MYANMAR LETTER WESTERN PWO KAREN PWA
+	{runeRange{0x106E, 0x1070}, sbprOLetter},   // Lo   [3] MYANMAR LETTER EASTERN PWO KAREN NNA..MYANMAR LETTER EASTERN PWO KAREN GHWA
+	{runeRange{0x1075, 0x1081}, sbprOLetter},   // Lo  [13] MYANMAR LETTER SHAN KA..MYANMAR LETTER SHAN HA
+	{runeRange{0x1083, 0x1084}, sbprExtend},    // Mc   [2] MYANMAR VOWEL SIGN SHAN AA..MYANMAR VOWEL SIGN SHAN E
+	{runeRange{0x1087, 0x108C}, sbprExtend},    // Mc   [6] MYANMAR SIGN SHAN TONE-2..MYANMAR SIGN SHAN COUNCIL TONE-3
+	{runeRange{0x108E, 0x108E}, sbprOLetter},   // Lo       MYANMAR LETTER RUMAI PALAUNG FA
+	{runeRange{0x1090, 0x1099}, sbprNumeric},   // Nd  [10] MYANMAR SHAN DIGIT ZERO..MYANMAR SHAN DIGIT NINE
+	{runeRange{0x109D, 0x109D}, sbprExtend},    // Mn       MYANMAR VOWEL SIGN AITON AI
+	{runeRange{0x10C7, 0x10C7}, sbprUpper},     // L&       GEORGIAN CAPITAL LETTER YN
+	{runeRange{0x10D0, 0x10FA}, sbprOLetter},   // L&  [43] GEORGIAN LETTER AN..GEORGIAN LETTER AIN
+	{runeRange{0x10FD, 0x10FF}, sbprOLetter},   // L&   [3] GEORGIAN LETTER AEN..GEORGIAN LETTER LABIAL SIGN
+	{runeRange{0x124A, 0x124D}, sbprOLetter},   // Lo   [4] ETHIOPIC SYLLABLE QWI..ETHIOPIC SYLLABLE QWE
+	{runeRange{0x1258, 0x1258}, sbprOLetter},   // Lo       ETHIOPIC SYLLABLE QHWA
+	{runeRange{0x1260, 0x1288}, sbprOLetter},   // Lo  [41] ETHIOPIC SYLLABLE BA..ETHIOPIC SYLLABLE XWA
+	{runeRange{0x1290, 0x12B0}, sbprOLetter},   // Lo  [33] ETHIOPIC SYLLABLE NA..ETHIOPIC SYLLABLE KWA
+	{runeRange{0x12B8, 0x12BE}, sbprOLetter},   // Lo   [7] ETHIOPIC SYLLABLE KXA..ETHIOPIC SYLLABLE KXO
+	{runeRange{0x12C2, 0x12C5}, sbprOLetter},   // Lo   [4] ETHIOPIC SYLLABLE KXWI..ETHIOPIC SYLLABLE KXWE
+	{runeRange{0x12D8, 0x1310}, sbprOLetter},   // Lo  [57] ETHIOPIC SYLLABLE ZA..ETHIOPIC SYLLABLE GWA
+	{runeRange{0x1318, 0x135A}, sbprOLetter},   // Lo  [67] ETHIOPIC SYLLABLE GGA..ETHIOPIC SYLLABLE FYA
+	{runeRange{0x1362, 0x1362}, sbprSTerm},     // Po       ETHIOPIC FULL STOP
+	{runeRange{0x1380, 0x138F}, sbprOLetter},   // Lo  [16] ETHIOPIC SYLLABLE SEBATBEIT MWA..ETHIOPIC SYLLABLE PWE
+	{runeRange{0x13F8, 0x13FD}, sbprLower},     // L&   [6] CHEROKEE SMALL LETTER YE..CHEROKEE SMALL LETTER MV
+	{runeRange{0x166E, 0x166E}, sbprSTerm},     // Po       CANADIAN SYLLABICS FULL STOP
+	{runeRange{0x1680, 0x1680}, sbprSp},        // Zs       OGHAM SPACE MARK
+	{runeRange{0x169B, 0x169B}, sbprClose},     // Ps       OGHAM FEATHER MARK
+	{runeRange{0x16A0, 0x16EA}, sbprOLetter},   // Lo  [75] RUNIC LETTER FEHU FEOH FE F..RUNIC LETTER X
+	{runeRange{0x16F1, 0x16F8}, sbprOLetter},   // Lo   [8] RUNIC LETTER K..RUNIC LETTER FRANKS CASKET AESC
+	{runeRange{0x1712, 0x1714}, sbprExtend},    // Mn   [3] TAGALOG VOWEL SIGN I..TAGALOG SIGN VIRAMA
+	{runeRange{0x171F, 0x1731}, sbprOLetter},   // Lo  [19] TAGALOG LETTER ARCHAIC RA..HANUNOO LETTER HA
+	{runeRange{0x1734, 0x1734}, sbprExtend},    // Mc       HANUNOO SIGN PAMUDPOD
+	{runeRange{0x1740, 0x1751}, sbprOLetter},   // Lo  [18] BUHID LETTER A..BUHID LETTER HA
+	{runeRange{0x1760, 0x176C}, sbprOLetter},   // Lo  [13] TAGBANWA LETTER A..TAGBANWA LETTER YA
+	{runeRange{0x1772, 0x1773}, sbprExtend},    // Mn   [2] TAGBANWA VOWEL SIGN I..TAGBANWA VOWEL SIGN U
+	{runeRange{0x17B4, 0x17B5}, sbprExtend},    // Mn   [2] KHMER VOWEL INHERENT AQ..KHMER VOWEL INHERENT AA
+	{runeRange{0x17B7, 0x17BD}, sbprExtend},    // Mn   [7] KHMER VOWEL SIGN I..KHMER VOWEL SIGN UA
+	{runeRange{0x17C6, 0x17C6}, sbprExtend},    // Mn       KHMER SIGN NIKAHIT
+	{runeRange{0x17C9, 0x17D3}, sbprExtend},    // Mn  [11] KHMER SIGN MUUSIKATOAN..KHMER SIGN BATHAMASAT
+	{runeRange{0x17DC, 0x17DC}, sbprOLetter},   // Lo       KHMER SIGN AVAKRAHASANYA
+	{runeRange{0x17E0, 0x17E9}, sbprNumeric},   // Nd  [10] KHMER DIGIT ZERO..KHMER DIGIT NINE
+	{runeRange{0x1803, 0x1803}, sbprSTerm},     // Po       MONGOLIAN FULL STOP
+	{runeRange{0x1809, 0x1809}, sbprSTerm},     // Po       MONGOLIAN MANCHU FULL STOP
+	{runeRange{0x180E, 0x180E}, sbprFormat},    // Cf       MONGOLIAN VOWEL SEPARATOR
+	{runeRange{0x1810, 0x1819}, sbprNumeric},   // Nd  [10] MONGOLIAN DIGIT ZERO..MONGOLIAN DIGIT NINE
+	{runeRange{0x1843, 0x1843}, sbprOLetter},   // Lm       MONGOLIAN LETTER TODO LONG VOWEL SIGN
+	{runeRange{0x1880, 0x1884}, sbprOLetter},   // Lo   [5] MONGOLIAN LETTER ALI GALI ANUSVARA ONE..MONGOLIAN LETTER ALI GALI INVERTED UBADAMA
+	{runeRange{0x1887, 0x18A8}, sbprOLetter},   // Lo  [34] MONGOLIAN LETTER ALI GALI A..MONGOLIAN LETTER MANCHU ALI GALI BHA
+	{runeRange{0x18AA, 0x18AA}, sbprOLetter},   // Lo       MONGOLIAN LETTER MANCHU ALI GALI LHA
+	{runeRange{0x1900, 0x191E}, sbprOLetter},   // Lo  [31] LIMBU VOWEL-CARRIER LETTER..LIMBU LETTER TRA
+	{runeRange{0x1923, 0x1926}, sbprExtend},    // Mc   [4] LIMBU VOWEL SIGN EE..LIMBU VOWEL SIGN AU
+	{runeRange{0x1929, 0x192B}, sbprExtend},    // Mc   [3] LIMBU SUBJOINED LETTER YA..LIMBU SUBJOINED LETTER WA
+	{runeRange{0x1932, 0x1932}, sbprExtend},    // Mn       LIMBU SMALL LETTER ANUSVARA
+	{runeRange{0x1939, 0x193B}, sbprExtend},    // Mn   [3] LIMBU SIGN MUKPHRENG..LIMBU SIGN SA-I
+	{runeRange{0x1946, 0x194F}, sbprNumeric},   // Nd  [10] LIMBU DIGIT ZERO..LIMBU DIGIT NINE
+	{runeRange{0x1970, 0x1974}, sbprOLetter},   // Lo   [5] TAI LE LETTER TONE-2..TAI LE LETTER TONE-6
+	{runeRange{0x19B0, 0x19C9}, sbprOLetter},   // Lo  [26] NEW TAI LUE VOWEL SIGN VOWEL SHORTENER..NEW TAI LUE TONE MARK-2
+	{runeRange{0x1A00, 0x1A16}, sbprOLetter},   // Lo  [23] BUGINESE LETTER KA..BUGINESE LETTER HA
+	{runeRange{0x1A19, 0x1A1A}, sbprExtend},    // Mc   [2] BUGINESE VOWEL SIGN E..BUGINESE VOWEL SIGN O
+	{runeRange{0x1A20, 0x1A54}, sbprOLetter},   // Lo  [53] TAI THAM LETTER HIGH KA..TAI THAM LETTER GREAT SA
+	{runeRange{0x1A56, 0x1A56}, sbprExtend},    // Mn       TAI THAM CONSONANT SIGN MEDIAL LA
+	{runeRange{0x1A58, 0x1A5E}, sbprExtend},    // Mn   [7] TAI THAM SIGN MAI KANG LAI..TAI THAM CONSONANT SIGN SA
+	{runeRange{0x1A61, 0x1A61}, sbprExtend},    // Mc       TAI THAM VOWEL SIGN A
+	{runeRange{0x1A63, 0x1A64}, sbprExtend},    // Mc   [2] TAI THAM VOWEL SIGN AA..TAI THAM VOWEL SIGN TALL AA
+	{runeRange{0x1A6D, 0x1A72}, sbprExtend},    // Mc   [6] TAI THAM VOWEL SIGN OY..TAI THAM VOWEL SIGN THAM AI
+	{runeRange{0x1A7F, 0x1A7F}, sbprExtend},    // Mn       TAI THAM COMBINING CRYPTOGRAMMIC DOT
+	{runeRange{0x1A90, 0x1A99}, sbprNumeric},   // Nd  [10] TAI THAM THAM DIGIT ZERO..TAI THAM THAM DIGIT NINE
+	{runeRange{0x1AA8, 0x1AAB}, sbprSTerm},     // Po   [4] TAI THAM SIGN KAAN..TAI THAM SIGN SATKAANKUU
+	{runeRange{0x1ABE, 0x1ABE}, sbprExtend},    // Me       COMBINING PARENTHESES OVERLAY
+	{runeRange{0x1B00, 0x1B03}, sbprExtend},    // Mn   [4] BALINESE SIGN ULU RICEM..BALINESE SIGN SURANG
+	{runeRange{0x1B05, 0x1B33}, sbprOLetter},   // Lo  [47] BALINESE LETTER AKARA..BALINESE LETTER HA
+	{runeRange{0x1B35, 0x1B35}, sbprExtend},    // Mc       BALINESE VOWEL SIGN TEDUNG
+	{runeRange{0x1B3B, 0x1B3B}, sbprExtend},    // Mc       BALINESE VOWEL SIGN RA REPA TEDUNG
+	{runeRange{0x1B3D, 0x1B41}, sbprExtend},    // Mc   [5] BALINESE VOWEL SIGN LA LENGA TEDUNG..BALINESE VOWEL SIGN TALING REPA TEDUNG
+	{runeRange{0x1B43, 0x1B44}, sbprExtend},    // Mc   [2] BALINESE VOWEL SIGN PEPET TEDUNG..BALINESE ADEG ADEG
+	{runeRange{0x1B50, 0x1B59}, sbprNumeric},   // Nd  [10] BALINESE DIGIT ZERO..BALINESE DIGIT NINE
+	{runeRange{0x1B5E, 0x1B5F}, sbprSTerm},     // Po   [2] BALINESE CARIK SIKI..BALINESE CARIK PAREREN
+	{runeRange{0x1B7D, 0x1B7E}, sbprSTerm},     // Po   [2] BALINESE PANTI LANTANG..BALINESE PAMADA LANTANG
+	{runeRange{0x1B82, 0x1B82}, sbprExtend},    // Mc       SUNDANESE SIGN PANGWISAD
+	{runeRange{0x1BA1, 0x1BA1}, sbprExtend},    // Mc       SUNDANESE CONSONANT SIGN PAMINGKAL
+	{runeRange{0x1BA6, 0x1BA7}, sbprExtend},    // Mc   [2] SUNDANESE VOWEL SIGN PANAELAENG..SUNDANESE VOWEL SIGN PANOLONG
+	{runeRange{0x1BAA, 0x1BAA}, sbprExtend},    // Mc       SUNDANESE SIGN PAMAAEH
+	{runeRange{0x1BAE, 0x1BAF}, sbprOLetter},   // Lo   [2] SUNDANESE LETTER KHA..SUNDANESE LETTER SYA
+	{runeRange{0x1BBA, 0x1BE5}, sbprOLetter},   // Lo  [44] SUNDANESE AVAGRAHA..BATAK LETTER U
+	{runeRange{0x1BE7, 0x1BE7}, sbprExtend},    // Mc       BATAK VOWEL SIGN E
+	{runeRange{0x1BEA, 0x1BEC}, sbprExtend},    // Mc   [3] BATAK VOWEL SIGN I..BATAK VOWEL SIGN O
+	{runeRange{0x1BEE, 0x1BEE}, sbprExtend},    // Mc       BATAK VOWEL SIGN U
+	{runeRange{0x1BF2, 0x1BF3}, sbprExtend},    // Mc   [2] BATAK PANGOLAT..BATAK PANONGONAN
+	{runeRange{0x1C24, 0x1C2B}, sbprExtend},    // Mc   [8] LEPCHA SUBJOINED LETTER YA..LEPCHA VOWEL SIGN UU
+	{runeRange{0x1C34, 0x1C35}, sbprExtend},    // Mc   [2] LEPCHA CONSONANT SIGN NYIN-DO..LEPCHA CONSONANT SIGN KANG
+	{runeRange{0x1C3B, 0x1C3C}, sbprSTerm},     // Po   [2] LEPCHA PUNCTUATION TA-ROL..LEPCHA PUNCTUATION NYET THYOOM TA-ROL
+	{runeRange{0x1C4D, 0x1C4F}, sbprOLetter},   // Lo   [3] LEPCHA LETTER TTA..LEPCHA LETTER DDA
+	{runeRange{0x1C5A, 0x1C77}, sbprOLetter},   // Lo  [30] OL CHIKI LETTER LA..OL CHIKI LETTER OH
+	{runeRange{0x1C7E, 0x1C7F}, sbprSTerm},     // Po   [2] OL CHIKI PUNCTUATION MUCAAD..OL CHIKI PUNCTUATION DOUBLE MUCAAD
+	{runeRange{0x1C90, 0x1CBA}, sbprOLetter},   // L&  [43] GEORGIAN MTAVRULI CAPITAL LETTER AN..GEORGIAN MTAVRULI CAPITAL LETTER AIN
+	{runeRange{0x1CD0, 0x1CD2}, sbprExtend},    // Mn   [3] VEDIC TONE KARSHANA..VEDIC TONE PRENKHA
+	{runeRange{0x1CE1, 0x1CE1}, sbprExtend},    // Mc       VEDIC TONE ATHARVAVEDIC INDEPENDENT SVARITA
+	{runeRange{0x1CE9, 0x1CEC}, sbprOLetter},   // Lo   [4] VEDIC SIGN ANUSVARA ANTARGOMUKHA..VEDIC SIGN ANUSVARA VAMAGOMUKHA WITH TAIL
+	{runeRange{0x1CEE, 0x1CF3}, sbprOLetter},   // Lo   [6] VEDIC SIGN HEXIFORM LONG ANUSVARA..VEDIC SIGN ROTATED ARDHAVISARGA
+	{runeRange{0x1CF5, 0x1CF6}, sbprOLetter},   // Lo   [2] VEDIC SIGN JIHVAMULIYA..VEDIC SIGN UPADHMANIYA
+	{runeRange{0x1CF8, 0x1CF9}, sbprExtend},    // Mn   [2] VEDIC TONE RING ABOVE..VEDIC TONE DOUBLE RING ABOVE
+	{runeRange{0x1D00, 0x1D2B}, sbprLower},     // L&  [44] LATIN LETTER SMALL CAPITAL A..CYRILLIC LETTER SMALL CAPITAL EL
+	{runeRange{0x1D6B, 0x1D77}, sbprLower},     // L&  [13] LATIN SMALL LETTER UE..LATIN SMALL LETTER TURNED G
+	{runeRange{0x1D79, 0x1D9A}, sbprLower},     // L&  [34] LATIN SMALL LETTER INSULAR G..LATIN SMALL LETTER EZH WITH RETROFLEX HOOK
+	{runeRange{0x1DC0, 0x1DFF}, sbprExtend},    // Mn  [64] COMBINING DOTTED GRAVE ACCENT..COMBINING RIGHT ARROWHEAD AND DOWN ARROWHEAD BELOW
+	{runeRange{0x1E01, 0x1E01}, sbprLower},     // L&       LATIN SMALL LETTER A WITH RING BELOW
+	{runeRange{0x1E03, 0x1E03}, sbprLower},     // L&       LATIN SMALL LETTER B WITH DOT ABOVE
+	{runeRange{0x1E05, 0x1E05}, sbprLower},     // L&       LATIN SMALL LETTER B WITH DOT BELOW
+	{runeRange{0x1E07, 0x1E07}, sbprLower},     // L&       LATIN SMALL LETTER B WITH LINE BELOW
+	{runeRange{0x1E09, 0x1E09}, sbprLower},     // L&       LATIN SMALL LETTER C WITH CEDILLA AND ACUTE
+	{runeRange{0x1E0B, 0x1E0B}, sbprLower},     // L&       LATIN SMALL LETTER D WITH DOT ABOVE
+	{runeRange{0x1E0D, 0x1E0D}, sbprLower},     // L&       LATIN SMALL LETTER D WITH DOT BELOW
+	{runeRange{0x1E0F, 0x1E0F}, sbprLower},     // L&       LATIN SMALL LETTER D WITH LINE BELOW
+	{runeRange{0x1E11, 0x1E11}, sbprLower},     // L&       LATIN SMALL LETTER D WITH CEDILLA
+	{runeRange{0x1E13, 0x1E13}, sbprLower},     // L&       LATIN SMALL LETTER D WITH CIRCUMFLEX BELOW
+	{runeRange{0x1E15, 0x1E15}, sbprLower},     // L&       LATIN SMALL LETTER E WITH MACRON AND GRAVE
+	{runeRange{0x1E17, 0x1E17}, sbprLower},     // L&       LATIN SMALL LETTER E WITH MACRON AND ACUTE
+	{runeRange{0x1E19, 0x1E19}, sbprLower},     // L&       LATIN SMALL LETTER E WITH CIRCUMFLEX BELOW
+	{runeRange{0x1E1B, 0x1E1B}, sbprLower},     // L&       LATIN SMALL LETTER E WITH TILDE BELOW
+	{runeRange{0x1E1D, 0x1E1D}, sbprLower},     // L&       LATIN SMALL LETTER E WITH CEDILLA AND BREVE
+	{runeRange{0x1E1F, 0x1E1F}, sbprLower},     // L&       LATIN SMALL LETTER F WITH DOT ABOVE
+	{runeRange{0x1E21, 0x1E21}, sbprLower},     // L&       LATIN SMALL LETTER G WITH MACRON
+	{runeRange{0x1E23, 0x1E23}, sbprLower},     // L&       LATIN SMALL LETTER H WITH DOT ABOVE
+	{runeRange{0x1E25, 0x1E25}, sbprLower},     // L&       LATIN SMALL LETTER H WITH DOT BELOW
+	{runeRange{0x1E27, 0x1E27}, sbprLower},     // L&       LATIN SMALL LETTER H WITH DIAERESIS
+	{runeRange{0x1E29, 0x1E29}, sbprLower},     // L&       LATIN SMALL LETTER H WITH CEDILLA
+	{runeRange{0x1E2B, 0x1E2B}, sbprLower},     // L&       LATIN SMALL LETTER H WITH BREVE BELOW
+	{runeRange{0x1E2D, 0x1E2D}, sbprLower},     // L&       LATIN SMALL LETTER I WITH TILDE BELOW
+	{runeRange{0x1E2F, 0x1E2F}, sbprLower},     // L&       LATIN SMALL LETTER I WITH DIAERESIS AND ACUTE
+	{runeRange{0x1E31, 0x1E31}, sbprLower},     // L&       LATIN SMALL LETTER K WITH ACUTE
+	{runeRange{0x1E33, 0x1E33}, sbprLower},     // L&       LATIN SMALL LETTER K WITH DOT BELOW
+	{runeRange{0x1E35, 0x1E35}, sbprLower},     // L&       LATIN SMALL LETTER K WITH LINE BELOW
+	{runeRange{0x1E37, 0x1E37}, sbprLower},     // L&       LATIN SMALL LETTER L WITH DOT BELOW
+	{runeRange{0x1E39, 0x1E39}, sbprLower},     // L&       LATIN SMALL LETTER L WITH DOT BELOW AND MACRON
+	{runeRange{0x1E3B, 0x1E3B}, sbprLower},     // L&       LATIN SMALL LETTER L WITH LINE BELOW
+	{runeRange{0x1E3D, 0x1E3D}, sbprLower},     // L&       LATIN SMALL LETTER L WITH CIRCUMFLEX BELOW
+	{runeRange{0x1E3F, 0x1E3F}, sbprLower},     // L&       LATIN SMALL LETTER M WITH ACUTE
+	{runeRange{0x1E41, 0x1E41}, sbprLower},     // L&       LATIN SMALL LETTER M WITH DOT ABOVE
+	{runeRange{0x1E43, 0x1E43}, sbprLower},     // L&       LATIN SMALL LETTER M WITH DOT BELOW
+	{runeRange{0x1E45, 0x1E45}, sbprLower},     // L&       LATIN SMALL LETTER N WITH DOT ABOVE
+	{runeRange{0x1E47, 0x1E47}, sbprLower},     // L&       LATIN SMALL LETTER N WITH DOT BELOW
+	{runeRange{0x1E49, 0x1E49}, sbprLower},     // L&       LATIN SMALL LETTER N WITH LINE BELOW
+	{runeRange{0x1E4B, 0x1E4B}, sbprLower},     // L&       LATIN SMALL LETTER N WITH CIRCUMFLEX BELOW
+	{runeRange{0x1E4D, 0x1E4D}, sbprLower},     // L&       LATIN SMALL LETTER O WITH TILDE AND ACUTE
+	{runeRange{0x1E4F, 0x1E4F}, sbprLower},     // L&       LATIN SMALL LETTER O WITH TILDE AND DIAERESIS
+	{runeRange{0x1E51, 0x1E51}, sbprLower},     // L&       LATIN SMALL LETTER O WITH MACRON AND GRAVE
+	{runeRange{0x1E53, 0x1E53}, sbprLower},     // L&       LATIN SMALL LETTER O WITH MACRON AND ACUTE
+	{runeRange{0x1E55, 0x1E55}, sbprLower},     // L&       LATIN SMALL LETTER P WITH ACUTE
+	{runeRange{0x1E57, 0x1E57}, sbprLower},     // L&       LATIN SMALL LETTER P WITH DOT ABOVE
+	{runeRange{0x1E59, 0x1E59}, sbprLower},     // L&       LATIN SMALL LETTER R WITH DOT ABOVE
+	{runeRange{0x1E5B, 0x1E5B}, sbprLower},     // L&       LATIN SMALL LETTER R WITH DOT BELOW
+	{runeRange{0x1E5D, 0x1E5D}, sbprLower},     // L&       LATIN SMALL LETTER R WITH DOT BELOW AND MACRON
+	{runeRange{0x1E5F, 0x1E5F}, sbprLower},     // L&       LATIN SMALL LETTER R WITH LINE BELOW
+	{runeRange{0x1E61, 0x1E61}, sbprLower},     // L&       LATIN SMALL LETTER S WITH DOT ABOVE
+	{runeRange{0x1E63, 0x1E63}, sbprLower},     // L&       LATIN SMALL LETTER S WITH DOT BELOW
+	{runeRange{0x1E65, 0x1E65}, sbprLower},     // L&       LATIN SMALL LETTER S WITH ACUTE AND DOT ABOVE
+	{runeRange{0x1E67, 0x1E67}, sbprLower},     // L&       LATIN SMALL LETTER S WITH CARON AND DOT ABOVE
+	{runeRange{0x1E69, 0x1E69}, sbprLower},     // L&       LATIN SMALL LETTER S WITH DOT BELOW AND DOT ABOVE
+	{runeRange{0x1E6B, 0x1E6B}, sbprLower},     // L&       LATIN SMALL LETTER T WITH DOT ABOVE
+	{runeRange{0x1E6D, 0x1E6D}, sbprLower},     // L&       LATIN SMALL LETTER T WITH DOT BELOW
+	{runeRange{0x1E6F, 0x1E6F}, sbprLower},     // L&       LATIN SMALL LETTER T WITH LINE BELOW
+	{runeRange{0x1E71, 0x1E71}, sbprLower},     // L&       LATIN SMALL LETTER T WITH CIRCUMFLEX BELOW
+	{runeRange{0x1E73, 0x1E73}, sbprLower},     // L&       LATIN SMALL LETTER U WITH DIAERESIS BELOW
+	{runeRange{0x1E75, 0x1E75}, sbprLower},     // L&       LATIN SMALL LETTER U WITH TILDE BELOW
+	{runeRange{0x1E77, 0x1E77}, sbprLower},     // L&       LATIN SMALL LETTER U WITH CIRCUMFLEX BELOW
+	{runeRange{0x1E79, 0x1E79}, sbprLower},     // L&       LATIN SMALL LETTER U WITH TILDE AND ACUTE
+	{runeRange{0x1E7B, 0x1E7B}, sbprLower},     // L&       LATIN SMALL LETTER U WITH MACRON AND DIAERESIS
+	{runeRange{0x1E7D, 0x1E7D}, sbprLower},     // L&       LATIN SMALL LETTER V WITH TILDE
+	{runeRange{0x1E7F, 0x1E7F}, sbprLower},     // L&       LATIN SMALL LETTER V WITH DOT BELOW
+	{runeRange{0x1E81, 0x1E81}, sbprLower},     // L&       LATIN SMALL LETTER W WITH GRAVE
+	{runeRange{0x1E83, 0x1E83}, sbprLower},     // L&       LATIN SMALL LETTER W WITH ACUTE
+	{runeRange{0x1E85, 0x1E85}, sbprLower},     // L&       LATIN SMALL LETTER W WITH DIAERESIS
+	{runeRange{0x1E87, 0x1E87}, sbprLower},     // L&       LATIN SMALL LETTER W WITH DOT ABOVE
+	{runeRange{0x1E89, 0x1E89}, sbprLower},     // L&       LATIN SMALL LETTER W WITH DOT BELOW
+	{runeRange{0x1E8B, 0x1E8B}, sbprLower},     // L&       LATIN SMALL LETTER X WITH DOT ABOVE
+	{runeRange{0x1E8D, 0x1E8D}, sbprLower},     // L&       LATIN SMALL LETTER X WITH DIAERESIS
+	{runeRange{0x1E8F, 0x1E8F}, sbprLower},     // L&       LATIN SMALL LETTER Y WITH DOT ABOVE
+	{runeRange{0x1E91, 0x1E91}, sbprLower},     // L&       LATIN SMALL LETTER Z WITH CIRCUMFLEX
+	{runeRange{0x1E93, 0x1E93}, sbprLower},     // L&       LATIN SMALL LETTER Z WITH DOT BELOW
+	{runeRange{0x1E95, 0x1E9D}, sbprLower},     // L&   [9] LATIN SMALL LETTER Z WITH LINE BELOW..LATIN SMALL LETTER LONG S WITH HIGH STROKE
+	{runeRange{0x1E9F, 0x1E9F}, sbprLower},     // L&       LATIN SMALL LETTER DELTA
+	{runeRange{0x1EA1, 0x1EA1}, sbprLower},     // L&       LATIN SMALL LETTER A WITH DOT BELOW
+	{runeRange{0x1EA3, 0x1EA3}, sbprLower},     // L&       LATIN SMALL LETTER A WITH HOOK ABOVE
+	{runeRange{0x1EA5, 0x1EA5}, sbprLower},     // L&       LATIN SMALL LETTER A WITH CIRCUMFLEX AND ACUTE
+	{runeRange{0x1EA7, 0x1EA7}, sbprLower},     // L&       LATIN SMALL LETTER A WITH CIRCUMFLEX AND GRAVE
+	{runeRange{0x1EA9, 0x1EA9}, sbprLower},     // L&       LATIN SMALL LETTER A WITH CIRCUMFLEX AND HOOK ABOVE
+	{runeRange{0x1EAB, 0x1EAB}, sbprLower},     // L&       LATIN SMALL LETTER A WITH CIRCUMFLEX AND TILDE
+	{runeRange{0x1EAD, 0x1EAD}, sbprLower},     // L&       LATIN SMALL LETTER A WITH CIRCUMFLEX AND DOT BELOW
+	{runeRange{0x1EAF, 0x1EAF}, sbprLower},     // L&       LATIN SMALL LETTER A WITH BREVE AND ACUTE
+	{runeRange{0x1EB1, 0x1EB1}, sbprLower},     // L&       LATIN SMALL LETTER A WITH BREVE AND GRAVE
+	{runeRange{0x1EB3, 0x1EB3}, sbprLower},     // L&       LATIN SMALL LETTER A WITH BREVE AND HOOK ABOVE
+	{runeRange{0x1EB5, 0x1EB5}, sbprLower},     // L&       LATIN SMALL LETTER A WITH BREVE AND TILDE
+	{runeRange{0x1EB7, 0x1EB7}, sbprLower},     // L&       LATIN SMALL LETTER A WITH BREVE AND DOT BELOW
+	{runeRange{0x1EB9, 0x1EB9}, sbprLower},     // L&       LATIN SMALL LETTER E WITH DOT BELOW
+	{runeRange{0x1EBB, 0x1EBB}, sbprLower},     // L&       LATIN SMALL LETTER E WITH HOOK ABOVE
+	{runeRange{0x1EBD, 0x1EBD}, sbprLower},     // L&       LATIN SMALL LETTER E WITH TILDE
+	{runeRange{0x1EBF, 0x1EBF}, sbprLower},     // L&       LATIN SMALL LETTER E WITH CIRCUMFLEX AND ACUTE
+	{runeRange{0x1EC1, 0x1EC1}, sbprLower},     // L&       LATIN SMALL LETTER E WITH CIRCUMFLEX AND GRAVE
+	{runeRange{0x1EC3, 0x1EC3}, sbprLower},     // L&       LATIN SMALL LETTER E WITH CIRCUMFLEX AND HOOK ABOVE
+	{runeRange{0x1EC5, 0x1EC5}, sbprLower},     // L&       LATIN SMALL LETTER E WITH CIRCUMFLEX AND TILDE
+	{runeRange{0x1EC7, 0x1EC7}, sbprLower},     // L&       LATIN SMALL LETTER E WITH CIRCUMFLEX AND DOT BELOW
+	{runeRange{0x1EC9, 0x1EC9}, sbprLower},     // L&       LATIN SMALL LETTER I WITH HOOK ABOVE
+	{runeRange{0x1ECB, 0x1ECB}, sbprLower},     // L&       LATIN SMALL LETTER I WITH DOT BELOW
+	{runeRange{0x1ECD, 0x1ECD}, sbprLower},     // L&       LATIN SMALL LETTER O WITH DOT BELOW
+	{runeRange{0x1ECF, 0x1ECF}, sbprLower},     // L&       LATIN SMALL LETTER O WITH HOOK ABOVE
+	{runeRange{0x1ED1, 0x1ED1}, sbprLower},     // L&       LATIN SMALL LETTER O WITH CIRCUMFLEX AND ACUTE
+	{runeRange{0x1ED3, 0x1ED3}, sbprLower},     // L&       LATIN SMALL LETTER O WITH CIRCUMFLEX AND GRAVE
+	{runeRange{0x1ED5, 0x1ED5}, sbprLower},     // L&       LATIN SMALL LETTER O WITH CIRCUMFLEX AND HOOK ABOVE
+	{runeRange{0x1ED7, 0x1ED7}, sbprLower},     // L&       LATIN SMALL LETTER O WITH CIRCUMFLEX AND TILDE
+	{runeRange{0x1ED9, 0x1ED9}, sbprLower},     // L&       LATIN SMALL LETTER O WITH CIRCUMFLEX AND DOT BELOW
+	{runeRange{0x1EDB, 0x1EDB}, sbprLower},     // L&       LATIN SMALL LETTER O WITH HORN AND ACUTE
+	{runeRange{0x1EDD, 0x1EDD}, sbprLower},     // L&       LATIN SMALL LETTER O WITH HORN AND GRAVE
+	{runeRange{0x1EDF, 0x1EDF}, sbprLower},     // L&       LATIN SMALL LETTER O WITH HORN AND HOOK ABOVE
+	{runeRange{0x1EE1, 0x1EE1}, sbprLower},     // L&       LATIN SMALL LETTER O WITH HORN AND TILDE
+	{runeRange{0x1EE3, 0x1EE3}, sbprLower},     // L&       LATIN SMALL LETTER O WITH HORN AND DOT BELOW
+	{runeRange{0x1EE5, 0x1EE5}, sbprLower},     // L&       LATIN SMALL LETTER U WITH DOT BELOW
+	{runeRange{0x1EE7, 0x1EE7}, sbprLower},     // L&       LATIN SMALL LETTER U WITH HOOK ABOVE
+	{runeRange{0x1EE9, 0x1EE9}, sbprLower},     // L&       LATIN SMALL LETTER U WITH HORN AND ACUTE
+	{runeRange{0x1EEB, 0x1EEB}, sbprLower},     // L&       LATIN SMALL LETTER U WITH HORN AND GRAVE
+	{runeRange{0x1EED, 0x1EED}, sbprLower},     // L&       LATIN SMALL LETTER U WITH HORN AND HOOK ABOVE
+	{runeRange{0x1EEF, 0x1EEF}, sbprLower},     // L&       LATIN SMALL LETTER U WITH HORN AND TILDE
+	{runeRange{0x1EF1, 0x1EF1}, sbprLower},     // L&       LATIN SMALL LETTER U WITH HORN AND DOT BELOW
+	{runeRange{0x1EF3, 0x1EF3}, sbprLower},     // L&       LATIN SMALL LETTER Y WITH GRAVE
+	{runeRange{0x1EF5, 0x1EF5}, sbprLower},     // L&       LATIN SMALL LETTER Y WITH DOT BELOW
+	{runeRange{0x1EF7, 0x1EF7}, sbprLower},     // L&       LATIN SMALL LETTER Y WITH HOOK ABOVE
+	{runeRange{0x1EF9, 0x1EF9}, sbprLower},     // L&       LATIN SMALL LETTER Y WITH TILDE
+	{runeRange{0x1EFB, 0x1EFB}, sbprLower},     // L&       LATIN SMALL LETTER MIDDLE-WELSH LL
+	{runeRange{0x1EFD, 0x1EFD}, sbprLower},     // L&       LATIN SMALL LETTER MIDDLE-WELSH V
+	{runeRange{0x1EFF, 0x1F07}, sbprLower},     // L&   [9] LATIN SMALL LETTER Y WITH LOOP..GREEK SMALL LETTER ALPHA WITH DASIA AND PERISPOMENI
+	{runeRange{0x1F10, 0x1F15}, sbprLower},     // L&   [6] GREEK SMALL LETTER EPSILON WITH PSILI..GREEK SMALL LETTER EPSILON WITH DASIA AND OXIA
+	{runeRange{0x1F20, 0x1F27}, sbprLower},     // L&   [8] GREEK SMALL LETTER ETA WITH PSILI..GREEK SMALL LETTER ETA WITH DASIA AND PERISPOMENI
+	{runeRange{0x1F30, 0x1F37}, sbprLower},     // L&   [8] GREEK SMALL LETTER IOTA WITH PSILI..GREEK SMALL LETTER IOTA WITH DASIA AND PERISPOMENI
+	{runeRange{0x1F40, 0x1F45}, sbprLower},     // L&   [6] GREEK SMALL LETTER OMICRON WITH PSILI..GREEK SMALL LETTER OMICRON WITH DASIA AND OXIA
+	{runeRange{0x1F50, 0x1F57}, sbprLower},     // L&   [8] GREEK SMALL LETTER UPSILON WITH PSILI..GREEK SMALL LETTER UPSILON WITH DASIA AND PERISPOMENI
+	{runeRange{0x1F5B, 0x1F5B}, sbprUpper},     // L&       GREEK CAPITAL LETTER UPSILON WITH DASIA AND VARIA
+	{runeRange{0x1F5F, 0x1F5F}, sbprUpper},     // L&       GREEK CAPITAL LETTER UPSILON WITH DASIA AND PERISPOMENI
+	{runeRange{0x1F68, 0x1F6F}, sbprUpper},     // L&   [8] GREEK CAPITAL LETTER OMEGA WITH PSILI..GREEK CAPITAL LETTER OMEGA WITH DASIA AND PERISPOMENI
+	{runeRange{0x1F80, 0x1F87}, sbprLower},     // L&   [8] GREEK SMALL LETTER ALPHA WITH PSILI AND YPOGEGRAMMENI..GREEK SMALL LETTER ALPHA WITH DASIA AND PERISPOMENI AND YPOGEGRAMMENI
+	{runeRange{0x1F90, 0x1F97}, sbprLower},     // L&   [8] GREEK SMALL LETTER ETA WITH PSILI AND YPOGEGRAMMENI..GREEK SMALL LETTER ETA WITH DASIA AND PERISPOMENI AND YPOGEGRAMMENI
+	{runeRange{0x1FA0, 0x1FA7}, sbprLower},     // L&   [8] GREEK SMALL LETTER OMEGA WITH PSILI AND YPOGEGRAMMENI..GREEK SMALL LETTER OMEGA WITH DASIA AND PERISPOMENI AND YPOGEGRAMMENI
+	{runeRange{0x1FB0, 0x1FB4}, sbprLower},     // L&   [5] GREEK SMALL LETTER ALPHA WITH VRACHY..GREEK SMALL LETTER ALPHA WITH OXIA AND YPOGEGRAMMENI
+	{runeRange{0x1FB8, 0x1FBC}, sbprUpper},     // L&   [5] GREEK CAPITAL LETTER ALPHA WITH VRACHY..GREEK CAPITAL LETTER ALPHA WITH PROSGEGRAMMENI
+	{runeRange{0x1FC2, 0x1FC4}, sbprLower},     // L&   [3] GREEK SMALL LETTER ETA WITH VARIA AND YPOGEGRAMMENI..GREEK SMALL LETTER ETA WITH OXIA AND YPOGEGRAMMENI
+	{runeRange{0x1FC8, 0x1FCC}, sbprUpper},     // L&   [5] GREEK CAPITAL LETTER EPSILON WITH VARIA..GREEK CAPITAL LETTER ETA WITH PROSGEGRAMMENI
+	{runeRange{0x1FD6, 0x1FD7}, sbprLower},     // L&   [2] GREEK SMALL LETTER IOTA WITH PERISPOMENI..GREEK SMALL LETTER IOTA WITH DIALYTIKA AND PERISPOMENI
+	{runeRange{0x1FE0, 0x1FE7}, sbprLower},     // L&   [8] GREEK SMALL LETTER UPSILON WITH VRACHY..GREEK SMALL LETTER UPSILON WITH DIALYTIKA AND PERISPOMENI
+	{runeRange{0x1FF2, 0x1FF4}, sbprLower},     // L&   [3] GREEK SMALL LETTER OMEGA WITH VARIA AND YPOGEGRAMMENI..GREEK SMALL LETTER OMEGA WITH OXIA AND YPOGEGRAMMENI
+	{runeRange{0x1FF8, 0x1FFC}, sbprUpper},     // L&   [5] GREEK CAPITAL LETTER OMICRON WITH VARIA..GREEK CAPITAL LETTER OMEGA WITH PROSGEGRAMMENI
+	{runeRange{0x200B, 0x200B}, sbprFormat},    // Cf       ZERO WIDTH SPACE
+	{runeRange{0x200E, 0x200F}, sbprFormat},    // Cf   [2] LEFT-TO-RIGHT MARK..RIGHT-TO-LEFT MARK
+	{runeRange{0x2018, 0x2018}, sbprClose},     // Pi       LEFT SINGLE QUOTATION MARK
+	{runeRange{0x201A, 0x201A}, sbprClose},     // Ps       SINGLE LOW-9 QUOTATION MARK
+	{runeRange{0x201D, 0x201D}, sbprClose},     // Pf       RIGHT DOUBLE QUOTATION MARK
+	{runeRange{0x201F, 0x201F}, sbprClose},     // Pi       DOUBLE HIGH-REVERSED-9 QUOTATION MARK
+	{runeRange{0x2028, 0x2028}, sbprSep},       // Zl       LINE SEPARATOR
+	{runeRange{0x202A, 0x202E}, sbprFormat},    // Cf   [5] LEFT-TO-RIGHT EMBEDDING..RIGHT-TO-LEFT OVERRIDE
+	{runeRange{0x2039, 0x2039}, sbprClose},     // Pi       SINGLE LEFT-POINTING ANGLE QUOTATION MARK
+	{runeRange{0x203C, 0x203D}, sbprSTerm},     // Po   [2] DOUBLE EXCLAMATION MARK..INTERROBANG
+	{runeRange{0x2046, 0x2046}, sbprClose},     // Pe       RIGHT SQUARE BRACKET WITH QUILL
+	{runeRange{0x205F, 0x205F}, sbprSp},        // Zs       MEDIUM MATHEMATICAL SPACE
+	{runeRange{0x2066, 0x206F}, sbprFormat},    // Cf  [10] LEFT-TO-RIGHT ISOLATE..NOMINAL DIGIT SHAPES
+	{runeRange{0x207D, 0x207D}, sbprClose},     // Ps       SUPERSCRIPT LEFT PARENTHESIS
+	{runeRange{0x207F, 0x207F}, sbprLower},     // Lm       SUPERSCRIPT LATIN SMALL LETTER N
+	{runeRange{0x208E, 0x208E}, sbprClose},     // Pe       SUBSCRIPT RIGHT PARENTHESIS
+	{runeRange{0x20D0, 0x20DC}, sbprExtend},    // Mn  [13] COMBINING LEFT HARPOON ABOVE..COMBINING FOUR DOTS ABOVE
+	{runeRange{0x20E1, 0x20E1}, sbprExtend},    // Mn       COMBINING LEFT RIGHT ARROW ABOVE
+	{runeRange{0x20E5, 0x20F0}, sbprExtend},    // Mn  [12] COMBINING REVERSE SOLIDUS OVERLAY..COMBINING ASTERISK ABOVE
+	{runeRange{0x2107, 0x2107}, sbprUpper},     // L&       EULER CONSTANT
+	{runeRange{0x210B, 0x210D}, sbprUpper},     // L&   [3] SCRIPT CAPITAL H..DOUBLE-STRUCK CAPITAL H
+	{runeRange{0x2110, 0x2112}, sbprUpper},     // L&   [3] SCRIPT CAPITAL I..SCRIPT CAPITAL L
+	{runeRange{0x2115, 0x2115}, sbprUpper},     // L&       DOUBLE-STRUCK CAPITAL N
+	{runeRange{0x2124, 0x2124}, sbprUpper},     // L&       DOUBLE-STRUCK CAPITAL Z
+	{runeRange{0x2128, 0x2128}, sbprUpper},     // L&       BLACK-LETTER CAPITAL Z
+	{runeRange{0x212F, 0x212F}, sbprLower},     // L&       SCRIPT SMALL E
+	{runeRange{0x2134, 0x2134}, sbprLower},     // L&       SCRIPT SMALL O
+	{runeRange{0x2139, 0x2139}, sbprLower},     // L&       INFORMATION SOURCE
+	{runeRange{0x213E, 0x213F}, sbprUpper},     // L&   [2] DOUBLE-STRUCK CAPITAL GAMMA..DOUBLE-STRUCK CAPITAL PI
+	{runeRange{0x2146, 0x2149}, sbprLower},     // L&   [4] DOUBLE-STRUCK ITALIC SMALL D..DOUBLE-STRUCK ITALIC SMALL J
+	{runeRange{0x2160, 0x216F}, sbprUpper},     // Nl  [16] ROMAN NUMERAL ONE..ROMAN NUMERAL ONE THOUSAND
+	{runeRange{0x2180, 0x2182}, sbprOLetter},   // Nl   [3] ROMAN NUMERAL ONE THOUSAND C D..ROMAN NUMERAL TEN THOUSAND
+	{runeRange{0x2184, 0x2184}, sbprLower},     // L&       LATIN SMALL LETTER REVERSED C
+	{runeRange{0x2308, 0x2308}, sbprClose},     // Ps       LEFT CEILING
+	{runeRange{0x230A, 0x230A}, sbprClose},     // Ps       LEFT FLOOR
+	{runeRange{0x2329, 0x2329}, sbprClose},     // Ps       LEFT-POINTING ANGLE BRACKET
+	{runeRange{0x24B6, 0x24CF}, sbprUpper},     // So  [26] CIRCLED LATIN CAPITAL LETTER A..CIRCLED LATIN CAPITAL LETTER Z
+	{runeRange{0x275B, 0x2760}, sbprClose},     // So   [6] HEAVY SINGLE TURNED COMMA QUOTATION MARK ORNAMENT..HEAVY LOW DOUBLE COMMA QUOTATION MARK ORNAMENT
+	{runeRange{0x2769, 0x2769}, sbprClose},     // Pe       MEDIUM RIGHT PARENTHESIS ORNAMENT
+	{runeRange{0x276B, 0x276B}, sbprClose},     // Pe       MEDIUM FLATTENED RIGHT PARENTHESIS ORNAMENT
+	{runeRange{0x276D, 0x276D}, sbprClose},     // Pe       MEDIUM RIGHT-POINTING ANGLE BRACKET ORNAMENT
+	{runeRange{0x276F, 0x276F}, sbprClose},     // Pe       HEAVY RIGHT-POINTING ANGLE QUOTATION MARK ORNAMENT
+	{runeRange{0x2771, 0x2771}, sbprClose},     // Pe       HEAVY RIGHT-POINTING ANGLE BRACKET ORNAMENT
+	{runeRange{0x2773, 0x2773}, sbprClose},     // Pe       LIGHT RIGHT TORTOISE SHELL BRACKET ORNAMENT
+	{runeRange{0x2775, 0x2775}, sbprClose},     // Pe       MEDIUM RIGHT CURLY BRACKET ORNAMENT
+	{runeRange{0x27C6, 0x27C6}, sbprClose},     // Pe       RIGHT S-SHAPED BAG DELIMITER
+	{runeRange{0x27E7, 0x27E7}, sbprClose},     // Pe       MATHEMATICAL RIGHT WHITE SQUARE BRACKET
+	{runeRange{0x27E9, 0x27E9}, sbprClose},     // Pe       MATHEMATICAL RIGHT ANGLE BRACKET
+	{runeRange{0x27EB, 0x27EB}, sbprClose},     // Pe       MATHEMATICAL RIGHT DOUBLE ANGLE BRACKET
+	{runeRange{0x27ED, 0x27ED}, sbprClose},     // Pe       MATHEMATICAL RIGHT WHITE TORTOISE SHELL BRACKET
+	{runeRange{0x27EF, 0x27EF}, sbprClose},     // Pe       MATHEMATICAL RIGHT FLATTENED PARENTHESIS
+	{runeRange{0x2984, 0x2984}, sbprClose},     // Pe       RIGHT WHITE CURLY BRACKET
+	{runeRange{0x2986, 0x2986}, sbprClose},     // Pe       RIGHT WHITE PARENTHESIS
+	{runeRange{0x2988, 0x2988}, sbprClose},     // Pe       Z NOTATION RIGHT IMAGE BRACKET
+	{runeRange{0x298A, 0x298A}, sbprClose},     // Pe       Z NOTATION RIGHT BINDING BRACKET
+	{runeRange{0x298C, 0x298C}, sbprClose},     // Pe       RIGHT SQUARE BRACKET WITH UNDERBAR
+	{runeRange{0x298E, 0x298E}, sbprClose},     // Pe       RIGHT SQUARE BRACKET WITH TICK IN BOTTOM CORNER
+	{runeRange{0x2990, 0x2990}, sbprClose},     // Pe       RIGHT SQUARE BRACKET WITH TICK IN TOP CORNER
+	{runeRange{0x2992, 0x2992}, sbprClose},     // Pe       RIGHT ANGLE BRACKET WITH DOT
+	{runeRange{0x2994, 0x2994}, sbprClose},     // Pe       RIGHT ARC GREATER-THAN BRACKET
+	{runeRange{0x2996, 0x2996}, sbprClose},     // Pe       DOUBLE RIGHT ARC LESS-THAN BRACKET
+	{runeRange{0x2998, 0x2998}, sbprClose},     // Pe       RIGHT BLACK TORTOISE SHELL BRACKET
+	{runeRange{0x29D9, 0x29D9}, sbprClose},     // Pe       RIGHT WIGGLY FENCE
+	{runeRange{0x29DB, 0x29DB}, sbprClose},     // Pe       RIGHT DOUBLE WIGGLY FENCE
+	{runeRange{0x29FD, 0x29FD}, sbprClose},     // Pe       RIGHT-POINTING CURVED ANGLE BRACKET
+	{runeRange{0x2C30, 0x2C5F}, sbprLower},     // L&  [48] GLAGOLITIC SMALL LETTER AZU..GLAGOLITIC SMALL LETTER CAUDATE CHRIVI
+	{runeRange{0x2C61, 0x2C61}, sbprLower},     // L&       LATIN SMALL LETTER L WITH DOUBLE BAR
+	{runeRange{0x2C65, 0x2C66}, sbprLower},     // L&   [2] LATIN SMALL LETTER A WITH STROKE..LATIN SMALL LETTER T WITH DIAGONAL STROKE
+	{runeRange{0x2C68, 0x2C68}, sbprLower},     // L&       LATIN SMALL LETTER H WITH DESCENDER
+	{runeRange{0x2C6A, 0x2C6A}, sbprLower},     // L&       LATIN SMALL LETTER K WITH DESCENDER
+	{runeRange{0x2C6C, 0x2C6C}, sbprLower},     // L&       LATIN SMALL LETTER Z WITH DESCENDER
+	{runeRange{0x2C71, 0x2C71}, sbprLower},     // L&       LATIN SMALL LETTER V WITH RIGHT HOOK
+	{runeRange{0x2C73, 0x2C74}, sbprLower},     // L&   [2] LATIN SMALL LETTER W WITH HOOK..LATIN SMALL LETTER V WITH CURL
+	{runeRange{0x2C76, 0x2C7B}, sbprLower},     // L&   [6] LATIN SMALL LETTER HALF H..LATIN LETTER SMALL CAPITAL TURNED E
 }

--- a/wordproperties.go
+++ b/wordproperties.go
@@ -9,1874 +9,1874 @@ package uniseg
 // ("Extended_Pictographic" only)
 // See https://www.unicode.org/license.html for the Unicode license agreement.
 var workBreakCodePoints = dictionary[wbProperty]{
-	{runeRange{0x000A, 0x000A}, wbprLF},                     // Cc       <control-000A>
-	{runeRange{0x000B, 0x000C}, wbprNewline},                // Cc   [2] <control-000B>..<control-000C>
-	{runeRange{0x000D, 0x000D}, wbprCR},                     // Cc       <control-000D>
-	{runeRange{0x0020, 0x0020}, wbprWSegSpace},              // Zs       SPACE
-	{runeRange{0x0022, 0x0022}, wbprDoubleQuote},            // Po       QUOTATION MARK
-	{runeRange{0x0027, 0x0027}, wbprSingleQuote},            // Po       APOSTROPHE
-	{runeRange{0x002C, 0x002C}, wbprMidNum},                 // Po       COMMA
-	{runeRange{0x002E, 0x002E}, wbprMidNumLet},              // Po       FULL STOP
-	{runeRange{0x0030, 0x0039}, wbprNumeric},                // Nd  [10] DIGIT ZERO..DIGIT NINE
-	{runeRange{0x003A, 0x003A}, wbprMidLetter},              // Po       COLON
-	{runeRange{0x003B, 0x003B}, wbprMidNum},                 // Po       SEMICOLON
-	{runeRange{0x0041, 0x005A}, wbprALetter},                // L&  [26] LATIN CAPITAL LETTER A..LATIN CAPITAL LETTER Z
-	{runeRange{0x005F, 0x005F}, wbprExtendNumLet},           // Pc       LOW LINE
-	{runeRange{0x0061, 0x007A}, wbprALetter},                // L&  [26] LATIN SMALL LETTER A..LATIN SMALL LETTER Z
-	{runeRange{0x0085, 0x0085}, wbprNewline},                // Cc       <control-0085>
-	{runeRange{0x00A9, 0x00A9}, wbprExtendedPictographic},   // E0.6   [1] (©️)       copyright
-	{runeRange{0x00AA, 0x00AA}, wbprALetter},                // Lo       FEMININE ORDINAL INDICATOR
-	{runeRange{0x00AD, 0x00AD}, wbprFormat},                 // Cf       SOFT HYPHEN
-	{runeRange{0x00AE, 0x00AE}, wbprExtendedPictographic},   // E0.6   [1] (®️)       registered
-	{runeRange{0x00B5, 0x00B5}, wbprALetter},                // L&       MICRO SIGN
-	{runeRange{0x00B7, 0x00B7}, wbprMidLetter},              // Po       MIDDLE DOT
-	{runeRange{0x00BA, 0x00BA}, wbprALetter},                // Lo       MASCULINE ORDINAL INDICATOR
-	{runeRange{0x00C0, 0x00D6}, wbprALetter},                // L&  [23] LATIN CAPITAL LETTER A WITH GRAVE..LATIN CAPITAL LETTER O WITH DIAERESIS
-	{runeRange{0x00D8, 0x00F6}, wbprALetter},                // L&  [31] LATIN CAPITAL LETTER O WITH STROKE..LATIN SMALL LETTER O WITH DIAERESIS
-	{runeRange{0x00F8, 0x01BA}, wbprALetter},                // L& [195] LATIN SMALL LETTER O WITH STROKE..LATIN SMALL LETTER EZH WITH TAIL
-	{runeRange{0x01BB, 0x01BB}, wbprALetter},                // Lo       LATIN LETTER TWO WITH STROKE
-	{runeRange{0x01BC, 0x01BF}, wbprALetter},                // L&   [4] LATIN CAPITAL LETTER TONE FIVE..LATIN LETTER WYNN
-	{runeRange{0x01C0, 0x01C3}, wbprALetter},                // Lo   [4] LATIN LETTER DENTAL CLICK..LATIN LETTER RETROFLEX CLICK
-	{runeRange{0x01C4, 0x0293}, wbprALetter},                // L& [208] LATIN CAPITAL LETTER DZ WITH CARON..LATIN SMALL LETTER EZH WITH CURL
-	{runeRange{0x0294, 0x0294}, wbprALetter},                // Lo       LATIN LETTER GLOTTAL STOP
-	{runeRange{0x0295, 0x02AF}, wbprALetter},                // L&  [27] LATIN LETTER PHARYNGEAL VOICED FRICATIVE..LATIN SMALL LETTER TURNED H WITH FISHHOOK AND TAIL
-	{runeRange{0x02B0, 0x02C1}, wbprALetter},                // Lm  [18] MODIFIER LETTER SMALL H..MODIFIER LETTER REVERSED GLOTTAL STOP
-	{runeRange{0x02C2, 0x02C5}, wbprALetter},                // Sk   [4] MODIFIER LETTER LEFT ARROWHEAD..MODIFIER LETTER DOWN ARROWHEAD
-	{runeRange{0x02C6, 0x02D1}, wbprALetter},                // Lm  [12] MODIFIER LETTER CIRCUMFLEX ACCENT..MODIFIER LETTER HALF TRIANGULAR COLON
-	{runeRange{0x02D2, 0x02D7}, wbprALetter},                // Sk   [6] MODIFIER LETTER CENTRED RIGHT HALF RING..MODIFIER LETTER MINUS SIGN
-	{runeRange{0x02DE, 0x02DF}, wbprALetter},                // Sk   [2] MODIFIER LETTER RHOTIC HOOK..MODIFIER LETTER CROSS ACCENT
-	{runeRange{0x02E0, 0x02E4}, wbprALetter},                // Lm   [5] MODIFIER LETTER SMALL GAMMA..MODIFIER LETTER SMALL REVERSED GLOTTAL STOP
-	{runeRange{0x02E5, 0x02EB}, wbprALetter},                // Sk   [7] MODIFIER LETTER EXTRA-HIGH TONE BAR..MODIFIER LETTER YANG DEPARTING TONE MARK
-	{runeRange{0x02EC, 0x02EC}, wbprALetter},                // Lm       MODIFIER LETTER VOICING
-	{runeRange{0x02ED, 0x02ED}, wbprALetter},                // Sk       MODIFIER LETTER UNASPIRATED
-	{runeRange{0x02EE, 0x02EE}, wbprALetter},                // Lm       MODIFIER LETTER DOUBLE APOSTROPHE
-	{runeRange{0x02EF, 0x02FF}, wbprALetter},                // Sk  [17] MODIFIER LETTER LOW DOWN ARROWHEAD..MODIFIER LETTER LOW LEFT ARROW
-	{runeRange{0x0300, 0x036F}, wbprExtend},                 // Mn [112] COMBINING GRAVE ACCENT..COMBINING LATIN SMALL LETTER X
-	{runeRange{0x0370, 0x0373}, wbprALetter},                // L&   [4] GREEK CAPITAL LETTER HETA..GREEK SMALL LETTER ARCHAIC SAMPI
-	{runeRange{0x0374, 0x0374}, wbprALetter},                // Lm       GREEK NUMERAL SIGN
-	{runeRange{0x0376, 0x0377}, wbprALetter},                // L&   [2] GREEK CAPITAL LETTER PAMPHYLIAN DIGAMMA..GREEK SMALL LETTER PAMPHYLIAN DIGAMMA
-	{runeRange{0x037A, 0x037A}, wbprALetter},                // Lm       GREEK YPOGEGRAMMENI
-	{runeRange{0x037B, 0x037D}, wbprALetter},                // L&   [3] GREEK SMALL REVERSED LUNATE SIGMA SYMBOL..GREEK SMALL REVERSED DOTTED LUNATE SIGMA SYMBOL
-	{runeRange{0x037E, 0x037E}, wbprMidNum},                 // Po       GREEK QUESTION MARK
-	{runeRange{0x037F, 0x037F}, wbprALetter},                // L&       GREEK CAPITAL LETTER YOT
-	{runeRange{0x0386, 0x0386}, wbprALetter},                // L&       GREEK CAPITAL LETTER ALPHA WITH TONOS
-	{runeRange{0x0387, 0x0387}, wbprMidLetter},              // Po       GREEK ANO TELEIA
-	{runeRange{0x0388, 0x038A}, wbprALetter},                // L&   [3] GREEK CAPITAL LETTER EPSILON WITH TONOS..GREEK CAPITAL LETTER IOTA WITH TONOS
-	{runeRange{0x038C, 0x038C}, wbprALetter},                // L&       GREEK CAPITAL LETTER OMICRON WITH TONOS
-	{runeRange{0x038E, 0x03A1}, wbprALetter},                // L&  [20] GREEK CAPITAL LETTER UPSILON WITH TONOS..GREEK CAPITAL LETTER RHO
-	{runeRange{0x03A3, 0x03F5}, wbprALetter},                // L&  [83] GREEK CAPITAL LETTER SIGMA..GREEK LUNATE EPSILON SYMBOL
-	{runeRange{0x03F7, 0x0481}, wbprALetter},                // L& [139] GREEK CAPITAL LETTER SHO..CYRILLIC SMALL LETTER KOPPA
-	{runeRange{0x0483, 0x0487}, wbprExtend},                 // Mn   [5] COMBINING CYRILLIC TITLO..COMBINING CYRILLIC POKRYTIE
-	{runeRange{0x0488, 0x0489}, wbprExtend},                 // Me   [2] COMBINING CYRILLIC HUNDRED THOUSANDS SIGN..COMBINING CYRILLIC MILLIONS SIGN
-	{runeRange{0x048A, 0x052F}, wbprALetter},                // L& [166] CYRILLIC CAPITAL LETTER SHORT I WITH TAIL..CYRILLIC SMALL LETTER EL WITH DESCENDER
-	{runeRange{0x0531, 0x0556}, wbprALetter},                // L&  [38] ARMENIAN CAPITAL LETTER AYB..ARMENIAN CAPITAL LETTER FEH
-	{runeRange{0x0559, 0x0559}, wbprALetter},                // Lm       ARMENIAN MODIFIER LETTER LEFT HALF RING
-	{runeRange{0x055A, 0x055C}, wbprALetter},                // Po   [3] ARMENIAN APOSTROPHE..ARMENIAN EXCLAMATION MARK
-	{runeRange{0x055E, 0x055E}, wbprALetter},                // Po       ARMENIAN QUESTION MARK
-	{runeRange{0x055F, 0x055F}, wbprMidLetter},              // Po       ARMENIAN ABBREVIATION MARK
-	{runeRange{0x0560, 0x0588}, wbprALetter},                // L&  [41] ARMENIAN SMALL LETTER TURNED AYB..ARMENIAN SMALL LETTER YI WITH STROKE
-	{runeRange{0x0589, 0x0589}, wbprMidNum},                 // Po       ARMENIAN FULL STOP
-	{runeRange{0x058A, 0x058A}, wbprALetter},                // Pd       ARMENIAN HYPHEN
-	{runeRange{0x0591, 0x05BD}, wbprExtend},                 // Mn  [45] HEBREW ACCENT ETNAHTA..HEBREW POINT METEG
-	{runeRange{0x05BF, 0x05BF}, wbprExtend},                 // Mn       HEBREW POINT RAFE
-	{runeRange{0x05C1, 0x05C2}, wbprExtend},                 // Mn   [2] HEBREW POINT SHIN DOT..HEBREW POINT SIN DOT
-	{runeRange{0x05C4, 0x05C5}, wbprExtend},                 // Mn   [2] HEBREW MARK UPPER DOT..HEBREW MARK LOWER DOT
-	{runeRange{0x05C7, 0x05C7}, wbprExtend},                 // Mn       HEBREW POINT QAMATS QATAN
-	{runeRange{0x05D0, 0x05EA}, wbprHebrewLetter},           // Lo  [27] HEBREW LETTER ALEF..HEBREW LETTER TAV
-	{runeRange{0x05EF, 0x05F2}, wbprHebrewLetter},           // Lo   [4] HEBREW YOD TRIANGLE..HEBREW LIGATURE YIDDISH DOUBLE YOD
-	{runeRange{0x05F3, 0x05F3}, wbprALetter},                // Po       HEBREW PUNCTUATION GERESH
-	{runeRange{0x05F4, 0x05F4}, wbprMidLetter},              // Po       HEBREW PUNCTUATION GERSHAYIM
-	{runeRange{0x0600, 0x0605}, wbprFormat},                 // Cf   [6] ARABIC NUMBER SIGN..ARABIC NUMBER MARK ABOVE
-	{runeRange{0x060C, 0x060D}, wbprMidNum},                 // Po   [2] ARABIC COMMA..ARABIC DATE SEPARATOR
-	{runeRange{0x0610, 0x061A}, wbprExtend},                 // Mn  [11] ARABIC SIGN SALLALLAHOU ALAYHE WASSALLAM..ARABIC SMALL KASRA
-	{runeRange{0x061C, 0x061C}, wbprFormat},                 // Cf       ARABIC LETTER MARK
-	{runeRange{0x0620, 0x063F}, wbprALetter},                // Lo  [32] ARABIC LETTER KASHMIRI YEH..ARABIC LETTER FARSI YEH WITH THREE DOTS ABOVE
-	{runeRange{0x0640, 0x0640}, wbprALetter},                // Lm       ARABIC TATWEEL
-	{runeRange{0x0641, 0x064A}, wbprALetter},                // Lo  [10] ARABIC LETTER FEH..ARABIC LETTER YEH
-	{runeRange{0x064B, 0x065F}, wbprExtend},                 // Mn  [21] ARABIC FATHATAN..ARABIC WAVY HAMZA BELOW
-	{runeRange{0x0660, 0x0669}, wbprNumeric},                // Nd  [10] ARABIC-INDIC DIGIT ZERO..ARABIC-INDIC DIGIT NINE
-	{runeRange{0x066B, 0x066B}, wbprNumeric},                // Po       ARABIC DECIMAL SEPARATOR
-	{runeRange{0x066C, 0x066C}, wbprMidNum},                 // Po       ARABIC THOUSANDS SEPARATOR
-	{runeRange{0x066E, 0x066F}, wbprALetter},                // Lo   [2] ARABIC LETTER DOTLESS BEH..ARABIC LETTER DOTLESS QAF
-	{runeRange{0x0670, 0x0670}, wbprExtend},                 // Mn       ARABIC LETTER SUPERSCRIPT ALEF
-	{runeRange{0x0671, 0x06D3}, wbprALetter},                // Lo  [99] ARABIC LETTER ALEF WASLA..ARABIC LETTER YEH BARREE WITH HAMZA ABOVE
-	{runeRange{0x06D5, 0x06D5}, wbprALetter},                // Lo       ARABIC LETTER AE
-	{runeRange{0x06D6, 0x06DC}, wbprExtend},                 // Mn   [7] ARABIC SMALL HIGH LIGATURE SAD WITH LAM WITH ALEF MAKSURA..ARABIC SMALL HIGH SEEN
-	{runeRange{0x06DD, 0x06DD}, wbprFormat},                 // Cf       ARABIC END OF AYAH
-	{runeRange{0x06DF, 0x06E4}, wbprExtend},                 // Mn   [6] ARABIC SMALL HIGH ROUNDED ZERO..ARABIC SMALL HIGH MADDA
-	{runeRange{0x06E5, 0x06E6}, wbprALetter},                // Lm   [2] ARABIC SMALL WAW..ARABIC SMALL YEH
-	{runeRange{0x06E7, 0x06E8}, wbprExtend},                 // Mn   [2] ARABIC SMALL HIGH YEH..ARABIC SMALL HIGH NOON
-	{runeRange{0x06EA, 0x06ED}, wbprExtend},                 // Mn   [4] ARABIC EMPTY CENTRE LOW STOP..ARABIC SMALL LOW MEEM
-	{runeRange{0x06EE, 0x06EF}, wbprALetter},                // Lo   [2] ARABIC LETTER DAL WITH INVERTED V..ARABIC LETTER REH WITH INVERTED V
-	{runeRange{0x06F0, 0x06F9}, wbprNumeric},                // Nd  [10] EXTENDED ARABIC-INDIC DIGIT ZERO..EXTENDED ARABIC-INDIC DIGIT NINE
-	{runeRange{0x06FA, 0x06FC}, wbprALetter},                // Lo   [3] ARABIC LETTER SHEEN WITH DOT BELOW..ARABIC LETTER GHAIN WITH DOT BELOW
-	{runeRange{0x06FF, 0x06FF}, wbprALetter},                // Lo       ARABIC LETTER HEH WITH INVERTED V
-	{runeRange{0x070F, 0x070F}, wbprFormat},                 // Cf       SYRIAC ABBREVIATION MARK
-	{runeRange{0x0710, 0x0710}, wbprALetter},                // Lo       SYRIAC LETTER ALAPH
-	{runeRange{0x0711, 0x0711}, wbprExtend},                 // Mn       SYRIAC LETTER SUPERSCRIPT ALAPH
-	{runeRange{0x0712, 0x072F}, wbprALetter},                // Lo  [30] SYRIAC LETTER BETH..SYRIAC LETTER PERSIAN DHALATH
-	{runeRange{0x0730, 0x074A}, wbprExtend},                 // Mn  [27] SYRIAC PTHAHA ABOVE..SYRIAC BARREKH
-	{runeRange{0x074D, 0x07A5}, wbprALetter},                // Lo  [89] SYRIAC LETTER SOGDIAN ZHAIN..THAANA LETTER WAAVU
-	{runeRange{0x07A6, 0x07B0}, wbprExtend},                 // Mn  [11] THAANA ABAFILI..THAANA SUKUN
-	{runeRange{0x07B1, 0x07B1}, wbprALetter},                // Lo       THAANA LETTER NAA
-	{runeRange{0x07C0, 0x07C9}, wbprNumeric},                // Nd  [10] NKO DIGIT ZERO..NKO DIGIT NINE
-	{runeRange{0x07CA, 0x07EA}, wbprALetter},                // Lo  [33] NKO LETTER A..NKO LETTER JONA RA
-	{runeRange{0x07EB, 0x07F3}, wbprExtend},                 // Mn   [9] NKO COMBINING SHORT HIGH TONE..NKO COMBINING DOUBLE DOT ABOVE
-	{runeRange{0x07F4, 0x07F5}, wbprALetter},                // Lm   [2] NKO HIGH TONE APOSTROPHE..NKO LOW TONE APOSTROPHE
-	{runeRange{0x07F8, 0x07F8}, wbprMidNum},                 // Po       NKO COMMA
-	{runeRange{0x07FA, 0x07FA}, wbprALetter},                // Lm       NKO LAJANYALAN
-	{runeRange{0x07FD, 0x07FD}, wbprExtend},                 // Mn       NKO DANTAYALAN
-	{runeRange{0x0800, 0x0815}, wbprALetter},                // Lo  [22] SAMARITAN LETTER ALAF..SAMARITAN LETTER TAAF
-	{runeRange{0x0816, 0x0819}, wbprExtend},                 // Mn   [4] SAMARITAN MARK IN..SAMARITAN MARK DAGESH
-	{runeRange{0x081A, 0x081A}, wbprALetter},                // Lm       SAMARITAN MODIFIER LETTER EPENTHETIC YUT
-	{runeRange{0x081B, 0x0823}, wbprExtend},                 // Mn   [9] SAMARITAN MARK EPENTHETIC YUT..SAMARITAN VOWEL SIGN A
-	{runeRange{0x0824, 0x0824}, wbprALetter},                // Lm       SAMARITAN MODIFIER LETTER SHORT A
-	{runeRange{0x0825, 0x0827}, wbprExtend},                 // Mn   [3] SAMARITAN VOWEL SIGN SHORT A..SAMARITAN VOWEL SIGN U
-	{runeRange{0x0828, 0x0828}, wbprALetter},                // Lm       SAMARITAN MODIFIER LETTER I
-	{runeRange{0x0829, 0x082D}, wbprExtend},                 // Mn   [5] SAMARITAN VOWEL SIGN LONG I..SAMARITAN MARK NEQUDAA
-	{runeRange{0x0840, 0x0858}, wbprALetter},                // Lo  [25] MANDAIC LETTER HALQA..MANDAIC LETTER AIN
-	{runeRange{0x0859, 0x085B}, wbprExtend},                 // Mn   [3] MANDAIC AFFRICATION MARK..MANDAIC GEMINATION MARK
-	{runeRange{0x0860, 0x086A}, wbprALetter},                // Lo  [11] SYRIAC LETTER MALAYALAM NGA..SYRIAC LETTER MALAYALAM SSA
-	{runeRange{0x0870, 0x0887}, wbprALetter},                // Lo  [24] ARABIC LETTER ALEF WITH ATTACHED FATHA..ARABIC BASELINE ROUND DOT
-	{runeRange{0x0889, 0x088E}, wbprALetter},                // Lo   [6] ARABIC LETTER NOON WITH INVERTED SMALL V..ARABIC VERTICAL TAIL
-	{runeRange{0x0890, 0x0891}, wbprFormat},                 // Cf   [2] ARABIC POUND MARK ABOVE..ARABIC PIASTRE MARK ABOVE
-	{runeRange{0x0898, 0x089F}, wbprExtend},                 // Mn   [8] ARABIC SMALL HIGH WORD AL-JUZ..ARABIC HALF MADDA OVER MADDA
-	{runeRange{0x08A0, 0x08C8}, wbprALetter},                // Lo  [41] ARABIC LETTER BEH WITH SMALL V BELOW..ARABIC LETTER GRAF
-	{runeRange{0x08C9, 0x08C9}, wbprALetter},                // Lm       ARABIC SMALL FARSI YEH
-	{runeRange{0x08CA, 0x08E1}, wbprExtend},                 // Mn  [24] ARABIC SMALL HIGH FARSI YEH..ARABIC SMALL HIGH SIGN SAFHA
-	{runeRange{0x08E2, 0x08E2}, wbprFormat},                 // Cf       ARABIC DISPUTED END OF AYAH
-	{runeRange{0x08E3, 0x0902}, wbprExtend},                 // Mn  [32] ARABIC TURNED DAMMA BELOW..DEVANAGARI SIGN ANUSVARA
-	{runeRange{0x0903, 0x0903}, wbprExtend},                 // Mc       DEVANAGARI SIGN VISARGA
-	{runeRange{0x0904, 0x0939}, wbprALetter},                // Lo  [54] DEVANAGARI LETTER SHORT A..DEVANAGARI LETTER HA
-	{runeRange{0x093A, 0x093A}, wbprExtend},                 // Mn       DEVANAGARI VOWEL SIGN OE
-	{runeRange{0x093B, 0x093B}, wbprExtend},                 // Mc       DEVANAGARI VOWEL SIGN OOE
-	{runeRange{0x093C, 0x093C}, wbprExtend},                 // Mn       DEVANAGARI SIGN NUKTA
-	{runeRange{0x093D, 0x093D}, wbprALetter},                // Lo       DEVANAGARI SIGN AVAGRAHA
-	{runeRange{0x093E, 0x0940}, wbprExtend},                 // Mc   [3] DEVANAGARI VOWEL SIGN AA..DEVANAGARI VOWEL SIGN II
-	{runeRange{0x0941, 0x0948}, wbprExtend},                 // Mn   [8] DEVANAGARI VOWEL SIGN U..DEVANAGARI VOWEL SIGN AI
-	{runeRange{0x0949, 0x094C}, wbprExtend},                 // Mc   [4] DEVANAGARI VOWEL SIGN CANDRA O..DEVANAGARI VOWEL SIGN AU
-	{runeRange{0x094D, 0x094D}, wbprExtend},                 // Mn       DEVANAGARI SIGN VIRAMA
-	{runeRange{0x094E, 0x094F}, wbprExtend},                 // Mc   [2] DEVANAGARI VOWEL SIGN PRISHTHAMATRA E..DEVANAGARI VOWEL SIGN AW
-	{runeRange{0x0950, 0x0950}, wbprALetter},                // Lo       DEVANAGARI OM
-	{runeRange{0x0951, 0x0957}, wbprExtend},                 // Mn   [7] DEVANAGARI STRESS SIGN UDATTA..DEVANAGARI VOWEL SIGN UUE
-	{runeRange{0x0958, 0x0961}, wbprALetter},                // Lo  [10] DEVANAGARI LETTER QA..DEVANAGARI LETTER VOCALIC LL
-	{runeRange{0x0962, 0x0963}, wbprExtend},                 // Mn   [2] DEVANAGARI VOWEL SIGN VOCALIC L..DEVANAGARI VOWEL SIGN VOCALIC LL
-	{runeRange{0x0966, 0x096F}, wbprNumeric},                // Nd  [10] DEVANAGARI DIGIT ZERO..DEVANAGARI DIGIT NINE
-	{runeRange{0x0971, 0x0971}, wbprALetter},                // Lm       DEVANAGARI SIGN HIGH SPACING DOT
-	{runeRange{0x0972, 0x0980}, wbprALetter},                // Lo  [15] DEVANAGARI LETTER CANDRA A..BENGALI ANJI
-	{runeRange{0x0981, 0x0981}, wbprExtend},                 // Mn       BENGALI SIGN CANDRABINDU
-	{runeRange{0x0982, 0x0983}, wbprExtend},                 // Mc   [2] BENGALI SIGN ANUSVARA..BENGALI SIGN VISARGA
-	{runeRange{0x0985, 0x098C}, wbprALetter},                // Lo   [8] BENGALI LETTER A..BENGALI LETTER VOCALIC L
-	{runeRange{0x098F, 0x0990}, wbprALetter},                // Lo   [2] BENGALI LETTER E..BENGALI LETTER AI
-	{runeRange{0x0993, 0x09A8}, wbprALetter},                // Lo  [22] BENGALI LETTER O..BENGALI LETTER NA
-	{runeRange{0x09AA, 0x09B0}, wbprALetter},                // Lo   [7] BENGALI LETTER PA..BENGALI LETTER RA
-	{runeRange{0x09B2, 0x09B2}, wbprALetter},                // Lo       BENGALI LETTER LA
-	{runeRange{0x09B6, 0x09B9}, wbprALetter},                // Lo   [4] BENGALI LETTER SHA..BENGALI LETTER HA
-	{runeRange{0x09BC, 0x09BC}, wbprExtend},                 // Mn       BENGALI SIGN NUKTA
-	{runeRange{0x09BD, 0x09BD}, wbprALetter},                // Lo       BENGALI SIGN AVAGRAHA
-	{runeRange{0x09BE, 0x09C0}, wbprExtend},                 // Mc   [3] BENGALI VOWEL SIGN AA..BENGALI VOWEL SIGN II
-	{runeRange{0x09C1, 0x09C4}, wbprExtend},                 // Mn   [4] BENGALI VOWEL SIGN U..BENGALI VOWEL SIGN VOCALIC RR
-	{runeRange{0x09C7, 0x09C8}, wbprExtend},                 // Mc   [2] BENGALI VOWEL SIGN E..BENGALI VOWEL SIGN AI
-	{runeRange{0x09CB, 0x09CC}, wbprExtend},                 // Mc   [2] BENGALI VOWEL SIGN O..BENGALI VOWEL SIGN AU
-	{runeRange{0x09CD, 0x09CD}, wbprExtend},                 // Mn       BENGALI SIGN VIRAMA
-	{runeRange{0x09CE, 0x09CE}, wbprALetter},                // Lo       BENGALI LETTER KHANDA TA
-	{runeRange{0x09D7, 0x09D7}, wbprExtend},                 // Mc       BENGALI AU LENGTH MARK
-	{runeRange{0x09DC, 0x09DD}, wbprALetter},                // Lo   [2] BENGALI LETTER RRA..BENGALI LETTER RHA
-	{runeRange{0x09DF, 0x09E1}, wbprALetter},                // Lo   [3] BENGALI LETTER YYA..BENGALI LETTER VOCALIC LL
-	{runeRange{0x09E2, 0x09E3}, wbprExtend},                 // Mn   [2] BENGALI VOWEL SIGN VOCALIC L..BENGALI VOWEL SIGN VOCALIC LL
-	{runeRange{0x09E6, 0x09EF}, wbprNumeric},                // Nd  [10] BENGALI DIGIT ZERO..BENGALI DIGIT NINE
-	{runeRange{0x09F0, 0x09F1}, wbprALetter},                // Lo   [2] BENGALI LETTER RA WITH MIDDLE DIAGONAL..BENGALI LETTER RA WITH LOWER DIAGONAL
-	{runeRange{0x09FC, 0x09FC}, wbprALetter},                // Lo       BENGALI LETTER VEDIC ANUSVARA
-	{runeRange{0x09FE, 0x09FE}, wbprExtend},                 // Mn       BENGALI SANDHI MARK
-	{runeRange{0x0A01, 0x0A02}, wbprExtend},                 // Mn   [2] GURMUKHI SIGN ADAK BINDI..GURMUKHI SIGN BINDI
-	{runeRange{0x0A03, 0x0A03}, wbprExtend},                 // Mc       GURMUKHI SIGN VISARGA
-	{runeRange{0x0A05, 0x0A0A}, wbprALetter},                // Lo   [6] GURMUKHI LETTER A..GURMUKHI LETTER UU
-	{runeRange{0x0A0F, 0x0A10}, wbprALetter},                // Lo   [2] GURMUKHI LETTER EE..GURMUKHI LETTER AI
-	{runeRange{0x0A13, 0x0A28}, wbprALetter},                // Lo  [22] GURMUKHI LETTER OO..GURMUKHI LETTER NA
-	{runeRange{0x0A2A, 0x0A30}, wbprALetter},                // Lo   [7] GURMUKHI LETTER PA..GURMUKHI LETTER RA
-	{runeRange{0x0A32, 0x0A33}, wbprALetter},                // Lo   [2] GURMUKHI LETTER LA..GURMUKHI LETTER LLA
-	{runeRange{0x0A35, 0x0A36}, wbprALetter},                // Lo   [2] GURMUKHI LETTER VA..GURMUKHI LETTER SHA
-	{runeRange{0x0A38, 0x0A39}, wbprALetter},                // Lo   [2] GURMUKHI LETTER SA..GURMUKHI LETTER HA
-	{runeRange{0x0A3C, 0x0A3C}, wbprExtend},                 // Mn       GURMUKHI SIGN NUKTA
-	{runeRange{0x0A3E, 0x0A40}, wbprExtend},                 // Mc   [3] GURMUKHI VOWEL SIGN AA..GURMUKHI VOWEL SIGN II
-	{runeRange{0x0A41, 0x0A42}, wbprExtend},                 // Mn   [2] GURMUKHI VOWEL SIGN U..GURMUKHI VOWEL SIGN UU
-	{runeRange{0x0A47, 0x0A48}, wbprExtend},                 // Mn   [2] GURMUKHI VOWEL SIGN EE..GURMUKHI VOWEL SIGN AI
-	{runeRange{0x0A4B, 0x0A4D}, wbprExtend},                 // Mn   [3] GURMUKHI VOWEL SIGN OO..GURMUKHI SIGN VIRAMA
-	{runeRange{0x0A51, 0x0A51}, wbprExtend},                 // Mn       GURMUKHI SIGN UDAAT
-	{runeRange{0x0A59, 0x0A5C}, wbprALetter},                // Lo   [4] GURMUKHI LETTER KHHA..GURMUKHI LETTER RRA
-	{runeRange{0x0A5E, 0x0A5E}, wbprALetter},                // Lo       GURMUKHI LETTER FA
-	{runeRange{0x0A66, 0x0A6F}, wbprNumeric},                // Nd  [10] GURMUKHI DIGIT ZERO..GURMUKHI DIGIT NINE
-	{runeRange{0x0A70, 0x0A71}, wbprExtend},                 // Mn   [2] GURMUKHI TIPPI..GURMUKHI ADDAK
-	{runeRange{0x0A72, 0x0A74}, wbprALetter},                // Lo   [3] GURMUKHI IRI..GURMUKHI EK ONKAR
-	{runeRange{0x0A75, 0x0A75}, wbprExtend},                 // Mn       GURMUKHI SIGN YAKASH
-	{runeRange{0x0A81, 0x0A82}, wbprExtend},                 // Mn   [2] GUJARATI SIGN CANDRABINDU..GUJARATI SIGN ANUSVARA
-	{runeRange{0x0A83, 0x0A83}, wbprExtend},                 // Mc       GUJARATI SIGN VISARGA
-	{runeRange{0x0A85, 0x0A8D}, wbprALetter},                // Lo   [9] GUJARATI LETTER A..GUJARATI VOWEL CANDRA E
-	{runeRange{0x0A8F, 0x0A91}, wbprALetter},                // Lo   [3] GUJARATI LETTER E..GUJARATI VOWEL CANDRA O
-	{runeRange{0x0A93, 0x0AA8}, wbprALetter},                // Lo  [22] GUJARATI LETTER O..GUJARATI LETTER NA
-	{runeRange{0x0AAA, 0x0AB0}, wbprALetter},                // Lo   [7] GUJARATI LETTER PA..GUJARATI LETTER RA
-	{runeRange{0x0AB2, 0x0AB3}, wbprALetter},                // Lo   [2] GUJARATI LETTER LA..GUJARATI LETTER LLA
-	{runeRange{0x0AB5, 0x0AB9}, wbprALetter},                // Lo   [5] GUJARATI LETTER VA..GUJARATI LETTER HA
-	{runeRange{0x0ABC, 0x0ABC}, wbprExtend},                 // Mn       GUJARATI SIGN NUKTA
-	{runeRange{0x0ABD, 0x0ABD}, wbprALetter},                // Lo       GUJARATI SIGN AVAGRAHA
-	{runeRange{0x0ABE, 0x0AC0}, wbprExtend},                 // Mc   [3] GUJARATI VOWEL SIGN AA..GUJARATI VOWEL SIGN II
-	{runeRange{0x0AC1, 0x0AC5}, wbprExtend},                 // Mn   [5] GUJARATI VOWEL SIGN U..GUJARATI VOWEL SIGN CANDRA E
-	{runeRange{0x0AC7, 0x0AC8}, wbprExtend},                 // Mn   [2] GUJARATI VOWEL SIGN E..GUJARATI VOWEL SIGN AI
-	{runeRange{0x0AC9, 0x0AC9}, wbprExtend},                 // Mc       GUJARATI VOWEL SIGN CANDRA O
-	{runeRange{0x0ACB, 0x0ACC}, wbprExtend},                 // Mc   [2] GUJARATI VOWEL SIGN O..GUJARATI VOWEL SIGN AU
-	{runeRange{0x0ACD, 0x0ACD}, wbprExtend},                 // Mn       GUJARATI SIGN VIRAMA
-	{runeRange{0x0AD0, 0x0AD0}, wbprALetter},                // Lo       GUJARATI OM
-	{runeRange{0x0AE0, 0x0AE1}, wbprALetter},                // Lo   [2] GUJARATI LETTER VOCALIC RR..GUJARATI LETTER VOCALIC LL
-	{runeRange{0x0AE2, 0x0AE3}, wbprExtend},                 // Mn   [2] GUJARATI VOWEL SIGN VOCALIC L..GUJARATI VOWEL SIGN VOCALIC LL
-	{runeRange{0x0AE6, 0x0AEF}, wbprNumeric},                // Nd  [10] GUJARATI DIGIT ZERO..GUJARATI DIGIT NINE
-	{runeRange{0x0AF9, 0x0AF9}, wbprALetter},                // Lo       GUJARATI LETTER ZHA
-	{runeRange{0x0AFA, 0x0AFF}, wbprExtend},                 // Mn   [6] GUJARATI SIGN SUKUN..GUJARATI SIGN TWO-CIRCLE NUKTA ABOVE
-	{runeRange{0x0B01, 0x0B01}, wbprExtend},                 // Mn       ORIYA SIGN CANDRABINDU
-	{runeRange{0x0B02, 0x0B03}, wbprExtend},                 // Mc   [2] ORIYA SIGN ANUSVARA..ORIYA SIGN VISARGA
-	{runeRange{0x0B05, 0x0B0C}, wbprALetter},                // Lo   [8] ORIYA LETTER A..ORIYA LETTER VOCALIC L
-	{runeRange{0x0B0F, 0x0B10}, wbprALetter},                // Lo   [2] ORIYA LETTER E..ORIYA LETTER AI
-	{runeRange{0x0B13, 0x0B28}, wbprALetter},                // Lo  [22] ORIYA LETTER O..ORIYA LETTER NA
-	{runeRange{0x0B2A, 0x0B30}, wbprALetter},                // Lo   [7] ORIYA LETTER PA..ORIYA LETTER RA
-	{runeRange{0x0B32, 0x0B33}, wbprALetter},                // Lo   [2] ORIYA LETTER LA..ORIYA LETTER LLA
-	{runeRange{0x0B35, 0x0B39}, wbprALetter},                // Lo   [5] ORIYA LETTER VA..ORIYA LETTER HA
-	{runeRange{0x0B3C, 0x0B3C}, wbprExtend},                 // Mn       ORIYA SIGN NUKTA
-	{runeRange{0x0B3D, 0x0B3D}, wbprALetter},                // Lo       ORIYA SIGN AVAGRAHA
-	{runeRange{0x0B3E, 0x0B3E}, wbprExtend},                 // Mc       ORIYA VOWEL SIGN AA
-	{runeRange{0x0B3F, 0x0B3F}, wbprExtend},                 // Mn       ORIYA VOWEL SIGN I
-	{runeRange{0x0B40, 0x0B40}, wbprExtend},                 // Mc       ORIYA VOWEL SIGN II
-	{runeRange{0x0B41, 0x0B44}, wbprExtend},                 // Mn   [4] ORIYA VOWEL SIGN U..ORIYA VOWEL SIGN VOCALIC RR
-	{runeRange{0x0B47, 0x0B48}, wbprExtend},                 // Mc   [2] ORIYA VOWEL SIGN E..ORIYA VOWEL SIGN AI
-	{runeRange{0x0B4B, 0x0B4C}, wbprExtend},                 // Mc   [2] ORIYA VOWEL SIGN O..ORIYA VOWEL SIGN AU
-	{runeRange{0x0B4D, 0x0B4D}, wbprExtend},                 // Mn       ORIYA SIGN VIRAMA
-	{runeRange{0x0B55, 0x0B56}, wbprExtend},                 // Mn   [2] ORIYA SIGN OVERLINE..ORIYA AI LENGTH MARK
-	{runeRange{0x0B57, 0x0B57}, wbprExtend},                 // Mc       ORIYA AU LENGTH MARK
-	{runeRange{0x0B5C, 0x0B5D}, wbprALetter},                // Lo   [2] ORIYA LETTER RRA..ORIYA LETTER RHA
-	{runeRange{0x0B5F, 0x0B61}, wbprALetter},                // Lo   [3] ORIYA LETTER YYA..ORIYA LETTER VOCALIC LL
-	{runeRange{0x0B62, 0x0B63}, wbprExtend},                 // Mn   [2] ORIYA VOWEL SIGN VOCALIC L..ORIYA VOWEL SIGN VOCALIC LL
-	{runeRange{0x0B66, 0x0B6F}, wbprNumeric},                // Nd  [10] ORIYA DIGIT ZERO..ORIYA DIGIT NINE
-	{runeRange{0x0B71, 0x0B71}, wbprALetter},                // Lo       ORIYA LETTER WA
-	{runeRange{0x0B82, 0x0B82}, wbprExtend},                 // Mn       TAMIL SIGN ANUSVARA
-	{runeRange{0x0B83, 0x0B83}, wbprALetter},                // Lo       TAMIL SIGN VISARGA
-	{runeRange{0x0B85, 0x0B8A}, wbprALetter},                // Lo   [6] TAMIL LETTER A..TAMIL LETTER UU
-	{runeRange{0x0B8E, 0x0B90}, wbprALetter},                // Lo   [3] TAMIL LETTER E..TAMIL LETTER AI
-	{runeRange{0x0B92, 0x0B95}, wbprALetter},                // Lo   [4] TAMIL LETTER O..TAMIL LETTER KA
-	{runeRange{0x0B99, 0x0B9A}, wbprALetter},                // Lo   [2] TAMIL LETTER NGA..TAMIL LETTER CA
-	{runeRange{0x0B9C, 0x0B9C}, wbprALetter},                // Lo       TAMIL LETTER JA
-	{runeRange{0x0B9E, 0x0B9F}, wbprALetter},                // Lo   [2] TAMIL LETTER NYA..TAMIL LETTER TTA
-	{runeRange{0x0BA3, 0x0BA4}, wbprALetter},                // Lo   [2] TAMIL LETTER NNA..TAMIL LETTER TA
-	{runeRange{0x0BA8, 0x0BAA}, wbprALetter},                // Lo   [3] TAMIL LETTER NA..TAMIL LETTER PA
-	{runeRange{0x0BAE, 0x0BB9}, wbprALetter},                // Lo  [12] TAMIL LETTER MA..TAMIL LETTER HA
-	{runeRange{0x0BBE, 0x0BBF}, wbprExtend},                 // Mc   [2] TAMIL VOWEL SIGN AA..TAMIL VOWEL SIGN I
-	{runeRange{0x0BC0, 0x0BC0}, wbprExtend},                 // Mn       TAMIL VOWEL SIGN II
-	{runeRange{0x0BC1, 0x0BC2}, wbprExtend},                 // Mc   [2] TAMIL VOWEL SIGN U..TAMIL VOWEL SIGN UU
-	{runeRange{0x0BC6, 0x0BC8}, wbprExtend},                 // Mc   [3] TAMIL VOWEL SIGN E..TAMIL VOWEL SIGN AI
-	{runeRange{0x0BCA, 0x0BCC}, wbprExtend},                 // Mc   [3] TAMIL VOWEL SIGN O..TAMIL VOWEL SIGN AU
-	{runeRange{0x0BCD, 0x0BCD}, wbprExtend},                 // Mn       TAMIL SIGN VIRAMA
-	{runeRange{0x0BD0, 0x0BD0}, wbprALetter},                // Lo       TAMIL OM
-	{runeRange{0x0BD7, 0x0BD7}, wbprExtend},                 // Mc       TAMIL AU LENGTH MARK
-	{runeRange{0x0BE6, 0x0BEF}, wbprNumeric},                // Nd  [10] TAMIL DIGIT ZERO..TAMIL DIGIT NINE
-	{runeRange{0x0C00, 0x0C00}, wbprExtend},                 // Mn       TELUGU SIGN COMBINING CANDRABINDU ABOVE
-	{runeRange{0x0C01, 0x0C03}, wbprExtend},                 // Mc   [3] TELUGU SIGN CANDRABINDU..TELUGU SIGN VISARGA
-	{runeRange{0x0C04, 0x0C04}, wbprExtend},                 // Mn       TELUGU SIGN COMBINING ANUSVARA ABOVE
-	{runeRange{0x0C05, 0x0C0C}, wbprALetter},                // Lo   [8] TELUGU LETTER A..TELUGU LETTER VOCALIC L
-	{runeRange{0x0C0E, 0x0C10}, wbprALetter},                // Lo   [3] TELUGU LETTER E..TELUGU LETTER AI
-	{runeRange{0x0C12, 0x0C28}, wbprALetter},                // Lo  [23] TELUGU LETTER O..TELUGU LETTER NA
-	{runeRange{0x0C2A, 0x0C39}, wbprALetter},                // Lo  [16] TELUGU LETTER PA..TELUGU LETTER HA
-	{runeRange{0x0C3C, 0x0C3C}, wbprExtend},                 // Mn       TELUGU SIGN NUKTA
-	{runeRange{0x0C3D, 0x0C3D}, wbprALetter},                // Lo       TELUGU SIGN AVAGRAHA
-	{runeRange{0x0C3E, 0x0C40}, wbprExtend},                 // Mn   [3] TELUGU VOWEL SIGN AA..TELUGU VOWEL SIGN II
-	{runeRange{0x0C41, 0x0C44}, wbprExtend},                 // Mc   [4] TELUGU VOWEL SIGN U..TELUGU VOWEL SIGN VOCALIC RR
-	{runeRange{0x0C46, 0x0C48}, wbprExtend},                 // Mn   [3] TELUGU VOWEL SIGN E..TELUGU VOWEL SIGN AI
-	{runeRange{0x0C4A, 0x0C4D}, wbprExtend},                 // Mn   [4] TELUGU VOWEL SIGN O..TELUGU SIGN VIRAMA
-	{runeRange{0x0C55, 0x0C56}, wbprExtend},                 // Mn   [2] TELUGU LENGTH MARK..TELUGU AI LENGTH MARK
-	{runeRange{0x0C58, 0x0C5A}, wbprALetter},                // Lo   [3] TELUGU LETTER TSA..TELUGU LETTER RRRA
-	{runeRange{0x0C5D, 0x0C5D}, wbprALetter},                // Lo       TELUGU LETTER NAKAARA POLLU
-	{runeRange{0x0C60, 0x0C61}, wbprALetter},                // Lo   [2] TELUGU LETTER VOCALIC RR..TELUGU LETTER VOCALIC LL
-	{runeRange{0x0C62, 0x0C63}, wbprExtend},                 // Mn   [2] TELUGU VOWEL SIGN VOCALIC L..TELUGU VOWEL SIGN VOCALIC LL
-	{runeRange{0x0C66, 0x0C6F}, wbprNumeric},                // Nd  [10] TELUGU DIGIT ZERO..TELUGU DIGIT NINE
-	{runeRange{0x0C80, 0x0C80}, wbprALetter},                // Lo       KANNADA SIGN SPACING CANDRABINDU
-	{runeRange{0x0C81, 0x0C81}, wbprExtend},                 // Mn       KANNADA SIGN CANDRABINDU
-	{runeRange{0x0C82, 0x0C83}, wbprExtend},                 // Mc   [2] KANNADA SIGN ANUSVARA..KANNADA SIGN VISARGA
-	{runeRange{0x0C85, 0x0C8C}, wbprALetter},                // Lo   [8] KANNADA LETTER A..KANNADA LETTER VOCALIC L
-	{runeRange{0x0C8E, 0x0C90}, wbprALetter},                // Lo   [3] KANNADA LETTER E..KANNADA LETTER AI
-	{runeRange{0x0C92, 0x0CA8}, wbprALetter},                // Lo  [23] KANNADA LETTER O..KANNADA LETTER NA
-	{runeRange{0x0CAA, 0x0CB3}, wbprALetter},                // Lo  [10] KANNADA LETTER PA..KANNADA LETTER LLA
-	{runeRange{0x0CB5, 0x0CB9}, wbprALetter},                // Lo   [5] KANNADA LETTER VA..KANNADA LETTER HA
-	{runeRange{0x0CBC, 0x0CBC}, wbprExtend},                 // Mn       KANNADA SIGN NUKTA
-	{runeRange{0x0CBD, 0x0CBD}, wbprALetter},                // Lo       KANNADA SIGN AVAGRAHA
-	{runeRange{0x0CBE, 0x0CBE}, wbprExtend},                 // Mc       KANNADA VOWEL SIGN AA
-	{runeRange{0x0CBF, 0x0CBF}, wbprExtend},                 // Mn       KANNADA VOWEL SIGN I
-	{runeRange{0x0CC0, 0x0CC4}, wbprExtend},                 // Mc   [5] KANNADA VOWEL SIGN II..KANNADA VOWEL SIGN VOCALIC RR
-	{runeRange{0x0CC6, 0x0CC6}, wbprExtend},                 // Mn       KANNADA VOWEL SIGN E
-	{runeRange{0x0CC7, 0x0CC8}, wbprExtend},                 // Mc   [2] KANNADA VOWEL SIGN EE..KANNADA VOWEL SIGN AI
-	{runeRange{0x0CCA, 0x0CCB}, wbprExtend},                 // Mc   [2] KANNADA VOWEL SIGN O..KANNADA VOWEL SIGN OO
-	{runeRange{0x0CCC, 0x0CCD}, wbprExtend},                 // Mn   [2] KANNADA VOWEL SIGN AU..KANNADA SIGN VIRAMA
-	{runeRange{0x0CD5, 0x0CD6}, wbprExtend},                 // Mc   [2] KANNADA LENGTH MARK..KANNADA AI LENGTH MARK
-	{runeRange{0x0CDD, 0x0CDE}, wbprALetter},                // Lo   [2] KANNADA LETTER NAKAARA POLLU..KANNADA LETTER FA
-	{runeRange{0x0CE0, 0x0CE1}, wbprALetter},                // Lo   [2] KANNADA LETTER VOCALIC RR..KANNADA LETTER VOCALIC LL
-	{runeRange{0x0CE2, 0x0CE3}, wbprExtend},                 // Mn   [2] KANNADA VOWEL SIGN VOCALIC L..KANNADA VOWEL SIGN VOCALIC LL
-	{runeRange{0x0CE6, 0x0CEF}, wbprNumeric},                // Nd  [10] KANNADA DIGIT ZERO..KANNADA DIGIT NINE
-	{runeRange{0x0CF1, 0x0CF2}, wbprALetter},                // Lo   [2] KANNADA SIGN JIHVAMULIYA..KANNADA SIGN UPADHMANIYA
-	{runeRange{0x0CF3, 0x0CF3}, wbprExtend},                 // Mc       KANNADA SIGN COMBINING ANUSVARA ABOVE RIGHT
-	{runeRange{0x0D00, 0x0D01}, wbprExtend},                 // Mn   [2] MALAYALAM SIGN COMBINING ANUSVARA ABOVE..MALAYALAM SIGN CANDRABINDU
-	{runeRange{0x0D02, 0x0D03}, wbprExtend},                 // Mc   [2] MALAYALAM SIGN ANUSVARA..MALAYALAM SIGN VISARGA
-	{runeRange{0x0D04, 0x0D0C}, wbprALetter},                // Lo   [9] MALAYALAM LETTER VEDIC ANUSVARA..MALAYALAM LETTER VOCALIC L
-	{runeRange{0x0D0E, 0x0D10}, wbprALetter},                // Lo   [3] MALAYALAM LETTER E..MALAYALAM LETTER AI
-	{runeRange{0x0D12, 0x0D3A}, wbprALetter},                // Lo  [41] MALAYALAM LETTER O..MALAYALAM LETTER TTTA
-	{runeRange{0x0D3B, 0x0D3C}, wbprExtend},                 // Mn   [2] MALAYALAM SIGN VERTICAL BAR VIRAMA..MALAYALAM SIGN CIRCULAR VIRAMA
-	{runeRange{0x0D3D, 0x0D3D}, wbprALetter},                // Lo       MALAYALAM SIGN AVAGRAHA
-	{runeRange{0x0D3E, 0x0D40}, wbprExtend},                 // Mc   [3] MALAYALAM VOWEL SIGN AA..MALAYALAM VOWEL SIGN II
-	{runeRange{0x0D41, 0x0D44}, wbprExtend},                 // Mn   [4] MALAYALAM VOWEL SIGN U..MALAYALAM VOWEL SIGN VOCALIC RR
-	{runeRange{0x0D46, 0x0D48}, wbprExtend},                 // Mc   [3] MALAYALAM VOWEL SIGN E..MALAYALAM VOWEL SIGN AI
-	{runeRange{0x0D4A, 0x0D4C}, wbprExtend},                 // Mc   [3] MALAYALAM VOWEL SIGN O..MALAYALAM VOWEL SIGN AU
-	{runeRange{0x0D4D, 0x0D4D}, wbprExtend},                 // Mn       MALAYALAM SIGN VIRAMA
-	{runeRange{0x0D4E, 0x0D4E}, wbprALetter},                // Lo       MALAYALAM LETTER DOT REPH
-	{runeRange{0x0D54, 0x0D56}, wbprALetter},                // Lo   [3] MALAYALAM LETTER CHILLU M..MALAYALAM LETTER CHILLU LLL
-	{runeRange{0x0D57, 0x0D57}, wbprExtend},                 // Mc       MALAYALAM AU LENGTH MARK
-	{runeRange{0x0D5F, 0x0D61}, wbprALetter},                // Lo   [3] MALAYALAM LETTER ARCHAIC II..MALAYALAM LETTER VOCALIC LL
-	{runeRange{0x0D62, 0x0D63}, wbprExtend},                 // Mn   [2] MALAYALAM VOWEL SIGN VOCALIC L..MALAYALAM VOWEL SIGN VOCALIC LL
-	{runeRange{0x0D66, 0x0D6F}, wbprNumeric},                // Nd  [10] MALAYALAM DIGIT ZERO..MALAYALAM DIGIT NINE
-	{runeRange{0x0D7A, 0x0D7F}, wbprALetter},                // Lo   [6] MALAYALAM LETTER CHILLU NN..MALAYALAM LETTER CHILLU K
-	{runeRange{0x0D81, 0x0D81}, wbprExtend},                 // Mn       SINHALA SIGN CANDRABINDU
-	{runeRange{0x0D82, 0x0D83}, wbprExtend},                 // Mc   [2] SINHALA SIGN ANUSVARAYA..SINHALA SIGN VISARGAYA
-	{runeRange{0x0D85, 0x0D96}, wbprALetter},                // Lo  [18] SINHALA LETTER AYANNA..SINHALA LETTER AUYANNA
-	{runeRange{0x0D9A, 0x0DB1}, wbprALetter},                // Lo  [24] SINHALA LETTER ALPAPRAANA KAYANNA..SINHALA LETTER DANTAJA NAYANNA
-	{runeRange{0x0DB3, 0x0DBB}, wbprALetter},                // Lo   [9] SINHALA LETTER SANYAKA DAYANNA..SINHALA LETTER RAYANNA
-	{runeRange{0x0DBD, 0x0DBD}, wbprALetter},                // Lo       SINHALA LETTER DANTAJA LAYANNA
-	{runeRange{0x0DC0, 0x0DC6}, wbprALetter},                // Lo   [7] SINHALA LETTER VAYANNA..SINHALA LETTER FAYANNA
-	{runeRange{0x0DCA, 0x0DCA}, wbprExtend},                 // Mn       SINHALA SIGN AL-LAKUNA
-	{runeRange{0x0DCF, 0x0DD1}, wbprExtend},                 // Mc   [3] SINHALA VOWEL SIGN AELA-PILLA..SINHALA VOWEL SIGN DIGA AEDA-PILLA
-	{runeRange{0x0DD2, 0x0DD4}, wbprExtend},                 // Mn   [3] SINHALA VOWEL SIGN KETTI IS-PILLA..SINHALA VOWEL SIGN KETTI PAA-PILLA
-	{runeRange{0x0DD6, 0x0DD6}, wbprExtend},                 // Mn       SINHALA VOWEL SIGN DIGA PAA-PILLA
-	{runeRange{0x0DD8, 0x0DDF}, wbprExtend},                 // Mc   [8] SINHALA VOWEL SIGN GAETTA-PILLA..SINHALA VOWEL SIGN GAYANUKITTA
-	{runeRange{0x0DE6, 0x0DEF}, wbprNumeric},                // Nd  [10] SINHALA LITH DIGIT ZERO..SINHALA LITH DIGIT NINE
-	{runeRange{0x0DF2, 0x0DF3}, wbprExtend},                 // Mc   [2] SINHALA VOWEL SIGN DIGA GAETTA-PILLA..SINHALA VOWEL SIGN DIGA GAYANUKITTA
-	{runeRange{0x0E31, 0x0E31}, wbprExtend},                 // Mn       THAI CHARACTER MAI HAN-AKAT
-	{runeRange{0x0E34, 0x0E3A}, wbprExtend},                 // Mn   [7] THAI CHARACTER SARA I..THAI CHARACTER PHINTHU
-	{runeRange{0x0E47, 0x0E4E}, wbprExtend},                 // Mn   [8] THAI CHARACTER MAITAIKHU..THAI CHARACTER YAMAKKAN
-	{runeRange{0x0E50, 0x0E59}, wbprNumeric},                // Nd  [10] THAI DIGIT ZERO..THAI DIGIT NINE
-	{runeRange{0x0EB1, 0x0EB1}, wbprExtend},                 // Mn       LAO VOWEL SIGN MAI KAN
-	{runeRange{0x0EB4, 0x0EBC}, wbprExtend},                 // Mn   [9] LAO VOWEL SIGN I..LAO SEMIVOWEL SIGN LO
-	{runeRange{0x0EC8, 0x0ECE}, wbprExtend},                 // Mn   [7] LAO TONE MAI EK..LAO YAMAKKAN
-	{runeRange{0x0ED0, 0x0ED9}, wbprNumeric},                // Nd  [10] LAO DIGIT ZERO..LAO DIGIT NINE
-	{runeRange{0x0F00, 0x0F00}, wbprALetter},                // Lo       TIBETAN SYLLABLE OM
-	{runeRange{0x0F18, 0x0F19}, wbprExtend},                 // Mn   [2] TIBETAN ASTROLOGICAL SIGN -KHYUD PA..TIBETAN ASTROLOGICAL SIGN SDONG TSHUGS
-	{runeRange{0x0F20, 0x0F29}, wbprNumeric},                // Nd  [10] TIBETAN DIGIT ZERO..TIBETAN DIGIT NINE
-	{runeRange{0x0F35, 0x0F35}, wbprExtend},                 // Mn       TIBETAN MARK NGAS BZUNG NYI ZLA
-	{runeRange{0x0F37, 0x0F37}, wbprExtend},                 // Mn       TIBETAN MARK NGAS BZUNG SGOR RTAGS
-	{runeRange{0x0F39, 0x0F39}, wbprExtend},                 // Mn       TIBETAN MARK TSA -PHRU
-	{runeRange{0x0F3E, 0x0F3F}, wbprExtend},                 // Mc   [2] TIBETAN SIGN YAR TSHES..TIBETAN SIGN MAR TSHES
-	{runeRange{0x0F40, 0x0F47}, wbprALetter},                // Lo   [8] TIBETAN LETTER KA..TIBETAN LETTER JA
-	{runeRange{0x0F49, 0x0F6C}, wbprALetter},                // Lo  [36] TIBETAN LETTER NYA..TIBETAN LETTER RRA
-	{runeRange{0x0F71, 0x0F7E}, wbprExtend},                 // Mn  [14] TIBETAN VOWEL SIGN AA..TIBETAN SIGN RJES SU NGA RO
-	{runeRange{0x0F7F, 0x0F7F}, wbprExtend},                 // Mc       TIBETAN SIGN RNAM BCAD
-	{runeRange{0x0F80, 0x0F84}, wbprExtend},                 // Mn   [5] TIBETAN VOWEL SIGN REVERSED I..TIBETAN MARK HALANTA
-	{runeRange{0x0F86, 0x0F87}, wbprExtend},                 // Mn   [2] TIBETAN SIGN LCI RTAGS..TIBETAN SIGN YANG RTAGS
-	{runeRange{0x0F88, 0x0F8C}, wbprALetter},                // Lo   [5] TIBETAN SIGN LCE TSA CAN..TIBETAN SIGN INVERTED MCHU CAN
-	{runeRange{0x0F8D, 0x0F97}, wbprExtend},                 // Mn  [11] TIBETAN SUBJOINED SIGN LCE TSA CAN..TIBETAN SUBJOINED LETTER JA
-	{runeRange{0x0F99, 0x0FBC}, wbprExtend},                 // Mn  [36] TIBETAN SUBJOINED LETTER NYA..TIBETAN SUBJOINED LETTER FIXED-FORM RA
-	{runeRange{0x0FC6, 0x0FC6}, wbprExtend},                 // Mn       TIBETAN SYMBOL PADMA GDAN
-	{runeRange{0x102B, 0x102C}, wbprExtend},                 // Mc   [2] MYANMAR VOWEL SIGN TALL AA..MYANMAR VOWEL SIGN AA
-	{runeRange{0x102D, 0x1030}, wbprExtend},                 // Mn   [4] MYANMAR VOWEL SIGN I..MYANMAR VOWEL SIGN UU
-	{runeRange{0x1031, 0x1031}, wbprExtend},                 // Mc       MYANMAR VOWEL SIGN E
-	{runeRange{0x1032, 0x1037}, wbprExtend},                 // Mn   [6] MYANMAR VOWEL SIGN AI..MYANMAR SIGN DOT BELOW
-	{runeRange{0x1038, 0x1038}, wbprExtend},                 // Mc       MYANMAR SIGN VISARGA
-	{runeRange{0x1039, 0x103A}, wbprExtend},                 // Mn   [2] MYANMAR SIGN VIRAMA..MYANMAR SIGN ASAT
-	{runeRange{0x103B, 0x103C}, wbprExtend},                 // Mc   [2] MYANMAR CONSONANT SIGN MEDIAL YA..MYANMAR CONSONANT SIGN MEDIAL RA
-	{runeRange{0x103D, 0x103E}, wbprExtend},                 // Mn   [2] MYANMAR CONSONANT SIGN MEDIAL WA..MYANMAR CONSONANT SIGN MEDIAL HA
-	{runeRange{0x1040, 0x1049}, wbprNumeric},                // Nd  [10] MYANMAR DIGIT ZERO..MYANMAR DIGIT NINE
-	{runeRange{0x1056, 0x1057}, wbprExtend},                 // Mc   [2] MYANMAR VOWEL SIGN VOCALIC R..MYANMAR VOWEL SIGN VOCALIC RR
-	{runeRange{0x1058, 0x1059}, wbprExtend},                 // Mn   [2] MYANMAR VOWEL SIGN VOCALIC L..MYANMAR VOWEL SIGN VOCALIC LL
-	{runeRange{0x105E, 0x1060}, wbprExtend},                 // Mn   [3] MYANMAR CONSONANT SIGN MON MEDIAL NA..MYANMAR CONSONANT SIGN MON MEDIAL LA
-	{runeRange{0x1062, 0x1064}, wbprExtend},                 // Mc   [3] MYANMAR VOWEL SIGN SGAW KAREN EU..MYANMAR TONE MARK SGAW KAREN KE PHO
-	{runeRange{0x1067, 0x106D}, wbprExtend},                 // Mc   [7] MYANMAR VOWEL SIGN WESTERN PWO KAREN EU..MYANMAR SIGN WESTERN PWO KAREN TONE-5
-	{runeRange{0x1071, 0x1074}, wbprExtend},                 // Mn   [4] MYANMAR VOWEL SIGN GEBA KAREN I..MYANMAR VOWEL SIGN KAYAH EE
-	{runeRange{0x1082, 0x1082}, wbprExtend},                 // Mn       MYANMAR CONSONANT SIGN SHAN MEDIAL WA
-	{runeRange{0x1083, 0x1084}, wbprExtend},                 // Mc   [2] MYANMAR VOWEL SIGN SHAN AA..MYANMAR VOWEL SIGN SHAN E
-	{runeRange{0x1085, 0x1086}, wbprExtend},                 // Mn   [2] MYANMAR VOWEL SIGN SHAN E ABOVE..MYANMAR VOWEL SIGN SHAN FINAL Y
-	{runeRange{0x1087, 0x108C}, wbprExtend},                 // Mc   [6] MYANMAR SIGN SHAN TONE-2..MYANMAR SIGN SHAN COUNCIL TONE-3
-	{runeRange{0x108D, 0x108D}, wbprExtend},                 // Mn       MYANMAR SIGN SHAN COUNCIL EMPHATIC TONE
-	{runeRange{0x108F, 0x108F}, wbprExtend},                 // Mc       MYANMAR SIGN RUMAI PALAUNG TONE-5
-	{runeRange{0x1090, 0x1099}, wbprNumeric},                // Nd  [10] MYANMAR SHAN DIGIT ZERO..MYANMAR SHAN DIGIT NINE
-	{runeRange{0x109A, 0x109C}, wbprExtend},                 // Mc   [3] MYANMAR SIGN KHAMTI TONE-1..MYANMAR VOWEL SIGN AITON A
-	{runeRange{0x109D, 0x109D}, wbprExtend},                 // Mn       MYANMAR VOWEL SIGN AITON AI
-	{runeRange{0x10A0, 0x10C5}, wbprALetter},                // L&  [38] GEORGIAN CAPITAL LETTER AN..GEORGIAN CAPITAL LETTER HOE
-	{runeRange{0x10C7, 0x10C7}, wbprALetter},                // L&       GEORGIAN CAPITAL LETTER YN
-	{runeRange{0x10CD, 0x10CD}, wbprALetter},                // L&       GEORGIAN CAPITAL LETTER AEN
-	{runeRange{0x10D0, 0x10FA}, wbprALetter},                // L&  [43] GEORGIAN LETTER AN..GEORGIAN LETTER AIN
-	{runeRange{0x10FC, 0x10FC}, wbprALetter},                // Lm       MODIFIER LETTER GEORGIAN NAR
-	{runeRange{0x10FD, 0x10FF}, wbprALetter},                // L&   [3] GEORGIAN LETTER AEN..GEORGIAN LETTER LABIAL SIGN
-	{runeRange{0x1100, 0x1248}, wbprALetter},                // Lo [329] HANGUL CHOSEONG KIYEOK..ETHIOPIC SYLLABLE QWA
-	{runeRange{0x124A, 0x124D}, wbprALetter},                // Lo   [4] ETHIOPIC SYLLABLE QWI..ETHIOPIC SYLLABLE QWE
-	{runeRange{0x1250, 0x1256}, wbprALetter},                // Lo   [7] ETHIOPIC SYLLABLE QHA..ETHIOPIC SYLLABLE QHO
-	{runeRange{0x1258, 0x1258}, wbprALetter},                // Lo       ETHIOPIC SYLLABLE QHWA
-	{runeRange{0x125A, 0x125D}, wbprALetter},                // Lo   [4] ETHIOPIC SYLLABLE QHWI..ETHIOPIC SYLLABLE QHWE
-	{runeRange{0x1260, 0x1288}, wbprALetter},                // Lo  [41] ETHIOPIC SYLLABLE BA..ETHIOPIC SYLLABLE XWA
-	{runeRange{0x128A, 0x128D}, wbprALetter},                // Lo   [4] ETHIOPIC SYLLABLE XWI..ETHIOPIC SYLLABLE XWE
-	{runeRange{0x1290, 0x12B0}, wbprALetter},                // Lo  [33] ETHIOPIC SYLLABLE NA..ETHIOPIC SYLLABLE KWA
-	{runeRange{0x12B2, 0x12B5}, wbprALetter},                // Lo   [4] ETHIOPIC SYLLABLE KWI..ETHIOPIC SYLLABLE KWE
-	{runeRange{0x12B8, 0x12BE}, wbprALetter},                // Lo   [7] ETHIOPIC SYLLABLE KXA..ETHIOPIC SYLLABLE KXO
-	{runeRange{0x12C0, 0x12C0}, wbprALetter},                // Lo       ETHIOPIC SYLLABLE KXWA
-	{runeRange{0x12C2, 0x12C5}, wbprALetter},                // Lo   [4] ETHIOPIC SYLLABLE KXWI..ETHIOPIC SYLLABLE KXWE
-	{runeRange{0x12C8, 0x12D6}, wbprALetter},                // Lo  [15] ETHIOPIC SYLLABLE WA..ETHIOPIC SYLLABLE PHARYNGEAL O
-	{runeRange{0x12D8, 0x1310}, wbprALetter},                // Lo  [57] ETHIOPIC SYLLABLE ZA..ETHIOPIC SYLLABLE GWA
-	{runeRange{0x1312, 0x1315}, wbprALetter},                // Lo   [4] ETHIOPIC SYLLABLE GWI..ETHIOPIC SYLLABLE GWE
-	{runeRange{0x1318, 0x135A}, wbprALetter},                // Lo  [67] ETHIOPIC SYLLABLE GGA..ETHIOPIC SYLLABLE FYA
-	{runeRange{0x135D, 0x135F}, wbprExtend},                 // Mn   [3] ETHIOPIC COMBINING GEMINATION AND VOWEL LENGTH MARK..ETHIOPIC COMBINING GEMINATION MARK
-	{runeRange{0x1380, 0x138F}, wbprALetter},                // Lo  [16] ETHIOPIC SYLLABLE SEBATBEIT MWA..ETHIOPIC SYLLABLE PWE
-	{runeRange{0x13A0, 0x13F5}, wbprALetter},                // L&  [86] CHEROKEE LETTER A..CHEROKEE LETTER MV
-	{runeRange{0x13F8, 0x13FD}, wbprALetter},                // L&   [6] CHEROKEE SMALL LETTER YE..CHEROKEE SMALL LETTER MV
-	{runeRange{0x1401, 0x166C}, wbprALetter},                // Lo [620] CANADIAN SYLLABICS E..CANADIAN SYLLABICS CARRIER TTSA
-	{runeRange{0x166F, 0x167F}, wbprALetter},                // Lo  [17] CANADIAN SYLLABICS QAI..CANADIAN SYLLABICS BLACKFOOT W
-	{runeRange{0x1680, 0x1680}, wbprWSegSpace},              // Zs       OGHAM SPACE MARK
-	{runeRange{0x1681, 0x169A}, wbprALetter},                // Lo  [26] OGHAM LETTER BEITH..OGHAM LETTER PEITH
-	{runeRange{0x16A0, 0x16EA}, wbprALetter},                // Lo  [75] RUNIC LETTER FEHU FEOH FE F..RUNIC LETTER X
-	{runeRange{0x16EE, 0x16F0}, wbprALetter},                // Nl   [3] RUNIC ARLAUG SYMBOL..RUNIC BELGTHOR SYMBOL
-	{runeRange{0x16F1, 0x16F8}, wbprALetter},                // Lo   [8] RUNIC LETTER K..RUNIC LETTER FRANKS CASKET AESC
-	{runeRange{0x1700, 0x1711}, wbprALetter},                // Lo  [18] TAGALOG LETTER A..TAGALOG LETTER HA
-	{runeRange{0x1712, 0x1714}, wbprExtend},                 // Mn   [3] TAGALOG VOWEL SIGN I..TAGALOG SIGN VIRAMA
-	{runeRange{0x1715, 0x1715}, wbprExtend},                 // Mc       TAGALOG SIGN PAMUDPOD
-	{runeRange{0x171F, 0x1731}, wbprALetter},                // Lo  [19] TAGALOG LETTER ARCHAIC RA..HANUNOO LETTER HA
-	{runeRange{0x1732, 0x1733}, wbprExtend},                 // Mn   [2] HANUNOO VOWEL SIGN I..HANUNOO VOWEL SIGN U
-	{runeRange{0x1734, 0x1734}, wbprExtend},                 // Mc       HANUNOO SIGN PAMUDPOD
-	{runeRange{0x1740, 0x1751}, wbprALetter},                // Lo  [18] BUHID LETTER A..BUHID LETTER HA
-	{runeRange{0x1752, 0x1753}, wbprExtend},                 // Mn   [2] BUHID VOWEL SIGN I..BUHID VOWEL SIGN U
-	{runeRange{0x1760, 0x176C}, wbprALetter},                // Lo  [13] TAGBANWA LETTER A..TAGBANWA LETTER YA
-	{runeRange{0x176E, 0x1770}, wbprALetter},                // Lo   [3] TAGBANWA LETTER LA..TAGBANWA LETTER SA
-	{runeRange{0x1772, 0x1773}, wbprExtend},                 // Mn   [2] TAGBANWA VOWEL SIGN I..TAGBANWA VOWEL SIGN U
-	{runeRange{0x17B4, 0x17B5}, wbprExtend},                 // Mn   [2] KHMER VOWEL INHERENT AQ..KHMER VOWEL INHERENT AA
-	{runeRange{0x17B6, 0x17B6}, wbprExtend},                 // Mc       KHMER VOWEL SIGN AA
-	{runeRange{0x17B7, 0x17BD}, wbprExtend},                 // Mn   [7] KHMER VOWEL SIGN I..KHMER VOWEL SIGN UA
-	{runeRange{0x17BE, 0x17C5}, wbprExtend},                 // Mc   [8] KHMER VOWEL SIGN OE..KHMER VOWEL SIGN AU
-	{runeRange{0x17C6, 0x17C6}, wbprExtend},                 // Mn       KHMER SIGN NIKAHIT
-	{runeRange{0x17C7, 0x17C8}, wbprExtend},                 // Mc   [2] KHMER SIGN REAHMUK..KHMER SIGN YUUKALEAPINTU
-	{runeRange{0x17C9, 0x17D3}, wbprExtend},                 // Mn  [11] KHMER SIGN MUUSIKATOAN..KHMER SIGN BATHAMASAT
-	{runeRange{0x17DD, 0x17DD}, wbprExtend},                 // Mn       KHMER SIGN ATTHACAN
-	{runeRange{0x17E0, 0x17E9}, wbprNumeric},                // Nd  [10] KHMER DIGIT ZERO..KHMER DIGIT NINE
-	{runeRange{0x180B, 0x180D}, wbprExtend},                 // Mn   [3] MONGOLIAN FREE VARIATION SELECTOR ONE..MONGOLIAN FREE VARIATION SELECTOR THREE
-	{runeRange{0x180E, 0x180E}, wbprFormat},                 // Cf       MONGOLIAN VOWEL SEPARATOR
-	{runeRange{0x180F, 0x180F}, wbprExtend},                 // Mn       MONGOLIAN FREE VARIATION SELECTOR FOUR
-	{runeRange{0x1810, 0x1819}, wbprNumeric},                // Nd  [10] MONGOLIAN DIGIT ZERO..MONGOLIAN DIGIT NINE
-	{runeRange{0x1820, 0x1842}, wbprALetter},                // Lo  [35] MONGOLIAN LETTER A..MONGOLIAN LETTER CHI
-	{runeRange{0x1843, 0x1843}, wbprALetter},                // Lm       MONGOLIAN LETTER TODO LONG VOWEL SIGN
-	{runeRange{0x1844, 0x1878}, wbprALetter},                // Lo  [53] MONGOLIAN LETTER TODO E..MONGOLIAN LETTER CHA WITH TWO DOTS
-	{runeRange{0x1880, 0x1884}, wbprALetter},                // Lo   [5] MONGOLIAN LETTER ALI GALI ANUSVARA ONE..MONGOLIAN LETTER ALI GALI INVERTED UBADAMA
-	{runeRange{0x1885, 0x1886}, wbprExtend},                 // Mn   [2] MONGOLIAN LETTER ALI GALI BALUDA..MONGOLIAN LETTER ALI GALI THREE BALUDA
-	{runeRange{0x1887, 0x18A8}, wbprALetter},                // Lo  [34] MONGOLIAN LETTER ALI GALI A..MONGOLIAN LETTER MANCHU ALI GALI BHA
-	{runeRange{0x18A9, 0x18A9}, wbprExtend},                 // Mn       MONGOLIAN LETTER ALI GALI DAGALGA
-	{runeRange{0x18AA, 0x18AA}, wbprALetter},                // Lo       MONGOLIAN LETTER MANCHU ALI GALI LHA
-	{runeRange{0x18B0, 0x18F5}, wbprALetter},                // Lo  [70] CANADIAN SYLLABICS OY..CANADIAN SYLLABICS CARRIER DENTAL S
-	{runeRange{0x1900, 0x191E}, wbprALetter},                // Lo  [31] LIMBU VOWEL-CARRIER LETTER..LIMBU LETTER TRA
-	{runeRange{0x1920, 0x1922}, wbprExtend},                 // Mn   [3] LIMBU VOWEL SIGN A..LIMBU VOWEL SIGN U
-	{runeRange{0x1923, 0x1926}, wbprExtend},                 // Mc   [4] LIMBU VOWEL SIGN EE..LIMBU VOWEL SIGN AU
-	{runeRange{0x1927, 0x1928}, wbprExtend},                 // Mn   [2] LIMBU VOWEL SIGN E..LIMBU VOWEL SIGN O
-	{runeRange{0x1929, 0x192B}, wbprExtend},                 // Mc   [3] LIMBU SUBJOINED LETTER YA..LIMBU SUBJOINED LETTER WA
-	{runeRange{0x1930, 0x1931}, wbprExtend},                 // Mc   [2] LIMBU SMALL LETTER KA..LIMBU SMALL LETTER NGA
-	{runeRange{0x1932, 0x1932}, wbprExtend},                 // Mn       LIMBU SMALL LETTER ANUSVARA
-	{runeRange{0x1933, 0x1938}, wbprExtend},                 // Mc   [6] LIMBU SMALL LETTER TA..LIMBU SMALL LETTER LA
-	{runeRange{0x1939, 0x193B}, wbprExtend},                 // Mn   [3] LIMBU SIGN MUKPHRENG..LIMBU SIGN SA-I
-	{runeRange{0x1946, 0x194F}, wbprNumeric},                // Nd  [10] LIMBU DIGIT ZERO..LIMBU DIGIT NINE
-	{runeRange{0x19D0, 0x19D9}, wbprNumeric},                // Nd  [10] NEW TAI LUE DIGIT ZERO..NEW TAI LUE DIGIT NINE
-	{runeRange{0x1A00, 0x1A16}, wbprALetter},                // Lo  [23] BUGINESE LETTER KA..BUGINESE LETTER HA
-	{runeRange{0x1A17, 0x1A18}, wbprExtend},                 // Mn   [2] BUGINESE VOWEL SIGN I..BUGINESE VOWEL SIGN U
-	{runeRange{0x1A19, 0x1A1A}, wbprExtend},                 // Mc   [2] BUGINESE VOWEL SIGN E..BUGINESE VOWEL SIGN O
-	{runeRange{0x1A1B, 0x1A1B}, wbprExtend},                 // Mn       BUGINESE VOWEL SIGN AE
-	{runeRange{0x1A55, 0x1A55}, wbprExtend},                 // Mc       TAI THAM CONSONANT SIGN MEDIAL RA
-	{runeRange{0x1A56, 0x1A56}, wbprExtend},                 // Mn       TAI THAM CONSONANT SIGN MEDIAL LA
-	{runeRange{0x1A57, 0x1A57}, wbprExtend},                 // Mc       TAI THAM CONSONANT SIGN LA TANG LAI
-	{runeRange{0x1A58, 0x1A5E}, wbprExtend},                 // Mn   [7] TAI THAM SIGN MAI KANG LAI..TAI THAM CONSONANT SIGN SA
-	{runeRange{0x1A60, 0x1A60}, wbprExtend},                 // Mn       TAI THAM SIGN SAKOT
-	{runeRange{0x1A61, 0x1A61}, wbprExtend},                 // Mc       TAI THAM VOWEL SIGN A
-	{runeRange{0x1A62, 0x1A62}, wbprExtend},                 // Mn       TAI THAM VOWEL SIGN MAI SAT
-	{runeRange{0x1A63, 0x1A64}, wbprExtend},                 // Mc   [2] TAI THAM VOWEL SIGN AA..TAI THAM VOWEL SIGN TALL AA
-	{runeRange{0x1A65, 0x1A6C}, wbprExtend},                 // Mn   [8] TAI THAM VOWEL SIGN I..TAI THAM VOWEL SIGN OA BELOW
-	{runeRange{0x1A6D, 0x1A72}, wbprExtend},                 // Mc   [6] TAI THAM VOWEL SIGN OY..TAI THAM VOWEL SIGN THAM AI
-	{runeRange{0x1A73, 0x1A7C}, wbprExtend},                 // Mn  [10] TAI THAM VOWEL SIGN OA ABOVE..TAI THAM SIGN KHUEN-LUE KARAN
-	{runeRange{0x1A7F, 0x1A7F}, wbprExtend},                 // Mn       TAI THAM COMBINING CRYPTOGRAMMIC DOT
-	{runeRange{0x1A80, 0x1A89}, wbprNumeric},                // Nd  [10] TAI THAM HORA DIGIT ZERO..TAI THAM HORA DIGIT NINE
-	{runeRange{0x1A90, 0x1A99}, wbprNumeric},                // Nd  [10] TAI THAM THAM DIGIT ZERO..TAI THAM THAM DIGIT NINE
-	{runeRange{0x1AB0, 0x1ABD}, wbprExtend},                 // Mn  [14] COMBINING DOUBLED CIRCUMFLEX ACCENT..COMBINING PARENTHESES BELOW
-	{runeRange{0x1ABE, 0x1ABE}, wbprExtend},                 // Me       COMBINING PARENTHESES OVERLAY
-	{runeRange{0x1ABF, 0x1ACE}, wbprExtend},                 // Mn  [16] COMBINING LATIN SMALL LETTER W BELOW..COMBINING LATIN SMALL LETTER INSULAR T
-	{runeRange{0x1B00, 0x1B03}, wbprExtend},                 // Mn   [4] BALINESE SIGN ULU RICEM..BALINESE SIGN SURANG
-	{runeRange{0x1B04, 0x1B04}, wbprExtend},                 // Mc       BALINESE SIGN BISAH
-	{runeRange{0x1B05, 0x1B33}, wbprALetter},                // Lo  [47] BALINESE LETTER AKARA..BALINESE LETTER HA
-	{runeRange{0x1B34, 0x1B34}, wbprExtend},                 // Mn       BALINESE SIGN REREKAN
-	{runeRange{0x1B35, 0x1B35}, wbprExtend},                 // Mc       BALINESE VOWEL SIGN TEDUNG
-	{runeRange{0x1B36, 0x1B3A}, wbprExtend},                 // Mn   [5] BALINESE VOWEL SIGN ULU..BALINESE VOWEL SIGN RA REPA
-	{runeRange{0x1B3B, 0x1B3B}, wbprExtend},                 // Mc       BALINESE VOWEL SIGN RA REPA TEDUNG
-	{runeRange{0x1B3C, 0x1B3C}, wbprExtend},                 // Mn       BALINESE VOWEL SIGN LA LENGA
-	{runeRange{0x1B3D, 0x1B41}, wbprExtend},                 // Mc   [5] BALINESE VOWEL SIGN LA LENGA TEDUNG..BALINESE VOWEL SIGN TALING REPA TEDUNG
-	{runeRange{0x1B42, 0x1B42}, wbprExtend},                 // Mn       BALINESE VOWEL SIGN PEPET
-	{runeRange{0x1B43, 0x1B44}, wbprExtend},                 // Mc   [2] BALINESE VOWEL SIGN PEPET TEDUNG..BALINESE ADEG ADEG
-	{runeRange{0x1B45, 0x1B4C}, wbprALetter},                // Lo   [8] BALINESE LETTER KAF SASAK..BALINESE LETTER ARCHAIC JNYA
-	{runeRange{0x1B50, 0x1B59}, wbprNumeric},                // Nd  [10] BALINESE DIGIT ZERO..BALINESE DIGIT NINE
-	{runeRange{0x1B6B, 0x1B73}, wbprExtend},                 // Mn   [9] BALINESE MUSICAL SYMBOL COMBINING TEGEH..BALINESE MUSICAL SYMBOL COMBINING GONG
-	{runeRange{0x1B80, 0x1B81}, wbprExtend},                 // Mn   [2] SUNDANESE SIGN PANYECEK..SUNDANESE SIGN PANGLAYAR
-	{runeRange{0x1B82, 0x1B82}, wbprExtend},                 // Mc       SUNDANESE SIGN PANGWISAD
-	{runeRange{0x1B83, 0x1BA0}, wbprALetter},                // Lo  [30] SUNDANESE LETTER A..SUNDANESE LETTER HA
-	{runeRange{0x1BA1, 0x1BA1}, wbprExtend},                 // Mc       SUNDANESE CONSONANT SIGN PAMINGKAL
-	{runeRange{0x1BA2, 0x1BA5}, wbprExtend},                 // Mn   [4] SUNDANESE CONSONANT SIGN PANYAKRA..SUNDANESE VOWEL SIGN PANYUKU
-	{runeRange{0x1BA6, 0x1BA7}, wbprExtend},                 // Mc   [2] SUNDANESE VOWEL SIGN PANAELAENG..SUNDANESE VOWEL SIGN PANOLONG
-	{runeRange{0x1BA8, 0x1BA9}, wbprExtend},                 // Mn   [2] SUNDANESE VOWEL SIGN PAMEPET..SUNDANESE VOWEL SIGN PANEULEUNG
-	{runeRange{0x1BAA, 0x1BAA}, wbprExtend},                 // Mc       SUNDANESE SIGN PAMAAEH
-	{runeRange{0x1BAB, 0x1BAD}, wbprExtend},                 // Mn   [3] SUNDANESE SIGN VIRAMA..SUNDANESE CONSONANT SIGN PASANGAN WA
-	{runeRange{0x1BAE, 0x1BAF}, wbprALetter},                // Lo   [2] SUNDANESE LETTER KHA..SUNDANESE LETTER SYA
-	{runeRange{0x1BB0, 0x1BB9}, wbprNumeric},                // Nd  [10] SUNDANESE DIGIT ZERO..SUNDANESE DIGIT NINE
-	{runeRange{0x1BBA, 0x1BE5}, wbprALetter},                // Lo  [44] SUNDANESE AVAGRAHA..BATAK LETTER U
-	{runeRange{0x1BE6, 0x1BE6}, wbprExtend},                 // Mn       BATAK SIGN TOMPI
-	{runeRange{0x1BE7, 0x1BE7}, wbprExtend},                 // Mc       BATAK VOWEL SIGN E
-	{runeRange{0x1BE8, 0x1BE9}, wbprExtend},                 // Mn   [2] BATAK VOWEL SIGN PAKPAK E..BATAK VOWEL SIGN EE
-	{runeRange{0x1BEA, 0x1BEC}, wbprExtend},                 // Mc   [3] BATAK VOWEL SIGN I..BATAK VOWEL SIGN O
-	{runeRange{0x1BED, 0x1BED}, wbprExtend},                 // Mn       BATAK VOWEL SIGN KARO O
-	{runeRange{0x1BEE, 0x1BEE}, wbprExtend},                 // Mc       BATAK VOWEL SIGN U
-	{runeRange{0x1BEF, 0x1BF1}, wbprExtend},                 // Mn   [3] BATAK VOWEL SIGN U FOR SIMALUNGUN SA..BATAK CONSONANT SIGN H
-	{runeRange{0x1BF2, 0x1BF3}, wbprExtend},                 // Mc   [2] BATAK PANGOLAT..BATAK PANONGONAN
-	{runeRange{0x1C00, 0x1C23}, wbprALetter},                // Lo  [36] LEPCHA LETTER KA..LEPCHA LETTER A
-	{runeRange{0x1C24, 0x1C2B}, wbprExtend},                 // Mc   [8] LEPCHA SUBJOINED LETTER YA..LEPCHA VOWEL SIGN UU
-	{runeRange{0x1C2C, 0x1C33}, wbprExtend},                 // Mn   [8] LEPCHA VOWEL SIGN E..LEPCHA CONSONANT SIGN T
-	{runeRange{0x1C34, 0x1C35}, wbprExtend},                 // Mc   [2] LEPCHA CONSONANT SIGN NYIN-DO..LEPCHA CONSONANT SIGN KANG
-	{runeRange{0x1C36, 0x1C37}, wbprExtend},                 // Mn   [2] LEPCHA SIGN RAN..LEPCHA SIGN NUKTA
-	{runeRange{0x1C40, 0x1C49}, wbprNumeric},                // Nd  [10] LEPCHA DIGIT ZERO..LEPCHA DIGIT NINE
-	{runeRange{0x1C4D, 0x1C4F}, wbprALetter},                // Lo   [3] LEPCHA LETTER TTA..LEPCHA LETTER DDA
-	{runeRange{0x1C50, 0x1C59}, wbprNumeric},                // Nd  [10] OL CHIKI DIGIT ZERO..OL CHIKI DIGIT NINE
-	{runeRange{0x1C5A, 0x1C77}, wbprALetter},                // Lo  [30] OL CHIKI LETTER LA..OL CHIKI LETTER OH
-	{runeRange{0x1C78, 0x1C7D}, wbprALetter},                // Lm   [6] OL CHIKI MU TTUDDAG..OL CHIKI AHAD
-	{runeRange{0x1C80, 0x1C88}, wbprALetter},                // L&   [9] CYRILLIC SMALL LETTER ROUNDED VE..CYRILLIC SMALL LETTER UNBLENDED UK
-	{runeRange{0x1C90, 0x1CBA}, wbprALetter},                // L&  [43] GEORGIAN MTAVRULI CAPITAL LETTER AN..GEORGIAN MTAVRULI CAPITAL LETTER AIN
-	{runeRange{0x1CBD, 0x1CBF}, wbprALetter},                // L&   [3] GEORGIAN MTAVRULI CAPITAL LETTER AEN..GEORGIAN MTAVRULI CAPITAL LETTER LABIAL SIGN
-	{runeRange{0x1CD0, 0x1CD2}, wbprExtend},                 // Mn   [3] VEDIC TONE KARSHANA..VEDIC TONE PRENKHA
-	{runeRange{0x1CD4, 0x1CE0}, wbprExtend},                 // Mn  [13] VEDIC SIGN YAJURVEDIC MIDLINE SVARITA..VEDIC TONE RIGVEDIC KASHMIRI INDEPENDENT SVARITA
-	{runeRange{0x1CE1, 0x1CE1}, wbprExtend},                 // Mc       VEDIC TONE ATHARVAVEDIC INDEPENDENT SVARITA
-	{runeRange{0x1CE2, 0x1CE8}, wbprExtend},                 // Mn   [7] VEDIC SIGN VISARGA SVARITA..VEDIC SIGN VISARGA ANUDATTA WITH TAIL
-	{runeRange{0x1CE9, 0x1CEC}, wbprALetter},                // Lo   [4] VEDIC SIGN ANUSVARA ANTARGOMUKHA..VEDIC SIGN ANUSVARA VAMAGOMUKHA WITH TAIL
-	{runeRange{0x1CED, 0x1CED}, wbprExtend},                 // Mn       VEDIC SIGN TIRYAK
-	{runeRange{0x1CEE, 0x1CF3}, wbprALetter},                // Lo   [6] VEDIC SIGN HEXIFORM LONG ANUSVARA..VEDIC SIGN ROTATED ARDHAVISARGA
-	{runeRange{0x1CF4, 0x1CF4}, wbprExtend},                 // Mn       VEDIC TONE CANDRA ABOVE
-	{runeRange{0x1CF5, 0x1CF6}, wbprALetter},                // Lo   [2] VEDIC SIGN JIHVAMULIYA..VEDIC SIGN UPADHMANIYA
-	{runeRange{0x1CF7, 0x1CF7}, wbprExtend},                 // Mc       VEDIC SIGN ATIKRAMA
-	{runeRange{0x1CF8, 0x1CF9}, wbprExtend},                 // Mn   [2] VEDIC TONE RING ABOVE..VEDIC TONE DOUBLE RING ABOVE
-	{runeRange{0x1CFA, 0x1CFA}, wbprALetter},                // Lo       VEDIC SIGN DOUBLE ANUSVARA ANTARGOMUKHA
-	{runeRange{0x1D00, 0x1D2B}, wbprALetter},                // L&  [44] LATIN LETTER SMALL CAPITAL A..CYRILLIC LETTER SMALL CAPITAL EL
-	{runeRange{0x1D2C, 0x1D6A}, wbprALetter},                // Lm  [63] MODIFIER LETTER CAPITAL A..GREEK SUBSCRIPT SMALL LETTER CHI
-	{runeRange{0x1D6B, 0x1D77}, wbprALetter},                // L&  [13] LATIN SMALL LETTER UE..LATIN SMALL LETTER TURNED G
-	{runeRange{0x1D78, 0x1D78}, wbprALetter},                // Lm       MODIFIER LETTER CYRILLIC EN
-	{runeRange{0x1D79, 0x1D9A}, wbprALetter},                // L&  [34] LATIN SMALL LETTER INSULAR G..LATIN SMALL LETTER EZH WITH RETROFLEX HOOK
-	{runeRange{0x1D9B, 0x1DBF}, wbprALetter},                // Lm  [37] MODIFIER LETTER SMALL TURNED ALPHA..MODIFIER LETTER SMALL THETA
-	{runeRange{0x1DC0, 0x1DFF}, wbprExtend},                 // Mn  [64] COMBINING DOTTED GRAVE ACCENT..COMBINING RIGHT ARROWHEAD AND DOWN ARROWHEAD BELOW
-	{runeRange{0x1E00, 0x1F15}, wbprALetter},                // L& [278] LATIN CAPITAL LETTER A WITH RING BELOW..GREEK SMALL LETTER EPSILON WITH DASIA AND OXIA
-	{runeRange{0x1F18, 0x1F1D}, wbprALetter},                // L&   [6] GREEK CAPITAL LETTER EPSILON WITH PSILI..GREEK CAPITAL LETTER EPSILON WITH DASIA AND OXIA
-	{runeRange{0x1F20, 0x1F45}, wbprALetter},                // L&  [38] GREEK SMALL LETTER ETA WITH PSILI..GREEK SMALL LETTER OMICRON WITH DASIA AND OXIA
-	{runeRange{0x1F48, 0x1F4D}, wbprALetter},                // L&   [6] GREEK CAPITAL LETTER OMICRON WITH PSILI..GREEK CAPITAL LETTER OMICRON WITH DASIA AND OXIA
-	{runeRange{0x1F50, 0x1F57}, wbprALetter},                // L&   [8] GREEK SMALL LETTER UPSILON WITH PSILI..GREEK SMALL LETTER UPSILON WITH DASIA AND PERISPOMENI
-	{runeRange{0x1F59, 0x1F59}, wbprALetter},                // L&       GREEK CAPITAL LETTER UPSILON WITH DASIA
-	{runeRange{0x1F5B, 0x1F5B}, wbprALetter},                // L&       GREEK CAPITAL LETTER UPSILON WITH DASIA AND VARIA
-	{runeRange{0x1F5D, 0x1F5D}, wbprALetter},                // L&       GREEK CAPITAL LETTER UPSILON WITH DASIA AND OXIA
-	{runeRange{0x1F5F, 0x1F7D}, wbprALetter},                // L&  [31] GREEK CAPITAL LETTER UPSILON WITH DASIA AND PERISPOMENI..GREEK SMALL LETTER OMEGA WITH OXIA
-	{runeRange{0x1F80, 0x1FB4}, wbprALetter},                // L&  [53] GREEK SMALL LETTER ALPHA WITH PSILI AND YPOGEGRAMMENI..GREEK SMALL LETTER ALPHA WITH OXIA AND YPOGEGRAMMENI
-	{runeRange{0x1FB6, 0x1FBC}, wbprALetter},                // L&   [7] GREEK SMALL LETTER ALPHA WITH PERISPOMENI..GREEK CAPITAL LETTER ALPHA WITH PROSGEGRAMMENI
-	{runeRange{0x1FBE, 0x1FBE}, wbprALetter},                // L&       GREEK PROSGEGRAMMENI
-	{runeRange{0x1FC2, 0x1FC4}, wbprALetter},                // L&   [3] GREEK SMALL LETTER ETA WITH VARIA AND YPOGEGRAMMENI..GREEK SMALL LETTER ETA WITH OXIA AND YPOGEGRAMMENI
-	{runeRange{0x1FC6, 0x1FCC}, wbprALetter},                // L&   [7] GREEK SMALL LETTER ETA WITH PERISPOMENI..GREEK CAPITAL LETTER ETA WITH PROSGEGRAMMENI
-	{runeRange{0x1FD0, 0x1FD3}, wbprALetter},                // L&   [4] GREEK SMALL LETTER IOTA WITH VRACHY..GREEK SMALL LETTER IOTA WITH DIALYTIKA AND OXIA
-	{runeRange{0x1FD6, 0x1FDB}, wbprALetter},                // L&   [6] GREEK SMALL LETTER IOTA WITH PERISPOMENI..GREEK CAPITAL LETTER IOTA WITH OXIA
-	{runeRange{0x1FE0, 0x1FEC}, wbprALetter},                // L&  [13] GREEK SMALL LETTER UPSILON WITH VRACHY..GREEK CAPITAL LETTER RHO WITH DASIA
-	{runeRange{0x1FF2, 0x1FF4}, wbprALetter},                // L&   [3] GREEK SMALL LETTER OMEGA WITH VARIA AND YPOGEGRAMMENI..GREEK SMALL LETTER OMEGA WITH OXIA AND YPOGEGRAMMENI
-	{runeRange{0x1FF6, 0x1FFC}, wbprALetter},                // L&   [7] GREEK SMALL LETTER OMEGA WITH PERISPOMENI..GREEK CAPITAL LETTER OMEGA WITH PROSGEGRAMMENI
-	{runeRange{0x2000, 0x2006}, wbprWSegSpace},              // Zs   [7] EN QUAD..SIX-PER-EM SPACE
-	{runeRange{0x2008, 0x200A}, wbprWSegSpace},              // Zs   [3] PUNCTUATION SPACE..HAIR SPACE
-	{runeRange{0x200C, 0x200C}, wbprExtend},                 // Cf       ZERO WIDTH NON-JOINER
-	{runeRange{0x200D, 0x200D}, wbprZWJ},                    // Cf       ZERO WIDTH JOINER
-	{runeRange{0x200E, 0x200F}, wbprFormat},                 // Cf   [2] LEFT-TO-RIGHT MARK..RIGHT-TO-LEFT MARK
-	{runeRange{0x2018, 0x2018}, wbprMidNumLet},              // Pi       LEFT SINGLE QUOTATION MARK
-	{runeRange{0x2019, 0x2019}, wbprMidNumLet},              // Pf       RIGHT SINGLE QUOTATION MARK
-	{runeRange{0x2024, 0x2024}, wbprMidNumLet},              // Po       ONE DOT LEADER
-	{runeRange{0x2027, 0x2027}, wbprMidLetter},              // Po       HYPHENATION POINT
-	{runeRange{0x2028, 0x2028}, wbprNewline},                // Zl       LINE SEPARATOR
-	{runeRange{0x2029, 0x2029}, wbprNewline},                // Zp       PARAGRAPH SEPARATOR
-	{runeRange{0x202A, 0x202E}, wbprFormat},                 // Cf   [5] LEFT-TO-RIGHT EMBEDDING..RIGHT-TO-LEFT OVERRIDE
-	{runeRange{0x202F, 0x202F}, wbprExtendNumLet},           // Zs       NARROW NO-BREAK SPACE
-	{runeRange{0x203C, 0x203C}, wbprExtendedPictographic},   // E0.6   [1] (‼️)       double exclamation mark
-	{runeRange{0x203F, 0x2040}, wbprExtendNumLet},           // Pc   [2] UNDERTIE..CHARACTER TIE
-	{runeRange{0x2044, 0x2044}, wbprMidNum},                 // Sm       FRACTION SLASH
-	{runeRange{0x2049, 0x2049}, wbprExtendedPictographic},   // E0.6   [1] (⁉️)       exclamation question mark
-	{runeRange{0x2054, 0x2054}, wbprExtendNumLet},           // Pc       INVERTED UNDERTIE
-	{runeRange{0x205F, 0x205F}, wbprWSegSpace},              // Zs       MEDIUM MATHEMATICAL SPACE
-	{runeRange{0x2060, 0x2064}, wbprFormat},                 // Cf   [5] WORD JOINER..INVISIBLE PLUS
-	{runeRange{0x2066, 0x206F}, wbprFormat},                 // Cf  [10] LEFT-TO-RIGHT ISOLATE..NOMINAL DIGIT SHAPES
-	{runeRange{0x2071, 0x2071}, wbprALetter},                // Lm       SUPERSCRIPT LATIN SMALL LETTER I
-	{runeRange{0x207F, 0x207F}, wbprALetter},                // Lm       SUPERSCRIPT LATIN SMALL LETTER N
-	{runeRange{0x2090, 0x209C}, wbprALetter},                // Lm  [13] LATIN SUBSCRIPT SMALL LETTER A..LATIN SUBSCRIPT SMALL LETTER T
-	{runeRange{0x20D0, 0x20DC}, wbprExtend},                 // Mn  [13] COMBINING LEFT HARPOON ABOVE..COMBINING FOUR DOTS ABOVE
-	{runeRange{0x20DD, 0x20E0}, wbprExtend},                 // Me   [4] COMBINING ENCLOSING CIRCLE..COMBINING ENCLOSING CIRCLE BACKSLASH
-	{runeRange{0x20E1, 0x20E1}, wbprExtend},                 // Mn       COMBINING LEFT RIGHT ARROW ABOVE
-	{runeRange{0x20E2, 0x20E4}, wbprExtend},                 // Me   [3] COMBINING ENCLOSING SCREEN..COMBINING ENCLOSING UPWARD POINTING TRIANGLE
-	{runeRange{0x20E5, 0x20F0}, wbprExtend},                 // Mn  [12] COMBINING REVERSE SOLIDUS OVERLAY..COMBINING ASTERISK ABOVE
-	{runeRange{0x2102, 0x2102}, wbprALetter},                // L&       DOUBLE-STRUCK CAPITAL C
-	{runeRange{0x2107, 0x2107}, wbprALetter},                // L&       EULER CONSTANT
-	{runeRange{0x210A, 0x2113}, wbprALetter},                // L&  [10] SCRIPT SMALL G..SCRIPT SMALL L
-	{runeRange{0x2115, 0x2115}, wbprALetter},                // L&       DOUBLE-STRUCK CAPITAL N
-	{runeRange{0x2119, 0x211D}, wbprALetter},                // L&   [5] DOUBLE-STRUCK CAPITAL P..DOUBLE-STRUCK CAPITAL R
-	{runeRange{0x2122, 0x2122}, wbprExtendedPictographic},   // E0.6   [1] (™️)       trade mark
-	{runeRange{0x2124, 0x2124}, wbprALetter},                // L&       DOUBLE-STRUCK CAPITAL Z
-	{runeRange{0x2126, 0x2126}, wbprALetter},                // L&       OHM SIGN
-	{runeRange{0x2128, 0x2128}, wbprALetter},                // L&       BLACK-LETTER CAPITAL Z
-	{runeRange{0x212A, 0x212D}, wbprALetter},                // L&   [4] KELVIN SIGN..BLACK-LETTER CAPITAL C
-	{runeRange{0x212F, 0x2134}, wbprALetter},                // L&   [6] SCRIPT SMALL E..SCRIPT SMALL O
-	{runeRange{0x2135, 0x2138}, wbprALetter},                // Lo   [4] ALEF SYMBOL..DALET SYMBOL
-	{runeRange{0x2139, 0x2139}, wbprExtendedPictographic},   // E0.6   [1] (ℹ️)       information
-	{runeRange{0x2139, 0x2139}, wbprALetter},                // L&       INFORMATION SOURCE
-	{runeRange{0x213C, 0x213F}, wbprALetter},                // L&   [4] DOUBLE-STRUCK SMALL PI..DOUBLE-STRUCK CAPITAL PI
-	{runeRange{0x2145, 0x2149}, wbprALetter},                // L&   [5] DOUBLE-STRUCK ITALIC CAPITAL D..DOUBLE-STRUCK ITALIC SMALL J
-	{runeRange{0x214E, 0x214E}, wbprALetter},                // L&       TURNED SMALL F
-	{runeRange{0x2160, 0x2182}, wbprALetter},                // Nl  [35] ROMAN NUMERAL ONE..ROMAN NUMERAL TEN THOUSAND
-	{runeRange{0x2183, 0x2184}, wbprALetter},                // L&   [2] ROMAN NUMERAL REVERSED ONE HUNDRED..LATIN SMALL LETTER REVERSED C
-	{runeRange{0x2185, 0x2188}, wbprALetter},                // Nl   [4] ROMAN NUMERAL SIX LATE FORM..ROMAN NUMERAL ONE HUNDRED THOUSAND
-	{runeRange{0x2194, 0x2199}, wbprExtendedPictographic},   // E0.6   [6] (↔️..↙️)    left-right arrow..down-left arrow
-	{runeRange{0x21A9, 0x21AA}, wbprExtendedPictographic},   // E0.6   [2] (↩️..↪️)    right arrow curving left..left arrow curving right
-	{runeRange{0x231A, 0x231B}, wbprExtendedPictographic},   // E0.6   [2] (⌚..⌛)    watch..hourglass done
-	{runeRange{0x2328, 0x2328}, wbprExtendedPictographic},   // E1.0   [1] (⌨️)       keyboard
-	{runeRange{0x2388, 0x2388}, wbprExtendedPictographic},   // E0.0   [1] (⎈)       HELM SYMBOL
-	{runeRange{0x23CF, 0x23CF}, wbprExtendedPictographic},   // E1.0   [1] (⏏️)       eject button
-	{runeRange{0x23E9, 0x23EC}, wbprExtendedPictographic},   // E0.6   [4] (⏩..⏬)    fast-forward button..fast down button
-	{runeRange{0x23ED, 0x23EE}, wbprExtendedPictographic},   // E0.7   [2] (⏭️..⏮️)    next track button..last track button
-	{runeRange{0x23EF, 0x23EF}, wbprExtendedPictographic},   // E1.0   [1] (⏯️)       play or pause button
-	{runeRange{0x23F0, 0x23F0}, wbprExtendedPictographic},   // E0.6   [1] (⏰)       alarm clock
-	{runeRange{0x23F1, 0x23F2}, wbprExtendedPictographic},   // E1.0   [2] (⏱️..⏲️)    stopwatch..timer clock
-	{runeRange{0x23F3, 0x23F3}, wbprExtendedPictographic},   // E0.6   [1] (⏳)       hourglass not done
-	{runeRange{0x23F8, 0x23FA}, wbprExtendedPictographic},   // E0.7   [3] (⏸️..⏺️)    pause button..record button
-	{runeRange{0x24B6, 0x24E9}, wbprALetter},                // So  [52] CIRCLED LATIN CAPITAL LETTER A..CIRCLED LATIN SMALL LETTER Z
-	{runeRange{0x24C2, 0x24C2}, wbprExtendedPictographic},   // E0.6   [1] (Ⓜ️)       circled M
-	{runeRange{0x25AA, 0x25AB}, wbprExtendedPictographic},   // E0.6   [2] (▪️..▫️)    black small square..white small square
-	{runeRange{0x25B6, 0x25B6}, wbprExtendedPictographic},   // E0.6   [1] (▶️)       play button
-	{runeRange{0x25C0, 0x25C0}, wbprExtendedPictographic},   // E0.6   [1] (◀️)       reverse button
-	{runeRange{0x25FB, 0x25FE}, wbprExtendedPictographic},   // E0.6   [4] (◻️..◾)    white medium square..black medium-small square
-	{runeRange{0x2600, 0x2601}, wbprExtendedPictographic},   // E0.6   [2] (☀️..☁️)    sun..cloud
-	{runeRange{0x2602, 0x2603}, wbprExtendedPictographic},   // E0.7   [2] (☂️..☃️)    umbrella..snowman
-	{runeRange{0x2604, 0x2604}, wbprExtendedPictographic},   // E1.0   [1] (☄️)       comet
-	{runeRange{0x2605, 0x2605}, wbprExtendedPictographic},   // E0.0   [1] (★)       BLACK STAR
-	{runeRange{0x2607, 0x260D}, wbprExtendedPictographic},   // E0.0   [7] (☇..☍)    LIGHTNING..OPPOSITION
-	{runeRange{0x260E, 0x260E}, wbprExtendedPictographic},   // E0.6   [1] (☎️)       telephone
-	{runeRange{0x260F, 0x2610}, wbprExtendedPictographic},   // E0.0   [2] (☏..☐)    WHITE TELEPHONE..BALLOT BOX
-	{runeRange{0x2611, 0x2611}, wbprExtendedPictographic},   // E0.6   [1] (☑️)       check box with check
-	{runeRange{0x2612, 0x2612}, wbprExtendedPictographic},   // E0.0   [1] (☒)       BALLOT BOX WITH X
-	{runeRange{0x2614, 0x2615}, wbprExtendedPictographic},   // E0.6   [2] (☔..☕)    umbrella with rain drops..hot beverage
-	{runeRange{0x2616, 0x2617}, wbprExtendedPictographic},   // E0.0   [2] (☖..☗)    WHITE SHOGI PIECE..BLACK SHOGI PIECE
-	{runeRange{0x2618, 0x2618}, wbprExtendedPictographic},   // E1.0   [1] (☘️)       shamrock
-	{runeRange{0x2619, 0x261C}, wbprExtendedPictographic},   // E0.0   [4] (☙..☜)    REVERSED ROTATED FLORAL HEART BULLET..WHITE LEFT POINTING INDEX
-	{runeRange{0x261D, 0x261D}, wbprExtendedPictographic},   // E0.6   [1] (☝️)       index pointing up
-	{runeRange{0x261E, 0x261F}, wbprExtendedPictographic},   // E0.0   [2] (☞..☟)    WHITE RIGHT POINTING INDEX..WHITE DOWN POINTING INDEX
-	{runeRange{0x2620, 0x2620}, wbprExtendedPictographic},   // E1.0   [1] (☠️)       skull and crossbones
-	{runeRange{0x2621, 0x2621}, wbprExtendedPictographic},   // E0.0   [1] (☡)       CAUTION SIGN
-	{runeRange{0x2622, 0x2623}, wbprExtendedPictographic},   // E1.0   [2] (☢️..☣️)    radioactive..biohazard
-	{runeRange{0x2624, 0x2625}, wbprExtendedPictographic},   // E0.0   [2] (☤..☥)    CADUCEUS..ANKH
-	{runeRange{0x2626, 0x2626}, wbprExtendedPictographic},   // E1.0   [1] (☦️)       orthodox cross
-	{runeRange{0x2627, 0x2629}, wbprExtendedPictographic},   // E0.0   [3] (☧..☩)    CHI RHO..CROSS OF JERUSALEM
-	{runeRange{0x262A, 0x262A}, wbprExtendedPictographic},   // E0.7   [1] (☪️)       star and crescent
-	{runeRange{0x262B, 0x262D}, wbprExtendedPictographic},   // E0.0   [3] (☫..☭)    FARSI SYMBOL..HAMMER AND SICKLE
-	{runeRange{0x262E, 0x262E}, wbprExtendedPictographic},   // E1.0   [1] (☮️)       peace symbol
-	{runeRange{0x262F, 0x262F}, wbprExtendedPictographic},   // E0.7   [1] (☯️)       yin yang
-	{runeRange{0x2630, 0x2637}, wbprExtendedPictographic},   // E0.0   [8] (☰..☷)    TRIGRAM FOR HEAVEN..TRIGRAM FOR EARTH
-	{runeRange{0x2638, 0x2639}, wbprExtendedPictographic},   // E0.7   [2] (☸️..☹️)    wheel of dharma..frowning face
-	{runeRange{0x263A, 0x263A}, wbprExtendedPictographic},   // E0.6   [1] (☺️)       smiling face
-	{runeRange{0x263B, 0x263F}, wbprExtendedPictographic},   // E0.0   [5] (☻..☿)    BLACK SMILING FACE..MERCURY
-	{runeRange{0x2640, 0x2640}, wbprExtendedPictographic},   // E4.0   [1] (♀️)       female sign
-	{runeRange{0x2641, 0x2641}, wbprExtendedPictographic},   // E0.0   [1] (♁)       EARTH
-	{runeRange{0x2642, 0x2642}, wbprExtendedPictographic},   // E4.0   [1] (♂️)       male sign
-	{runeRange{0x2643, 0x2647}, wbprExtendedPictographic},   // E0.0   [5] (♃..♇)    JUPITER..PLUTO
-	{runeRange{0x2648, 0x2653}, wbprExtendedPictographic},   // E0.6  [12] (♈..♓)    Aries..Pisces
-	{runeRange{0x2654, 0x265E}, wbprExtendedPictographic},   // E0.0  [11] (♔..♞)    WHITE CHESS KING..BLACK CHESS KNIGHT
-	{runeRange{0x265F, 0x265F}, wbprExtendedPictographic},   // E11.0  [1] (♟️)       chess pawn
-	{runeRange{0x2660, 0x2660}, wbprExtendedPictographic},   // E0.6   [1] (♠️)       spade suit
-	{runeRange{0x2661, 0x2662}, wbprExtendedPictographic},   // E0.0   [2] (♡..♢)    WHITE HEART SUIT..WHITE DIAMOND SUIT
-	{runeRange{0x2663, 0x2663}, wbprExtendedPictographic},   // E0.6   [1] (♣️)       club suit
-	{runeRange{0x2664, 0x2664}, wbprExtendedPictographic},   // E0.0   [1] (♤)       WHITE SPADE SUIT
-	{runeRange{0x2665, 0x2666}, wbprExtendedPictographic},   // E0.6   [2] (♥️..♦️)    heart suit..diamond suit
-	{runeRange{0x2667, 0x2667}, wbprExtendedPictographic},   // E0.0   [1] (♧)       WHITE CLUB SUIT
-	{runeRange{0x2668, 0x2668}, wbprExtendedPictographic},   // E0.6   [1] (♨️)       hot springs
-	{runeRange{0x2669, 0x267A}, wbprExtendedPictographic},   // E0.0  [18] (♩..♺)    QUARTER NOTE..RECYCLING SYMBOL FOR GENERIC MATERIALS
-	{runeRange{0x267B, 0x267B}, wbprExtendedPictographic},   // E0.6   [1] (♻️)       recycling symbol
-	{runeRange{0x267C, 0x267D}, wbprExtendedPictographic},   // E0.0   [2] (♼..♽)    RECYCLED PAPER SYMBOL..PARTIALLY-RECYCLED PAPER SYMBOL
-	{runeRange{0x267E, 0x267E}, wbprExtendedPictographic},   // E11.0  [1] (♾️)       infinity
-	{runeRange{0x267F, 0x267F}, wbprExtendedPictographic},   // E0.6   [1] (♿)       wheelchair symbol
-	{runeRange{0x2680, 0x2685}, wbprExtendedPictographic},   // E0.0   [6] (⚀..⚅)    DIE FACE-1..DIE FACE-6
-	{runeRange{0x2690, 0x2691}, wbprExtendedPictographic},   // E0.0   [2] (⚐..⚑)    WHITE FLAG..BLACK FLAG
-	{runeRange{0x2692, 0x2692}, wbprExtendedPictographic},   // E1.0   [1] (⚒️)       hammer and pick
-	{runeRange{0x2693, 0x2693}, wbprExtendedPictographic},   // E0.6   [1] (⚓)       anchor
-	{runeRange{0x2694, 0x2694}, wbprExtendedPictographic},   // E1.0   [1] (⚔️)       crossed swords
-	{runeRange{0x2695, 0x2695}, wbprExtendedPictographic},   // E4.0   [1] (⚕️)       medical symbol
-	{runeRange{0x2696, 0x2697}, wbprExtendedPictographic},   // E1.0   [2] (⚖️..⚗️)    balance scale..alembic
-	{runeRange{0x2698, 0x2698}, wbprExtendedPictographic},   // E0.0   [1] (⚘)       FLOWER
-	{runeRange{0x2699, 0x2699}, wbprExtendedPictographic},   // E1.0   [1] (⚙️)       gear
-	{runeRange{0x269A, 0x269A}, wbprExtendedPictographic},   // E0.0   [1] (⚚)       STAFF OF HERMES
-	{runeRange{0x269B, 0x269C}, wbprExtendedPictographic},   // E1.0   [2] (⚛️..⚜️)    atom symbol..fleur-de-lis
-	{runeRange{0x269D, 0x269F}, wbprExtendedPictographic},   // E0.0   [3] (⚝..⚟)    OUTLINED WHITE STAR..THREE LINES CONVERGING LEFT
-	{runeRange{0x26A0, 0x26A1}, wbprExtendedPictographic},   // E0.6   [2] (⚠️..⚡)    warning..high voltage
-	{runeRange{0x26A2, 0x26A6}, wbprExtendedPictographic},   // E0.0   [5] (⚢..⚦)    DOUBLED FEMALE SIGN..MALE WITH STROKE SIGN
-	{runeRange{0x26A7, 0x26A7}, wbprExtendedPictographic},   // E13.0  [1] (⚧️)       transgender symbol
-	{runeRange{0x26A8, 0x26A9}, wbprExtendedPictographic},   // E0.0   [2] (⚨..⚩)    VERTICAL MALE WITH STROKE SIGN..HORIZONTAL MALE WITH STROKE SIGN
-	{runeRange{0x26AA, 0x26AB}, wbprExtendedPictographic},   // E0.6   [2] (⚪..⚫)    white circle..black circle
-	{runeRange{0x26AC, 0x26AF}, wbprExtendedPictographic},   // E0.0   [4] (⚬..⚯)    MEDIUM SMALL WHITE CIRCLE..UNMARRIED PARTNERSHIP SYMBOL
-	{runeRange{0x26B0, 0x26B1}, wbprExtendedPictographic},   // E1.0   [2] (⚰️..⚱️)    coffin..funeral urn
-	{runeRange{0x26B2, 0x26BC}, wbprExtendedPictographic},   // E0.0  [11] (⚲..⚼)    NEUTER..SESQUIQUADRATE
-	{runeRange{0x26BD, 0x26BE}, wbprExtendedPictographic},   // E0.6   [2] (⚽..⚾)    soccer ball..baseball
-	{runeRange{0x26BF, 0x26C3}, wbprExtendedPictographic},   // E0.0   [5] (⚿..⛃)    SQUARED KEY..BLACK DRAUGHTS KING
-	{runeRange{0x26C4, 0x26C5}, wbprExtendedPictographic},   // E0.6   [2] (⛄..⛅)    snowman without snow..sun behind cloud
-	{runeRange{0x26C6, 0x26C7}, wbprExtendedPictographic},   // E0.0   [2] (⛆..⛇)    RAIN..BLACK SNOWMAN
-	{runeRange{0x26C8, 0x26C8}, wbprExtendedPictographic},   // E0.7   [1] (⛈️)       cloud with lightning and rain
-	{runeRange{0x26C9, 0x26CD}, wbprExtendedPictographic},   // E0.0   [5] (⛉..⛍)    TURNED WHITE SHOGI PIECE..DISABLED CAR
-	{runeRange{0x26CE, 0x26CE}, wbprExtendedPictographic},   // E0.6   [1] (⛎)       Ophiuchus
-	{runeRange{0x26CF, 0x26CF}, wbprExtendedPictographic},   // E0.7   [1] (⛏️)       pick
-	{runeRange{0x26D0, 0x26D0}, wbprExtendedPictographic},   // E0.0   [1] (⛐)       CAR SLIDING
-	{runeRange{0x26D1, 0x26D1}, wbprExtendedPictographic},   // E0.7   [1] (⛑️)       rescue worker’s helmet
-	{runeRange{0x26D2, 0x26D2}, wbprExtendedPictographic},   // E0.0   [1] (⛒)       CIRCLED CROSSING LANES
-	{runeRange{0x26D3, 0x26D3}, wbprExtendedPictographic},   // E0.7   [1] (⛓️)       chains
-	{runeRange{0x26D4, 0x26D4}, wbprExtendedPictographic},   // E0.6   [1] (⛔)       no entry
-	{runeRange{0x26D5, 0x26E8}, wbprExtendedPictographic},   // E0.0  [20] (⛕..⛨)    ALTERNATE ONE-WAY LEFT WAY TRAFFIC..BLACK CROSS ON SHIELD
-	{runeRange{0x26E9, 0x26E9}, wbprExtendedPictographic},   // E0.7   [1] (⛩️)       shinto shrine
-	{runeRange{0x26EA, 0x26EA}, wbprExtendedPictographic},   // E0.6   [1] (⛪)       church
-	{runeRange{0x26EB, 0x26EF}, wbprExtendedPictographic},   // E0.0   [5] (⛫..⛯)    CASTLE..MAP SYMBOL FOR LIGHTHOUSE
-	{runeRange{0x26F0, 0x26F1}, wbprExtendedPictographic},   // E0.7   [2] (⛰️..⛱️)    mountain..umbrella on ground
-	{runeRange{0x26F2, 0x26F3}, wbprExtendedPictographic},   // E0.6   [2] (⛲..⛳)    fountain..flag in hole
-	{runeRange{0x26F4, 0x26F4}, wbprExtendedPictographic},   // E0.7   [1] (⛴️)       ferry
-	{runeRange{0x26F5, 0x26F5}, wbprExtendedPictographic},   // E0.6   [1] (⛵)       sailboat
-	{runeRange{0x26F6, 0x26F6}, wbprExtendedPictographic},   // E0.0   [1] (⛶)       SQUARE FOUR CORNERS
-	{runeRange{0x26F7, 0x26F9}, wbprExtendedPictographic},   // E0.7   [3] (⛷️..⛹️)    skier..person bouncing ball
-	{runeRange{0x26FA, 0x26FA}, wbprExtendedPictographic},   // E0.6   [1] (⛺)       tent
-	{runeRange{0x26FB, 0x26FC}, wbprExtendedPictographic},   // E0.0   [2] (⛻..⛼)    JAPANESE BANK SYMBOL..HEADSTONE GRAVEYARD SYMBOL
-	{runeRange{0x26FD, 0x26FD}, wbprExtendedPictographic},   // E0.6   [1] (⛽)       fuel pump
-	{runeRange{0x26FE, 0x2701}, wbprExtendedPictographic},   // E0.0   [4] (⛾..✁)    CUP ON BLACK SQUARE..UPPER BLADE SCISSORS
-	{runeRange{0x2702, 0x2702}, wbprExtendedPictographic},   // E0.6   [1] (✂️)       scissors
-	{runeRange{0x2703, 0x2704}, wbprExtendedPictographic},   // E0.0   [2] (✃..✄)    LOWER BLADE SCISSORS..WHITE SCISSORS
-	{runeRange{0x2705, 0x2705}, wbprExtendedPictographic},   // E0.6   [1] (✅)       check mark button
-	{runeRange{0x2708, 0x270C}, wbprExtendedPictographic},   // E0.6   [5] (✈️..✌️)    airplane..victory hand
-	{runeRange{0x270D, 0x270D}, wbprExtendedPictographic},   // E0.7   [1] (✍️)       writing hand
-	{runeRange{0x270E, 0x270E}, wbprExtendedPictographic},   // E0.0   [1] (✎)       LOWER RIGHT PENCIL
-	{runeRange{0x270F, 0x270F}, wbprExtendedPictographic},   // E0.6   [1] (✏️)       pencil
-	{runeRange{0x2710, 0x2711}, wbprExtendedPictographic},   // E0.0   [2] (✐..✑)    UPPER RIGHT PENCIL..WHITE NIB
-	{runeRange{0x2712, 0x2712}, wbprExtendedPictographic},   // E0.6   [1] (✒️)       black nib
-	{runeRange{0x2714, 0x2714}, wbprExtendedPictographic},   // E0.6   [1] (✔️)       check mark
-	{runeRange{0x2716, 0x2716}, wbprExtendedPictographic},   // E0.6   [1] (✖️)       multiply
-	{runeRange{0x271D, 0x271D}, wbprExtendedPictographic},   // E0.7   [1] (✝️)       latin cross
-	{runeRange{0x2721, 0x2721}, wbprExtendedPictographic},   // E0.7   [1] (✡️)       star of David
-	{runeRange{0x2728, 0x2728}, wbprExtendedPictographic},   // E0.6   [1] (✨)       sparkles
-	{runeRange{0x2733, 0x2734}, wbprExtendedPictographic},   // E0.6   [2] (✳️..✴️)    eight-spoked asterisk..eight-pointed star
-	{runeRange{0x2744, 0x2744}, wbprExtendedPictographic},   // E0.6   [1] (❄️)       snowflake
-	{runeRange{0x2747, 0x2747}, wbprExtendedPictographic},   // E0.6   [1] (❇️)       sparkle
-	{runeRange{0x274C, 0x274C}, wbprExtendedPictographic},   // E0.6   [1] (❌)       cross mark
-	{runeRange{0x274E, 0x274E}, wbprExtendedPictographic},   // E0.6   [1] (❎)       cross mark button
-	{runeRange{0x2753, 0x2755}, wbprExtendedPictographic},   // E0.6   [3] (❓..❕)    red question mark..white exclamation mark
-	{runeRange{0x2757, 0x2757}, wbprExtendedPictographic},   // E0.6   [1] (❗)       red exclamation mark
-	{runeRange{0x2763, 0x2763}, wbprExtendedPictographic},   // E1.0   [1] (❣️)       heart exclamation
-	{runeRange{0x2764, 0x2764}, wbprExtendedPictographic},   // E0.6   [1] (❤️)       red heart
-	{runeRange{0x2765, 0x2767}, wbprExtendedPictographic},   // E0.0   [3] (❥..❧)    ROTATED HEAVY BLACK HEART BULLET..ROTATED FLORAL HEART BULLET
-	{runeRange{0x2795, 0x2797}, wbprExtendedPictographic},   // E0.6   [3] (➕..➗)    plus..divide
-	{runeRange{0x27A1, 0x27A1}, wbprExtendedPictographic},   // E0.6   [1] (➡️)       right arrow
-	{runeRange{0x27B0, 0x27B0}, wbprExtendedPictographic},   // E0.6   [1] (➰)       curly loop
-	{runeRange{0x27BF, 0x27BF}, wbprExtendedPictographic},   // E1.0   [1] (➿)       double curly loop
-	{runeRange{0x2934, 0x2935}, wbprExtendedPictographic},   // E0.6   [2] (⤴️..⤵️)    right arrow curving up..right arrow curving down
-	{runeRange{0x2B05, 0x2B07}, wbprExtendedPictographic},   // E0.6   [3] (⬅️..⬇️)    left arrow..down arrow
-	{runeRange{0x2B1B, 0x2B1C}, wbprExtendedPictographic},   // E0.6   [2] (⬛..⬜)    black large square..white large square
-	{runeRange{0x2B50, 0x2B50}, wbprExtendedPictographic},   // E0.6   [1] (⭐)       star
-	{runeRange{0x2B55, 0x2B55}, wbprExtendedPictographic},   // E0.6   [1] (⭕)       hollow red circle
-	{runeRange{0x2C00, 0x2C7B}, wbprALetter},                // L& [124] GLAGOLITIC CAPITAL LETTER AZU..LATIN LETTER SMALL CAPITAL TURNED E
-	{runeRange{0x2C7C, 0x2C7D}, wbprALetter},                // Lm   [2] LATIN SUBSCRIPT SMALL LETTER J..MODIFIER LETTER CAPITAL V
-	{runeRange{0x2C7E, 0x2CE4}, wbprALetter},                // L& [103] LATIN CAPITAL LETTER S WITH SWASH TAIL..COPTIC SYMBOL KAI
-	{runeRange{0x2CEB, 0x2CEE}, wbprALetter},                // L&   [4] COPTIC CAPITAL LETTER CRYPTOGRAMMIC SHEI..COPTIC SMALL LETTER CRYPTOGRAMMIC GANGIA
-	{runeRange{0x2CEF, 0x2CF1}, wbprExtend},                 // Mn   [3] COPTIC COMBINING NI ABOVE..COPTIC COMBINING SPIRITUS LENIS
-	{runeRange{0x2CF2, 0x2CF3}, wbprALetter},                // L&   [2] COPTIC CAPITAL LETTER BOHAIRIC KHEI..COPTIC SMALL LETTER BOHAIRIC KHEI
-	{runeRange{0x2D00, 0x2D25}, wbprALetter},                // L&  [38] GEORGIAN SMALL LETTER AN..GEORGIAN SMALL LETTER HOE
-	{runeRange{0x2D27, 0x2D27}, wbprALetter},                // L&       GEORGIAN SMALL LETTER YN
-	{runeRange{0x2D2D, 0x2D2D}, wbprALetter},                // L&       GEORGIAN SMALL LETTER AEN
-	{runeRange{0x2D30, 0x2D67}, wbprALetter},                // Lo  [56] TIFINAGH LETTER YA..TIFINAGH LETTER YO
-	{runeRange{0x2D6F, 0x2D6F}, wbprALetter},                // Lm       TIFINAGH MODIFIER LETTER LABIALIZATION MARK
-	{runeRange{0x2D7F, 0x2D7F}, wbprExtend},                 // Mn       TIFINAGH CONSONANT JOINER
-	{runeRange{0x2D80, 0x2D96}, wbprALetter},                // Lo  [23] ETHIOPIC SYLLABLE LOA..ETHIOPIC SYLLABLE GGWE
-	{runeRange{0x2DA0, 0x2DA6}, wbprALetter},                // Lo   [7] ETHIOPIC SYLLABLE SSA..ETHIOPIC SYLLABLE SSO
-	{runeRange{0x2DA8, 0x2DAE}, wbprALetter},                // Lo   [7] ETHIOPIC SYLLABLE CCA..ETHIOPIC SYLLABLE CCO
-	{runeRange{0x2DB0, 0x2DB6}, wbprALetter},                // Lo   [7] ETHIOPIC SYLLABLE ZZA..ETHIOPIC SYLLABLE ZZO
-	{runeRange{0x2DB8, 0x2DBE}, wbprALetter},                // Lo   [7] ETHIOPIC SYLLABLE CCHA..ETHIOPIC SYLLABLE CCHO
-	{runeRange{0x2DC0, 0x2DC6}, wbprALetter},                // Lo   [7] ETHIOPIC SYLLABLE QYA..ETHIOPIC SYLLABLE QYO
-	{runeRange{0x2DC8, 0x2DCE}, wbprALetter},                // Lo   [7] ETHIOPIC SYLLABLE KYA..ETHIOPIC SYLLABLE KYO
-	{runeRange{0x2DD0, 0x2DD6}, wbprALetter},                // Lo   [7] ETHIOPIC SYLLABLE XYA..ETHIOPIC SYLLABLE XYO
-	{runeRange{0x2DD8, 0x2DDE}, wbprALetter},                // Lo   [7] ETHIOPIC SYLLABLE GYA..ETHIOPIC SYLLABLE GYO
-	{runeRange{0x2DE0, 0x2DFF}, wbprExtend},                 // Mn  [32] COMBINING CYRILLIC LETTER BE..COMBINING CYRILLIC LETTER IOTIFIED BIG YUS
-	{runeRange{0x2E2F, 0x2E2F}, wbprALetter},                // Lm       VERTICAL TILDE
-	{runeRange{0x3000, 0x3000}, wbprWSegSpace},              // Zs       IDEOGRAPHIC SPACE
-	{runeRange{0x3005, 0x3005}, wbprALetter},                // Lm       IDEOGRAPHIC ITERATION MARK
-	{runeRange{0x302A, 0x302D}, wbprExtend},                 // Mn   [4] IDEOGRAPHIC LEVEL TONE MARK..IDEOGRAPHIC ENTERING TONE MARK
-	{runeRange{0x302E, 0x302F}, wbprExtend},                 // Mc   [2] HANGUL SINGLE DOT TONE MARK..HANGUL DOUBLE DOT TONE MARK
-	{runeRange{0x3030, 0x3030}, wbprExtendedPictographic},   // E0.6   [1] (〰️)       wavy dash
-	{runeRange{0x3031, 0x3035}, wbprKatakana},               // Lm   [5] VERTICAL KANA REPEAT MARK..VERTICAL KANA REPEAT MARK LOWER HALF
-	{runeRange{0x303B, 0x303B}, wbprALetter},                // Lm       VERTICAL IDEOGRAPHIC ITERATION MARK
-	{runeRange{0x303C, 0x303C}, wbprALetter},                // Lo       MASU MARK
-	{runeRange{0x303D, 0x303D}, wbprExtendedPictographic},   // E0.6   [1] (〽️)       part alternation mark
-	{runeRange{0x3099, 0x309A}, wbprExtend},                 // Mn   [2] COMBINING KATAKANA-HIRAGANA VOICED SOUND MARK..COMBINING KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK
-	{runeRange{0x309B, 0x309C}, wbprKatakana},               // Sk   [2] KATAKANA-HIRAGANA VOICED SOUND MARK..KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK
-	{runeRange{0x30A0, 0x30A0}, wbprKatakana},               // Pd       KATAKANA-HIRAGANA DOUBLE HYPHEN
-	{runeRange{0x30A1, 0x30FA}, wbprKatakana},               // Lo  [90] KATAKANA LETTER SMALL A..KATAKANA LETTER VO
-	{runeRange{0x30FC, 0x30FE}, wbprKatakana},               // Lm   [3] KATAKANA-HIRAGANA PROLONGED SOUND MARK..KATAKANA VOICED ITERATION MARK
-	{runeRange{0x30FF, 0x30FF}, wbprKatakana},               // Lo       KATAKANA DIGRAPH KOTO
-	{runeRange{0x3105, 0x312F}, wbprALetter},                // Lo  [43] BOPOMOFO LETTER B..BOPOMOFO LETTER NN
-	{runeRange{0x3131, 0x318E}, wbprALetter},                // Lo  [94] HANGUL LETTER KIYEOK..HANGUL LETTER ARAEAE
-	{runeRange{0x31A0, 0x31BF}, wbprALetter},                // Lo  [32] BOPOMOFO LETTER BU..BOPOMOFO LETTER AH
-	{runeRange{0x31F0, 0x31FF}, wbprKatakana},               // Lo  [16] KATAKANA LETTER SMALL KU..KATAKANA LETTER SMALL RO
-	{runeRange{0x3297, 0x3297}, wbprExtendedPictographic},   // E0.6   [1] (㊗️)       Japanese “congratulations” button
-	{runeRange{0x3299, 0x3299}, wbprExtendedPictographic},   // E0.6   [1] (㊙️)       Japanese “secret” button
-	{runeRange{0x32D0, 0x32FE}, wbprKatakana},               // So  [47] CIRCLED KATAKANA A..CIRCLED KATAKANA WO
-	{runeRange{0x3300, 0x3357}, wbprKatakana},               // So  [88] SQUARE APAATO..SQUARE WATTO
-	{runeRange{0xA000, 0xA014}, wbprALetter},                // Lo  [21] YI SYLLABLE IT..YI SYLLABLE E
-	{runeRange{0xA015, 0xA015}, wbprALetter},                // Lm       YI SYLLABLE WU
-	{runeRange{0xA016, 0xA48C}, wbprALetter},                // Lo [1143] YI SYLLABLE BIT..YI SYLLABLE YYR
-	{runeRange{0xA4D0, 0xA4F7}, wbprALetter},                // Lo  [40] LISU LETTER BA..LISU LETTER OE
-	{runeRange{0xA4F8, 0xA4FD}, wbprALetter},                // Lm   [6] LISU LETTER TONE MYA TI..LISU LETTER TONE MYA JEU
-	{runeRange{0xA500, 0xA60B}, wbprALetter},                // Lo [268] VAI SYLLABLE EE..VAI SYLLABLE NG
-	{runeRange{0xA60C, 0xA60C}, wbprALetter},                // Lm       VAI SYLLABLE LENGTHENER
-	{runeRange{0xA610, 0xA61F}, wbprALetter},                // Lo  [16] VAI SYLLABLE NDOLE FA..VAI SYMBOL JONG
-	{runeRange{0xA620, 0xA629}, wbprNumeric},                // Nd  [10] VAI DIGIT ZERO..VAI DIGIT NINE
-	{runeRange{0xA62A, 0xA62B}, wbprALetter},                // Lo   [2] VAI SYLLABLE NDOLE MA..VAI SYLLABLE NDOLE DO
-	{runeRange{0xA640, 0xA66D}, wbprALetter},                // L&  [46] CYRILLIC CAPITAL LETTER ZEMLYA..CYRILLIC SMALL LETTER DOUBLE MONOCULAR O
-	{runeRange{0xA66E, 0xA66E}, wbprALetter},                // Lo       CYRILLIC LETTER MULTIOCULAR O
-	{runeRange{0xA66F, 0xA66F}, wbprExtend},                 // Mn       COMBINING CYRILLIC VZMET
-	{runeRange{0xA670, 0xA672}, wbprExtend},                 // Me   [3] COMBINING CYRILLIC TEN MILLIONS SIGN..COMBINING CYRILLIC THOUSAND MILLIONS SIGN
-	{runeRange{0xA674, 0xA67D}, wbprExtend},                 // Mn  [10] COMBINING CYRILLIC LETTER UKRAINIAN IE..COMBINING CYRILLIC PAYEROK
-	{runeRange{0xA67F, 0xA67F}, wbprALetter},                // Lm       CYRILLIC PAYEROK
-	{runeRange{0xA680, 0xA69B}, wbprALetter},                // L&  [28] CYRILLIC CAPITAL LETTER DWE..CYRILLIC SMALL LETTER CROSSED O
-	{runeRange{0xA69C, 0xA69D}, wbprALetter},                // Lm   [2] MODIFIER LETTER CYRILLIC HARD SIGN..MODIFIER LETTER CYRILLIC SOFT SIGN
-	{runeRange{0xA69E, 0xA69F}, wbprExtend},                 // Mn   [2] COMBINING CYRILLIC LETTER EF..COMBINING CYRILLIC LETTER IOTIFIED E
-	{runeRange{0xA6A0, 0xA6E5}, wbprALetter},                // Lo  [70] BAMUM LETTER A..BAMUM LETTER KI
-	{runeRange{0xA6E6, 0xA6EF}, wbprALetter},                // Nl  [10] BAMUM LETTER MO..BAMUM LETTER KOGHOM
-	{runeRange{0xA6F0, 0xA6F1}, wbprExtend},                 // Mn   [2] BAMUM COMBINING MARK KOQNDON..BAMUM COMBINING MARK TUKWENTIS
-	{runeRange{0xA708, 0xA716}, wbprALetter},                // Sk  [15] MODIFIER LETTER EXTRA-HIGH DOTTED TONE BAR..MODIFIER LETTER EXTRA-LOW LEFT-STEM TONE BAR
-	{runeRange{0xA717, 0xA71F}, wbprALetter},                // Lm   [9] MODIFIER LETTER DOT VERTICAL BAR..MODIFIER LETTER LOW INVERTED EXCLAMATION MARK
-	{runeRange{0xA720, 0xA721}, wbprALetter},                // Sk   [2] MODIFIER LETTER STRESS AND HIGH TONE..MODIFIER LETTER STRESS AND LOW TONE
-	{runeRange{0xA722, 0xA76F}, wbprALetter},                // L&  [78] LATIN CAPITAL LETTER EGYPTOLOGICAL ALEF..LATIN SMALL LETTER CON
-	{runeRange{0xA770, 0xA770}, wbprALetter},                // Lm       MODIFIER LETTER US
-	{runeRange{0xA771, 0xA787}, wbprALetter},                // L&  [23] LATIN SMALL LETTER DUM..LATIN SMALL LETTER INSULAR T
-	{runeRange{0xA788, 0xA788}, wbprALetter},                // Lm       MODIFIER LETTER LOW CIRCUMFLEX ACCENT
-	{runeRange{0xA789, 0xA78A}, wbprALetter},                // Sk   [2] MODIFIER LETTER COLON..MODIFIER LETTER SHORT EQUALS SIGN
-	{runeRange{0xA78B, 0xA78E}, wbprALetter},                // L&   [4] LATIN CAPITAL LETTER SALTILLO..LATIN SMALL LETTER L WITH RETROFLEX HOOK AND BELT
-	{runeRange{0xA78F, 0xA78F}, wbprALetter},                // Lo       LATIN LETTER SINOLOGICAL DOT
-	{runeRange{0xA790, 0xA7CA}, wbprALetter},                // L&  [59] LATIN CAPITAL LETTER N WITH DESCENDER..LATIN SMALL LETTER S WITH SHORT STROKE OVERLAY
-	{runeRange{0xA7D0, 0xA7D1}, wbprALetter},                // L&   [2] LATIN CAPITAL LETTER CLOSED INSULAR G..LATIN SMALL LETTER CLOSED INSULAR G
-	{runeRange{0xA7D3, 0xA7D3}, wbprALetter},                // L&       LATIN SMALL LETTER DOUBLE THORN
-	{runeRange{0xA7D5, 0xA7D9}, wbprALetter},                // L&   [5] LATIN SMALL LETTER DOUBLE WYNN..LATIN SMALL LETTER SIGMOID S
-	{runeRange{0xA7F2, 0xA7F4}, wbprALetter},                // Lm   [3] MODIFIER LETTER CAPITAL C..MODIFIER LETTER CAPITAL Q
-	{runeRange{0xA7F5, 0xA7F6}, wbprALetter},                // L&   [2] LATIN CAPITAL LETTER REVERSED HALF H..LATIN SMALL LETTER REVERSED HALF H
-	{runeRange{0xA7F7, 0xA7F7}, wbprALetter},                // Lo       LATIN EPIGRAPHIC LETTER SIDEWAYS I
-	{runeRange{0xA7F8, 0xA7F9}, wbprALetter},                // Lm   [2] MODIFIER LETTER CAPITAL H WITH STROKE..MODIFIER LETTER SMALL LIGATURE OE
-	{runeRange{0xA7FA, 0xA7FA}, wbprALetter},                // L&       LATIN LETTER SMALL CAPITAL TURNED M
-	{runeRange{0xA7FB, 0xA801}, wbprALetter},                // Lo   [7] LATIN EPIGRAPHIC LETTER REVERSED F..SYLOTI NAGRI LETTER I
-	{runeRange{0xA802, 0xA802}, wbprExtend},                 // Mn       SYLOTI NAGRI SIGN DVISVARA
-	{runeRange{0xA803, 0xA805}, wbprALetter},                // Lo   [3] SYLOTI NAGRI LETTER U..SYLOTI NAGRI LETTER O
-	{runeRange{0xA806, 0xA806}, wbprExtend},                 // Mn       SYLOTI NAGRI SIGN HASANTA
-	{runeRange{0xA807, 0xA80A}, wbprALetter},                // Lo   [4] SYLOTI NAGRI LETTER KO..SYLOTI NAGRI LETTER GHO
-	{runeRange{0xA80B, 0xA80B}, wbprExtend},                 // Mn       SYLOTI NAGRI SIGN ANUSVARA
-	{runeRange{0xA80C, 0xA822}, wbprALetter},                // Lo  [23] SYLOTI NAGRI LETTER CO..SYLOTI NAGRI LETTER HO
-	{runeRange{0xA823, 0xA824}, wbprExtend},                 // Mc   [2] SYLOTI NAGRI VOWEL SIGN A..SYLOTI NAGRI VOWEL SIGN I
-	{runeRange{0xA825, 0xA826}, wbprExtend},                 // Mn   [2] SYLOTI NAGRI VOWEL SIGN U..SYLOTI NAGRI VOWEL SIGN E
-	{runeRange{0xA827, 0xA827}, wbprExtend},                 // Mc       SYLOTI NAGRI VOWEL SIGN OO
-	{runeRange{0xA82C, 0xA82C}, wbprExtend},                 // Mn       SYLOTI NAGRI SIGN ALTERNATE HASANTA
-	{runeRange{0xA840, 0xA873}, wbprALetter},                // Lo  [52] PHAGS-PA LETTER KA..PHAGS-PA LETTER CANDRABINDU
-	{runeRange{0xA880, 0xA881}, wbprExtend},                 // Mc   [2] SAURASHTRA SIGN ANUSVARA..SAURASHTRA SIGN VISARGA
-	{runeRange{0xA882, 0xA8B3}, wbprALetter},                // Lo  [50] SAURASHTRA LETTER A..SAURASHTRA LETTER LLA
-	{runeRange{0xA8B4, 0xA8C3}, wbprExtend},                 // Mc  [16] SAURASHTRA CONSONANT SIGN HAARU..SAURASHTRA VOWEL SIGN AU
-	{runeRange{0xA8C4, 0xA8C5}, wbprExtend},                 // Mn   [2] SAURASHTRA SIGN VIRAMA..SAURASHTRA SIGN CANDRABINDU
-	{runeRange{0xA8D0, 0xA8D9}, wbprNumeric},                // Nd  [10] SAURASHTRA DIGIT ZERO..SAURASHTRA DIGIT NINE
-	{runeRange{0xA8E0, 0xA8F1}, wbprExtend},                 // Mn  [18] COMBINING DEVANAGARI DIGIT ZERO..COMBINING DEVANAGARI SIGN AVAGRAHA
-	{runeRange{0xA8F2, 0xA8F7}, wbprALetter},                // Lo   [6] DEVANAGARI SIGN SPACING CANDRABINDU..DEVANAGARI SIGN CANDRABINDU AVAGRAHA
-	{runeRange{0xA8FB, 0xA8FB}, wbprALetter},                // Lo       DEVANAGARI HEADSTROKE
-	{runeRange{0xA8FD, 0xA8FE}, wbprALetter},                // Lo   [2] DEVANAGARI JAIN OM..DEVANAGARI LETTER AY
-	{runeRange{0xA8FF, 0xA8FF}, wbprExtend},                 // Mn       DEVANAGARI VOWEL SIGN AY
-	{runeRange{0xA900, 0xA909}, wbprNumeric},                // Nd  [10] KAYAH LI DIGIT ZERO..KAYAH LI DIGIT NINE
-	{runeRange{0xA90A, 0xA925}, wbprALetter},                // Lo  [28] KAYAH LI LETTER KA..KAYAH LI LETTER OO
-	{runeRange{0xA926, 0xA92D}, wbprExtend},                 // Mn   [8] KAYAH LI VOWEL UE..KAYAH LI TONE CALYA PLOPHU
-	{runeRange{0xA930, 0xA946}, wbprALetter},                // Lo  [23] REJANG LETTER KA..REJANG LETTER A
-	{runeRange{0xA947, 0xA951}, wbprExtend},                 // Mn  [11] REJANG VOWEL SIGN I..REJANG CONSONANT SIGN R
-	{runeRange{0xA952, 0xA953}, wbprExtend},                 // Mc   [2] REJANG CONSONANT SIGN H..REJANG VIRAMA
-	{runeRange{0xA960, 0xA97C}, wbprALetter},                // Lo  [29] HANGUL CHOSEONG TIKEUT-MIEUM..HANGUL CHOSEONG SSANGYEORINHIEUH
-	{runeRange{0xA980, 0xA982}, wbprExtend},                 // Mn   [3] JAVANESE SIGN PANYANGGA..JAVANESE SIGN LAYAR
-	{runeRange{0xA983, 0xA983}, wbprExtend},                 // Mc       JAVANESE SIGN WIGNYAN
-	{runeRange{0xA984, 0xA9B2}, wbprALetter},                // Lo  [47] JAVANESE LETTER A..JAVANESE LETTER HA
-	{runeRange{0xA9B3, 0xA9B3}, wbprExtend},                 // Mn       JAVANESE SIGN CECAK TELU
-	{runeRange{0xA9B4, 0xA9B5}, wbprExtend},                 // Mc   [2] JAVANESE VOWEL SIGN TARUNG..JAVANESE VOWEL SIGN TOLONG
-	{runeRange{0xA9B6, 0xA9B9}, wbprExtend},                 // Mn   [4] JAVANESE VOWEL SIGN WULU..JAVANESE VOWEL SIGN SUKU MENDUT
-	{runeRange{0xA9BA, 0xA9BB}, wbprExtend},                 // Mc   [2] JAVANESE VOWEL SIGN TALING..JAVANESE VOWEL SIGN DIRGA MURE
-	{runeRange{0xA9BC, 0xA9BD}, wbprExtend},                 // Mn   [2] JAVANESE VOWEL SIGN PEPET..JAVANESE CONSONANT SIGN KERET
-	{runeRange{0xA9BE, 0xA9C0}, wbprExtend},                 // Mc   [3] JAVANESE CONSONANT SIGN PENGKAL..JAVANESE PANGKON
-	{runeRange{0xA9CF, 0xA9CF}, wbprALetter},                // Lm       JAVANESE PANGRANGKEP
-	{runeRange{0xA9D0, 0xA9D9}, wbprNumeric},                // Nd  [10] JAVANESE DIGIT ZERO..JAVANESE DIGIT NINE
-	{runeRange{0xA9E5, 0xA9E5}, wbprExtend},                 // Mn       MYANMAR SIGN SHAN SAW
-	{runeRange{0xA9F0, 0xA9F9}, wbprNumeric},                // Nd  [10] MYANMAR TAI LAING DIGIT ZERO..MYANMAR TAI LAING DIGIT NINE
-	{runeRange{0xAA00, 0xAA28}, wbprALetter},                // Lo  [41] CHAM LETTER A..CHAM LETTER HA
-	{runeRange{0xAA29, 0xAA2E}, wbprExtend},                 // Mn   [6] CHAM VOWEL SIGN AA..CHAM VOWEL SIGN OE
-	{runeRange{0xAA2F, 0xAA30}, wbprExtend},                 // Mc   [2] CHAM VOWEL SIGN O..CHAM VOWEL SIGN AI
-	{runeRange{0xAA31, 0xAA32}, wbprExtend},                 // Mn   [2] CHAM VOWEL SIGN AU..CHAM VOWEL SIGN UE
-	{runeRange{0xAA33, 0xAA34}, wbprExtend},                 // Mc   [2] CHAM CONSONANT SIGN YA..CHAM CONSONANT SIGN RA
-	{runeRange{0xAA35, 0xAA36}, wbprExtend},                 // Mn   [2] CHAM CONSONANT SIGN LA..CHAM CONSONANT SIGN WA
-	{runeRange{0xAA40, 0xAA42}, wbprALetter},                // Lo   [3] CHAM LETTER FINAL K..CHAM LETTER FINAL NG
-	{runeRange{0xAA43, 0xAA43}, wbprExtend},                 // Mn       CHAM CONSONANT SIGN FINAL NG
-	{runeRange{0xAA44, 0xAA4B}, wbprALetter},                // Lo   [8] CHAM LETTER FINAL CH..CHAM LETTER FINAL SS
-	{runeRange{0xAA4C, 0xAA4C}, wbprExtend},                 // Mn       CHAM CONSONANT SIGN FINAL M
-	{runeRange{0xAA4D, 0xAA4D}, wbprExtend},                 // Mc       CHAM CONSONANT SIGN FINAL H
-	{runeRange{0xAA50, 0xAA59}, wbprNumeric},                // Nd  [10] CHAM DIGIT ZERO..CHAM DIGIT NINE
-	{runeRange{0xAA7B, 0xAA7B}, wbprExtend},                 // Mc       MYANMAR SIGN PAO KAREN TONE
-	{runeRange{0xAA7C, 0xAA7C}, wbprExtend},                 // Mn       MYANMAR SIGN TAI LAING TONE-2
-	{runeRange{0xAA7D, 0xAA7D}, wbprExtend},                 // Mc       MYANMAR SIGN TAI LAING TONE-5
-	{runeRange{0xAAB0, 0xAAB0}, wbprExtend},                 // Mn       TAI VIET MAI KANG
-	{runeRange{0xAAB2, 0xAAB4}, wbprExtend},                 // Mn   [3] TAI VIET VOWEL I..TAI VIET VOWEL U
-	{runeRange{0xAAB7, 0xAAB8}, wbprExtend},                 // Mn   [2] TAI VIET MAI KHIT..TAI VIET VOWEL IA
-	{runeRange{0xAABE, 0xAABF}, wbprExtend},                 // Mn   [2] TAI VIET VOWEL AM..TAI VIET TONE MAI EK
-	{runeRange{0xAAC1, 0xAAC1}, wbprExtend},                 // Mn       TAI VIET TONE MAI THO
-	{runeRange{0xAAE0, 0xAAEA}, wbprALetter},                // Lo  [11] MEETEI MAYEK LETTER E..MEETEI MAYEK LETTER SSA
-	{runeRange{0xAAEB, 0xAAEB}, wbprExtend},                 // Mc       MEETEI MAYEK VOWEL SIGN II
-	{runeRange{0xAAEC, 0xAAED}, wbprExtend},                 // Mn   [2] MEETEI MAYEK VOWEL SIGN UU..MEETEI MAYEK VOWEL SIGN AAI
-	{runeRange{0xAAEE, 0xAAEF}, wbprExtend},                 // Mc   [2] MEETEI MAYEK VOWEL SIGN AU..MEETEI MAYEK VOWEL SIGN AAU
-	{runeRange{0xAAF2, 0xAAF2}, wbprALetter},                // Lo       MEETEI MAYEK ANJI
-	{runeRange{0xAAF3, 0xAAF4}, wbprALetter},                // Lm   [2] MEETEI MAYEK SYLLABLE REPETITION MARK..MEETEI MAYEK WORD REPETITION MARK
-	{runeRange{0xAAF5, 0xAAF5}, wbprExtend},                 // Mc       MEETEI MAYEK VOWEL SIGN VISARGA
-	{runeRange{0xAAF6, 0xAAF6}, wbprExtend},                 // Mn       MEETEI MAYEK VIRAMA
-	{runeRange{0xAB01, 0xAB06}, wbprALetter},                // Lo   [6] ETHIOPIC SYLLABLE TTHU..ETHIOPIC SYLLABLE TTHO
-	{runeRange{0xAB09, 0xAB0E}, wbprALetter},                // Lo   [6] ETHIOPIC SYLLABLE DDHU..ETHIOPIC SYLLABLE DDHO
-	{runeRange{0xAB11, 0xAB16}, wbprALetter},                // Lo   [6] ETHIOPIC SYLLABLE DZU..ETHIOPIC SYLLABLE DZO
-	{runeRange{0xAB20, 0xAB26}, wbprALetter},                // Lo   [7] ETHIOPIC SYLLABLE CCHHA..ETHIOPIC SYLLABLE CCHHO
-	{runeRange{0xAB28, 0xAB2E}, wbprALetter},                // Lo   [7] ETHIOPIC SYLLABLE BBA..ETHIOPIC SYLLABLE BBO
-	{runeRange{0xAB30, 0xAB5A}, wbprALetter},                // L&  [43] LATIN SMALL LETTER BARRED ALPHA..LATIN SMALL LETTER Y WITH SHORT RIGHT LEG
-	{runeRange{0xAB5B, 0xAB5B}, wbprALetter},                // Sk       MODIFIER BREVE WITH INVERTED BREVE
-	{runeRange{0xAB5C, 0xAB5F}, wbprALetter},                // Lm   [4] MODIFIER LETTER SMALL HENG..MODIFIER LETTER SMALL U WITH LEFT HOOK
-	{runeRange{0xAB60, 0xAB68}, wbprALetter},                // L&   [9] LATIN SMALL LETTER SAKHA YAT..LATIN SMALL LETTER TURNED R WITH MIDDLE TILDE
-	{runeRange{0xAB69, 0xAB69}, wbprALetter},                // Lm       MODIFIER LETTER SMALL TURNED W
-	{runeRange{0xAB70, 0xABBF}, wbprALetter},                // L&  [80] CHEROKEE SMALL LETTER A..CHEROKEE SMALL LETTER YA
-	{runeRange{0xABC0, 0xABE2}, wbprALetter},                // Lo  [35] MEETEI MAYEK LETTER KOK..MEETEI MAYEK LETTER I LONSUM
-	{runeRange{0xABE3, 0xABE4}, wbprExtend},                 // Mc   [2] MEETEI MAYEK VOWEL SIGN ONAP..MEETEI MAYEK VOWEL SIGN INAP
-	{runeRange{0xABE5, 0xABE5}, wbprExtend},                 // Mn       MEETEI MAYEK VOWEL SIGN ANAP
-	{runeRange{0xABE6, 0xABE7}, wbprExtend},                 // Mc   [2] MEETEI MAYEK VOWEL SIGN YENAP..MEETEI MAYEK VOWEL SIGN SOUNAP
-	{runeRange{0xABE8, 0xABE8}, wbprExtend},                 // Mn       MEETEI MAYEK VOWEL SIGN UNAP
-	{runeRange{0xABE9, 0xABEA}, wbprExtend},                 // Mc   [2] MEETEI MAYEK VOWEL SIGN CHEINAP..MEETEI MAYEK VOWEL SIGN NUNG
-	{runeRange{0xABEC, 0xABEC}, wbprExtend},                 // Mc       MEETEI MAYEK LUM IYEK
-	{runeRange{0xABED, 0xABED}, wbprExtend},                 // Mn       MEETEI MAYEK APUN IYEK
-	{runeRange{0xABF0, 0xABF9}, wbprNumeric},                // Nd  [10] MEETEI MAYEK DIGIT ZERO..MEETEI MAYEK DIGIT NINE
-	{runeRange{0xAC00, 0xD7A3}, wbprALetter},                // Lo [11172] HANGUL SYLLABLE GA..HANGUL SYLLABLE HIH
-	{runeRange{0xD7B0, 0xD7C6}, wbprALetter},                // Lo  [23] HANGUL JUNGSEONG O-YEO..HANGUL JUNGSEONG ARAEA-E
-	{runeRange{0xD7CB, 0xD7FB}, wbprALetter},                // Lo  [49] HANGUL JONGSEONG NIEUN-RIEUL..HANGUL JONGSEONG PHIEUPH-THIEUTH
-	{runeRange{0xFB00, 0xFB06}, wbprALetter},                // L&   [7] LATIN SMALL LIGATURE FF..LATIN SMALL LIGATURE ST
-	{runeRange{0xFB13, 0xFB17}, wbprALetter},                // L&   [5] ARMENIAN SMALL LIGATURE MEN NOW..ARMENIAN SMALL LIGATURE MEN XEH
-	{runeRange{0xFB1D, 0xFB1D}, wbprHebrewLetter},           // Lo       HEBREW LETTER YOD WITH HIRIQ
-	{runeRange{0xFB1E, 0xFB1E}, wbprExtend},                 // Mn       HEBREW POINT JUDEO-SPANISH VARIKA
-	{runeRange{0xFB1F, 0xFB28}, wbprHebrewLetter},           // Lo  [10] HEBREW LIGATURE YIDDISH YOD YOD PATAH..HEBREW LETTER WIDE TAV
-	{runeRange{0xFB2A, 0xFB36}, wbprHebrewLetter},           // Lo  [13] HEBREW LETTER SHIN WITH SHIN DOT..HEBREW LETTER ZAYIN WITH DAGESH
-	{runeRange{0xFB38, 0xFB3C}, wbprHebrewLetter},           // Lo   [5] HEBREW LETTER TET WITH DAGESH..HEBREW LETTER LAMED WITH DAGESH
-	{runeRange{0xFB3E, 0xFB3E}, wbprHebrewLetter},           // Lo       HEBREW LETTER MEM WITH DAGESH
-	{runeRange{0xFB40, 0xFB41}, wbprHebrewLetter},           // Lo   [2] HEBREW LETTER NUN WITH DAGESH..HEBREW LETTER SAMEKH WITH DAGESH
-	{runeRange{0xFB43, 0xFB44}, wbprHebrewLetter},           // Lo   [2] HEBREW LETTER FINAL PE WITH DAGESH..HEBREW LETTER PE WITH DAGESH
-	{runeRange{0xFB46, 0xFB4F}, wbprHebrewLetter},           // Lo  [10] HEBREW LETTER TSADI WITH DAGESH..HEBREW LIGATURE ALEF LAMED
-	{runeRange{0xFB50, 0xFBB1}, wbprALetter},                // Lo  [98] ARABIC LETTER ALEF WASLA ISOLATED FORM..ARABIC LETTER YEH BARREE WITH HAMZA ABOVE FINAL FORM
-	{runeRange{0xFBD3, 0xFD3D}, wbprALetter},                // Lo [363] ARABIC LETTER NG ISOLATED FORM..ARABIC LIGATURE ALEF WITH FATHATAN ISOLATED FORM
-	{runeRange{0xFD50, 0xFD8F}, wbprALetter},                // Lo  [64] ARABIC LIGATURE TEH WITH JEEM WITH MEEM INITIAL FORM..ARABIC LIGATURE MEEM WITH KHAH WITH MEEM INITIAL FORM
-	{runeRange{0xFD92, 0xFDC7}, wbprALetter},                // Lo  [54] ARABIC LIGATURE MEEM WITH JEEM WITH KHAH INITIAL FORM..ARABIC LIGATURE NOON WITH JEEM WITH YEH FINAL FORM
-	{runeRange{0xFDF0, 0xFDFB}, wbprALetter},                // Lo  [12] ARABIC LIGATURE SALLA USED AS KORANIC STOP SIGN ISOLATED FORM..ARABIC LIGATURE JALLAJALALOUHOU
-	{runeRange{0xFE00, 0xFE0F}, wbprExtend},                 // Mn  [16] VARIATION SELECTOR-1..VARIATION SELECTOR-16
-	{runeRange{0xFE10, 0xFE10}, wbprMidNum},                 // Po       PRESENTATION FORM FOR VERTICAL COMMA
-	{runeRange{0xFE13, 0xFE13}, wbprMidLetter},              // Po       PRESENTATION FORM FOR VERTICAL COLON
-	{runeRange{0xFE14, 0xFE14}, wbprMidNum},                 // Po       PRESENTATION FORM FOR VERTICAL SEMICOLON
-	{runeRange{0xFE20, 0xFE2F}, wbprExtend},                 // Mn  [16] COMBINING LIGATURE LEFT HALF..COMBINING CYRILLIC TITLO RIGHT HALF
-	{runeRange{0xFE33, 0xFE34}, wbprExtendNumLet},           // Pc   [2] PRESENTATION FORM FOR VERTICAL LOW LINE..PRESENTATION FORM FOR VERTICAL WAVY LOW LINE
-	{runeRange{0xFE4D, 0xFE4F}, wbprExtendNumLet},           // Pc   [3] DASHED LOW LINE..WAVY LOW LINE
-	{runeRange{0xFE50, 0xFE50}, wbprMidNum},                 // Po       SMALL COMMA
-	{runeRange{0xFE52, 0xFE52}, wbprMidNumLet},              // Po       SMALL FULL STOP
-	{runeRange{0xFE54, 0xFE54}, wbprMidNum},                 // Po       SMALL SEMICOLON
-	{runeRange{0xFE55, 0xFE55}, wbprMidLetter},              // Po       SMALL COLON
-	{runeRange{0xFE70, 0xFE74}, wbprALetter},                // Lo   [5] ARABIC FATHATAN ISOLATED FORM..ARABIC KASRATAN ISOLATED FORM
-	{runeRange{0xFE76, 0xFEFC}, wbprALetter},                // Lo [135] ARABIC FATHA ISOLATED FORM..ARABIC LIGATURE LAM WITH ALEF FINAL FORM
-	{runeRange{0xFEFF, 0xFEFF}, wbprFormat},                 // Cf       ZERO WIDTH NO-BREAK SPACE
-	{runeRange{0xFF07, 0xFF07}, wbprMidNumLet},              // Po       FULLWIDTH APOSTROPHE
-	{runeRange{0xFF0C, 0xFF0C}, wbprMidNum},                 // Po       FULLWIDTH COMMA
-	{runeRange{0xFF0E, 0xFF0E}, wbprMidNumLet},              // Po       FULLWIDTH FULL STOP
-	{runeRange{0xFF10, 0xFF19}, wbprNumeric},                // Nd  [10] FULLWIDTH DIGIT ZERO..FULLWIDTH DIGIT NINE
-	{runeRange{0xFF1A, 0xFF1A}, wbprMidLetter},              // Po       FULLWIDTH COLON
-	{runeRange{0xFF1B, 0xFF1B}, wbprMidNum},                 // Po       FULLWIDTH SEMICOLON
-	{runeRange{0xFF21, 0xFF3A}, wbprALetter},                // L&  [26] FULLWIDTH LATIN CAPITAL LETTER A..FULLWIDTH LATIN CAPITAL LETTER Z
-	{runeRange{0xFF3F, 0xFF3F}, wbprExtendNumLet},           // Pc       FULLWIDTH LOW LINE
-	{runeRange{0xFF41, 0xFF5A}, wbprALetter},                // L&  [26] FULLWIDTH LATIN SMALL LETTER A..FULLWIDTH LATIN SMALL LETTER Z
-	{runeRange{0xFF66, 0xFF6F}, wbprKatakana},               // Lo  [10] HALFWIDTH KATAKANA LETTER WO..HALFWIDTH KATAKANA LETTER SMALL TU
-	{runeRange{0xFF70, 0xFF70}, wbprKatakana},               // Lm       HALFWIDTH KATAKANA-HIRAGANA PROLONGED SOUND MARK
-	{runeRange{0xFF71, 0xFF9D}, wbprKatakana},               // Lo  [45] HALFWIDTH KATAKANA LETTER A..HALFWIDTH KATAKANA LETTER N
-	{runeRange{0xFF9E, 0xFF9F}, wbprExtend},                 // Lm   [2] HALFWIDTH KATAKANA VOICED SOUND MARK..HALFWIDTH KATAKANA SEMI-VOICED SOUND MARK
-	{runeRange{0xFFA0, 0xFFBE}, wbprALetter},                // Lo  [31] HALFWIDTH HANGUL FILLER..HALFWIDTH HANGUL LETTER HIEUH
-	{runeRange{0xFFC2, 0xFFC7}, wbprALetter},                // Lo   [6] HALFWIDTH HANGUL LETTER A..HALFWIDTH HANGUL LETTER E
-	{runeRange{0xFFCA, 0xFFCF}, wbprALetter},                // Lo   [6] HALFWIDTH HANGUL LETTER YEO..HALFWIDTH HANGUL LETTER OE
-	{runeRange{0xFFD2, 0xFFD7}, wbprALetter},                // Lo   [6] HALFWIDTH HANGUL LETTER YO..HALFWIDTH HANGUL LETTER YU
-	{runeRange{0xFFDA, 0xFFDC}, wbprALetter},                // Lo   [3] HALFWIDTH HANGUL LETTER EU..HALFWIDTH HANGUL LETTER I
-	{runeRange{0xFFF9, 0xFFFB}, wbprFormat},                 // Cf   [3] INTERLINEAR ANNOTATION ANCHOR..INTERLINEAR ANNOTATION TERMINATOR
-	{runeRange{0x10000, 0x1000B}, wbprALetter},              // Lo  [12] LINEAR B SYLLABLE B008 A..LINEAR B SYLLABLE B046 JE
-	{runeRange{0x1000D, 0x10026}, wbprALetter},              // Lo  [26] LINEAR B SYLLABLE B036 JO..LINEAR B SYLLABLE B032 QO
-	{runeRange{0x10028, 0x1003A}, wbprALetter},              // Lo  [19] LINEAR B SYLLABLE B060 RA..LINEAR B SYLLABLE B042 WO
-	{runeRange{0x1003C, 0x1003D}, wbprALetter},              // Lo   [2] LINEAR B SYLLABLE B017 ZA..LINEAR B SYLLABLE B074 ZE
-	{runeRange{0x1003F, 0x1004D}, wbprALetter},              // Lo  [15] LINEAR B SYLLABLE B020 ZO..LINEAR B SYLLABLE B091 TWO
-	{runeRange{0x10050, 0x1005D}, wbprALetter},              // Lo  [14] LINEAR B SYMBOL B018..LINEAR B SYMBOL B089
-	{runeRange{0x10080, 0x100FA}, wbprALetter},              // Lo [123] LINEAR B IDEOGRAM B100 MAN..LINEAR B IDEOGRAM VESSEL B305
-	{runeRange{0x10140, 0x10174}, wbprALetter},              // Nl  [53] GREEK ACROPHONIC ATTIC ONE QUARTER..GREEK ACROPHONIC STRATIAN FIFTY MNAS
-	{runeRange{0x101FD, 0x101FD}, wbprExtend},               // Mn       PHAISTOS DISC SIGN COMBINING OBLIQUE STROKE
-	{runeRange{0x10280, 0x1029C}, wbprALetter},              // Lo  [29] LYCIAN LETTER A..LYCIAN LETTER X
-	{runeRange{0x102A0, 0x102D0}, wbprALetter},              // Lo  [49] CARIAN LETTER A..CARIAN LETTER UUU3
-	{runeRange{0x102E0, 0x102E0}, wbprExtend},               // Mn       COPTIC EPACT THOUSANDS MARK
-	{runeRange{0x10300, 0x1031F}, wbprALetter},              // Lo  [32] OLD ITALIC LETTER A..OLD ITALIC LETTER ESS
-	{runeRange{0x1032D, 0x10340}, wbprALetter},              // Lo  [20] OLD ITALIC LETTER YE..GOTHIC LETTER PAIRTHRA
-	{runeRange{0x10341, 0x10341}, wbprALetter},              // Nl       GOTHIC LETTER NINETY
-	{runeRange{0x10342, 0x10349}, wbprALetter},              // Lo   [8] GOTHIC LETTER RAIDA..GOTHIC LETTER OTHAL
-	{runeRange{0x1034A, 0x1034A}, wbprALetter},              // Nl       GOTHIC LETTER NINE HUNDRED
-	{runeRange{0x10350, 0x10375}, wbprALetter},              // Lo  [38] OLD PERMIC LETTER AN..OLD PERMIC LETTER IA
-	{runeRange{0x10376, 0x1037A}, wbprExtend},               // Mn   [5] COMBINING OLD PERMIC LETTER AN..COMBINING OLD PERMIC LETTER SII
-	{runeRange{0x10380, 0x1039D}, wbprALetter},              // Lo  [30] UGARITIC LETTER ALPA..UGARITIC LETTER SSU
-	{runeRange{0x103A0, 0x103C3}, wbprALetter},              // Lo  [36] OLD PERSIAN SIGN A..OLD PERSIAN SIGN HA
-	{runeRange{0x103C8, 0x103CF}, wbprALetter},              // Lo   [8] OLD PERSIAN SIGN AURAMAZDAA..OLD PERSIAN SIGN BUUMISH
-	{runeRange{0x103D1, 0x103D5}, wbprALetter},              // Nl   [5] OLD PERSIAN NUMBER ONE..OLD PERSIAN NUMBER HUNDRED
-	{runeRange{0x10400, 0x1044F}, wbprALetter},              // L&  [80] DESERET CAPITAL LETTER LONG I..DESERET SMALL LETTER EW
 	{runeRange{0x10450, 0x1049D}, wbprALetter},              // Lo  [78] SHAVIAN LETTER PEEP..OSMANYA LETTER OO
-	{runeRange{0x104A0, 0x104A9}, wbprNumeric},              // Nd  [10] OSMANYA DIGIT ZERO..OSMANYA DIGIT NINE
-	{runeRange{0x104B0, 0x104D3}, wbprALetter},              // L&  [36] OSAGE CAPITAL LETTER A..OSAGE CAPITAL LETTER ZHA
-	{runeRange{0x104D8, 0x104FB}, wbprALetter},              // L&  [36] OSAGE SMALL LETTER A..OSAGE SMALL LETTER ZHA
-	{runeRange{0x10500, 0x10527}, wbprALetter},              // Lo  [40] ELBASAN LETTER A..ELBASAN LETTER KHE
-	{runeRange{0x10530, 0x10563}, wbprALetter},              // Lo  [52] CAUCASIAN ALBANIAN LETTER ALT..CAUCASIAN ALBANIAN LETTER KIW
-	{runeRange{0x10570, 0x1057A}, wbprALetter},              // L&  [11] VITHKUQI CAPITAL LETTER A..VITHKUQI CAPITAL LETTER GA
-	{runeRange{0x1057C, 0x1058A}, wbprALetter},              // L&  [15] VITHKUQI CAPITAL LETTER HA..VITHKUQI CAPITAL LETTER RE
-	{runeRange{0x1058C, 0x10592}, wbprALetter},              // L&   [7] VITHKUQI CAPITAL LETTER SE..VITHKUQI CAPITAL LETTER XE
-	{runeRange{0x10594, 0x10595}, wbprALetter},              // L&   [2] VITHKUQI CAPITAL LETTER Y..VITHKUQI CAPITAL LETTER ZE
-	{runeRange{0x10597, 0x105A1}, wbprALetter},              // L&  [11] VITHKUQI SMALL LETTER A..VITHKUQI SMALL LETTER GA
-	{runeRange{0x105A3, 0x105B1}, wbprALetter},              // L&  [15] VITHKUQI SMALL LETTER HA..VITHKUQI SMALL LETTER RE
-	{runeRange{0x105B3, 0x105B9}, wbprALetter},              // L&   [7] VITHKUQI SMALL LETTER SE..VITHKUQI SMALL LETTER XE
-	{runeRange{0x105BB, 0x105BC}, wbprALetter},              // L&   [2] VITHKUQI SMALL LETTER Y..VITHKUQI SMALL LETTER ZE
-	{runeRange{0x10600, 0x10736}, wbprALetter},              // Lo [311] LINEAR A SIGN AB001..LINEAR A SIGN A664
-	{runeRange{0x10740, 0x10755}, wbprALetter},              // Lo  [22] LINEAR A SIGN A701 A..LINEAR A SIGN A732 JE
-	{runeRange{0x10760, 0x10767}, wbprALetter},              // Lo   [8] LINEAR A SIGN A800..LINEAR A SIGN A807
-	{runeRange{0x10780, 0x10785}, wbprALetter},              // Lm   [6] MODIFIER LETTER SMALL CAPITAL AA..MODIFIER LETTER SMALL B WITH HOOK
-	{runeRange{0x10787, 0x107B0}, wbprALetter},              // Lm  [42] MODIFIER LETTER SMALL DZ DIGRAPH..MODIFIER LETTER SMALL V WITH RIGHT HOOK
-	{runeRange{0x107B2, 0x107BA}, wbprALetter},              // Lm   [9] MODIFIER LETTER SMALL CAPITAL Y..MODIFIER LETTER SMALL S WITH CURL
-	{runeRange{0x10800, 0x10805}, wbprALetter},              // Lo   [6] CYPRIOT SYLLABLE A..CYPRIOT SYLLABLE JA
-	{runeRange{0x10808, 0x10808}, wbprALetter},              // Lo       CYPRIOT SYLLABLE JO
-	{runeRange{0x1080A, 0x10835}, wbprALetter},              // Lo  [44] CYPRIOT SYLLABLE KA..CYPRIOT SYLLABLE WO
-	{runeRange{0x10837, 0x10838}, wbprALetter},              // Lo   [2] CYPRIOT SYLLABLE XA..CYPRIOT SYLLABLE XE
-	{runeRange{0x1083C, 0x1083C}, wbprALetter},              // Lo       CYPRIOT SYLLABLE ZA
-	{runeRange{0x1083F, 0x10855}, wbprALetter},              // Lo  [23] CYPRIOT SYLLABLE ZO..IMPERIAL ARAMAIC LETTER TAW
-	{runeRange{0x10860, 0x10876}, wbprALetter},              // Lo  [23] PALMYRENE LETTER ALEPH..PALMYRENE LETTER TAW
-	{runeRange{0x10880, 0x1089E}, wbprALetter},              // Lo  [31] NABATAEAN LETTER FINAL ALEPH..NABATAEAN LETTER TAW
-	{runeRange{0x108E0, 0x108F2}, wbprALetter},              // Lo  [19] HATRAN LETTER ALEPH..HATRAN LETTER QOPH
-	{runeRange{0x108F4, 0x108F5}, wbprALetter},              // Lo   [2] HATRAN LETTER SHIN..HATRAN LETTER TAW
-	{runeRange{0x10900, 0x10915}, wbprALetter},              // Lo  [22] PHOENICIAN LETTER ALF..PHOENICIAN LETTER TAU
-	{runeRange{0x10920, 0x10939}, wbprALetter},              // Lo  [26] LYDIAN LETTER A..LYDIAN LETTER C
-	{runeRange{0x10980, 0x109B7}, wbprALetter},              // Lo  [56] MEROITIC HIEROGLYPHIC LETTER A..MEROITIC CURSIVE LETTER DA
-	{runeRange{0x109BE, 0x109BF}, wbprALetter},              // Lo   [2] MEROITIC CURSIVE LOGOGRAM RMT..MEROITIC CURSIVE LOGOGRAM IMN
-	{runeRange{0x10A00, 0x10A00}, wbprALetter},              // Lo       KHAROSHTHI LETTER A
-	{runeRange{0x10A01, 0x10A03}, wbprExtend},               // Mn   [3] KHAROSHTHI VOWEL SIGN I..KHAROSHTHI VOWEL SIGN VOCALIC R
-	{runeRange{0x10A05, 0x10A06}, wbprExtend},               // Mn   [2] KHAROSHTHI VOWEL SIGN E..KHAROSHTHI VOWEL SIGN O
-	{runeRange{0x10A0C, 0x10A0F}, wbprExtend},               // Mn   [4] KHAROSHTHI VOWEL LENGTH MARK..KHAROSHTHI SIGN VISARGA
-	{runeRange{0x10A10, 0x10A13}, wbprALetter},              // Lo   [4] KHAROSHTHI LETTER KA..KHAROSHTHI LETTER GHA
-	{runeRange{0x10A15, 0x10A17}, wbprALetter},              // Lo   [3] KHAROSHTHI LETTER CA..KHAROSHTHI LETTER JA
-	{runeRange{0x10A19, 0x10A35}, wbprALetter},              // Lo  [29] KHAROSHTHI LETTER NYA..KHAROSHTHI LETTER VHA
-	{runeRange{0x10A38, 0x10A3A}, wbprExtend},               // Mn   [3] KHAROSHTHI SIGN BAR ABOVE..KHAROSHTHI SIGN DOT BELOW
-	{runeRange{0x10A3F, 0x10A3F}, wbprExtend},               // Mn       KHAROSHTHI VIRAMA
-	{runeRange{0x10A60, 0x10A7C}, wbprALetter},              // Lo  [29] OLD SOUTH ARABIAN LETTER HE..OLD SOUTH ARABIAN LETTER THETH
-	{runeRange{0x10A80, 0x10A9C}, wbprALetter},              // Lo  [29] OLD NORTH ARABIAN LETTER HEH..OLD NORTH ARABIAN LETTER ZAH
-	{runeRange{0x10AC0, 0x10AC7}, wbprALetter},              // Lo   [8] MANICHAEAN LETTER ALEPH..MANICHAEAN LETTER WAW
-	{runeRange{0x10AC9, 0x10AE4}, wbprALetter},              // Lo  [28] MANICHAEAN LETTER ZAYIN..MANICHAEAN LETTER TAW
-	{runeRange{0x10AE5, 0x10AE6}, wbprExtend},               // Mn   [2] MANICHAEAN ABBREVIATION MARK ABOVE..MANICHAEAN ABBREVIATION MARK BELOW
-	{runeRange{0x10B00, 0x10B35}, wbprALetter},              // Lo  [54] AVESTAN LETTER A..AVESTAN LETTER HE
-	{runeRange{0x10B40, 0x10B55}, wbprALetter},              // Lo  [22] INSCRIPTIONAL PARTHIAN LETTER ALEPH..INSCRIPTIONAL PARTHIAN LETTER TAW
-	{runeRange{0x10B60, 0x10B72}, wbprALetter},              // Lo  [19] INSCRIPTIONAL PAHLAVI LETTER ALEPH..INSCRIPTIONAL PAHLAVI LETTER TAW
-	{runeRange{0x10B80, 0x10B91}, wbprALetter},              // Lo  [18] PSALTER PAHLAVI LETTER ALEPH..PSALTER PAHLAVI LETTER TAW
-	{runeRange{0x10C00, 0x10C48}, wbprALetter},              // Lo  [73] OLD TURKIC LETTER ORKHON A..OLD TURKIC LETTER ORKHON BASH
-	{runeRange{0x10C80, 0x10CB2}, wbprALetter},              // L&  [51] OLD HUNGARIAN CAPITAL LETTER A..OLD HUNGARIAN CAPITAL LETTER US
-	{runeRange{0x10CC0, 0x10CF2}, wbprALetter},              // L&  [51] OLD HUNGARIAN SMALL LETTER A..OLD HUNGARIAN SMALL LETTER US
-	{runeRange{0x10D00, 0x10D23}, wbprALetter},              // Lo  [36] HANIFI ROHINGYA LETTER A..HANIFI ROHINGYA MARK NA KHONNA
-	{runeRange{0x10D24, 0x10D27}, wbprExtend},               // Mn   [4] HANIFI ROHINGYA SIGN HARBAHAY..HANIFI ROHINGYA SIGN TASSI
-	{runeRange{0x10D30, 0x10D39}, wbprNumeric},              // Nd  [10] HANIFI ROHINGYA DIGIT ZERO..HANIFI ROHINGYA DIGIT NINE
-	{runeRange{0x10E80, 0x10EA9}, wbprALetter},              // Lo  [42] YEZIDI LETTER ELIF..YEZIDI LETTER ET
-	{runeRange{0x10EAB, 0x10EAC}, wbprExtend},               // Mn   [2] YEZIDI COMBINING HAMZA MARK..YEZIDI COMBINING MADDA MARK
-	{runeRange{0x10EB0, 0x10EB1}, wbprALetter},              // Lo   [2] YEZIDI LETTER LAM WITH DOT ABOVE..YEZIDI LETTER YOT WITH CIRCUMFLEX ABOVE
-	{runeRange{0x10EFD, 0x10EFF}, wbprExtend},               // Mn   [3] ARABIC SMALL LOW WORD SAKTA..ARABIC SMALL LOW WORD MADDA
-	{runeRange{0x10F00, 0x10F1C}, wbprALetter},              // Lo  [29] OLD SOGDIAN LETTER ALEPH..OLD SOGDIAN LETTER FINAL TAW WITH VERTICAL TAIL
-	{runeRange{0x10F27, 0x10F27}, wbprALetter},              // Lo       OLD SOGDIAN LIGATURE AYIN-DALETH
-	{runeRange{0x10F30, 0x10F45}, wbprALetter},              // Lo  [22] SOGDIAN LETTER ALEPH..SOGDIAN INDEPENDENT SHIN
-	{runeRange{0x10F46, 0x10F50}, wbprExtend},               // Mn  [11] SOGDIAN COMBINING DOT BELOW..SOGDIAN COMBINING STROKE BELOW
-	{runeRange{0x10F70, 0x10F81}, wbprALetter},              // Lo  [18] OLD UYGHUR LETTER ALEPH..OLD UYGHUR LETTER LESH
-	{runeRange{0x10F82, 0x10F85}, wbprExtend},               // Mn   [4] OLD UYGHUR COMBINING DOT ABOVE..OLD UYGHUR COMBINING TWO DOTS BELOW
-	{runeRange{0x10FB0, 0x10FC4}, wbprALetter},              // Lo  [21] CHORASMIAN LETTER ALEPH..CHORASMIAN LETTER TAW
-	{runeRange{0x10FE0, 0x10FF6}, wbprALetter},              // Lo  [23] ELYMAIC LETTER ALEPH..ELYMAIC LIGATURE ZAYIN-YODH
-	{runeRange{0x11000, 0x11000}, wbprExtend},               // Mc       BRAHMI SIGN CANDRABINDU
-	{runeRange{0x11001, 0x11001}, wbprExtend},               // Mn       BRAHMI SIGN ANUSVARA
-	{runeRange{0x11002, 0x11002}, wbprExtend},               // Mc       BRAHMI SIGN VISARGA
-	{runeRange{0x11003, 0x11037}, wbprALetter},              // Lo  [53] BRAHMI SIGN JIHVAMULIYA..BRAHMI LETTER OLD TAMIL NNNA
-	{runeRange{0x11038, 0x11046}, wbprExtend},               // Mn  [15] BRAHMI VOWEL SIGN AA..BRAHMI VIRAMA
-	{runeRange{0x11066, 0x1106F}, wbprNumeric},              // Nd  [10] BRAHMI DIGIT ZERO..BRAHMI DIGIT NINE
-	{runeRange{0x11070, 0x11070}, wbprExtend},               // Mn       BRAHMI SIGN OLD TAMIL VIRAMA
-	{runeRange{0x11071, 0x11072}, wbprALetter},              // Lo   [2] BRAHMI LETTER OLD TAMIL SHORT E..BRAHMI LETTER OLD TAMIL SHORT O
-	{runeRange{0x11073, 0x11074}, wbprExtend},               // Mn   [2] BRAHMI VOWEL SIGN OLD TAMIL SHORT E..BRAHMI VOWEL SIGN OLD TAMIL SHORT O
-	{runeRange{0x11075, 0x11075}, wbprALetter},              // Lo       BRAHMI LETTER OLD TAMIL LLA
-	{runeRange{0x1107F, 0x11081}, wbprExtend},               // Mn   [3] BRAHMI NUMBER JOINER..KAITHI SIGN ANUSVARA
-	{runeRange{0x11082, 0x11082}, wbprExtend},               // Mc       KAITHI SIGN VISARGA
-	{runeRange{0x11083, 0x110AF}, wbprALetter},              // Lo  [45] KAITHI LETTER A..KAITHI LETTER HA
-	{runeRange{0x110B0, 0x110B2}, wbprExtend},               // Mc   [3] KAITHI VOWEL SIGN AA..KAITHI VOWEL SIGN II
-	{runeRange{0x110B3, 0x110B6}, wbprExtend},               // Mn   [4] KAITHI VOWEL SIGN U..KAITHI VOWEL SIGN AI
-	{runeRange{0x110B7, 0x110B8}, wbprExtend},               // Mc   [2] KAITHI VOWEL SIGN O..KAITHI VOWEL SIGN AU
-	{runeRange{0x110B9, 0x110BA}, wbprExtend},               // Mn   [2] KAITHI SIGN VIRAMA..KAITHI SIGN NUKTA
-	{runeRange{0x110BD, 0x110BD}, wbprFormat},               // Cf       KAITHI NUMBER SIGN
-	{runeRange{0x110C2, 0x110C2}, wbprExtend},               // Mn       KAITHI VOWEL SIGN VOCALIC R
-	{runeRange{0x110CD, 0x110CD}, wbprFormat},               // Cf       KAITHI NUMBER SIGN ABOVE
-	{runeRange{0x110D0, 0x110E8}, wbprALetter},              // Lo  [25] SORA SOMPENG LETTER SAH..SORA SOMPENG LETTER MAE
-	{runeRange{0x110F0, 0x110F9}, wbprNumeric},              // Nd  [10] SORA SOMPENG DIGIT ZERO..SORA SOMPENG DIGIT NINE
-	{runeRange{0x11100, 0x11102}, wbprExtend},               // Mn   [3] CHAKMA SIGN CANDRABINDU..CHAKMA SIGN VISARGA
-	{runeRange{0x11103, 0x11126}, wbprALetter},              // Lo  [36] CHAKMA LETTER AA..CHAKMA LETTER HAA
-	{runeRange{0x11127, 0x1112B}, wbprExtend},               // Mn   [5] CHAKMA VOWEL SIGN A..CHAKMA VOWEL SIGN UU
-	{runeRange{0x1112C, 0x1112C}, wbprExtend},               // Mc       CHAKMA VOWEL SIGN E
-	{runeRange{0x1112D, 0x11134}, wbprExtend},               // Mn   [8] CHAKMA VOWEL SIGN AI..CHAKMA MAAYYAA
-	{runeRange{0x11136, 0x1113F}, wbprNumeric},              // Nd  [10] CHAKMA DIGIT ZERO..CHAKMA DIGIT NINE
-	{runeRange{0x11144, 0x11144}, wbprALetter},              // Lo       CHAKMA LETTER LHAA
-	{runeRange{0x11145, 0x11146}, wbprExtend},               // Mc   [2] CHAKMA VOWEL SIGN AA..CHAKMA VOWEL SIGN EI
-	{runeRange{0x11147, 0x11147}, wbprALetter},              // Lo       CHAKMA LETTER VAA
-	{runeRange{0x11150, 0x11172}, wbprALetter},              // Lo  [35] MAHAJANI LETTER A..MAHAJANI LETTER RRA
-	{runeRange{0x11173, 0x11173}, wbprExtend},               // Mn       MAHAJANI SIGN NUKTA
-	{runeRange{0x11176, 0x11176}, wbprALetter},              // Lo       MAHAJANI LIGATURE SHRI
-	{runeRange{0x11180, 0x11181}, wbprExtend},               // Mn   [2] SHARADA SIGN CANDRABINDU..SHARADA SIGN ANUSVARA
-	{runeRange{0x11182, 0x11182}, wbprExtend},               // Mc       SHARADA SIGN VISARGA
-	{runeRange{0x11183, 0x111B2}, wbprALetter},              // Lo  [48] SHARADA LETTER A..SHARADA LETTER HA
-	{runeRange{0x111B3, 0x111B5}, wbprExtend},               // Mc   [3] SHARADA VOWEL SIGN AA..SHARADA VOWEL SIGN II
-	{runeRange{0x111B6, 0x111BE}, wbprExtend},               // Mn   [9] SHARADA VOWEL SIGN U..SHARADA VOWEL SIGN O
-	{runeRange{0x111BF, 0x111C0}, wbprExtend},               // Mc   [2] SHARADA VOWEL SIGN AU..SHARADA SIGN VIRAMA
-	{runeRange{0x111C1, 0x111C4}, wbprALetter},              // Lo   [4] SHARADA SIGN AVAGRAHA..SHARADA OM
-	{runeRange{0x111C9, 0x111CC}, wbprExtend},               // Mn   [4] SHARADA SANDHI MARK..SHARADA EXTRA SHORT VOWEL MARK
-	{runeRange{0x111CE, 0x111CE}, wbprExtend},               // Mc       SHARADA VOWEL SIGN PRISHTHAMATRA E
-	{runeRange{0x111CF, 0x111CF}, wbprExtend},               // Mn       SHARADA SIGN INVERTED CANDRABINDU
-	{runeRange{0x111D0, 0x111D9}, wbprNumeric},              // Nd  [10] SHARADA DIGIT ZERO..SHARADA DIGIT NINE
-	{runeRange{0x111DA, 0x111DA}, wbprALetter},              // Lo       SHARADA EKAM
-	{runeRange{0x111DC, 0x111DC}, wbprALetter},              // Lo       SHARADA HEADSTROKE
-	{runeRange{0x11200, 0x11211}, wbprALetter},              // Lo  [18] KHOJKI LETTER A..KHOJKI LETTER JJA
-	{runeRange{0x11213, 0x1122B}, wbprALetter},              // Lo  [25] KHOJKI LETTER NYA..KHOJKI LETTER LLA
-	{runeRange{0x1122C, 0x1122E}, wbprExtend},               // Mc   [3] KHOJKI VOWEL SIGN AA..KHOJKI VOWEL SIGN II
-	{runeRange{0x1122F, 0x11231}, wbprExtend},               // Mn   [3] KHOJKI VOWEL SIGN U..KHOJKI VOWEL SIGN AI
-	{runeRange{0x11232, 0x11233}, wbprExtend},               // Mc   [2] KHOJKI VOWEL SIGN O..KHOJKI VOWEL SIGN AU
-	{runeRange{0x11234, 0x11234}, wbprExtend},               // Mn       KHOJKI SIGN ANUSVARA
-	{runeRange{0x11235, 0x11235}, wbprExtend},               // Mc       KHOJKI SIGN VIRAMA
-	{runeRange{0x11236, 0x11237}, wbprExtend},               // Mn   [2] KHOJKI SIGN NUKTA..KHOJKI SIGN SHADDA
-	{runeRange{0x1123E, 0x1123E}, wbprExtend},               // Mn       KHOJKI SIGN SUKUN
-	{runeRange{0x1123F, 0x11240}, wbprALetter},              // Lo   [2] KHOJKI LETTER QA..KHOJKI LETTER SHORT I
-	{runeRange{0x11241, 0x11241}, wbprExtend},               // Mn       KHOJKI VOWEL SIGN VOCALIC R
-	{runeRange{0x11280, 0x11286}, wbprALetter},              // Lo   [7] MULTANI LETTER A..MULTANI LETTER GA
-	{runeRange{0x11288, 0x11288}, wbprALetter},              // Lo       MULTANI LETTER GHA
-	{runeRange{0x1128A, 0x1128D}, wbprALetter},              // Lo   [4] MULTANI LETTER CA..MULTANI LETTER JJA
-	{runeRange{0x1128F, 0x1129D}, wbprALetter},              // Lo  [15] MULTANI LETTER NYA..MULTANI LETTER BA
-	{runeRange{0x1129F, 0x112A8}, wbprALetter},              // Lo  [10] MULTANI LETTER BHA..MULTANI LETTER RHA
-	{runeRange{0x112B0, 0x112DE}, wbprALetter},              // Lo  [47] KHUDAWADI LETTER A..KHUDAWADI LETTER HA
-	{runeRange{0x112DF, 0x112DF}, wbprExtend},               // Mn       KHUDAWADI SIGN ANUSVARA
-	{runeRange{0x112E0, 0x112E2}, wbprExtend},               // Mc   [3] KHUDAWADI VOWEL SIGN AA..KHUDAWADI VOWEL SIGN II
-	{runeRange{0x112E3, 0x112EA}, wbprExtend},               // Mn   [8] KHUDAWADI VOWEL SIGN U..KHUDAWADI SIGN VIRAMA
-	{runeRange{0x112F0, 0x112F9}, wbprNumeric},              // Nd  [10] KHUDAWADI DIGIT ZERO..KHUDAWADI DIGIT NINE
-	{runeRange{0x11300, 0x11301}, wbprExtend},               // Mn   [2] GRANTHA SIGN COMBINING ANUSVARA ABOVE..GRANTHA SIGN CANDRABINDU
-	{runeRange{0x11302, 0x11303}, wbprExtend},               // Mc   [2] GRANTHA SIGN ANUSVARA..GRANTHA SIGN VISARGA
-	{runeRange{0x11305, 0x1130C}, wbprALetter},              // Lo   [8] GRANTHA LETTER A..GRANTHA LETTER VOCALIC L
-	{runeRange{0x1130F, 0x11310}, wbprALetter},              // Lo   [2] GRANTHA LETTER EE..GRANTHA LETTER AI
-	{runeRange{0x11313, 0x11328}, wbprALetter},              // Lo  [22] GRANTHA LETTER OO..GRANTHA LETTER NA
-	{runeRange{0x1132A, 0x11330}, wbprALetter},              // Lo   [7] GRANTHA LETTER PA..GRANTHA LETTER RA
-	{runeRange{0x11332, 0x11333}, wbprALetter},              // Lo   [2] GRANTHA LETTER LA..GRANTHA LETTER LLA
-	{runeRange{0x11335, 0x11339}, wbprALetter},              // Lo   [5] GRANTHA LETTER VA..GRANTHA LETTER HA
-	{runeRange{0x1133B, 0x1133C}, wbprExtend},               // Mn   [2] COMBINING BINDU BELOW..GRANTHA SIGN NUKTA
-	{runeRange{0x1133D, 0x1133D}, wbprALetter},              // Lo       GRANTHA SIGN AVAGRAHA
-	{runeRange{0x1133E, 0x1133F}, wbprExtend},               // Mc   [2] GRANTHA VOWEL SIGN AA..GRANTHA VOWEL SIGN I
-	{runeRange{0x11340, 0x11340}, wbprExtend},               // Mn       GRANTHA VOWEL SIGN II
-	{runeRange{0x11341, 0x11344}, wbprExtend},               // Mc   [4] GRANTHA VOWEL SIGN U..GRANTHA VOWEL SIGN VOCALIC RR
-	{runeRange{0x11347, 0x11348}, wbprExtend},               // Mc   [2] GRANTHA VOWEL SIGN EE..GRANTHA VOWEL SIGN AI
-	{runeRange{0x1134B, 0x1134D}, wbprExtend},               // Mc   [3] GRANTHA VOWEL SIGN OO..GRANTHA SIGN VIRAMA
-	{runeRange{0x11350, 0x11350}, wbprALetter},              // Lo       GRANTHA OM
-	{runeRange{0x11357, 0x11357}, wbprExtend},               // Mc       GRANTHA AU LENGTH MARK
-	{runeRange{0x1135D, 0x11361}, wbprALetter},              // Lo   [5] GRANTHA SIGN PLUTA..GRANTHA LETTER VOCALIC LL
-	{runeRange{0x11362, 0x11363}, wbprExtend},               // Mc   [2] GRANTHA VOWEL SIGN VOCALIC L..GRANTHA VOWEL SIGN VOCALIC LL
-	{runeRange{0x11366, 0x1136C}, wbprExtend},               // Mn   [7] COMBINING GRANTHA DIGIT ZERO..COMBINING GRANTHA DIGIT SIX
-	{runeRange{0x11370, 0x11374}, wbprExtend},               // Mn   [5] COMBINING GRANTHA LETTER A..COMBINING GRANTHA LETTER PA
-	{runeRange{0x11400, 0x11434}, wbprALetter},              // Lo  [53] NEWA LETTER A..NEWA LETTER HA
-	{runeRange{0x11435, 0x11437}, wbprExtend},               // Mc   [3] NEWA VOWEL SIGN AA..NEWA VOWEL SIGN II
-	{runeRange{0x11438, 0x1143F}, wbprExtend},               // Mn   [8] NEWA VOWEL SIGN U..NEWA VOWEL SIGN AI
-	{runeRange{0x11440, 0x11441}, wbprExtend},               // Mc   [2] NEWA VOWEL SIGN O..NEWA VOWEL SIGN AU
-	{runeRange{0x11442, 0x11444}, wbprExtend},               // Mn   [3] NEWA SIGN VIRAMA..NEWA SIGN ANUSVARA
-	{runeRange{0x11445, 0x11445}, wbprExtend},               // Mc       NEWA SIGN VISARGA
-	{runeRange{0x11446, 0x11446}, wbprExtend},               // Mn       NEWA SIGN NUKTA
-	{runeRange{0x11447, 0x1144A}, wbprALetter},              // Lo   [4] NEWA SIGN AVAGRAHA..NEWA SIDDHI
-	{runeRange{0x11450, 0x11459}, wbprNumeric},              // Nd  [10] NEWA DIGIT ZERO..NEWA DIGIT NINE
-	{runeRange{0x1145E, 0x1145E}, wbprExtend},               // Mn       NEWA SANDHI MARK
-	{runeRange{0x1145F, 0x11461}, wbprALetter},              // Lo   [3] NEWA LETTER VEDIC ANUSVARA..NEWA SIGN UPADHMANIYA
-	{runeRange{0x11480, 0x114AF}, wbprALetter},              // Lo  [48] TIRHUTA ANJI..TIRHUTA LETTER HA
-	{runeRange{0x114B0, 0x114B2}, wbprExtend},               // Mc   [3] TIRHUTA VOWEL SIGN AA..TIRHUTA VOWEL SIGN II
-	{runeRange{0x114B3, 0x114B8}, wbprExtend},               // Mn   [6] TIRHUTA VOWEL SIGN U..TIRHUTA VOWEL SIGN VOCALIC LL
-	{runeRange{0x114B9, 0x114B9}, wbprExtend},               // Mc       TIRHUTA VOWEL SIGN E
-	{runeRange{0x114BA, 0x114BA}, wbprExtend},               // Mn       TIRHUTA VOWEL SIGN SHORT E
-	{runeRange{0x114BB, 0x114BE}, wbprExtend},               // Mc   [4] TIRHUTA VOWEL SIGN AI..TIRHUTA VOWEL SIGN AU
-	{runeRange{0x114BF, 0x114C0}, wbprExtend},               // Mn   [2] TIRHUTA SIGN CANDRABINDU..TIRHUTA SIGN ANUSVARA
-	{runeRange{0x114C1, 0x114C1}, wbprExtend},               // Mc       TIRHUTA SIGN VISARGA
-	{runeRange{0x114C2, 0x114C3}, wbprExtend},               // Mn   [2] TIRHUTA SIGN VIRAMA..TIRHUTA SIGN NUKTA
-	{runeRange{0x114C4, 0x114C5}, wbprALetter},              // Lo   [2] TIRHUTA SIGN AVAGRAHA..TIRHUTA GVANG
-	{runeRange{0x114C7, 0x114C7}, wbprALetter},              // Lo       TIRHUTA OM
-	{runeRange{0x114D0, 0x114D9}, wbprNumeric},              // Nd  [10] TIRHUTA DIGIT ZERO..TIRHUTA DIGIT NINE
-	{runeRange{0x11580, 0x115AE}, wbprALetter},              // Lo  [47] SIDDHAM LETTER A..SIDDHAM LETTER HA
-	{runeRange{0x115AF, 0x115B1}, wbprExtend},               // Mc   [3] SIDDHAM VOWEL SIGN AA..SIDDHAM VOWEL SIGN II
-	{runeRange{0x115B2, 0x115B5}, wbprExtend},               // Mn   [4] SIDDHAM VOWEL SIGN U..SIDDHAM VOWEL SIGN VOCALIC RR
-	{runeRange{0x115B8, 0x115BB}, wbprExtend},               // Mc   [4] SIDDHAM VOWEL SIGN E..SIDDHAM VOWEL SIGN AU
-	{runeRange{0x115BC, 0x115BD}, wbprExtend},               // Mn   [2] SIDDHAM SIGN CANDRABINDU..SIDDHAM SIGN ANUSVARA
-	{runeRange{0x115BE, 0x115BE}, wbprExtend},               // Mc       SIDDHAM SIGN VISARGA
-	{runeRange{0x115BF, 0x115C0}, wbprExtend},               // Mn   [2] SIDDHAM SIGN VIRAMA..SIDDHAM SIGN NUKTA
-	{runeRange{0x115D8, 0x115DB}, wbprALetter},              // Lo   [4] SIDDHAM LETTER THREE-CIRCLE ALTERNATE I..SIDDHAM LETTER ALTERNATE U
-	{runeRange{0x115DC, 0x115DD}, wbprExtend},               // Mn   [2] SIDDHAM VOWEL SIGN ALTERNATE U..SIDDHAM VOWEL SIGN ALTERNATE UU
-	{runeRange{0x11600, 0x1162F}, wbprALetter},              // Lo  [48] MODI LETTER A..MODI LETTER LLA
-	{runeRange{0x11630, 0x11632}, wbprExtend},               // Mc   [3] MODI VOWEL SIGN AA..MODI VOWEL SIGN II
-	{runeRange{0x11633, 0x1163A}, wbprExtend},               // Mn   [8] MODI VOWEL SIGN U..MODI VOWEL SIGN AI
-	{runeRange{0x1163B, 0x1163C}, wbprExtend},               // Mc   [2] MODI VOWEL SIGN O..MODI VOWEL SIGN AU
-	{runeRange{0x1163D, 0x1163D}, wbprExtend},               // Mn       MODI SIGN ANUSVARA
-	{runeRange{0x1163E, 0x1163E}, wbprExtend},               // Mc       MODI SIGN VISARGA
-	{runeRange{0x1163F, 0x11640}, wbprExtend},               // Mn   [2] MODI SIGN VIRAMA..MODI SIGN ARDHACANDRA
-	{runeRange{0x11644, 0x11644}, wbprALetter},              // Lo       MODI SIGN HUVA
-	{runeRange{0x11650, 0x11659}, wbprNumeric},              // Nd  [10] MODI DIGIT ZERO..MODI DIGIT NINE
-	{runeRange{0x11680, 0x116AA}, wbprALetter},              // Lo  [43] TAKRI LETTER A..TAKRI LETTER RRA
-	{runeRange{0x116AB, 0x116AB}, wbprExtend},               // Mn       TAKRI SIGN ANUSVARA
-	{runeRange{0x116AC, 0x116AC}, wbprExtend},               // Mc       TAKRI SIGN VISARGA
-	{runeRange{0x116AD, 0x116AD}, wbprExtend},               // Mn       TAKRI VOWEL SIGN AA
-	{runeRange{0x116AE, 0x116AF}, wbprExtend},               // Mc   [2] TAKRI VOWEL SIGN I..TAKRI VOWEL SIGN II
-	{runeRange{0x116B0, 0x116B5}, wbprExtend},               // Mn   [6] TAKRI VOWEL SIGN U..TAKRI VOWEL SIGN AU
-	{runeRange{0x116B6, 0x116B6}, wbprExtend},               // Mc       TAKRI SIGN VIRAMA
-	{runeRange{0x116B7, 0x116B7}, wbprExtend},               // Mn       TAKRI SIGN NUKTA
-	{runeRange{0x116B8, 0x116B8}, wbprALetter},              // Lo       TAKRI LETTER ARCHAIC KHA
-	{runeRange{0x116C0, 0x116C9}, wbprNumeric},              // Nd  [10] TAKRI DIGIT ZERO..TAKRI DIGIT NINE
-	{runeRange{0x1171D, 0x1171F}, wbprExtend},               // Mn   [3] AHOM CONSONANT SIGN MEDIAL LA..AHOM CONSONANT SIGN MEDIAL LIGATING RA
-	{runeRange{0x11720, 0x11721}, wbprExtend},               // Mc   [2] AHOM VOWEL SIGN A..AHOM VOWEL SIGN AA
-	{runeRange{0x11722, 0x11725}, wbprExtend},               // Mn   [4] AHOM VOWEL SIGN I..AHOM VOWEL SIGN UU
-	{runeRange{0x11726, 0x11726}, wbprExtend},               // Mc       AHOM VOWEL SIGN E
-	{runeRange{0x11727, 0x1172B}, wbprExtend},               // Mn   [5] AHOM VOWEL SIGN AW..AHOM SIGN KILLER
-	{runeRange{0x11730, 0x11739}, wbprNumeric},              // Nd  [10] AHOM DIGIT ZERO..AHOM DIGIT NINE
-	{runeRange{0x11800, 0x1182B}, wbprALetter},              // Lo  [44] DOGRA LETTER A..DOGRA LETTER RRA
-	{runeRange{0x1182C, 0x1182E}, wbprExtend},               // Mc   [3] DOGRA VOWEL SIGN AA..DOGRA VOWEL SIGN II
-	{runeRange{0x1182F, 0x11837}, wbprExtend},               // Mn   [9] DOGRA VOWEL SIGN U..DOGRA SIGN ANUSVARA
-	{runeRange{0x11838, 0x11838}, wbprExtend},               // Mc       DOGRA SIGN VISARGA
-	{runeRange{0x11839, 0x1183A}, wbprExtend},               // Mn   [2] DOGRA SIGN VIRAMA..DOGRA SIGN NUKTA
-	{runeRange{0x118A0, 0x118DF}, wbprALetter},              // L&  [64] WARANG CITI CAPITAL LETTER NGAA..WARANG CITI SMALL LETTER VIYO
-	{runeRange{0x118E0, 0x118E9}, wbprNumeric},              // Nd  [10] WARANG CITI DIGIT ZERO..WARANG CITI DIGIT NINE
-	{runeRange{0x118FF, 0x11906}, wbprALetter},              // Lo   [8] WARANG CITI OM..DIVES AKURU LETTER E
-	{runeRange{0x11909, 0x11909}, wbprALetter},              // Lo       DIVES AKURU LETTER O
-	{runeRange{0x1190C, 0x11913}, wbprALetter},              // Lo   [8] DIVES AKURU LETTER KA..DIVES AKURU LETTER JA
-	{runeRange{0x11915, 0x11916}, wbprALetter},              // Lo   [2] DIVES AKURU LETTER NYA..DIVES AKURU LETTER TTA
-	{runeRange{0x11918, 0x1192F}, wbprALetter},              // Lo  [24] DIVES AKURU LETTER DDA..DIVES AKURU LETTER ZA
-	{runeRange{0x11930, 0x11935}, wbprExtend},               // Mc   [6] DIVES AKURU VOWEL SIGN AA..DIVES AKURU VOWEL SIGN E
-	{runeRange{0x11937, 0x11938}, wbprExtend},               // Mc   [2] DIVES AKURU VOWEL SIGN AI..DIVES AKURU VOWEL SIGN O
-	{runeRange{0x1193B, 0x1193C}, wbprExtend},               // Mn   [2] DIVES AKURU SIGN ANUSVARA..DIVES AKURU SIGN CANDRABINDU
-	{runeRange{0x1193D, 0x1193D}, wbprExtend},               // Mc       DIVES AKURU SIGN HALANTA
-	{runeRange{0x1193E, 0x1193E}, wbprExtend},               // Mn       DIVES AKURU VIRAMA
-	{runeRange{0x1193F, 0x1193F}, wbprALetter},              // Lo       DIVES AKURU PREFIXED NASAL SIGN
-	{runeRange{0x11940, 0x11940}, wbprExtend},               // Mc       DIVES AKURU MEDIAL YA
-	{runeRange{0x11941, 0x11941}, wbprALetter},              // Lo       DIVES AKURU INITIAL RA
-	{runeRange{0x11942, 0x11942}, wbprExtend},               // Mc       DIVES AKURU MEDIAL RA
-	{runeRange{0x11943, 0x11943}, wbprExtend},               // Mn       DIVES AKURU SIGN NUKTA
-	{runeRange{0x11950, 0x11959}, wbprNumeric},              // Nd  [10] DIVES AKURU DIGIT ZERO..DIVES AKURU DIGIT NINE
-	{runeRange{0x119A0, 0x119A7}, wbprALetter},              // Lo   [8] NANDINAGARI LETTER A..NANDINAGARI LETTER VOCALIC RR
-	{runeRange{0x119AA, 0x119D0}, wbprALetter},              // Lo  [39] NANDINAGARI LETTER E..NANDINAGARI LETTER RRA
-	{runeRange{0x119D1, 0x119D3}, wbprExtend},               // Mc   [3] NANDINAGARI VOWEL SIGN AA..NANDINAGARI VOWEL SIGN II
-	{runeRange{0x119D4, 0x119D7}, wbprExtend},               // Mn   [4] NANDINAGARI VOWEL SIGN U..NANDINAGARI VOWEL SIGN VOCALIC RR
-	{runeRange{0x119DA, 0x119DB}, wbprExtend},               // Mn   [2] NANDINAGARI VOWEL SIGN E..NANDINAGARI VOWEL SIGN AI
-	{runeRange{0x119DC, 0x119DF}, wbprExtend},               // Mc   [4] NANDINAGARI VOWEL SIGN O..NANDINAGARI SIGN VISARGA
-	{runeRange{0x119E0, 0x119E0}, wbprExtend},               // Mn       NANDINAGARI SIGN VIRAMA
-	{runeRange{0x119E1, 0x119E1}, wbprALetter},              // Lo       NANDINAGARI SIGN AVAGRAHA
-	{runeRange{0x119E3, 0x119E3}, wbprALetter},              // Lo       NANDINAGARI HEADSTROKE
-	{runeRange{0x119E4, 0x119E4}, wbprExtend},               // Mc       NANDINAGARI VOWEL SIGN PRISHTHAMATRA E
-	{runeRange{0x11A00, 0x11A00}, wbprALetter},              // Lo       ZANABAZAR SQUARE LETTER A
-	{runeRange{0x11A01, 0x11A0A}, wbprExtend},               // Mn  [10] ZANABAZAR SQUARE VOWEL SIGN I..ZANABAZAR SQUARE VOWEL LENGTH MARK
-	{runeRange{0x11A0B, 0x11A32}, wbprALetter},              // Lo  [40] ZANABAZAR SQUARE LETTER KA..ZANABAZAR SQUARE LETTER KSSA
-	{runeRange{0x11A33, 0x11A38}, wbprExtend},               // Mn   [6] ZANABAZAR SQUARE FINAL CONSONANT MARK..ZANABAZAR SQUARE SIGN ANUSVARA
-	{runeRange{0x11A39, 0x11A39}, wbprExtend},               // Mc       ZANABAZAR SQUARE SIGN VISARGA
-	{runeRange{0x11A3A, 0x11A3A}, wbprALetter},              // Lo       ZANABAZAR SQUARE CLUSTER-INITIAL LETTER RA
-	{runeRange{0x11A3B, 0x11A3E}, wbprExtend},               // Mn   [4] ZANABAZAR SQUARE CLUSTER-FINAL LETTER YA..ZANABAZAR SQUARE CLUSTER-FINAL LETTER VA
-	{runeRange{0x11A47, 0x11A47}, wbprExtend},               // Mn       ZANABAZAR SQUARE SUBJOINER
-	{runeRange{0x11A50, 0x11A50}, wbprALetter},              // Lo       SOYOMBO LETTER A
-	{runeRange{0x11A51, 0x11A56}, wbprExtend},               // Mn   [6] SOYOMBO VOWEL SIGN I..SOYOMBO VOWEL SIGN OE
-	{runeRange{0x11A57, 0x11A58}, wbprExtend},               // Mc   [2] SOYOMBO VOWEL SIGN AI..SOYOMBO VOWEL SIGN AU
-	{runeRange{0x11A59, 0x11A5B}, wbprExtend},               // Mn   [3] SOYOMBO VOWEL SIGN VOCALIC R..SOYOMBO VOWEL LENGTH MARK
-	{runeRange{0x11A5C, 0x11A89}, wbprALetter},              // Lo  [46] SOYOMBO LETTER KA..SOYOMBO CLUSTER-INITIAL LETTER SA
-	{runeRange{0x11A8A, 0x11A96}, wbprExtend},               // Mn  [13] SOYOMBO FINAL CONSONANT SIGN G..SOYOMBO SIGN ANUSVARA
-	{runeRange{0x11A97, 0x11A97}, wbprExtend},               // Mc       SOYOMBO SIGN VISARGA
-	{runeRange{0x11A98, 0x11A99}, wbprExtend},               // Mn   [2] SOYOMBO GEMINATION MARK..SOYOMBO SUBJOINER
-	{runeRange{0x11A9D, 0x11A9D}, wbprALetter},              // Lo       SOYOMBO MARK PLUTA
-	{runeRange{0x11AB0, 0x11AF8}, wbprALetter},              // Lo  [73] CANADIAN SYLLABICS NATTILIK HI..PAU CIN HAU GLOTTAL STOP FINAL
-	{runeRange{0x11C00, 0x11C08}, wbprALetter},              // Lo   [9] BHAIKSUKI LETTER A..BHAIKSUKI LETTER VOCALIC L
-	{runeRange{0x11C0A, 0x11C2E}, wbprALetter},              // Lo  [37] BHAIKSUKI LETTER E..BHAIKSUKI LETTER HA
-	{runeRange{0x11C2F, 0x11C2F}, wbprExtend},               // Mc       BHAIKSUKI VOWEL SIGN AA
-	{runeRange{0x11C30, 0x11C36}, wbprExtend},               // Mn   [7] BHAIKSUKI VOWEL SIGN I..BHAIKSUKI VOWEL SIGN VOCALIC L
-	{runeRange{0x11C38, 0x11C3D}, wbprExtend},               // Mn   [6] BHAIKSUKI VOWEL SIGN E..BHAIKSUKI SIGN ANUSVARA
-	{runeRange{0x11C3E, 0x11C3E}, wbprExtend},               // Mc       BHAIKSUKI SIGN VISARGA
-	{runeRange{0x11C3F, 0x11C3F}, wbprExtend},               // Mn       BHAIKSUKI SIGN VIRAMA
-	{runeRange{0x11C40, 0x11C40}, wbprALetter},              // Lo       BHAIKSUKI SIGN AVAGRAHA
-	{runeRange{0x11C50, 0x11C59}, wbprNumeric},              // Nd  [10] BHAIKSUKI DIGIT ZERO..BHAIKSUKI DIGIT NINE
-	{runeRange{0x11C72, 0x11C8F}, wbprALetter},              // Lo  [30] MARCHEN LETTER KA..MARCHEN LETTER A
-	{runeRange{0x11C92, 0x11CA7}, wbprExtend},               // Mn  [22] MARCHEN SUBJOINED LETTER KA..MARCHEN SUBJOINED LETTER ZA
-	{runeRange{0x11CA9, 0x11CA9}, wbprExtend},               // Mc       MARCHEN SUBJOINED LETTER YA
-	{runeRange{0x11CAA, 0x11CB0}, wbprExtend},               // Mn   [7] MARCHEN SUBJOINED LETTER RA..MARCHEN VOWEL SIGN AA
-	{runeRange{0x11CB1, 0x11CB1}, wbprExtend},               // Mc       MARCHEN VOWEL SIGN I
-	{runeRange{0x11CB2, 0x11CB3}, wbprExtend},               // Mn   [2] MARCHEN VOWEL SIGN U..MARCHEN VOWEL SIGN E
-	{runeRange{0x11CB4, 0x11CB4}, wbprExtend},               // Mc       MARCHEN VOWEL SIGN O
-	{runeRange{0x11CB5, 0x11CB6}, wbprExtend},               // Mn   [2] MARCHEN SIGN ANUSVARA..MARCHEN SIGN CANDRABINDU
-	{runeRange{0x11D00, 0x11D06}, wbprALetter},              // Lo   [7] MASARAM GONDI LETTER A..MASARAM GONDI LETTER E
-	{runeRange{0x11D08, 0x11D09}, wbprALetter},              // Lo   [2] MASARAM GONDI LETTER AI..MASARAM GONDI LETTER O
-	{runeRange{0x11D0B, 0x11D30}, wbprALetter},              // Lo  [38] MASARAM GONDI LETTER AU..MASARAM GONDI LETTER TRA
-	{runeRange{0x11D31, 0x11D36}, wbprExtend},               // Mn   [6] MASARAM GONDI VOWEL SIGN AA..MASARAM GONDI VOWEL SIGN VOCALIC R
-	{runeRange{0x11D3A, 0x11D3A}, wbprExtend},               // Mn       MASARAM GONDI VOWEL SIGN E
-	{runeRange{0x11D3C, 0x11D3D}, wbprExtend},               // Mn   [2] MASARAM GONDI VOWEL SIGN AI..MASARAM GONDI VOWEL SIGN O
-	{runeRange{0x11D3F, 0x11D45}, wbprExtend},               // Mn   [7] MASARAM GONDI VOWEL SIGN AU..MASARAM GONDI VIRAMA
-	{runeRange{0x11D46, 0x11D46}, wbprALetter},              // Lo       MASARAM GONDI REPHA
-	{runeRange{0x11D47, 0x11D47}, wbprExtend},               // Mn       MASARAM GONDI RA-KARA
-	{runeRange{0x11D50, 0x11D59}, wbprNumeric},              // Nd  [10] MASARAM GONDI DIGIT ZERO..MASARAM GONDI DIGIT NINE
-	{runeRange{0x11D60, 0x11D65}, wbprALetter},              // Lo   [6] GUNJALA GONDI LETTER A..GUNJALA GONDI LETTER UU
-	{runeRange{0x11D67, 0x11D68}, wbprALetter},              // Lo   [2] GUNJALA GONDI LETTER EE..GUNJALA GONDI LETTER AI
-	{runeRange{0x11D6A, 0x11D89}, wbprALetter},              // Lo  [32] GUNJALA GONDI LETTER OO..GUNJALA GONDI LETTER SA
-	{runeRange{0x11D8A, 0x11D8E}, wbprExtend},               // Mc   [5] GUNJALA GONDI VOWEL SIGN AA..GUNJALA GONDI VOWEL SIGN UU
-	{runeRange{0x11D90, 0x11D91}, wbprExtend},               // Mn   [2] GUNJALA GONDI VOWEL SIGN EE..GUNJALA GONDI VOWEL SIGN AI
-	{runeRange{0x11D93, 0x11D94}, wbprExtend},               // Mc   [2] GUNJALA GONDI VOWEL SIGN OO..GUNJALA GONDI VOWEL SIGN AU
-	{runeRange{0x11D95, 0x11D95}, wbprExtend},               // Mn       GUNJALA GONDI SIGN ANUSVARA
-	{runeRange{0x11D96, 0x11D96}, wbprExtend},               // Mc       GUNJALA GONDI SIGN VISARGA
-	{runeRange{0x11D97, 0x11D97}, wbprExtend},               // Mn       GUNJALA GONDI VIRAMA
-	{runeRange{0x11D98, 0x11D98}, wbprALetter},              // Lo       GUNJALA GONDI OM
-	{runeRange{0x11DA0, 0x11DA9}, wbprNumeric},              // Nd  [10] GUNJALA GONDI DIGIT ZERO..GUNJALA GONDI DIGIT NINE
-	{runeRange{0x11EE0, 0x11EF2}, wbprALetter},              // Lo  [19] MAKASAR LETTER KA..MAKASAR ANGKA
-	{runeRange{0x11EF3, 0x11EF4}, wbprExtend},               // Mn   [2] MAKASAR VOWEL SIGN I..MAKASAR VOWEL SIGN U
-	{runeRange{0x11EF5, 0x11EF6}, wbprExtend},               // Mc   [2] MAKASAR VOWEL SIGN E..MAKASAR VOWEL SIGN O
-	{runeRange{0x11F00, 0x11F01}, wbprExtend},               // Mn   [2] KAWI SIGN CANDRABINDU..KAWI SIGN ANUSVARA
-	{runeRange{0x11F02, 0x11F02}, wbprALetter},              // Lo       KAWI SIGN REPHA
-	{runeRange{0x11F03, 0x11F03}, wbprExtend},               // Mc       KAWI SIGN VISARGA
-	{runeRange{0x11F04, 0x11F10}, wbprALetter},              // Lo  [13] KAWI LETTER A..KAWI LETTER O
-	{runeRange{0x11F12, 0x11F33}, wbprALetter},              // Lo  [34] KAWI LETTER KA..KAWI LETTER JNYA
-	{runeRange{0x11F34, 0x11F35}, wbprExtend},               // Mc   [2] KAWI VOWEL SIGN AA..KAWI VOWEL SIGN ALTERNATE AA
-	{runeRange{0x11F36, 0x11F3A}, wbprExtend},               // Mn   [5] KAWI VOWEL SIGN I..KAWI VOWEL SIGN VOCALIC R
-	{runeRange{0x11F3E, 0x11F3F}, wbprExtend},               // Mc   [2] KAWI VOWEL SIGN E..KAWI VOWEL SIGN AI
-	{runeRange{0x11F40, 0x11F40}, wbprExtend},               // Mn       KAWI VOWEL SIGN EU
-	{runeRange{0x11F41, 0x11F41}, wbprExtend},               // Mc       KAWI SIGN KILLER
-	{runeRange{0x11F42, 0x11F42}, wbprExtend},               // Mn       KAWI CONJOINER
-	{runeRange{0x11F50, 0x11F59}, wbprNumeric},              // Nd  [10] KAWI DIGIT ZERO..KAWI DIGIT NINE
-	{runeRange{0x11FB0, 0x11FB0}, wbprALetter},              // Lo       LISU LETTER YHA
-	{runeRange{0x12000, 0x12399}, wbprALetter},              // Lo [922] CUNEIFORM SIGN A..CUNEIFORM SIGN U U
-	{runeRange{0x12400, 0x1246E}, wbprALetter},              // Nl [111] CUNEIFORM NUMERIC SIGN TWO ASH..CUNEIFORM NUMERIC SIGN NINE U VARIANT FORM
-	{runeRange{0x12480, 0x12543}, wbprALetter},              // Lo [196] CUNEIFORM SIGN AB TIMES NUN TENU..CUNEIFORM SIGN ZU5 TIMES THREE DISH TENU
-	{runeRange{0x12F90, 0x12FF0}, wbprALetter},              // Lo  [97] CYPRO-MINOAN SIGN CM001..CYPRO-MINOAN SIGN CM114
-	{runeRange{0x13000, 0x1342F}, wbprALetter},              // Lo [1072] EGYPTIAN HIEROGLYPH A001..EGYPTIAN HIEROGLYPH V011D
-	{runeRange{0x13430, 0x1343F}, wbprFormat},               // Cf  [16] EGYPTIAN HIEROGLYPH VERTICAL JOINER..EGYPTIAN HIEROGLYPH END WALLED ENCLOSURE
-	{runeRange{0x13440, 0x13440}, wbprExtend},               // Mn       EGYPTIAN HIEROGLYPH MIRROR HORIZONTALLY
-	{runeRange{0x13441, 0x13446}, wbprALetter},              // Lo   [6] EGYPTIAN HIEROGLYPH FULL BLANK..EGYPTIAN HIEROGLYPH WIDE LOST SIGN
-	{runeRange{0x13447, 0x13455}, wbprExtend},               // Mn  [15] EGYPTIAN HIEROGLYPH MODIFIER DAMAGED AT TOP START..EGYPTIAN HIEROGLYPH MODIFIER DAMAGED
-	{runeRange{0x14400, 0x14646}, wbprALetter},              // Lo [583] ANATOLIAN HIEROGLYPH A001..ANATOLIAN HIEROGLYPH A530
-	{runeRange{0x16800, 0x16A38}, wbprALetter},              // Lo [569] BAMUM LETTER PHASE-A NGKUE MFON..BAMUM LETTER PHASE-F VUEQ
-	{runeRange{0x16A40, 0x16A5E}, wbprALetter},              // Lo  [31] MRO LETTER TA..MRO LETTER TEK
-	{runeRange{0x16A60, 0x16A69}, wbprNumeric},              // Nd  [10] MRO DIGIT ZERO..MRO DIGIT NINE
-	{runeRange{0x16A70, 0x16ABE}, wbprALetter},              // Lo  [79] TANGSA LETTER OZ..TANGSA LETTER ZA
-	{runeRange{0x16AC0, 0x16AC9}, wbprNumeric},              // Nd  [10] TANGSA DIGIT ZERO..TANGSA DIGIT NINE
-	{runeRange{0x16AD0, 0x16AED}, wbprALetter},              // Lo  [30] BASSA VAH LETTER ENNI..BASSA VAH LETTER I
-	{runeRange{0x16AF0, 0x16AF4}, wbprExtend},               // Mn   [5] BASSA VAH COMBINING HIGH TONE..BASSA VAH COMBINING HIGH-LOW TONE
-	{runeRange{0x16B00, 0x16B2F}, wbprALetter},              // Lo  [48] PAHAWH HMONG VOWEL KEEB..PAHAWH HMONG CONSONANT CAU
-	{runeRange{0x16B30, 0x16B36}, wbprExtend},               // Mn   [7] PAHAWH HMONG MARK CIM TUB..PAHAWH HMONG MARK CIM TAUM
-	{runeRange{0x16B40, 0x16B43}, wbprALetter},              // Lm   [4] PAHAWH HMONG SIGN VOS SEEV..PAHAWH HMONG SIGN IB YAM
-	{runeRange{0x16B50, 0x16B59}, wbprNumeric},              // Nd  [10] PAHAWH HMONG DIGIT ZERO..PAHAWH HMONG DIGIT NINE
-	{runeRange{0x16B63, 0x16B77}, wbprALetter},              // Lo  [21] PAHAWH HMONG SIGN VOS LUB..PAHAWH HMONG SIGN CIM NRES TOS
-	{runeRange{0x16B7D, 0x16B8F}, wbprALetter},              // Lo  [19] PAHAWH HMONG CLAN SIGN TSHEEJ..PAHAWH HMONG CLAN SIGN VWJ
-	{runeRange{0x16E40, 0x16E7F}, wbprALetter},              // L&  [64] MEDEFAIDRIN CAPITAL LETTER M..MEDEFAIDRIN SMALL LETTER Y
-	{runeRange{0x16F00, 0x16F4A}, wbprALetter},              // Lo  [75] MIAO LETTER PA..MIAO LETTER RTE
-	{runeRange{0x16F4F, 0x16F4F}, wbprExtend},               // Mn       MIAO SIGN CONSONANT MODIFIER BAR
-	{runeRange{0x16F50, 0x16F50}, wbprALetter},              // Lo       MIAO LETTER NASALIZATION
-	{runeRange{0x16F51, 0x16F87}, wbprExtend},               // Mc  [55] MIAO SIGN ASPIRATION..MIAO VOWEL SIGN UI
-	{runeRange{0x16F8F, 0x16F92}, wbprExtend},               // Mn   [4] MIAO TONE RIGHT..MIAO TONE BELOW
-	{runeRange{0x16F93, 0x16F9F}, wbprALetter},              // Lm  [13] MIAO LETTER TONE-2..MIAO LETTER REFORMED TONE-8
-	{runeRange{0x16FE0, 0x16FE1}, wbprALetter},              // Lm   [2] TANGUT ITERATION MARK..NUSHU ITERATION MARK
-	{runeRange{0x16FE3, 0x16FE3}, wbprALetter},              // Lm       OLD CHINESE ITERATION MARK
-	{runeRange{0x16FE4, 0x16FE4}, wbprExtend},               // Mn       KHITAN SMALL SCRIPT FILLER
-	{runeRange{0x16FF0, 0x16FF1}, wbprExtend},               // Mc   [2] VIETNAMESE ALTERNATE READING MARK CA..VIETNAMESE ALTERNATE READING MARK NHAY
-	{runeRange{0x1AFF0, 0x1AFF3}, wbprKatakana},             // Lm   [4] KATAKANA LETTER MINNAN TONE-2..KATAKANA LETTER MINNAN TONE-5
-	{runeRange{0x1AFF5, 0x1AFFB}, wbprKatakana},             // Lm   [7] KATAKANA LETTER MINNAN TONE-7..KATAKANA LETTER MINNAN NASALIZED TONE-5
-	{runeRange{0x1AFFD, 0x1AFFE}, wbprKatakana},             // Lm   [2] KATAKANA LETTER MINNAN NASALIZED TONE-7..KATAKANA LETTER MINNAN NASALIZED TONE-8
-	{runeRange{0x1B000, 0x1B000}, wbprKatakana},             // Lo       KATAKANA LETTER ARCHAIC E
-	{runeRange{0x1B120, 0x1B122}, wbprKatakana},             // Lo   [3] KATAKANA LETTER ARCHAIC YI..KATAKANA LETTER ARCHAIC WU
-	{runeRange{0x1B155, 0x1B155}, wbprKatakana},             // Lo       KATAKANA LETTER SMALL KO
-	{runeRange{0x1B164, 0x1B167}, wbprKatakana},             // Lo   [4] KATAKANA LETTER SMALL WI..KATAKANA LETTER SMALL N
-	{runeRange{0x1BC00, 0x1BC6A}, wbprALetter},              // Lo [107] DUPLOYAN LETTER H..DUPLOYAN LETTER VOCALIC M
-	{runeRange{0x1BC70, 0x1BC7C}, wbprALetter},              // Lo  [13] DUPLOYAN AFFIX LEFT HORIZONTAL SECANT..DUPLOYAN AFFIX ATTACHED TANGENT HOOK
-	{runeRange{0x1BC80, 0x1BC88}, wbprALetter},              // Lo   [9] DUPLOYAN AFFIX HIGH ACUTE..DUPLOYAN AFFIX HIGH VERTICAL
-	{runeRange{0x1BC90, 0x1BC99}, wbprALetter},              // Lo  [10] DUPLOYAN AFFIX LOW ACUTE..DUPLOYAN AFFIX LOW ARROW
-	{runeRange{0x1BC9D, 0x1BC9E}, wbprExtend},               // Mn   [2] DUPLOYAN THICK LETTER SELECTOR..DUPLOYAN DOUBLE MARK
-	{runeRange{0x1BCA0, 0x1BCA3}, wbprFormat},               // Cf   [4] SHORTHAND FORMAT LETTER OVERLAP..SHORTHAND FORMAT UP STEP
-	{runeRange{0x1CF00, 0x1CF2D}, wbprExtend},               // Mn  [46] ZNAMENNY COMBINING MARK GORAZDO NIZKO S KRYZHEM ON LEFT..ZNAMENNY COMBINING MARK KRYZH ON LEFT
-	{runeRange{0x1CF30, 0x1CF46}, wbprExtend},               // Mn  [23] ZNAMENNY COMBINING TONAL RANGE MARK MRACHNO..ZNAMENNY PRIZNAK MODIFIER ROG
-	{runeRange{0x1D165, 0x1D166}, wbprExtend},               // Mc   [2] MUSICAL SYMBOL COMBINING STEM..MUSICAL SYMBOL COMBINING SPRECHGESANG STEM
-	{runeRange{0x1D167, 0x1D169}, wbprExtend},               // Mn   [3] MUSICAL SYMBOL COMBINING TREMOLO-1..MUSICAL SYMBOL COMBINING TREMOLO-3
-	{runeRange{0x1D16D, 0x1D172}, wbprExtend},               // Mc   [6] MUSICAL SYMBOL COMBINING AUGMENTATION DOT..MUSICAL SYMBOL COMBINING FLAG-5
-	{runeRange{0x1D173, 0x1D17A}, wbprFormat},               // Cf   [8] MUSICAL SYMBOL BEGIN BEAM..MUSICAL SYMBOL END PHRASE
-	{runeRange{0x1D17B, 0x1D182}, wbprExtend},               // Mn   [8] MUSICAL SYMBOL COMBINING ACCENT..MUSICAL SYMBOL COMBINING LOURE
-	{runeRange{0x1D185, 0x1D18B}, wbprExtend},               // Mn   [7] MUSICAL SYMBOL COMBINING DOIT..MUSICAL SYMBOL COMBINING TRIPLE TONGUE
-	{runeRange{0x1D1AA, 0x1D1AD}, wbprExtend},               // Mn   [4] MUSICAL SYMBOL COMBINING DOWN BOW..MUSICAL SYMBOL COMBINING SNAP PIZZICATO
-	{runeRange{0x1D242, 0x1D244}, wbprExtend},               // Mn   [3] COMBINING GREEK MUSICAL TRISEME..COMBINING GREEK MUSICAL PENTASEME
-	{runeRange{0x1D400, 0x1D454}, wbprALetter},              // L&  [85] MATHEMATICAL BOLD CAPITAL A..MATHEMATICAL ITALIC SMALL G
-	{runeRange{0x1D456, 0x1D49C}, wbprALetter},              // L&  [71] MATHEMATICAL ITALIC SMALL I..MATHEMATICAL SCRIPT CAPITAL A
-	{runeRange{0x1D49E, 0x1D49F}, wbprALetter},              // L&   [2] MATHEMATICAL SCRIPT CAPITAL C..MATHEMATICAL SCRIPT CAPITAL D
-	{runeRange{0x1D4A2, 0x1D4A2}, wbprALetter},              // L&       MATHEMATICAL SCRIPT CAPITAL G
-	{runeRange{0x1D4A5, 0x1D4A6}, wbprALetter},              // L&   [2] MATHEMATICAL SCRIPT CAPITAL J..MATHEMATICAL SCRIPT CAPITAL K
-	{runeRange{0x1D4A9, 0x1D4AC}, wbprALetter},              // L&   [4] MATHEMATICAL SCRIPT CAPITAL N..MATHEMATICAL SCRIPT CAPITAL Q
-	{runeRange{0x1D4AE, 0x1D4B9}, wbprALetter},              // L&  [12] MATHEMATICAL SCRIPT CAPITAL S..MATHEMATICAL SCRIPT SMALL D
-	{runeRange{0x1D4BB, 0x1D4BB}, wbprALetter},              // L&       MATHEMATICAL SCRIPT SMALL F
-	{runeRange{0x1D4BD, 0x1D4C3}, wbprALetter},              // L&   [7] MATHEMATICAL SCRIPT SMALL H..MATHEMATICAL SCRIPT SMALL N
-	{runeRange{0x1D4C5, 0x1D505}, wbprALetter},              // L&  [65] MATHEMATICAL SCRIPT SMALL P..MATHEMATICAL FRAKTUR CAPITAL B
-	{runeRange{0x1D507, 0x1D50A}, wbprALetter},              // L&   [4] MATHEMATICAL FRAKTUR CAPITAL D..MATHEMATICAL FRAKTUR CAPITAL G
-	{runeRange{0x1D50D, 0x1D514}, wbprALetter},              // L&   [8] MATHEMATICAL FRAKTUR CAPITAL J..MATHEMATICAL FRAKTUR CAPITAL Q
-	{runeRange{0x1D516, 0x1D51C}, wbprALetter},              // L&   [7] MATHEMATICAL FRAKTUR CAPITAL S..MATHEMATICAL FRAKTUR CAPITAL Y
-	{runeRange{0x1D51E, 0x1D539}, wbprALetter},              // L&  [28] MATHEMATICAL FRAKTUR SMALL A..MATHEMATICAL DOUBLE-STRUCK CAPITAL B
-	{runeRange{0x1D53B, 0x1D53E}, wbprALetter},              // L&   [4] MATHEMATICAL DOUBLE-STRUCK CAPITAL D..MATHEMATICAL DOUBLE-STRUCK CAPITAL G
-	{runeRange{0x1D540, 0x1D544}, wbprALetter},              // L&   [5] MATHEMATICAL DOUBLE-STRUCK CAPITAL I..MATHEMATICAL DOUBLE-STRUCK CAPITAL M
-	{runeRange{0x1D546, 0x1D546}, wbprALetter},              // L&       MATHEMATICAL DOUBLE-STRUCK CAPITAL O
-	{runeRange{0x1D54A, 0x1D550}, wbprALetter},              // L&   [7] MATHEMATICAL DOUBLE-STRUCK CAPITAL S..MATHEMATICAL DOUBLE-STRUCK CAPITAL Y
-	{runeRange{0x1D552, 0x1D6A5}, wbprALetter},              // L& [340] MATHEMATICAL DOUBLE-STRUCK SMALL A..MATHEMATICAL ITALIC SMALL DOTLESS J
-	{runeRange{0x1D6A8, 0x1D6C0}, wbprALetter},              // L&  [25] MATHEMATICAL BOLD CAPITAL ALPHA..MATHEMATICAL BOLD CAPITAL OMEGA
-	{runeRange{0x1D6C2, 0x1D6DA}, wbprALetter},              // L&  [25] MATHEMATICAL BOLD SMALL ALPHA..MATHEMATICAL BOLD SMALL OMEGA
-	{runeRange{0x1D6DC, 0x1D6FA}, wbprALetter},              // L&  [31] MATHEMATICAL BOLD EPSILON SYMBOL..MATHEMATICAL ITALIC CAPITAL OMEGA
-	{runeRange{0x1D6FC, 0x1D714}, wbprALetter},              // L&  [25] MATHEMATICAL ITALIC SMALL ALPHA..MATHEMATICAL ITALIC SMALL OMEGA
-	{runeRange{0x1D716, 0x1D734}, wbprALetter},              // L&  [31] MATHEMATICAL ITALIC EPSILON SYMBOL..MATHEMATICAL BOLD ITALIC CAPITAL OMEGA
-	{runeRange{0x1D736, 0x1D74E}, wbprALetter},              // L&  [25] MATHEMATICAL BOLD ITALIC SMALL ALPHA..MATHEMATICAL BOLD ITALIC SMALL OMEGA
-	{runeRange{0x1D750, 0x1D76E}, wbprALetter},              // L&  [31] MATHEMATICAL BOLD ITALIC EPSILON SYMBOL..MATHEMATICAL SANS-SERIF BOLD CAPITAL OMEGA
-	{runeRange{0x1D770, 0x1D788}, wbprALetter},              // L&  [25] MATHEMATICAL SANS-SERIF BOLD SMALL ALPHA..MATHEMATICAL SANS-SERIF BOLD SMALL OMEGA
-	{runeRange{0x1D78A, 0x1D7A8}, wbprALetter},              // L&  [31] MATHEMATICAL SANS-SERIF BOLD EPSILON SYMBOL..MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL OMEGA
-	{runeRange{0x1D7AA, 0x1D7C2}, wbprALetter},              // L&  [25] MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL ALPHA..MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL OMEGA
-	{runeRange{0x1D7C4, 0x1D7CB}, wbprALetter},              // L&   [8] MATHEMATICAL SANS-SERIF BOLD ITALIC EPSILON SYMBOL..MATHEMATICAL BOLD SMALL DIGAMMA
-	{runeRange{0x1D7CE, 0x1D7FF}, wbprNumeric},              // Nd  [50] MATHEMATICAL BOLD DIGIT ZERO..MATHEMATICAL MONOSPACE DIGIT NINE
-	{runeRange{0x1DA00, 0x1DA36}, wbprExtend},               // Mn  [55] SIGNWRITING HEAD RIM..SIGNWRITING AIR SUCKING IN
-	{runeRange{0x1DA3B, 0x1DA6C}, wbprExtend},               // Mn  [50] SIGNWRITING MOUTH CLOSED NEUTRAL..SIGNWRITING EXCITEMENT
-	{runeRange{0x1DA75, 0x1DA75}, wbprExtend},               // Mn       SIGNWRITING UPPER BODY TILTING FROM HIP JOINTS
-	{runeRange{0x1DA84, 0x1DA84}, wbprExtend},               // Mn       SIGNWRITING LOCATION HEAD NECK
-	{runeRange{0x1DA9B, 0x1DA9F}, wbprExtend},               // Mn   [5] SIGNWRITING FILL MODIFIER-2..SIGNWRITING FILL MODIFIER-6
-	{runeRange{0x1DAA1, 0x1DAAF}, wbprExtend},               // Mn  [15] SIGNWRITING ROTATION MODIFIER-2..SIGNWRITING ROTATION MODIFIER-16
-	{runeRange{0x1DF00, 0x1DF09}, wbprALetter},              // L&  [10] LATIN SMALL LETTER FENG DIGRAPH WITH TRILL..LATIN SMALL LETTER T WITH HOOK AND RETROFLEX HOOK
-	{runeRange{0x1DF0A, 0x1DF0A}, wbprALetter},              // Lo       LATIN LETTER RETROFLEX CLICK WITH RETROFLEX HOOK
-	{runeRange{0x1DF0B, 0x1DF1E}, wbprALetter},              // L&  [20] LATIN SMALL LETTER ESH WITH DOUBLE BAR..LATIN SMALL LETTER S WITH CURL
-	{runeRange{0x1DF25, 0x1DF2A}, wbprALetter},              // L&   [6] LATIN SMALL LETTER D WITH MID-HEIGHT LEFT HOOK..LATIN SMALL LETTER T WITH MID-HEIGHT LEFT HOOK
-	{runeRange{0x1E000, 0x1E006}, wbprExtend},               // Mn   [7] COMBINING GLAGOLITIC LETTER AZU..COMBINING GLAGOLITIC LETTER ZHIVETE
-	{runeRange{0x1E008, 0x1E018}, wbprExtend},               // Mn  [17] COMBINING GLAGOLITIC LETTER ZEMLJA..COMBINING GLAGOLITIC LETTER HERU
-	{runeRange{0x1E01B, 0x1E021}, wbprExtend},               // Mn   [7] COMBINING GLAGOLITIC LETTER SHTA..COMBINING GLAGOLITIC LETTER YATI
-	{runeRange{0x1E023, 0x1E024}, wbprExtend},               // Mn   [2] COMBINING GLAGOLITIC LETTER YU..COMBINING GLAGOLITIC LETTER SMALL YUS
-	{runeRange{0x1E026, 0x1E02A}, wbprExtend},               // Mn   [5] COMBINING GLAGOLITIC LETTER YO..COMBINING GLAGOLITIC LETTER FITA
-	{runeRange{0x1E030, 0x1E06D}, wbprALetter},              // Lm  [62] MODIFIER LETTER CYRILLIC SMALL A..MODIFIER LETTER CYRILLIC SMALL STRAIGHT U WITH STROKE
-	{runeRange{0x1E08F, 0x1E08F}, wbprExtend},               // Mn       COMBINING CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I
-	{runeRange{0x1E100, 0x1E12C}, wbprALetter},              // Lo  [45] NYIAKENG PUACHUE HMONG LETTER MA..NYIAKENG PUACHUE HMONG LETTER W
-	{runeRange{0x1E130, 0x1E136}, wbprExtend},               // Mn   [7] NYIAKENG PUACHUE HMONG TONE-B..NYIAKENG PUACHUE HMONG TONE-D
-	{runeRange{0x1E137, 0x1E13D}, wbprALetter},              // Lm   [7] NYIAKENG PUACHUE HMONG SIGN FOR PERSON..NYIAKENG PUACHUE HMONG SYLLABLE LENGTHENER
-	{runeRange{0x1E140, 0x1E149}, wbprNumeric},              // Nd  [10] NYIAKENG PUACHUE HMONG DIGIT ZERO..NYIAKENG PUACHUE HMONG DIGIT NINE
-	{runeRange{0x1E14E, 0x1E14E}, wbprALetter},              // Lo       NYIAKENG PUACHUE HMONG LOGOGRAM NYAJ
-	{runeRange{0x1E290, 0x1E2AD}, wbprALetter},              // Lo  [30] TOTO LETTER PA..TOTO LETTER A
-	{runeRange{0x1E2AE, 0x1E2AE}, wbprExtend},               // Mn       TOTO SIGN RISING TONE
-	{runeRange{0x1E2C0, 0x1E2EB}, wbprALetter},              // Lo  [44] WANCHO LETTER AA..WANCHO LETTER YIH
-	{runeRange{0x1E2EC, 0x1E2EF}, wbprExtend},               // Mn   [4] WANCHO TONE TUP..WANCHO TONE KOINI
-	{runeRange{0x1E2F0, 0x1E2F9}, wbprNumeric},              // Nd  [10] WANCHO DIGIT ZERO..WANCHO DIGIT NINE
-	{runeRange{0x1E4D0, 0x1E4EA}, wbprALetter},              // Lo  [27] NAG MUNDARI LETTER O..NAG MUNDARI LETTER ELL
-	{runeRange{0x1E4EB, 0x1E4EB}, wbprALetter},              // Lm       NAG MUNDARI SIGN OJOD
-	{runeRange{0x1E4EC, 0x1E4EF}, wbprExtend},               // Mn   [4] NAG MUNDARI SIGN MUHOR..NAG MUNDARI SIGN SUTUH
-	{runeRange{0x1E4F0, 0x1E4F9}, wbprNumeric},              // Nd  [10] NAG MUNDARI DIGIT ZERO..NAG MUNDARI DIGIT NINE
-	{runeRange{0x1E7E0, 0x1E7E6}, wbprALetter},              // Lo   [7] ETHIOPIC SYLLABLE HHYA..ETHIOPIC SYLLABLE HHYO
-	{runeRange{0x1E7E8, 0x1E7EB}, wbprALetter},              // Lo   [4] ETHIOPIC SYLLABLE GURAGE HHWA..ETHIOPIC SYLLABLE HHWE
-	{runeRange{0x1E7ED, 0x1E7EE}, wbprALetter},              // Lo   [2] ETHIOPIC SYLLABLE GURAGE MWI..ETHIOPIC SYLLABLE GURAGE MWEE
-	{runeRange{0x1E7F0, 0x1E7FE}, wbprALetter},              // Lo  [15] ETHIOPIC SYLLABLE GURAGE QWI..ETHIOPIC SYLLABLE GURAGE PWEE
-	{runeRange{0x1E800, 0x1E8C4}, wbprALetter},              // Lo [197] MENDE KIKAKUI SYLLABLE M001 KI..MENDE KIKAKUI SYLLABLE M060 NYON
-	{runeRange{0x1E8D0, 0x1E8D6}, wbprExtend},               // Mn   [7] MENDE KIKAKUI COMBINING NUMBER TEENS..MENDE KIKAKUI COMBINING NUMBER MILLIONS
-	{runeRange{0x1E900, 0x1E943}, wbprALetter},              // L&  [68] ADLAM CAPITAL LETTER ALIF..ADLAM SMALL LETTER SHA
-	{runeRange{0x1E944, 0x1E94A}, wbprExtend},               // Mn   [7] ADLAM ALIF LENGTHENER..ADLAM NUKTA
-	{runeRange{0x1E94B, 0x1E94B}, wbprALetter},              // Lm       ADLAM NASALIZATION MARK
-	{runeRange{0x1E950, 0x1E959}, wbprNumeric},              // Nd  [10] ADLAM DIGIT ZERO..ADLAM DIGIT NINE
-	{runeRange{0x1EE00, 0x1EE03}, wbprALetter},              // Lo   [4] ARABIC MATHEMATICAL ALEF..ARABIC MATHEMATICAL DAL
-	{runeRange{0x1EE05, 0x1EE1F}, wbprALetter},              // Lo  [27] ARABIC MATHEMATICAL WAW..ARABIC MATHEMATICAL DOTLESS QAF
-	{runeRange{0x1EE21, 0x1EE22}, wbprALetter},              // Lo   [2] ARABIC MATHEMATICAL INITIAL BEH..ARABIC MATHEMATICAL INITIAL JEEM
-	{runeRange{0x1EE24, 0x1EE24}, wbprALetter},              // Lo       ARABIC MATHEMATICAL INITIAL HEH
-	{runeRange{0x1EE27, 0x1EE27}, wbprALetter},              // Lo       ARABIC MATHEMATICAL INITIAL HAH
-	{runeRange{0x1EE29, 0x1EE32}, wbprALetter},              // Lo  [10] ARABIC MATHEMATICAL INITIAL YEH..ARABIC MATHEMATICAL INITIAL QAF
-	{runeRange{0x1EE34, 0x1EE37}, wbprALetter},              // Lo   [4] ARABIC MATHEMATICAL INITIAL SHEEN..ARABIC MATHEMATICAL INITIAL KHAH
-	{runeRange{0x1EE39, 0x1EE39}, wbprALetter},              // Lo       ARABIC MATHEMATICAL INITIAL DAD
-	{runeRange{0x1EE3B, 0x1EE3B}, wbprALetter},              // Lo       ARABIC MATHEMATICAL INITIAL GHAIN
-	{runeRange{0x1EE42, 0x1EE42}, wbprALetter},              // Lo       ARABIC MATHEMATICAL TAILED JEEM
-	{runeRange{0x1EE47, 0x1EE47}, wbprALetter},              // Lo       ARABIC MATHEMATICAL TAILED HAH
-	{runeRange{0x1EE49, 0x1EE49}, wbprALetter},              // Lo       ARABIC MATHEMATICAL TAILED YEH
-	{runeRange{0x1EE4B, 0x1EE4B}, wbprALetter},              // Lo       ARABIC MATHEMATICAL TAILED LAM
-	{runeRange{0x1EE4D, 0x1EE4F}, wbprALetter},              // Lo   [3] ARABIC MATHEMATICAL TAILED NOON..ARABIC MATHEMATICAL TAILED AIN
-	{runeRange{0x1EE51, 0x1EE52}, wbprALetter},              // Lo   [2] ARABIC MATHEMATICAL TAILED SAD..ARABIC MATHEMATICAL TAILED QAF
-	{runeRange{0x1EE54, 0x1EE54}, wbprALetter},              // Lo       ARABIC MATHEMATICAL TAILED SHEEN
-	{runeRange{0x1EE57, 0x1EE57}, wbprALetter},              // Lo       ARABIC MATHEMATICAL TAILED KHAH
-	{runeRange{0x1EE59, 0x1EE59}, wbprALetter},              // Lo       ARABIC MATHEMATICAL TAILED DAD
-	{runeRange{0x1EE5B, 0x1EE5B}, wbprALetter},              // Lo       ARABIC MATHEMATICAL TAILED GHAIN
-	{runeRange{0x1EE5D, 0x1EE5D}, wbprALetter},              // Lo       ARABIC MATHEMATICAL TAILED DOTLESS NOON
-	{runeRange{0x1EE5F, 0x1EE5F}, wbprALetter},              // Lo       ARABIC MATHEMATICAL TAILED DOTLESS QAF
-	{runeRange{0x1EE61, 0x1EE62}, wbprALetter},              // Lo   [2] ARABIC MATHEMATICAL STRETCHED BEH..ARABIC MATHEMATICAL STRETCHED JEEM
-	{runeRange{0x1EE64, 0x1EE64}, wbprALetter},              // Lo       ARABIC MATHEMATICAL STRETCHED HEH
-	{runeRange{0x1EE67, 0x1EE6A}, wbprALetter},              // Lo   [4] ARABIC MATHEMATICAL STRETCHED HAH..ARABIC MATHEMATICAL STRETCHED KAF
-	{runeRange{0x1EE6C, 0x1EE72}, wbprALetter},              // Lo   [7] ARABIC MATHEMATICAL STRETCHED MEEM..ARABIC MATHEMATICAL STRETCHED QAF
-	{runeRange{0x1EE74, 0x1EE77}, wbprALetter},              // Lo   [4] ARABIC MATHEMATICAL STRETCHED SHEEN..ARABIC MATHEMATICAL STRETCHED KHAH
-	{runeRange{0x1EE79, 0x1EE7C}, wbprALetter},              // Lo   [4] ARABIC MATHEMATICAL STRETCHED DAD..ARABIC MATHEMATICAL STRETCHED DOTLESS BEH
-	{runeRange{0x1EE7E, 0x1EE7E}, wbprALetter},              // Lo       ARABIC MATHEMATICAL STRETCHED DOTLESS FEH
-	{runeRange{0x1EE80, 0x1EE89}, wbprALetter},              // Lo  [10] ARABIC MATHEMATICAL LOOPED ALEF..ARABIC MATHEMATICAL LOOPED YEH
-	{runeRange{0x1EE8B, 0x1EE9B}, wbprALetter},              // Lo  [17] ARABIC MATHEMATICAL LOOPED LAM..ARABIC MATHEMATICAL LOOPED GHAIN
-	{runeRange{0x1EEA1, 0x1EEA3}, wbprALetter},              // Lo   [3] ARABIC MATHEMATICAL DOUBLE-STRUCK BEH..ARABIC MATHEMATICAL DOUBLE-STRUCK DAL
-	{runeRange{0x1EEA5, 0x1EEA9}, wbprALetter},              // Lo   [5] ARABIC MATHEMATICAL DOUBLE-STRUCK WAW..ARABIC MATHEMATICAL DOUBLE-STRUCK YEH
-	{runeRange{0x1EEAB, 0x1EEBB}, wbprALetter},              // Lo  [17] ARABIC MATHEMATICAL DOUBLE-STRUCK LAM..ARABIC MATHEMATICAL DOUBLE-STRUCK GHAIN
-	{runeRange{0x1F000, 0x1F003}, wbprExtendedPictographic}, // E0.0   [4] (🀀..🀃)    MAHJONG TILE EAST WIND..MAHJONG TILE NORTH WIND
-	{runeRange{0x1F004, 0x1F004}, wbprExtendedPictographic}, // E0.6   [1] (🀄)       mahjong red dragon
-	{runeRange{0x1F005, 0x1F0CE}, wbprExtendedPictographic}, // E0.0 [202] (🀅..🃎)    MAHJONG TILE GREEN DRAGON..PLAYING CARD KING OF DIAMONDS
-	{runeRange{0x1F0CF, 0x1F0CF}, wbprExtendedPictographic}, // E0.6   [1] (🃏)       joker
-	{runeRange{0x1F0D0, 0x1F0FF}, wbprExtendedPictographic}, // E0.0  [48] (🃐..🃿)    <reserved-1F0D0>..<reserved-1F0FF>
-	{runeRange{0x1F10D, 0x1F10F}, wbprExtendedPictographic}, // E0.0   [3] (🄍..🄏)    CIRCLED ZERO WITH SLASH..CIRCLED DOLLAR SIGN WITH OVERLAID BACKSLASH
-	{runeRange{0x1F12F, 0x1F12F}, wbprExtendedPictographic}, // E0.0   [1] (🄯)       COPYLEFT SYMBOL
-	{runeRange{0x1F130, 0x1F149}, wbprALetter},              // So  [26] SQUARED LATIN CAPITAL LETTER A..SQUARED LATIN CAPITAL LETTER Z
-	{runeRange{0x1F150, 0x1F169}, wbprALetter},              // So  [26] NEGATIVE CIRCLED LATIN CAPITAL LETTER A..NEGATIVE CIRCLED LATIN CAPITAL LETTER Z
-	{runeRange{0x1F16C, 0x1F16F}, wbprExtendedPictographic}, // E0.0   [4] (🅬..🅯)    RAISED MR SIGN..CIRCLED HUMAN FIGURE
-	{runeRange{0x1F170, 0x1F189}, wbprALetter},              // So  [26] NEGATIVE SQUARED LATIN CAPITAL LETTER A..NEGATIVE SQUARED LATIN CAPITAL LETTER Z
-	{runeRange{0x1F170, 0x1F171}, wbprExtendedPictographic}, // E0.6   [2] (🅰️..🅱️)    A button (blood type)..B button (blood type)
-	{runeRange{0x1F17E, 0x1F17F}, wbprExtendedPictographic}, // E0.6   [2] (🅾️..🅿️)    O button (blood type)..P button
-	{runeRange{0x1F18E, 0x1F18E}, wbprExtendedPictographic}, // E0.6   [1] (🆎)       AB button (blood type)
-	{runeRange{0x1F191, 0x1F19A}, wbprExtendedPictographic}, // E0.6  [10] (🆑..🆚)    CL button..VS button
-	{runeRange{0x1F1AD, 0x1F1E5}, wbprExtendedPictographic}, // E0.0  [57] (🆭..🇥)    MASK WORK SYMBOL..<reserved-1F1E5>
-	{runeRange{0x1F1E6, 0x1F1FF}, wbprRegionalIndicator},    // So  [26] REGIONAL INDICATOR SYMBOL LETTER A..REGIONAL INDICATOR SYMBOL LETTER Z
-	{runeRange{0x1F201, 0x1F202}, wbprExtendedPictographic}, // E0.6   [2] (🈁..🈂️)    Japanese “here” button..Japanese “service charge” button
-	{runeRange{0x1F203, 0x1F20F}, wbprExtendedPictographic}, // E0.0  [13] (🈃..🈏)    <reserved-1F203>..<reserved-1F20F>
-	{runeRange{0x1F21A, 0x1F21A}, wbprExtendedPictographic}, // E0.6   [1] (🈚)       Japanese “free of charge” button
-	{runeRange{0x1F22F, 0x1F22F}, wbprExtendedPictographic}, // E0.6   [1] (🈯)       Japanese “reserved” button
-	{runeRange{0x1F232, 0x1F23A}, wbprExtendedPictographic}, // E0.6   [9] (🈲..🈺)    Japanese “prohibited” button..Japanese “open for business” button
-	{runeRange{0x1F23C, 0x1F23F}, wbprExtendedPictographic}, // E0.0   [4] (🈼..🈿)    <reserved-1F23C>..<reserved-1F23F>
-	{runeRange{0x1F249, 0x1F24F}, wbprExtendedPictographic}, // E0.0   [7] (🉉..🉏)    <reserved-1F249>..<reserved-1F24F>
-	{runeRange{0x1F250, 0x1F251}, wbprExtendedPictographic}, // E0.6   [2] (🉐..🉑)    Japanese “bargain” button..Japanese “acceptable” button
-	{runeRange{0x1F252, 0x1F2FF}, wbprExtendedPictographic}, // E0.0 [174] (🉒..🋿)    <reserved-1F252>..<reserved-1F2FF>
-	{runeRange{0x1F300, 0x1F30C}, wbprExtendedPictographic}, // E0.6  [13] (🌀..🌌)    cyclone..milky way
-	{runeRange{0x1F30D, 0x1F30E}, wbprExtendedPictographic}, // E0.7   [2] (🌍..🌎)    globe showing Europe-Africa..globe showing Americas
-	{runeRange{0x1F30F, 0x1F30F}, wbprExtendedPictographic}, // E0.6   [1] (🌏)       globe showing Asia-Australia
+	{runeRange{0x1BAB, 0x1BAD}, wbprExtend},                 // Mn   [3] SUNDANESE SIGN VIRAMA..SUNDANESE CONSONANT SIGN PASANGAN WA
 	{runeRange{0x1F310, 0x1F310}, wbprExtendedPictographic}, // E1.0   [1] (🌐)       globe with meridians
-	{runeRange{0x1F311, 0x1F311}, wbprExtendedPictographic}, // E0.6   [1] (🌑)       new moon
-	{runeRange{0x1F312, 0x1F312}, wbprExtendedPictographic}, // E1.0   [1] (🌒)       waxing crescent moon
-	{runeRange{0x1F313, 0x1F315}, wbprExtendedPictographic}, // E0.6   [3] (🌓..🌕)    first quarter moon..full moon
-	{runeRange{0x1F316, 0x1F318}, wbprExtendedPictographic}, // E1.0   [3] (🌖..🌘)    waning gibbous moon..waning crescent moon
-	{runeRange{0x1F319, 0x1F319}, wbprExtendedPictographic}, // E0.6   [1] (🌙)       crescent moon
-	{runeRange{0x1F31A, 0x1F31A}, wbprExtendedPictographic}, // E1.0   [1] (🌚)       new moon face
-	{runeRange{0x1F31B, 0x1F31B}, wbprExtendedPictographic}, // E0.6   [1] (🌛)       first quarter moon face
-	{runeRange{0x1F31C, 0x1F31C}, wbprExtendedPictographic}, // E0.7   [1] (🌜)       last quarter moon face
-	{runeRange{0x1F31D, 0x1F31E}, wbprExtendedPictographic}, // E1.0   [2] (🌝..🌞)    full moon face..sun with face
-	{runeRange{0x1F31F, 0x1F320}, wbprExtendedPictographic}, // E0.6   [2] (🌟..🌠)    glowing star..shooting star
-	{runeRange{0x1F321, 0x1F321}, wbprExtendedPictographic}, // E0.7   [1] (🌡️)       thermometer
-	{runeRange{0x1F322, 0x1F323}, wbprExtendedPictographic}, // E0.0   [2] (🌢..🌣)    BLACK DROPLET..WHITE SUN
-	{runeRange{0x1F324, 0x1F32C}, wbprExtendedPictographic}, // E0.7   [9] (🌤️..🌬️)    sun behind small cloud..wind face
-	{runeRange{0x1F32D, 0x1F32F}, wbprExtendedPictographic}, // E1.0   [3] (🌭..🌯)    hot dog..burrito
-	{runeRange{0x1F330, 0x1F331}, wbprExtendedPictographic}, // E0.6   [2] (🌰..🌱)    chestnut..seedling
-	{runeRange{0x1F332, 0x1F333}, wbprExtendedPictographic}, // E1.0   [2] (🌲..🌳)    evergreen tree..deciduous tree
-	{runeRange{0x1F334, 0x1F335}, wbprExtendedPictographic}, // E0.6   [2] (🌴..🌵)    palm tree..cactus
-	{runeRange{0x1F336, 0x1F336}, wbprExtendedPictographic}, // E0.7   [1] (🌶️)       hot pepper
-	{runeRange{0x1F337, 0x1F34A}, wbprExtendedPictographic}, // E0.6  [20] (🌷..🍊)    tulip..tangerine
-	{runeRange{0x1F34B, 0x1F34B}, wbprExtendedPictographic}, // E1.0   [1] (🍋)       lemon
-	{runeRange{0x1F34C, 0x1F34F}, wbprExtendedPictographic}, // E0.6   [4] (🍌..🍏)    banana..green apple
-	{runeRange{0x1F350, 0x1F350}, wbprExtendedPictographic}, // E1.0   [1] (🍐)       pear
-	{runeRange{0x1F351, 0x1F37B}, wbprExtendedPictographic}, // E0.6  [43] (🍑..🍻)    peach..clinking beer mugs
-	{runeRange{0x1F37C, 0x1F37C}, wbprExtendedPictographic}, // E1.0   [1] (🍼)       baby bottle
-	{runeRange{0x1F37D, 0x1F37D}, wbprExtendedPictographic}, // E0.7   [1] (🍽️)       fork and knife with plate
-	{runeRange{0x1F37E, 0x1F37F}, wbprExtendedPictographic}, // E1.0   [2] (🍾..🍿)    bottle with popping cork..popcorn
-	{runeRange{0x1F380, 0x1F393}, wbprExtendedPictographic}, // E0.6  [20] (🎀..🎓)    ribbon..graduation cap
-	{runeRange{0x1F394, 0x1F395}, wbprExtendedPictographic}, // E0.0   [2] (🎔..🎕)    HEART WITH TIP ON THE LEFT..BOUQUET OF FLOWERS
-	{runeRange{0x1F396, 0x1F397}, wbprExtendedPictographic}, // E0.7   [2] (🎖️..🎗️)    military medal..reminder ribbon
-	{runeRange{0x1F398, 0x1F398}, wbprExtendedPictographic}, // E0.0   [1] (🎘)       MUSICAL KEYBOARD WITH JACKS
-	{runeRange{0x1F399, 0x1F39B}, wbprExtendedPictographic}, // E0.7   [3] (🎙️..🎛️)    studio microphone..control knobs
-	{runeRange{0x1F39C, 0x1F39D}, wbprExtendedPictographic}, // E0.0   [2] (🎜..🎝)    BEAMED ASCENDING MUSICAL NOTES..BEAMED DESCENDING MUSICAL NOTES
-	{runeRange{0x1F39E, 0x1F39F}, wbprExtendedPictographic}, // E0.7   [2] (🎞️..🎟️)    film frames..admission tickets
-	{runeRange{0x1F3A0, 0x1F3C4}, wbprExtendedPictographic}, // E0.6  [37] (🎠..🏄)    carousel horse..person surfing
-	{runeRange{0x1F3C5, 0x1F3C5}, wbprExtendedPictographic}, // E1.0   [1] (🏅)       sports medal
-	{runeRange{0x1F3C6, 0x1F3C6}, wbprExtendedPictographic}, // E0.6   [1] (🏆)       trophy
-	{runeRange{0x1F3C7, 0x1F3C7}, wbprExtendedPictographic}, // E1.0   [1] (🏇)       horse racing
-	{runeRange{0x1F3C8, 0x1F3C8}, wbprExtendedPictographic}, // E0.6   [1] (🏈)       american football
-	{runeRange{0x1F3C9, 0x1F3C9}, wbprExtendedPictographic}, // E1.0   [1] (🏉)       rugby football
-	{runeRange{0x1F3CA, 0x1F3CA}, wbprExtendedPictographic}, // E0.6   [1] (🏊)       person swimming
-	{runeRange{0x1F3CB, 0x1F3CE}, wbprExtendedPictographic}, // E0.7   [4] (🏋️..🏎️)    person lifting weights..racing car
-	{runeRange{0x1F3CF, 0x1F3D3}, wbprExtendedPictographic}, // E1.0   [5] (🏏..🏓)    cricket game..ping pong
-	{runeRange{0x1F3D4, 0x1F3DF}, wbprExtendedPictographic}, // E0.7  [12] (🏔️..🏟️)    snow-capped mountain..stadium
-	{runeRange{0x1F3E0, 0x1F3E3}, wbprExtendedPictographic}, // E0.6   [4] (🏠..🏣)    house..Japanese post office
-	{runeRange{0x1F3E4, 0x1F3E4}, wbprExtendedPictographic}, // E1.0   [1] (🏤)       post office
-	{runeRange{0x1F3E5, 0x1F3F0}, wbprExtendedPictographic}, // E0.6  [12] (🏥..🏰)    hospital..castle
-	{runeRange{0x1F3F1, 0x1F3F2}, wbprExtendedPictographic}, // E0.0   [2] (🏱..🏲)    WHITE PENNANT..BLACK PENNANT
-	{runeRange{0x1F3F3, 0x1F3F3}, wbprExtendedPictographic}, // E0.7   [1] (🏳️)       white flag
-	{runeRange{0x1F3F4, 0x1F3F4}, wbprExtendedPictographic}, // E1.0   [1] (🏴)       black flag
-	{runeRange{0x1F3F5, 0x1F3F5}, wbprExtendedPictographic}, // E0.7   [1] (🏵️)       rosette
-	{runeRange{0x1F3F6, 0x1F3F6}, wbprExtendedPictographic}, // E0.0   [1] (🏶)       BLACK ROSETTE
-	{runeRange{0x1F3F7, 0x1F3F7}, wbprExtendedPictographic}, // E0.7   [1] (🏷️)       label
-	{runeRange{0x1F3F8, 0x1F3FA}, wbprExtendedPictographic}, // E1.0   [3] (🏸..🏺)    badminton..amphora
-	{runeRange{0x1F3FB, 0x1F3FF}, wbprExtend},               // Sk   [5] EMOJI MODIFIER FITZPATRICK TYPE-1-2..EMOJI MODIFIER FITZPATRICK TYPE-6
-	{runeRange{0x1F400, 0x1F407}, wbprExtendedPictographic}, // E1.0   [8] (🐀..🐇)    rat..rabbit
-	{runeRange{0x1F408, 0x1F408}, wbprExtendedPictographic}, // E0.7   [1] (🐈)       cat
-	{runeRange{0x1F409, 0x1F40B}, wbprExtendedPictographic}, // E1.0   [3] (🐉..🐋)    dragon..whale
-	{runeRange{0x1F40C, 0x1F40E}, wbprExtendedPictographic}, // E0.6   [3] (🐌..🐎)    snail..horse
-	{runeRange{0x1F40F, 0x1F410}, wbprExtendedPictographic}, // E1.0   [2] (🐏..🐐)    ram..goat
-	{runeRange{0x1F411, 0x1F412}, wbprExtendedPictographic}, // E0.6   [2] (🐑..🐒)    ewe..monkey
-	{runeRange{0x1F413, 0x1F413}, wbprExtendedPictographic}, // E1.0   [1] (🐓)       rooster
-	{runeRange{0x1F414, 0x1F414}, wbprExtendedPictographic}, // E0.6   [1] (🐔)       chicken
-	{runeRange{0x1F415, 0x1F415}, wbprExtendedPictographic}, // E0.7   [1] (🐕)       dog
-	{runeRange{0x1F416, 0x1F416}, wbprExtendedPictographic}, // E1.0   [1] (🐖)       pig
-	{runeRange{0x1F417, 0x1F429}, wbprExtendedPictographic}, // E0.6  [19] (🐗..🐩)    boar..poodle
-	{runeRange{0x1F42A, 0x1F42A}, wbprExtendedPictographic}, // E1.0   [1] (🐪)       camel
-	{runeRange{0x1F42B, 0x1F43E}, wbprExtendedPictographic}, // E0.6  [20] (🐫..🐾)    two-hump camel..paw prints
-	{runeRange{0x1F43F, 0x1F43F}, wbprExtendedPictographic}, // E0.7   [1] (🐿️)       chipmunk
-	{runeRange{0x1F440, 0x1F440}, wbprExtendedPictographic}, // E0.6   [1] (👀)       eyes
-	{runeRange{0x1F441, 0x1F441}, wbprExtendedPictographic}, // E0.7   [1] (👁️)       eye
-	{runeRange{0x1F442, 0x1F464}, wbprExtendedPictographic}, // E0.6  [35] (👂..👤)    ear..bust in silhouette
-	{runeRange{0x1F465, 0x1F465}, wbprExtendedPictographic}, // E1.0   [1] (👥)       busts in silhouette
-	{runeRange{0x1F466, 0x1F46B}, wbprExtendedPictographic}, // E0.6   [6] (👦..👫)    boy..woman and man holding hands
-	{runeRange{0x1F46C, 0x1F46D}, wbprExtendedPictographic}, // E1.0   [2] (👬..👭)    men holding hands..women holding hands
-	{runeRange{0x1F46E, 0x1F4AC}, wbprExtendedPictographic}, // E0.6  [63] (👮..💬)    police officer..speech balloon
-	{runeRange{0x1F4AD, 0x1F4AD}, wbprExtendedPictographic}, // E1.0   [1] (💭)       thought balloon
-	{runeRange{0x1F4AE, 0x1F4B5}, wbprExtendedPictographic}, // E0.6   [8] (💮..💵)    white flower..dollar banknote
-	{runeRange{0x1F4B6, 0x1F4B7}, wbprExtendedPictographic}, // E1.0   [2] (💶..💷)    euro banknote..pound banknote
-	{runeRange{0x1F4B8, 0x1F4EB}, wbprExtendedPictographic}, // E0.6  [52] (💸..📫)    money with wings..closed mailbox with raised flag
-	{runeRange{0x1F4EC, 0x1F4ED}, wbprExtendedPictographic}, // E0.7   [2] (📬..📭)    open mailbox with raised flag..open mailbox with lowered flag
-	{runeRange{0x1F4EE, 0x1F4EE}, wbprExtendedPictographic}, // E0.6   [1] (📮)       postbox
-	{runeRange{0x1F4EF, 0x1F4EF}, wbprExtendedPictographic}, // E1.0   [1] (📯)       postal horn
-	{runeRange{0x1F4F0, 0x1F4F4}, wbprExtendedPictographic}, // E0.6   [5] (📰..📴)    newspaper..mobile phone off
-	{runeRange{0x1F4F5, 0x1F4F5}, wbprExtendedPictographic}, // E1.0   [1] (📵)       no mobile phones
-	{runeRange{0x1F4F6, 0x1F4F7}, wbprExtendedPictographic}, // E0.6   [2] (📶..📷)    antenna bars..camera
-	{runeRange{0x1F4F8, 0x1F4F8}, wbprExtendedPictographic}, // E1.0   [1] (📸)       camera with flash
-	{runeRange{0x1F4F9, 0x1F4FC}, wbprExtendedPictographic}, // E0.6   [4] (📹..📼)    video camera..videocassette
-	{runeRange{0x1F4FD, 0x1F4FD}, wbprExtendedPictographic}, // E0.7   [1] (📽️)       film projector
-	{runeRange{0x1F4FE, 0x1F4FE}, wbprExtendedPictographic}, // E0.0   [1] (📾)       PORTABLE STEREO
-	{runeRange{0x1F4FF, 0x1F502}, wbprExtendedPictographic}, // E1.0   [4] (📿..🔂)    prayer beads..repeat single button
-	{runeRange{0x1F503, 0x1F503}, wbprExtendedPictographic}, // E0.6   [1] (🔃)       clockwise vertical arrows
-	{runeRange{0x1F504, 0x1F507}, wbprExtendedPictographic}, // E1.0   [4] (🔄..🔇)    counterclockwise arrows button..muted speaker
-	{runeRange{0x1F508, 0x1F508}, wbprExtendedPictographic}, // E0.7   [1] (🔈)       speaker low volume
-	{runeRange{0x1F509, 0x1F509}, wbprExtendedPictographic}, // E1.0   [1] (🔉)       speaker medium volume
-	{runeRange{0x1F50A, 0x1F514}, wbprExtendedPictographic}, // E0.6  [11] (🔊..🔔)    speaker high volume..bell
-	{runeRange{0x1F515, 0x1F515}, wbprExtendedPictographic}, // E1.0   [1] (🔕)       bell with slash
-	{runeRange{0x1F516, 0x1F52B}, wbprExtendedPictographic}, // E0.6  [22] (🔖..🔫)    bookmark..water pistol
-	{runeRange{0x1F52C, 0x1F52D}, wbprExtendedPictographic}, // E1.0   [2] (🔬..🔭)    microscope..telescope
-	{runeRange{0x1F52E, 0x1F53D}, wbprExtendedPictographic}, // E0.6  [16] (🔮..🔽)    crystal ball..downwards button
-	{runeRange{0x1F546, 0x1F548}, wbprExtendedPictographic}, // E0.0   [3] (🕆..🕈)    WHITE LATIN CROSS..CELTIC CROSS
-	{runeRange{0x1F549, 0x1F54A}, wbprExtendedPictographic}, // E0.7   [2] (🕉️..🕊️)    om..dove
-	{runeRange{0x1F54B, 0x1F54E}, wbprExtendedPictographic}, // E1.0   [4] (🕋..🕎)    kaaba..menorah
-	{runeRange{0x1F54F, 0x1F54F}, wbprExtendedPictographic}, // E0.0   [1] (🕏)       BOWL OF HYGIEIA
-	{runeRange{0x1F550, 0x1F55B}, wbprExtendedPictographic}, // E0.6  [12] (🕐..🕛)    one o’clock..twelve o’clock
-	{runeRange{0x1F55C, 0x1F567}, wbprExtendedPictographic}, // E0.7  [12] (🕜..🕧)    one-thirty..twelve-thirty
-	{runeRange{0x1F568, 0x1F56E}, wbprExtendedPictographic}, // E0.0   [7] (🕨..🕮)    RIGHT SPEAKER..BOOK
-	{runeRange{0x1F56F, 0x1F570}, wbprExtendedPictographic}, // E0.7   [2] (🕯️..🕰️)    candle..mantelpiece clock
-	{runeRange{0x1F571, 0x1F572}, wbprExtendedPictographic}, // E0.0   [2] (🕱..🕲)    BLACK SKULL AND CROSSBONES..NO PIRACY
-	{runeRange{0x1F573, 0x1F579}, wbprExtendedPictographic}, // E0.7   [7] (🕳️..🕹️)    hole..joystick
-	{runeRange{0x1F57A, 0x1F57A}, wbprExtendedPictographic}, // E3.0   [1] (🕺)       man dancing
-	{runeRange{0x1F57B, 0x1F586}, wbprExtendedPictographic}, // E0.0  [12] (🕻..🖆)    LEFT HAND TELEPHONE RECEIVER..PEN OVER STAMPED ENVELOPE
-	{runeRange{0x1F587, 0x1F587}, wbprExtendedPictographic}, // E0.7   [1] (🖇️)       linked paperclips
-	{runeRange{0x1F588, 0x1F589}, wbprExtendedPictographic}, // E0.0   [2] (🖈..🖉)    BLACK PUSHPIN..LOWER LEFT PENCIL
-	{runeRange{0x1F58A, 0x1F58D}, wbprExtendedPictographic}, // E0.7   [4] (🖊️..🖍️)    pen..crayon
-	{runeRange{0x1F58E, 0x1F58F}, wbprExtendedPictographic}, // E0.0   [2] (🖎..🖏)    LEFT WRITING HAND..TURNED OK HAND SIGN
-	{runeRange{0x1F590, 0x1F590}, wbprExtendedPictographic}, // E0.7   [1] (🖐️)       hand with fingers splayed
-	{runeRange{0x1F591, 0x1F594}, wbprExtendedPictographic}, // E0.0   [4] (🖑..🖔)    REVERSED RAISED HAND WITH FINGERS SPLAYED..REVERSED VICTORY HAND
-	{runeRange{0x1F595, 0x1F596}, wbprExtendedPictographic}, // E1.0   [2] (🖕..🖖)    middle finger..vulcan salute
-	{runeRange{0x1F597, 0x1F5A3}, wbprExtendedPictographic}, // E0.0  [13] (🖗..🖣)    WHITE DOWN POINTING LEFT HAND INDEX..BLACK DOWN POINTING BACKHAND INDEX
-	{runeRange{0x1F5A4, 0x1F5A4}, wbprExtendedPictographic}, // E3.0   [1] (🖤)       black heart
-	{runeRange{0x1F5A5, 0x1F5A5}, wbprExtendedPictographic}, // E0.7   [1] (🖥️)       desktop computer
-	{runeRange{0x1F5A6, 0x1F5A7}, wbprExtendedPictographic}, // E0.0   [2] (🖦..🖧)    KEYBOARD AND MOUSE..THREE NETWORKED COMPUTERS
-	{runeRange{0x1F5A8, 0x1F5A8}, wbprExtendedPictographic}, // E0.7   [1] (🖨️)       printer
-	{runeRange{0x1F5A9, 0x1F5B0}, wbprExtendedPictographic}, // E0.0   [8] (🖩..🖰)    POCKET CALCULATOR..TWO BUTTON MOUSE
-	{runeRange{0x1F5B1, 0x1F5B2}, wbprExtendedPictographic}, // E0.7   [2] (🖱️..🖲️)    computer mouse..trackball
-	{runeRange{0x1F5B3, 0x1F5BB}, wbprExtendedPictographic}, // E0.0   [9] (🖳..🖻)    OLD PERSONAL COMPUTER..DOCUMENT WITH PICTURE
-	{runeRange{0x1F5BC, 0x1F5BC}, wbprExtendedPictographic}, // E0.7   [1] (🖼️)       framed picture
-	{runeRange{0x1F5BD, 0x1F5C1}, wbprExtendedPictographic}, // E0.0   [5] (🖽..🗁)    FRAME WITH TILES..OPEN FOLDER
-	{runeRange{0x1F5C2, 0x1F5C4}, wbprExtendedPictographic}, // E0.7   [3] (🗂️..🗄️)    card index dividers..file cabinet
-	{runeRange{0x1F5C5, 0x1F5D0}, wbprExtendedPictographic}, // E0.0  [12] (🗅..🗐)    EMPTY NOTE..PAGES
-	{runeRange{0x1F5D1, 0x1F5D3}, wbprExtendedPictographic}, // E0.7   [3] (🗑️..🗓️)    wastebasket..spiral calendar
-	{runeRange{0x1F5D4, 0x1F5DB}, wbprExtendedPictographic}, // E0.0   [8] (🗔..🗛)    DESKTOP WINDOW..DECREASE FONT SIZE SYMBOL
-	{runeRange{0x1F5DC, 0x1F5DE}, wbprExtendedPictographic}, // E0.7   [3] (🗜️..🗞️)    clamp..rolled-up newspaper
-	{runeRange{0x1F5DF, 0x1F5E0}, wbprExtendedPictographic}, // E0.0   [2] (🗟..🗠)    PAGE WITH CIRCLED TEXT..STOCK CHART
-	{runeRange{0x1F5E1, 0x1F5E1}, wbprExtendedPictographic}, // E0.7   [1] (🗡️)       dagger
-	{runeRange{0x1F5E2, 0x1F5E2}, wbprExtendedPictographic}, // E0.0   [1] (🗢)       LIPS
-	{runeRange{0x1F5E3, 0x1F5E3}, wbprExtendedPictographic}, // E0.7   [1] (🗣️)       speaking head
-	{runeRange{0x1F5E4, 0x1F5E7}, wbprExtendedPictographic}, // E0.0   [4] (🗤..🗧)    THREE RAYS ABOVE..THREE RAYS RIGHT
-	{runeRange{0x1F5E8, 0x1F5E8}, wbprExtendedPictographic}, // E2.0   [1] (🗨️)       left speech bubble
-	{runeRange{0x1F5E9, 0x1F5EE}, wbprExtendedPictographic}, // E0.0   [6] (🗩..🗮)    RIGHT SPEECH BUBBLE..LEFT ANGER BUBBLE
-	{runeRange{0x1F5EF, 0x1F5EF}, wbprExtendedPictographic}, // E0.7   [1] (🗯️)       right anger bubble
-	{runeRange{0x1F5F0, 0x1F5F2}, wbprExtendedPictographic}, // E0.0   [3] (🗰..🗲)    MOOD BUBBLE..LIGHTNING MOOD
-	{runeRange{0x1F5F3, 0x1F5F3}, wbprExtendedPictographic}, // E0.7   [1] (🗳️)       ballot box with ballot
-	{runeRange{0x1F5F4, 0x1F5F9}, wbprExtendedPictographic}, // E0.0   [6] (🗴..🗹)    BALLOT SCRIPT X..BALLOT BOX WITH BOLD CHECK
-	{runeRange{0x1F5FA, 0x1F5FA}, wbprExtendedPictographic}, // E0.7   [1] (🗺️)       world map
-	{runeRange{0x1F5FB, 0x1F5FF}, wbprExtendedPictographic}, // E0.6   [5] (🗻..🗿)    mount fuji..moai
-	{runeRange{0x1F600, 0x1F600}, wbprExtendedPictographic}, // E1.0   [1] (😀)       grinning face
-	{runeRange{0x1F601, 0x1F606}, wbprExtendedPictographic}, // E0.6   [6] (😁..😆)    beaming face with smiling eyes..grinning squinting face
-	{runeRange{0x1F607, 0x1F608}, wbprExtendedPictographic}, // E1.0   [2] (😇..😈)    smiling face with halo..smiling face with horns
-	{runeRange{0x1F609, 0x1F60D}, wbprExtendedPictographic}, // E0.6   [5] (😉..😍)    winking face..smiling face with heart-eyes
-	{runeRange{0x1F60E, 0x1F60E}, wbprExtendedPictographic}, // E1.0   [1] (😎)       smiling face with sunglasses
-	{runeRange{0x1F60F, 0x1F60F}, wbprExtendedPictographic}, // E0.6   [1] (😏)       smirking face
-	{runeRange{0x1F610, 0x1F610}, wbprExtendedPictographic}, // E0.7   [1] (😐)       neutral face
-	{runeRange{0x1F611, 0x1F611}, wbprExtendedPictographic}, // E1.0   [1] (😑)       expressionless face
-	{runeRange{0x1F612, 0x1F614}, wbprExtendedPictographic}, // E0.6   [3] (😒..😔)    unamused face..pensive face
-	{runeRange{0x1F615, 0x1F615}, wbprExtendedPictographic}, // E1.0   [1] (😕)       confused face
-	{runeRange{0x1F616, 0x1F616}, wbprExtendedPictographic}, // E0.6   [1] (😖)       confounded face
-	{runeRange{0x1F617, 0x1F617}, wbprExtendedPictographic}, // E1.0   [1] (😗)       kissing face
-	{runeRange{0x1F618, 0x1F618}, wbprExtendedPictographic}, // E0.6   [1] (😘)       face blowing a kiss
-	{runeRange{0x1F619, 0x1F619}, wbprExtendedPictographic}, // E1.0   [1] (😙)       kissing face with smiling eyes
-	{runeRange{0x1F61A, 0x1F61A}, wbprExtendedPictographic}, // E0.6   [1] (😚)       kissing face with closed eyes
-	{runeRange{0x1F61B, 0x1F61B}, wbprExtendedPictographic}, // E1.0   [1] (😛)       face with tongue
-	{runeRange{0x1F61C, 0x1F61E}, wbprExtendedPictographic}, // E0.6   [3] (😜..😞)    winking face with tongue..disappointed face
-	{runeRange{0x1F61F, 0x1F61F}, wbprExtendedPictographic}, // E1.0   [1] (😟)       worried face
-	{runeRange{0x1F620, 0x1F625}, wbprExtendedPictographic}, // E0.6   [6] (😠..😥)    angry face..sad but relieved face
-	{runeRange{0x1F626, 0x1F627}, wbprExtendedPictographic}, // E1.0   [2] (😦..😧)    frowning face with open mouth..anguished face
-	{runeRange{0x1F628, 0x1F62B}, wbprExtendedPictographic}, // E0.6   [4] (😨..😫)    fearful face..tired face
-	{runeRange{0x1F62C, 0x1F62C}, wbprExtendedPictographic}, // E1.0   [1] (😬)       grimacing face
-	{runeRange{0x1F62D, 0x1F62D}, wbprExtendedPictographic}, // E0.6   [1] (😭)       loudly crying face
-	{runeRange{0x1F62E, 0x1F62F}, wbprExtendedPictographic}, // E1.0   [2] (😮..😯)    face with open mouth..hushed face
-	{runeRange{0x1F630, 0x1F633}, wbprExtendedPictographic}, // E0.6   [4] (😰..😳)    anxious face with sweat..flushed face
-	{runeRange{0x1F634, 0x1F634}, wbprExtendedPictographic}, // E1.0   [1] (😴)       sleeping face
-	{runeRange{0x1F635, 0x1F635}, wbprExtendedPictographic}, // E0.6   [1] (😵)       face with crossed-out eyes
-	{runeRange{0x1F636, 0x1F636}, wbprExtendedPictographic}, // E1.0   [1] (😶)       face without mouth
-	{runeRange{0x1F637, 0x1F640}, wbprExtendedPictographic}, // E0.6  [10] (😷..🙀)    face with medical mask..weary cat
-	{runeRange{0x1F641, 0x1F644}, wbprExtendedPictographic}, // E1.0   [4] (🙁..🙄)    slightly frowning face..face with rolling eyes
-	{runeRange{0x1F645, 0x1F64F}, wbprExtendedPictographic}, // E0.6  [11] (🙅..🙏)    person gesturing NO..folded hands
-	{runeRange{0x1F680, 0x1F680}, wbprExtendedPictographic}, // E0.6   [1] (🚀)       rocket
-	{runeRange{0x1F681, 0x1F682}, wbprExtendedPictographic}, // E1.0   [2] (🚁..🚂)    helicopter..locomotive
-	{runeRange{0x1F683, 0x1F685}, wbprExtendedPictographic}, // E0.6   [3] (🚃..🚅)    railway car..bullet train
-	{runeRange{0x1F686, 0x1F686}, wbprExtendedPictographic}, // E1.0   [1] (🚆)       train
-	{runeRange{0x1F687, 0x1F687}, wbprExtendedPictographic}, // E0.6   [1] (🚇)       metro
-	{runeRange{0x1F688, 0x1F688}, wbprExtendedPictographic}, // E1.0   [1] (🚈)       light rail
-	{runeRange{0x1F689, 0x1F689}, wbprExtendedPictographic}, // E0.6   [1] (🚉)       station
-	{runeRange{0x1F68A, 0x1F68B}, wbprExtendedPictographic}, // E1.0   [2] (🚊..🚋)    tram..tram car
-	{runeRange{0x1F68C, 0x1F68C}, wbprExtendedPictographic}, // E0.6   [1] (🚌)       bus
-	{runeRange{0x1F68D, 0x1F68D}, wbprExtendedPictographic}, // E0.7   [1] (🚍)       oncoming bus
-	{runeRange{0x1F68E, 0x1F68E}, wbprExtendedPictographic}, // E1.0   [1] (🚎)       trolleybus
-	{runeRange{0x1F68F, 0x1F68F}, wbprExtendedPictographic}, // E0.6   [1] (🚏)       bus stop
-	{runeRange{0x1F690, 0x1F690}, wbprExtendedPictographic}, // E1.0   [1] (🚐)       minibus
-	{runeRange{0x1F691, 0x1F693}, wbprExtendedPictographic}, // E0.6   [3] (🚑..🚓)    ambulance..police car
-	{runeRange{0x1F694, 0x1F694}, wbprExtendedPictographic}, // E0.7   [1] (🚔)       oncoming police car
-	{runeRange{0x1F695, 0x1F695}, wbprExtendedPictographic}, // E0.6   [1] (🚕)       taxi
-	{runeRange{0x1F696, 0x1F696}, wbprExtendedPictographic}, // E1.0   [1] (🚖)       oncoming taxi
-	{runeRange{0x1F697, 0x1F697}, wbprExtendedPictographic}, // E0.6   [1] (🚗)       automobile
-	{runeRange{0x1F698, 0x1F698}, wbprExtendedPictographic}, // E0.7   [1] (🚘)       oncoming automobile
-	{runeRange{0x1F699, 0x1F69A}, wbprExtendedPictographic}, // E0.6   [2] (🚙..🚚)    sport utility vehicle..delivery truck
-	{runeRange{0x1F69B, 0x1F6A1}, wbprExtendedPictographic}, // E1.0   [7] (🚛..🚡)    articulated lorry..aerial tramway
-	{runeRange{0x1F6A2, 0x1F6A2}, wbprExtendedPictographic}, // E0.6   [1] (🚢)       ship
-	{runeRange{0x1F6A3, 0x1F6A3}, wbprExtendedPictographic}, // E1.0   [1] (🚣)       person rowing boat
-	{runeRange{0x1F6A4, 0x1F6A5}, wbprExtendedPictographic}, // E0.6   [2] (🚤..🚥)    speedboat..horizontal traffic light
-	{runeRange{0x1F6A6, 0x1F6A6}, wbprExtendedPictographic}, // E1.0   [1] (🚦)       vertical traffic light
-	{runeRange{0x1F6A7, 0x1F6AD}, wbprExtendedPictographic}, // E0.6   [7] (🚧..🚭)    construction..no smoking
-	{runeRange{0x1F6AE, 0x1F6B1}, wbprExtendedPictographic}, // E1.0   [4] (🚮..🚱)    litter in bin sign..non-potable water
-	{runeRange{0x1F6B2, 0x1F6B2}, wbprExtendedPictographic}, // E0.6   [1] (🚲)       bicycle
-	{runeRange{0x1F6B3, 0x1F6B5}, wbprExtendedPictographic}, // E1.0   [3] (🚳..🚵)    no bicycles..person mountain biking
+	{runeRange{0x0BA8, 0x0BAA}, wbprALetter},                // Lo   [3] TAMIL LETTER NA..TAMIL LETTER PA
+	{runeRange{0x2B1B, 0x2B1C}, wbprExtendedPictographic},   // E0.6   [2] (⬛..⬜)    black large square..white large square
+	{runeRange{0x11A47, 0x11A47}, wbprExtend},               // Mn       ZANABAZAR SQUARE SUBJOINER
 	{runeRange{0x1F6B6, 0x1F6B6}, wbprExtendedPictographic}, // E0.6   [1] (🚶)       person walking
-	{runeRange{0x1F6B7, 0x1F6B8}, wbprExtendedPictographic}, // E1.0   [2] (🚷..🚸)    no pedestrians..children crossing
-	{runeRange{0x1F6B9, 0x1F6BE}, wbprExtendedPictographic}, // E0.6   [6] (🚹..🚾)    men’s room..water closet
-	{runeRange{0x1F6BF, 0x1F6BF}, wbprExtendedPictographic}, // E1.0   [1] (🚿)       shower
-	{runeRange{0x1F6C0, 0x1F6C0}, wbprExtendedPictographic}, // E0.6   [1] (🛀)       person taking bath
-	{runeRange{0x1F6C1, 0x1F6C5}, wbprExtendedPictographic}, // E1.0   [5] (🛁..🛅)    bathtub..left luggage
-	{runeRange{0x1F6C6, 0x1F6CA}, wbprExtendedPictographic}, // E0.0   [5] (🛆..🛊)    TRIANGLE WITH ROUNDED CORNERS..GIRLS SYMBOL
-	{runeRange{0x1F6CB, 0x1F6CB}, wbprExtendedPictographic}, // E0.7   [1] (🛋️)       couch and lamp
-	{runeRange{0x1F6CC, 0x1F6CC}, wbprExtendedPictographic}, // E1.0   [1] (🛌)       person in bed
-	{runeRange{0x1F6CD, 0x1F6CF}, wbprExtendedPictographic}, // E0.7   [3] (🛍️..🛏️)    shopping bags..bed
-	{runeRange{0x1F6D0, 0x1F6D0}, wbprExtendedPictographic}, // E1.0   [1] (🛐)       place of worship
-	{runeRange{0x1F6D1, 0x1F6D2}, wbprExtendedPictographic}, // E3.0   [2] (🛑..🛒)    stop sign..shopping cart
-	{runeRange{0x1F6D3, 0x1F6D4}, wbprExtendedPictographic}, // E0.0   [2] (🛓..🛔)    STUPA..PAGODA
-	{runeRange{0x1F6D5, 0x1F6D5}, wbprExtendedPictographic}, // E12.0  [1] (🛕)       hindu temple
-	{runeRange{0x1F6D6, 0x1F6D7}, wbprExtendedPictographic}, // E13.0  [2] (🛖..🛗)    hut..elevator
-	{runeRange{0x1F6D8, 0x1F6DB}, wbprExtendedPictographic}, // E0.0   [4] (🛘..🛛)    <reserved-1F6D8>..<reserved-1F6DB>
-	{runeRange{0x1F6DC, 0x1F6DC}, wbprExtendedPictographic}, // E15.0  [1] (🛜)       wireless
-	{runeRange{0x1F6DD, 0x1F6DF}, wbprExtendedPictographic}, // E14.0  [3] (🛝..🛟)    playground slide..ring buoy
-	{runeRange{0x1F6E0, 0x1F6E5}, wbprExtendedPictographic}, // E0.7   [6] (🛠️..🛥️)    hammer and wrench..motor boat
-	{runeRange{0x1F6E6, 0x1F6E8}, wbprExtendedPictographic}, // E0.0   [3] (🛦..🛨)    UP-POINTING MILITARY AIRPLANE..UP-POINTING SMALL AIRPLANE
-	{runeRange{0x1F6E9, 0x1F6E9}, wbprExtendedPictographic}, // E0.7   [1] (🛩️)       small airplane
-	{runeRange{0x1F6EA, 0x1F6EA}, wbprExtendedPictographic}, // E0.0   [1] (🛪)       NORTHEAST-POINTING AIRPLANE
-	{runeRange{0x1F6EB, 0x1F6EC}, wbprExtendedPictographic}, // E1.0   [2] (🛫..🛬)    airplane departure..airplane arrival
-	{runeRange{0x1F6ED, 0x1F6EF}, wbprExtendedPictographic}, // E0.0   [3] (🛭..🛯)    <reserved-1F6ED>..<reserved-1F6EF>
-	{runeRange{0x1F6F0, 0x1F6F0}, wbprExtendedPictographic}, // E0.7   [1] (🛰️)       satellite
-	{runeRange{0x1F6F1, 0x1F6F2}, wbprExtendedPictographic}, // E0.0   [2] (🛱..🛲)    ONCOMING FIRE ENGINE..DIESEL LOCOMOTIVE
-	{runeRange{0x1F6F3, 0x1F6F3}, wbprExtendedPictographic}, // E0.7   [1] (🛳️)       passenger ship
-	{runeRange{0x1F6F4, 0x1F6F6}, wbprExtendedPictographic}, // E3.0   [3] (🛴..🛶)    kick scooter..canoe
-	{runeRange{0x1F6F7, 0x1F6F8}, wbprExtendedPictographic}, // E5.0   [2] (🛷..🛸)    sled..flying saucer
-	{runeRange{0x1F6F9, 0x1F6F9}, wbprExtendedPictographic}, // E11.0  [1] (🛹)       skateboard
-	{runeRange{0x1F6FA, 0x1F6FA}, wbprExtendedPictographic}, // E12.0  [1] (🛺)       auto rickshaw
-	{runeRange{0x1F6FB, 0x1F6FC}, wbprExtendedPictographic}, // E13.0  [2] (🛻..🛼)    pickup truck..roller skate
-	{runeRange{0x1F6FD, 0x1F6FF}, wbprExtendedPictographic}, // E0.0   [3] (🛽..🛿)    <reserved-1F6FD>..<reserved-1F6FF>
-	{runeRange{0x1F774, 0x1F77F}, wbprExtendedPictographic}, // E0.0  [12] (🝴..🝿)    LOT OF FORTUNE..ORCUS
-	{runeRange{0x1F7D5, 0x1F7DF}, wbprExtendedPictographic}, // E0.0  [11] (🟕..🟟)    CIRCLED TRIANGLE..<reserved-1F7DF>
-	{runeRange{0x1F7E0, 0x1F7EB}, wbprExtendedPictographic}, // E12.0 [12] (🟠..🟫)    orange circle..brown square
-	{runeRange{0x1F7EC, 0x1F7EF}, wbprExtendedPictographic}, // E0.0   [4] (🟬..🟯)    <reserved-1F7EC>..<reserved-1F7EF>
-	{runeRange{0x1F7F0, 0x1F7F0}, wbprExtendedPictographic}, // E14.0  [1] (🟰)       heavy equals sign
-	{runeRange{0x1F7F1, 0x1F7FF}, wbprExtendedPictographic}, // E0.0  [15] (🟱..🟿)    <reserved-1F7F1>..<reserved-1F7FF>
-	{runeRange{0x1F80C, 0x1F80F}, wbprExtendedPictographic}, // E0.0   [4] (🠌..🠏)    <reserved-1F80C>..<reserved-1F80F>
-	{runeRange{0x1F848, 0x1F84F}, wbprExtendedPictographic}, // E0.0   [8] (🡈..🡏)    <reserved-1F848>..<reserved-1F84F>
-	{runeRange{0x1F85A, 0x1F85F}, wbprExtendedPictographic}, // E0.0   [6] (🡚..🡟)    <reserved-1F85A>..<reserved-1F85F>
-	{runeRange{0x1F888, 0x1F88F}, wbprExtendedPictographic}, // E0.0   [8] (🢈..🢏)    <reserved-1F888>..<reserved-1F88F>
-	{runeRange{0x1F8AE, 0x1F8FF}, wbprExtendedPictographic}, // E0.0  [82] (🢮..🣿)    <reserved-1F8AE>..<reserved-1F8FF>
-	{runeRange{0x1F90C, 0x1F90C}, wbprExtendedPictographic}, // E13.0  [1] (🤌)       pinched fingers
-	{runeRange{0x1F90D, 0x1F90F}, wbprExtendedPictographic}, // E12.0  [3] (🤍..🤏)    white heart..pinching hand
-	{runeRange{0x1F910, 0x1F918}, wbprExtendedPictographic}, // E1.0   [9] (🤐..🤘)    zipper-mouth face..sign of the horns
-	{runeRange{0x1F919, 0x1F91E}, wbprExtendedPictographic}, // E3.0   [6] (🤙..🤞)    call me hand..crossed fingers
-	{runeRange{0x1F91F, 0x1F91F}, wbprExtendedPictographic}, // E5.0   [1] (🤟)       love-you gesture
-	{runeRange{0x1F920, 0x1F927}, wbprExtendedPictographic}, // E3.0   [8] (🤠..🤧)    cowboy hat face..sneezing face
-	{runeRange{0x1F928, 0x1F92F}, wbprExtendedPictographic}, // E5.0   [8] (🤨..🤯)    face with raised eyebrow..exploding head
-	{runeRange{0x1F930, 0x1F930}, wbprExtendedPictographic}, // E3.0   [1] (🤰)       pregnant woman
-	{runeRange{0x1F931, 0x1F932}, wbprExtendedPictographic}, // E5.0   [2] (🤱..🤲)    breast-feeding..palms up together
-	{runeRange{0x1F933, 0x1F93A}, wbprExtendedPictographic}, // E3.0   [8] (🤳..🤺)    selfie..person fencing
-	{runeRange{0x1F93C, 0x1F93E}, wbprExtendedPictographic}, // E3.0   [3] (🤼..🤾)    people wrestling..person playing handball
-	{runeRange{0x1F93F, 0x1F93F}, wbprExtendedPictographic}, // E12.0  [1] (🤿)       diving mask
-	{runeRange{0x1F940, 0x1F945}, wbprExtendedPictographic}, // E3.0   [6] (🥀..🥅)    wilted flower..goal net
-	{runeRange{0x1F947, 0x1F94B}, wbprExtendedPictographic}, // E3.0   [5] (🥇..🥋)    1st place medal..martial arts uniform
-	{runeRange{0x1F94C, 0x1F94C}, wbprExtendedPictographic}, // E5.0   [1] (🥌)       curling stone
-	{runeRange{0x1F94D, 0x1F94F}, wbprExtendedPictographic}, // E11.0  [3] (🥍..🥏)    lacrosse..flying disc
-	{runeRange{0x1F950, 0x1F95E}, wbprExtendedPictographic}, // E3.0  [15] (🥐..🥞)    croissant..pancakes
-	{runeRange{0x1F95F, 0x1F96B}, wbprExtendedPictographic}, // E5.0  [13] (🥟..🥫)    dumpling..canned food
-	{runeRange{0x1F96C, 0x1F970}, wbprExtendedPictographic}, // E11.0  [5] (🥬..🥰)    leafy green..smiling face with hearts
-	{runeRange{0x1F971, 0x1F971}, wbprExtendedPictographic}, // E12.0  [1] (🥱)       yawning face
+	{runeRange{0x0860, 0x086A}, wbprALetter},                // Lo  [11] SYRIAC LETTER MALAYALAM NGA..SYRIAC LETTER MALAYALAM SSA
+	{runeRange{0x1083, 0x1084}, wbprExtend},                 // Mc   [2] MYANMAR VOWEL SIGN SHAN AA..MYANMAR VOWEL SIGN SHAN E
+	{runeRange{0x25B6, 0x25B6}, wbprExtendedPictographic},   // E0.6   [1] (▶️)       play button
+	{runeRange{0xA9CF, 0xA9CF}, wbprALetter},                // Lm       JAVANESE PANGRANGKEP
+	{runeRange{0x11280, 0x11286}, wbprALetter},              // Lo   [7] MULTANI LETTER A..MULTANI LETTER GA
+	{runeRange{0x1D4AE, 0x1D4B9}, wbprALetter},              // L&  [12] MATHEMATICAL SCRIPT CAPITAL S..MATHEMATICAL SCRIPT SMALL D
+	{runeRange{0x1F5BD, 0x1F5C1}, wbprExtendedPictographic}, // E0.0   [5] (🖽..🗁)    FRAME WITH TILES..OPEN FOLDER
 	{runeRange{0x1F972, 0x1F972}, wbprExtendedPictographic}, // E13.0  [1] (🥲)       smiling face with tear
-	{runeRange{0x1F973, 0x1F976}, wbprExtendedPictographic}, // E11.0  [4] (🥳..🥶)    partying face..cold face
-	{runeRange{0x1F977, 0x1F978}, wbprExtendedPictographic}, // E13.0  [2] (🥷..🥸)    ninja..disguised face
-	{runeRange{0x1F979, 0x1F979}, wbprExtendedPictographic}, // E14.0  [1] (🥹)       face holding back tears
-	{runeRange{0x1F97A, 0x1F97A}, wbprExtendedPictographic}, // E11.0  [1] (🥺)       pleading face
-	{runeRange{0x1F97B, 0x1F97B}, wbprExtendedPictographic}, // E12.0  [1] (🥻)       sari
-	{runeRange{0x1F97C, 0x1F97F}, wbprExtendedPictographic}, // E11.0  [4] (🥼..🥿)    lab coat..flat shoe
-	{runeRange{0x1F980, 0x1F984}, wbprExtendedPictographic}, // E1.0   [5] (🦀..🦄)    crab..unicorn
-	{runeRange{0x1F985, 0x1F991}, wbprExtendedPictographic}, // E3.0  [13] (🦅..🦑)    eagle..squid
-	{runeRange{0x1F992, 0x1F997}, wbprExtendedPictographic}, // E5.0   [6] (🦒..🦗)    giraffe..cricket
-	{runeRange{0x1F998, 0x1F9A2}, wbprExtendedPictographic}, // E11.0 [11] (🦘..🦢)    kangaroo..swan
-	{runeRange{0x1F9A3, 0x1F9A4}, wbprExtendedPictographic}, // E13.0  [2] (🦣..🦤)    mammoth..dodo
-	{runeRange{0x1F9A5, 0x1F9AA}, wbprExtendedPictographic}, // E12.0  [6] (🦥..🦪)    sloth..oyster
-	{runeRange{0x1F9AB, 0x1F9AD}, wbprExtendedPictographic}, // E13.0  [3] (🦫..🦭)    beaver..seal
-	{runeRange{0x1F9AE, 0x1F9AF}, wbprExtendedPictographic}, // E12.0  [2] (🦮..🦯)    guide dog..white cane
-	{runeRange{0x1F9B0, 0x1F9B9}, wbprExtendedPictographic}, // E11.0 [10] (🦰..🦹)    red hair..supervillain
-	{runeRange{0x1F9BA, 0x1F9BF}, wbprExtendedPictographic}, // E12.0  [6] (🦺..🦿)    safety vest..mechanical leg
-	{runeRange{0x1F9C0, 0x1F9C0}, wbprExtendedPictographic}, // E1.0   [1] (🧀)       cheese wedge
-	{runeRange{0x1F9C1, 0x1F9C2}, wbprExtendedPictographic}, // E11.0  [2] (🧁..🧂)    cupcake..salt
-	{runeRange{0x1F9C3, 0x1F9CA}, wbprExtendedPictographic}, // E12.0  [8] (🧃..🧊)    beverage box..ice
-	{runeRange{0x1F9CB, 0x1F9CB}, wbprExtendedPictographic}, // E13.0  [1] (🧋)       bubble tea
-	{runeRange{0x1F9CC, 0x1F9CC}, wbprExtendedPictographic}, // E14.0  [1] (🧌)       troll
-	{runeRange{0x1F9CD, 0x1F9CF}, wbprExtendedPictographic}, // E12.0  [3] (🧍..🧏)    person standing..deaf person
-	{runeRange{0x1F9D0, 0x1F9E6}, wbprExtendedPictographic}, // E5.0  [23] (🧐..🧦)    face with monocle..socks
-	{runeRange{0x1F9E7, 0x1F9FF}, wbprExtendedPictographic}, // E11.0 [25] (🧧..🧿)    red envelope..nazar amulet
-	{runeRange{0x1FA00, 0x1FA6F}, wbprExtendedPictographic}, // E0.0 [112] (🨀..🩯)    NEUTRAL CHESS KING..<reserved-1FA6F>
-	{runeRange{0x1FA70, 0x1FA73}, wbprExtendedPictographic}, // E12.0  [4] (🩰..🩳)    ballet shoes..shorts
-	{runeRange{0x1FA74, 0x1FA74}, wbprExtendedPictographic}, // E13.0  [1] (🩴)       thong sandal
-	{runeRange{0x1FA75, 0x1FA77}, wbprExtendedPictographic}, // E15.0  [3] (🩵..🩷)    light blue heart..pink heart
-	{runeRange{0x1FA78, 0x1FA7A}, wbprExtendedPictographic}, // E12.0  [3] (🩸..🩺)    drop of blood..stethoscope
-	{runeRange{0x1FA7B, 0x1FA7C}, wbprExtendedPictographic}, // E14.0  [2] (🩻..🩼)    x-ray..crutch
-	{runeRange{0x1FA7D, 0x1FA7F}, wbprExtendedPictographic}, // E0.0   [3] (🩽..🩿)    <reserved-1FA7D>..<reserved-1FA7F>
+	{runeRange{0x055E, 0x055E}, wbprALetter},                // Po       ARMENIAN QUESTION MARK
+	{runeRange{0x0A47, 0x0A48}, wbprExtend},                 // Mn   [2] GURMUKHI VOWEL SIGN EE..GURMUKHI VOWEL SIGN AI
+	{runeRange{0x0D4A, 0x0D4C}, wbprExtend},                 // Mc   [3] MALAYALAM VOWEL SIGN O..MALAYALAM VOWEL SIGN AU
+	{runeRange{0x1810, 0x1819}, wbprNumeric},                // Nd  [10] MONGOLIAN DIGIT ZERO..MONGOLIAN DIGIT NINE
+	{runeRange{0x2008, 0x200A}, wbprWSegSpace},              // Zs   [3] PUNCTUATION SPACE..HAIR SPACE
+	{runeRange{0x26A2, 0x26A6}, wbprExtendedPictographic},   // E0.0   [5] (⚢..⚦)    DOUBLED FEMALE SIGN..MALE WITH STROKE SIGN
+	{runeRange{0xA67F, 0xA67F}, wbprALetter},                // Lm       CYRILLIC PAYEROK
+	{runeRange{0xFB43, 0xFB44}, wbprHebrewLetter},           // Lo   [2] HEBREW LETTER FINAL PE WITH DAGESH..HEBREW LETTER PE WITH DAGESH
+	{runeRange{0x10F30, 0x10F45}, wbprALetter},              // Lo  [22] SOGDIAN LETTER ALEPH..SOGDIAN INDEPENDENT SHIN
+	{runeRange{0x11630, 0x11632}, wbprExtend},               // Mc   [3] MODI VOWEL SIGN AA..MODI VOWEL SIGN II
+	{runeRange{0x11FB0, 0x11FB0}, wbprALetter},              // Lo       LISU LETTER YHA
+	{runeRange{0x1E94B, 0x1E94B}, wbprALetter},              // Lm       ADLAM NASALIZATION MARK
+	{runeRange{0x1F416, 0x1F416}, wbprExtendedPictographic}, // E1.0   [1] (🐖)       pig
+	{runeRange{0x1F637, 0x1F640}, wbprExtendedPictographic}, // E0.6  [10] (😷..🙀)    face with medical mask..weary cat
+	{runeRange{0x1F6FD, 0x1F6FF}, wbprExtendedPictographic}, // E0.0   [3] (🛽..🛿)    <reserved-1F6FD>..<reserved-1F6FF>
 	{runeRange{0x1FA80, 0x1FA82}, wbprExtendedPictographic}, // E12.0  [3] (🪀..🪂)    yo-yo..parachute
-	{runeRange{0x1FA83, 0x1FA86}, wbprExtendedPictographic}, // E13.0  [4] (🪃..🪆)    boomerang..nesting dolls
-	{runeRange{0x1FA87, 0x1FA88}, wbprExtendedPictographic}, // E15.0  [2] (🪇..🪈)    maracas..flute
-	{runeRange{0x1FA89, 0x1FA8F}, wbprExtendedPictographic}, // E0.0   [7] (🪉..🪏)    <reserved-1FA89>..<reserved-1FA8F>
-	{runeRange{0x1FA90, 0x1FA95}, wbprExtendedPictographic}, // E12.0  [6] (🪐..🪕)    ringed planet..banjo
-	{runeRange{0x1FA96, 0x1FAA8}, wbprExtendedPictographic}, // E13.0 [19] (🪖..🪨)    military helmet..rock
-	{runeRange{0x1FAA9, 0x1FAAC}, wbprExtendedPictographic}, // E14.0  [4] (🪩..🪬)    mirror ball..hamsa
-	{runeRange{0x1FAAD, 0x1FAAF}, wbprExtendedPictographic}, // E15.0  [3] (🪭..🪯)    folding hand fan..khanda
-	{runeRange{0x1FAB0, 0x1FAB6}, wbprExtendedPictographic}, // E13.0  [7] (🪰..🪶)    fly..feather
-	{runeRange{0x1FAB7, 0x1FABA}, wbprExtendedPictographic}, // E14.0  [4] (🪷..🪺)    lotus..nest with eggs
-	{runeRange{0x1FABB, 0x1FABD}, wbprExtendedPictographic}, // E15.0  [3] (🪻..🪽)    hyacinth..wing
-	{runeRange{0x1FABE, 0x1FABE}, wbprExtendedPictographic}, // E0.0   [1] (🪾)       <reserved-1FABE>
-	{runeRange{0x1FABF, 0x1FABF}, wbprExtendedPictographic}, // E15.0  [1] (🪿)       goose
-	{runeRange{0x1FAC0, 0x1FAC2}, wbprExtendedPictographic}, // E13.0  [3] (🫀..🫂)    anatomical heart..people hugging
-	{runeRange{0x1FAC3, 0x1FAC5}, wbprExtendedPictographic}, // E14.0  [3] (🫃..🫅)    pregnant man..person with crown
-	{runeRange{0x1FAC6, 0x1FACD}, wbprExtendedPictographic}, // E0.0   [8] (🫆..🫍)    <reserved-1FAC6>..<reserved-1FACD>
+	{runeRange{0x02B0, 0x02C1}, wbprALetter},                // Lm  [18] MODIFIER LETTER SMALL H..MODIFIER LETTER REVERSED GLOTTAL STOP
+	{runeRange{0x06E5, 0x06E6}, wbprALetter},                // Lm   [2] ARABIC SMALL WAW..ARABIC SMALL YEH
+	{runeRange{0x0993, 0x09A8}, wbprALetter},                // Lo  [22] BENGALI LETTER O..BENGALI LETTER NA
+	{runeRange{0x0B02, 0x0B03}, wbprExtend},                 // Mc   [2] ORIYA SIGN ANUSVARA..ORIYA SIGN VISARGA
+	{runeRange{0x0C82, 0x0C83}, wbprExtend},                 // Mc   [2] KANNADA SIGN ANUSVARA..KANNADA SIGN VISARGA
+	{runeRange{0x0F18, 0x0F19}, wbprExtend},                 // Mn   [2] TIBETAN ASTROLOGICAL SIGN -KHYUD PA..TIBETAN ASTROLOGICAL SIGN SDONG TSHUGS
+	{runeRange{0x13A0, 0x13F5}, wbprALetter},                // L&  [86] CHEROKEE LETTER A..CHEROKEE LETTER MV
+	{runeRange{0x1A63, 0x1A64}, wbprExtend},                 // Mc   [2] TAI THAM VOWEL SIGN AA..TAI THAM VOWEL SIGN TALL AA
+	{runeRange{0x1CF4, 0x1CF4}, wbprExtend},                 // Mn       VEDIC TONE CANDRA ABOVE
+	{runeRange{0x2119, 0x211D}, wbprALetter},                // L&   [5] DOUBLE-STRUCK CAPITAL P..DOUBLE-STRUCK CAPITAL R
+	{runeRange{0x2640, 0x2640}, wbprExtendedPictographic},   // E4.0   [1] (♀️)       female sign
+	{runeRange{0x26FD, 0x26FD}, wbprExtendedPictographic},   // E0.6   [1] (⛽)       fuel pump
+	{runeRange{0x303B, 0x303B}, wbprALetter},                // Lm       VERTICAL IDEOGRAPHIC ITERATION MARK
+	{runeRange{0xA80C, 0xA822}, wbprALetter},                // Lo  [23] SYLOTI NAGRI LETTER CO..SYLOTI NAGRI LETTER HO
+	{runeRange{0xAB01, 0xAB06}, wbprALetter},                // Lo   [6] ETHIOPIC SYLLABLE TTHU..ETHIOPIC SYLLABLE TTHO
+	{runeRange{0xFF71, 0xFF9D}, wbprKatakana},               // Lo  [45] HALFWIDTH KATAKANA LETTER A..HALFWIDTH KATAKANA LETTER N
+	{runeRange{0x10980, 0x109B7}, wbprALetter},              // Lo  [56] MEROITIC HIEROGLYPHIC LETTER A..MEROITIC CURSIVE LETTER DA
+	{runeRange{0x1112D, 0x11134}, wbprExtend},               // Mn   [8] CHAKMA VOWEL SIGN AI..CHAKMA MAAYYAA
+	{runeRange{0x11435, 0x11437}, wbprExtend},               // Mc   [3] NEWA VOWEL SIGN AA..NEWA VOWEL SIGN II
+	{runeRange{0x11909, 0x11909}, wbprALetter},              // Lo       DIVES AKURU LETTER O
+	{runeRange{0x11D3A, 0x11D3A}, wbprExtend},               // Mn       MASARAM GONDI VOWEL SIGN E
+	{runeRange{0x16FE3, 0x16FE3}, wbprALetter},              // Lm       OLD CHINESE ITERATION MARK
+	{runeRange{0x1DF0A, 0x1DF0A}, wbprALetter},              // Lo       LATIN LETTER RETROFLEX CLICK WITH RETROFLEX HOOK
+	{runeRange{0x1EEA1, 0x1EEA3}, wbprALetter},              // Lo   [3] ARABIC MATHEMATICAL DOUBLE-STRUCK BEH..ARABIC MATHEMATICAL DOUBLE-STRUCK DAL
+	{runeRange{0x1F39C, 0x1F39D}, wbprExtendedPictographic}, // E0.0   [2] (🎜..🎝)    BEAMED ASCENDING MUSICAL NOTES..BEAMED DESCENDING MUSICAL NOTES
+	{runeRange{0x1F515, 0x1F515}, wbprExtendedPictographic}, // E1.0   [1] (🔕)       bell with slash
+	{runeRange{0x1F618, 0x1F618}, wbprExtendedPictographic}, // E0.6   [1] (😘)       face blowing a kiss
+	{runeRange{0x1F691, 0x1F693}, wbprExtendedPictographic}, // E0.6   [3] (🚑..🚓)    ambulance..police car
+	{runeRange{0x1F6DC, 0x1F6DC}, wbprExtendedPictographic}, // E15.0  [1] (🛜)       wireless
+	{runeRange{0x1F91F, 0x1F91F}, wbprExtendedPictographic}, // E5.0   [1] (🤟)       love-you gesture
+	{runeRange{0x1F9BA, 0x1F9BF}, wbprExtendedPictographic}, // E12.0  [6] (🦺..🦿)    safety vest..mechanical leg
 	{runeRange{0x1FACE, 0x1FACF}, wbprExtendedPictographic}, // E15.0  [2] (🫎..🫏)    moose..donkey
-	{runeRange{0x1FAD0, 0x1FAD6}, wbprExtendedPictographic}, // E13.0  [7] (🫐..🫖)    blueberries..teapot
-	{runeRange{0x1FAD7, 0x1FAD9}, wbprExtendedPictographic}, // E14.0  [3] (🫗..🫙)    pouring liquid..jar
-	{runeRange{0x1FADA, 0x1FADB}, wbprExtendedPictographic}, // E15.0  [2] (🫚..🫛)    ginger root..pea pod
-	{runeRange{0x1FADC, 0x1FADF}, wbprExtendedPictographic}, // E0.0   [4] (🫜..🫟)    <reserved-1FADC>..<reserved-1FADF>
-	{runeRange{0x1FAE0, 0x1FAE7}, wbprExtendedPictographic}, // E14.0  [8] (🫠..🫧)    melting face..bubbles
-	{runeRange{0x1FAE8, 0x1FAE8}, wbprExtendedPictographic}, // E15.0  [1] (🫨)       shaking face
-	{runeRange{0x1FAE9, 0x1FAEF}, wbprExtendedPictographic}, // E0.0   [7] (🫩..🫯)    <reserved-1FAE9>..<reserved-1FAEF>
+	{runeRange{0x00A9, 0x00A9}, wbprExtendedPictographic},   // E0.6   [1] (©️)       copyright
+	{runeRange{0x037B, 0x037D}, wbprALetter},                // L&   [3] GREEK SMALL REVERSED LUNATE SIGMA SYMBOL..GREEK SMALL REVERSED DOTTED LUNATE SIGMA SYMBOL
+	{runeRange{0x0610, 0x061A}, wbprExtend},                 // Mn  [11] ARABIC SIGN SALLALLAHOU ALAYHE WASSALLAM..ARABIC SMALL KASRA
+	{runeRange{0x07CA, 0x07EA}, wbprALetter},                // Lo  [33] NKO LETTER A..NKO LETTER JONA RA
+	{runeRange{0x093E, 0x0940}, wbprExtend},                 // Mc   [3] DEVANAGARI VOWEL SIGN AA..DEVANAGARI VOWEL SIGN II
+	{runeRange{0x09E6, 0x09EF}, wbprNumeric},                // Nd  [10] BENGALI DIGIT ZERO..BENGALI DIGIT NINE
+	{runeRange{0x0AB5, 0x0AB9}, wbprALetter},                // Lo   [5] GUJARATI LETTER VA..GUJARATI LETTER HA
+	{runeRange{0x0B55, 0x0B56}, wbprExtend},                 // Mn   [2] ORIYA SIGN OVERLINE..ORIYA AI LENGTH MARK
+	{runeRange{0x0C12, 0x0C28}, wbprALetter},                // Lo  [23] TELUGU LETTER O..TELUGU LETTER NA
+	{runeRange{0x0CDD, 0x0CDE}, wbprALetter},                // Lo   [2] KANNADA LETTER NAKAARA POLLU..KANNADA LETTER FA
+	{runeRange{0x0DCA, 0x0DCA}, wbprExtend},                 // Mn       SINHALA SIGN AL-LAKUNA
+	{runeRange{0x102B, 0x102C}, wbprExtend},                 // Mc   [2] MYANMAR VOWEL SIGN TALL AA..MYANMAR VOWEL SIGN AA
+	{runeRange{0x1250, 0x1256}, wbprALetter},                // Lo   [7] ETHIOPIC SYLLABLE QHA..ETHIOPIC SYLLABLE QHO
+	{runeRange{0x1752, 0x1753}, wbprExtend},                 // Mn   [2] BUHID VOWEL SIGN I..BUHID VOWEL SIGN U
+	{runeRange{0x1932, 0x1932}, wbprExtend},                 // Mn       LIMBU SMALL LETTER ANUSVARA
+	{runeRange{0x1B3B, 0x1B3B}, wbprExtend},                 // Mc       BALINESE VOWEL SIGN RA REPA TEDUNG
+	{runeRange{0x1C36, 0x1C37}, wbprExtend},                 // Mn   [2] LEPCHA SIGN RAN..LEPCHA SIGN NUKTA
+	{runeRange{0x1F50, 0x1F57}, wbprALetter},                // L&   [8] GREEK SMALL LETTER UPSILON WITH PSILI..GREEK SMALL LETTER UPSILON WITH DASIA AND PERISPOMENI
+	{runeRange{0x2054, 0x2054}, wbprExtendNumLet},           // Pc       INVERTED UNDERTIE
+	{runeRange{0x2194, 0x2199}, wbprExtendedPictographic},   // E0.6   [6] (↔️..↙️)    left-right arrow..down-left arrow
+	{runeRange{0x261D, 0x261D}, wbprExtendedPictographic},   // E0.6   [1] (☝️)       index pointing up
+	{runeRange{0x267C, 0x267D}, wbprExtendedPictographic},   // E0.0   [2] (♼..♽)    RECYCLED PAPER SYMBOL..PARTIALLY-RECYCLED PAPER SYMBOL
+	{runeRange{0x26D1, 0x26D1}, wbprExtendedPictographic},   // E0.7   [1] (⛑️)       rescue worker’s helmet
+	{runeRange{0x2733, 0x2734}, wbprExtendedPictographic},   // E0.6   [2] (✳️..✴️)    eight-spoked asterisk..eight-pointed star
+	{runeRange{0x2DA0, 0x2DA6}, wbprALetter},                // Lo   [7] ETHIOPIC SYLLABLE SSA..ETHIOPIC SYLLABLE SSO
+	{runeRange{0x3300, 0x3357}, wbprKatakana},               // So  [88] SQUARE APAATO..SQUARE WATTO
+	{runeRange{0xA78F, 0xA78F}, wbprALetter},                // Lo       LATIN LETTER SINOLOGICAL DOT
+	{runeRange{0xA900, 0xA909}, wbprNumeric},                // Nd  [10] KAYAH LI DIGIT ZERO..KAYAH LI DIGIT NINE
+	{runeRange{0xAA7B, 0xAA7B}, wbprExtend},                 // Mc       MYANMAR SIGN PAO KAREN TONE
+	{runeRange{0xABE9, 0xABEA}, wbprExtend},                 // Mc   [2] MEETEI MAYEK VOWEL SIGN CHEINAP..MEETEI MAYEK VOWEL SIGN NUNG
+	{runeRange{0xFE54, 0xFE54}, wbprMidNum},                 // Po       SMALL SEMICOLON
+	{runeRange{0x101FD, 0x101FD}, wbprExtend},               // Mn       PHAISTOS DISC SIGN COMBINING OBLIQUE STROKE
+	{runeRange{0x10760, 0x10767}, wbprALetter},              // Lo   [8] LINEAR A SIGN A800..LINEAR A SIGN A807
+	{runeRange{0x10B00, 0x10B35}, wbprALetter},              // Lo  [54] AVESTAN LETTER A..AVESTAN LETTER HE
+	{runeRange{0x1107F, 0x11081}, wbprExtend},               // Mn   [3] BRAHMI NUMBER JOINER..KAITHI SIGN ANUSVARA
+	{runeRange{0x111CE, 0x111CE}, wbprExtend},               // Mc       SHARADA VOWEL SIGN PRISHTHAMATRA E
+	{runeRange{0x11332, 0x11333}, wbprALetter},              // Lo   [2] GRANTHA LETTER LA..GRANTHA LETTER LLA
+	{runeRange{0x114BF, 0x114C0}, wbprExtend},               // Mn   [2] TIRHUTA SIGN CANDRABINDU..TIRHUTA SIGN ANUSVARA
+	{runeRange{0x116B8, 0x116B8}, wbprALetter},              // Lo       TAKRI LETTER ARCHAIC KHA
+	{runeRange{0x119AA, 0x119D0}, wbprALetter},              // Lo  [39] NANDINAGARI LETTER E..NANDINAGARI LETTER RRA
+	{runeRange{0x11C3E, 0x11C3E}, wbprExtend},               // Mc       BHAIKSUKI SIGN VISARGA
+	{runeRange{0x11DA0, 0x11DA9}, wbprNumeric},              // Nd  [10] GUNJALA GONDI DIGIT ZERO..GUNJALA GONDI DIGIT NINE
+	{runeRange{0x16AD0, 0x16AED}, wbprALetter},              // Lo  [30] BASSA VAH LETTER ENNI..BASSA VAH LETTER I
+	{runeRange{0x1CF00, 0x1CF2D}, wbprExtend},               // Mn  [46] ZNAMENNY COMBINING MARK GORAZDO NIZKO S KRYZHEM ON LEFT..ZNAMENNY COMBINING MARK KRYZH ON LEFT
+	{runeRange{0x1D6FC, 0x1D714}, wbprALetter},              // L&  [25] MATHEMATICAL ITALIC SMALL ALPHA..MATHEMATICAL ITALIC SMALL OMEGA
+	{runeRange{0x1E2AE, 0x1E2AE}, wbprExtend},               // Mn       TOTO SIGN RISING TONE
+	{runeRange{0x1EE51, 0x1EE52}, wbprALetter},              // Lo   [2] ARABIC MATHEMATICAL TAILED SAD..ARABIC MATHEMATICAL TAILED QAF
+	{runeRange{0x1F18E, 0x1F18E}, wbprExtendedPictographic}, // E0.6   [1] (🆎)       AB button (blood type)
+	{runeRange{0x1F332, 0x1F333}, wbprExtendedPictographic}, // E1.0   [2] (🌲..🌳)    evergreen tree..deciduous tree
+	{runeRange{0x1F3F3, 0x1F3F3}, wbprExtendedPictographic}, // E0.7   [1] (🏳️)       white flag
+	{runeRange{0x1F4EC, 0x1F4ED}, wbprExtendedPictographic}, // E0.7   [2] (📬..📭)    open mailbox with raised flag..open mailbox with lowered flag
+	{runeRange{0x1F587, 0x1F587}, wbprExtendedPictographic}, // E0.7   [1] (🖇️)       linked paperclips
+	{runeRange{0x1F5F4, 0x1F5F9}, wbprExtendedPictographic}, // E0.0   [6] (🗴..🗹)    BALLOT SCRIPT X..BALLOT BOX WITH BOLD CHECK
+	{runeRange{0x1F628, 0x1F62B}, wbprExtendedPictographic}, // E0.6   [4] (😨..😫)    fearful face..tired face
+	{runeRange{0x1F688, 0x1F688}, wbprExtendedPictographic}, // E1.0   [1] (🚈)       light rail
+	{runeRange{0x1F6A2, 0x1F6A2}, wbprExtendedPictographic}, // E0.6   [1] (🚢)       ship
+	{runeRange{0x1F6CC, 0x1F6CC}, wbprExtendedPictographic}, // E1.0   [1] (🛌)       person in bed
+	{runeRange{0x1F6F0, 0x1F6F0}, wbprExtendedPictographic}, // E0.7   [1] (🛰️)       satellite
+	{runeRange{0x1F848, 0x1F84F}, wbprExtendedPictographic}, // E0.0   [8] (🡈..🡏)    <reserved-1F848>..<reserved-1F84F>
+	{runeRange{0x1F940, 0x1F945}, wbprExtendedPictographic}, // E3.0   [6] (🥀..🥅)    wilted flower..goal net
+	{runeRange{0x1F985, 0x1F991}, wbprExtendedPictographic}, // E3.0  [13] (🦅..🦑)    eagle..squid
+	{runeRange{0x1F9E7, 0x1F9FF}, wbprExtendedPictographic}, // E11.0 [25] (🧧..🧿)    red envelope..nazar amulet
+	{runeRange{0x1FAB0, 0x1FAB6}, wbprExtendedPictographic}, // E13.0  [7] (🪰..🪶)    fly..feather
 	{runeRange{0x1FAF0, 0x1FAF6}, wbprExtendedPictographic}, // E14.0  [7] (🫰..🫶)    hand with index finger and thumb crossed..heart hands
-	{runeRange{0x1FAF7, 0x1FAF8}, wbprExtendedPictographic}, // E15.0  [2] (🫷..🫸)    leftwards pushing hand..rightwards pushing hand
-	{runeRange{0x1FAF9, 0x1FAFF}, wbprExtendedPictographic}, // E0.0   [7] (🫹..🫿)    <reserved-1FAF9>..<reserved-1FAFF>
-	{runeRange{0x1FBF0, 0x1FBF9}, wbprNumeric},              // Nd  [10] SEGMENTED DIGIT ZERO..SEGMENTED DIGIT NINE
+	{runeRange{0x002E, 0x002E}, wbprMidNumLet},              // Po       FULL STOP
+	{runeRange{0x00D8, 0x00F6}, wbprALetter},                // L&  [31] LATIN CAPITAL LETTER O WITH STROKE..LATIN SMALL LETTER O WITH DIAERESIS
+	{runeRange{0x02ED, 0x02ED}, wbprALetter},                // Sk       MODIFIER LETTER UNASPIRATED
+	{runeRange{0x03A3, 0x03F5}, wbprALetter},                // L&  [83] GREEK CAPITAL LETTER SIGMA..GREEK LUNATE EPSILON SYMBOL
+	{runeRange{0x05C4, 0x05C5}, wbprExtend},                 // Mn   [2] HEBREW MARK UPPER DOT..HEBREW MARK LOWER DOT
+	{runeRange{0x066C, 0x066C}, wbprMidNum},                 // Po       ARABIC THOUSANDS SEPARATOR
+	{runeRange{0x0710, 0x0710}, wbprALetter},                // Lo       SYRIAC LETTER ALAPH
+	{runeRange{0x081A, 0x081A}, wbprALetter},                // Lm       SAMARITAN MODIFIER LETTER EPENTHETIC YUT
+	{runeRange{0x08E2, 0x08E2}, wbprFormat},                 // Cf       ARABIC DISPUTED END OF AYAH
+	{runeRange{0x0962, 0x0963}, wbprExtend},                 // Mn   [2] DEVANAGARI VOWEL SIGN VOCALIC L..DEVANAGARI VOWEL SIGN VOCALIC LL
+	{runeRange{0x09C7, 0x09C8}, wbprExtend},                 // Mc   [2] BENGALI VOWEL SIGN E..BENGALI VOWEL SIGN AI
+	{runeRange{0x0A13, 0x0A28}, wbprALetter},                // Lo  [22] GURMUKHI LETTER OO..GURMUKHI LETTER NA
+	{runeRange{0x0A75, 0x0A75}, wbprExtend},                 // Mn       GURMUKHI SIGN YAKASH
+	{runeRange{0x0ACD, 0x0ACD}, wbprExtend},                 // Mn       GUJARATI SIGN VIRAMA
+	{runeRange{0x0B3D, 0x0B3D}, wbprALetter},                // Lo       ORIYA SIGN AVAGRAHA
+	{runeRange{0x0B83, 0x0B83}, wbprALetter},                // Lo       TAMIL SIGN VISARGA
+	{runeRange{0x0BD0, 0x0BD0}, wbprALetter},                // Lo       TAMIL OM
+	{runeRange{0x0C55, 0x0C56}, wbprExtend},                 // Mn   [2] TELUGU LENGTH MARK..TELUGU AI LENGTH MARK
+	{runeRange{0x0CBE, 0x0CBE}, wbprExtend},                 // Mc       KANNADA VOWEL SIGN AA
+	{runeRange{0x0D04, 0x0D0C}, wbprALetter},                // Lo   [9] MALAYALAM LETTER VEDIC ANUSVARA..MALAYALAM LETTER VOCALIC L
+	{runeRange{0x0D7A, 0x0D7F}, wbprALetter},                // Lo   [6] MALAYALAM LETTER CHILLU NN..MALAYALAM LETTER CHILLU K
+	{runeRange{0x0E34, 0x0E3A}, wbprExtend},                 // Mn   [7] THAI CHARACTER SARA I..THAI CHARACTER PHINTHU
+	{runeRange{0x0F71, 0x0F7E}, wbprExtend},                 // Mn  [14] TIBETAN VOWEL SIGN AA..TIBETAN SIGN RJES SU NGA RO
+	{runeRange{0x1040, 0x1049}, wbprNumeric},                // Nd  [10] MYANMAR DIGIT ZERO..MYANMAR DIGIT NINE
+	{runeRange{0x10A0, 0x10C5}, wbprALetter},                // L&  [38] GEORGIAN CAPITAL LETTER AN..GEORGIAN CAPITAL LETTER HOE
+	{runeRange{0x12C0, 0x12C0}, wbprALetter},                // Lo       ETHIOPIC SYLLABLE KXWA
+	{runeRange{0x16F1, 0x16F8}, wbprALetter},                // Lo   [8] RUNIC LETTER K..RUNIC LETTER FRANKS CASKET AESC
+	{runeRange{0x17C6, 0x17C6}, wbprExtend},                 // Mn       KHMER SIGN NIKAHIT
+	{runeRange{0x18AA, 0x18AA}, wbprALetter},                // Lo       MONGOLIAN LETTER MANCHU ALI GALI LHA
+	{runeRange{0x1A1B, 0x1A1B}, wbprExtend},                 // Mn       BUGINESE VOWEL SIGN AE
+	{runeRange{0x1ABE, 0x1ABE}, wbprExtend},                 // Me       COMBINING PARENTHESES OVERLAY
+	{runeRange{0x1B80, 0x1B81}, wbprExtend},                 // Mn   [2] SUNDANESE SIGN PANYECEK..SUNDANESE SIGN PANGLAYAR
+	{runeRange{0x1BED, 0x1BED}, wbprExtend},                 // Mn       BATAK VOWEL SIGN KARO O
+	{runeRange{0x1CBD, 0x1CBF}, wbprALetter},                // L&   [3] GEORGIAN MTAVRULI CAPITAL LETTER AEN..GEORGIAN MTAVRULI CAPITAL LETTER LABIAL SIGN
+	{runeRange{0x1D78, 0x1D78}, wbprALetter},                // Lm       MODIFIER LETTER CYRILLIC EN
+	{runeRange{0x1FC2, 0x1FC4}, wbprALetter},                // L&   [3] GREEK SMALL LETTER ETA WITH VARIA AND YPOGEGRAMMENI..GREEK SMALL LETTER ETA WITH OXIA AND YPOGEGRAMMENI
+	{runeRange{0x2028, 0x2028}, wbprNewline},                // Zl       LINE SEPARATOR
+	{runeRange{0x20DD, 0x20E0}, wbprExtend},                 // Me   [4] COMBINING ENCLOSING CIRCLE..COMBINING ENCLOSING CIRCLE BACKSLASH
+	{runeRange{0x2139, 0x2139}, wbprExtendedPictographic},   // E0.6   [1] (ℹ️)       information
+	{runeRange{0x23EF, 0x23EF}, wbprExtendedPictographic},   // E1.0   [1] (⏯️)       play or pause button
+	{runeRange{0x260E, 0x260E}, wbprExtendedPictographic},   // E0.6   [1] (☎️)       telephone
+	{runeRange{0x262A, 0x262A}, wbprExtendedPictographic},   // E0.7   [1] (☪️)       star and crescent
+	{runeRange{0x2661, 0x2662}, wbprExtendedPictographic},   // E0.0   [2] (♡..♢)    WHITE HEART SUIT..WHITE DIAMOND SUIT
+	{runeRange{0x2695, 0x2695}, wbprExtendedPictographic},   // E4.0   [1] (⚕️)       medical symbol
+	{runeRange{0x26BF, 0x26C3}, wbprExtendedPictographic},   // E0.0   [5] (⚿..⛃)    SQUARED KEY..BLACK DRAUGHTS KING
+	{runeRange{0x26F0, 0x26F1}, wbprExtendedPictographic},   // E0.7   [2] (⛰️..⛱️)    mountain..umbrella on ground
+	{runeRange{0x270F, 0x270F}, wbprExtendedPictographic},   // E0.6   [1] (✏️)       pencil
+	{runeRange{0x2764, 0x2764}, wbprExtendedPictographic},   // E0.6   [1] (❤️)       red heart
+	{runeRange{0x2CF2, 0x2CF3}, wbprALetter},                // L&   [2] COPTIC CAPITAL LETTER BOHAIRIC KHEI..COPTIC SMALL LETTER BOHAIRIC KHEI
+	{runeRange{0x2DE0, 0x2DFF}, wbprExtend},                 // Mn  [32] COMBINING CYRILLIC LETTER BE..COMBINING CYRILLIC LETTER IOTIFIED BIG YUS
+	{runeRange{0x30FF, 0x30FF}, wbprKatakana},               // Lo       KATAKANA DIGRAPH KOTO
+	{runeRange{0xA610, 0xA61F}, wbprALetter},                // Lo  [16] VAI SYLLABLE NDOLE FA..VAI SYMBOL JONG
+	{runeRange{0xA717, 0xA71F}, wbprALetter},                // Lm   [9] MODIFIER LETTER DOT VERTICAL BAR..MODIFIER LETTER LOW INVERTED EXCLAMATION MARK
+	{runeRange{0xA7F8, 0xA7F9}, wbprALetter},                // Lm   [2] MODIFIER LETTER CAPITAL H WITH STROKE..MODIFIER LETTER SMALL LIGATURE OE
+	{runeRange{0xA8B4, 0xA8C3}, wbprExtend},                 // Mc  [16] SAURASHTRA CONSONANT SIGN HAARU..SAURASHTRA VOWEL SIGN AU
+	{runeRange{0xA983, 0xA983}, wbprExtend},                 // Mc       JAVANESE SIGN WIGNYAN
+	{runeRange{0xAA33, 0xAA34}, wbprExtend},                 // Mc   [2] CHAM CONSONANT SIGN YA..CHAM CONSONANT SIGN RA
+	{runeRange{0xAAE0, 0xAAEA}, wbprALetter},                // Lo  [11] MEETEI MAYEK LETTER E..MEETEI MAYEK LETTER SSA
+	{runeRange{0xAB60, 0xAB68}, wbprALetter},                // L&   [9] LATIN SMALL LETTER SAKHA YAT..LATIN SMALL LETTER TURNED R WITH MIDDLE TILDE
+	{runeRange{0xFB13, 0xFB17}, wbprALetter},                // L&   [5] ARMENIAN SMALL LIGATURE MEN NOW..ARMENIAN SMALL LIGATURE MEN XEH
+	{runeRange{0xFE10, 0xFE10}, wbprMidNum},                 // Po       PRESENTATION FORM FOR VERTICAL COMMA
+	{runeRange{0xFF10, 0xFF19}, wbprNumeric},                // Nd  [10] FULLWIDTH DIGIT ZERO..FULLWIDTH DIGIT NINE
+	{runeRange{0x10000, 0x1000B}, wbprALetter},              // Lo  [12] LINEAR B SYLLABLE B008 A..LINEAR B SYLLABLE B046 JE
+	{runeRange{0x1034A, 0x1034A}, wbprALetter},              // Nl       GOTHIC LETTER NINE HUNDRED
+	{runeRange{0x1058C, 0x10592}, wbprALetter},              // L&   [7] VITHKUQI CAPITAL LETTER SE..VITHKUQI CAPITAL LETTER XE
+	{runeRange{0x1083C, 0x1083C}, wbprALetter},              // Lo       CYPRIOT SYLLABLE ZA
+	{runeRange{0x10A19, 0x10A35}, wbprALetter},              // Lo  [29] KHAROSHTHI LETTER NYA..KHAROSHTHI LETTER VHA
+	{runeRange{0x10D24, 0x10D27}, wbprExtend},               // Mn   [4] HANIFI ROHINGYA SIGN HARBAHAY..HANIFI ROHINGYA SIGN TASSI
+	{runeRange{0x11002, 0x11002}, wbprExtend},               // Mc       BRAHMI SIGN VISARGA
+	{runeRange{0x110C2, 0x110C2}, wbprExtend},               // Mn       KAITHI VOWEL SIGN VOCALIC R
+	{runeRange{0x11180, 0x11181}, wbprExtend},               // Mn   [2] SHARADA SIGN CANDRABINDU..SHARADA SIGN ANUSVARA
+	{runeRange{0x1122F, 0x11231}, wbprExtend},               // Mn   [3] KHOJKI VOWEL SIGN U..KHOJKI VOWEL SIGN AI
+	{runeRange{0x112E3, 0x112EA}, wbprExtend},               // Mn   [8] KHUDAWADI VOWEL SIGN U..KHUDAWADI SIGN VIRAMA
+	{runeRange{0x1134B, 0x1134D}, wbprExtend},               // Mc   [3] GRANTHA VOWEL SIGN OO..GRANTHA SIGN VIRAMA
+	{runeRange{0x1145E, 0x1145E}, wbprExtend},               // Mn       NEWA SANDHI MARK
+	{runeRange{0x115B2, 0x115B5}, wbprExtend},               // Mn   [4] SIDDHAM VOWEL SIGN U..SIDDHAM VOWEL SIGN VOCALIC RR
+	{runeRange{0x11680, 0x116AA}, wbprALetter},              // Lo  [43] TAKRI LETTER A..TAKRI LETTER RRA
+	{runeRange{0x11800, 0x1182B}, wbprALetter},              // Lo  [44] DOGRA LETTER A..DOGRA LETTER RRA
+	{runeRange{0x1193E, 0x1193E}, wbprExtend},               // Mn       DIVES AKURU VIRAMA
+	{runeRange{0x119E4, 0x119E4}, wbprExtend},               // Mc       NANDINAGARI VOWEL SIGN PRISHTHAMATRA E
+	{runeRange{0x11A98, 0x11A99}, wbprExtend},               // Mn   [2] SOYOMBO GEMINATION MARK..SOYOMBO SUBJOINER
+	{runeRange{0x11CB1, 0x11CB1}, wbprExtend},               // Mc       MARCHEN VOWEL SIGN I
+	{runeRange{0x11D6A, 0x11D89}, wbprALetter},              // Lo  [32] GUNJALA GONDI LETTER OO..GUNJALA GONDI LETTER SA
+	{runeRange{0x11F12, 0x11F33}, wbprALetter},              // Lo  [34] KAWI LETTER KA..KAWI LETTER JNYA
+	{runeRange{0x13441, 0x13446}, wbprALetter},              // Lo   [6] EGYPTIAN HIEROGLYPH FULL BLANK..EGYPTIAN HIEROGLYPH WIDE LOST SIGN
+	{runeRange{0x16E40, 0x16E7F}, wbprALetter},              // L&  [64] MEDEFAIDRIN CAPITAL LETTER M..MEDEFAIDRIN SMALL LETTER Y
+	{runeRange{0x1B155, 0x1B155}, wbprKatakana},             // Lo       KATAKANA LETTER SMALL KO
+	{runeRange{0x1D1AA, 0x1D1AD}, wbprExtend},               // Mn   [4] MUSICAL SYMBOL COMBINING DOWN BOW..MUSICAL SYMBOL COMBINING SNAP PIZZICATO
+	{runeRange{0x1D53B, 0x1D53E}, wbprALetter},              // L&   [4] MATHEMATICAL DOUBLE-STRUCK CAPITAL D..MATHEMATICAL DOUBLE-STRUCK CAPITAL G
+	{runeRange{0x1D7CE, 0x1D7FF}, wbprNumeric},              // Nd  [50] MATHEMATICAL BOLD DIGIT ZERO..MATHEMATICAL MONOSPACE DIGIT NINE
+	{runeRange{0x1E030, 0x1E06D}, wbprALetter},              // Lm  [62] MODIFIER LETTER CYRILLIC SMALL A..MODIFIER LETTER CYRILLIC SMALL STRAIGHT U WITH STROKE
+	{runeRange{0x1E7E0, 0x1E7E6}, wbprALetter},              // Lo   [7] ETHIOPIC SYLLABLE HHYA..ETHIOPIC SYLLABLE HHYO
+	{runeRange{0x1EE34, 0x1EE37}, wbprALetter},              // Lo   [4] ARABIC MATHEMATICAL INITIAL SHEEN..ARABIC MATHEMATICAL INITIAL KHAH
+	{runeRange{0x1EE64, 0x1EE64}, wbprALetter},              // Lo       ARABIC MATHEMATICAL STRETCHED HEH
+	{runeRange{0x1F10D, 0x1F10F}, wbprExtendedPictographic}, // E0.0   [3] (🄍..🄏)    CIRCLED ZERO WITH SLASH..CIRCLED DOLLAR SIGN WITH OVERLAID BACKSLASH
+	{runeRange{0x1F232, 0x1F23A}, wbprExtendedPictographic}, // E0.6   [9] (🈲..🈺)    Japanese “prohibited” button..Japanese “open for business” button
+	{runeRange{0x1F31C, 0x1F31C}, wbprExtendedPictographic}, // E0.7   [1] (🌜)       last quarter moon face
+	{runeRange{0x1F37C, 0x1F37C}, wbprExtendedPictographic}, // E1.0   [1] (🍼)       baby bottle
+	{runeRange{0x1F3CA, 0x1F3CA}, wbprExtendedPictographic}, // E0.6   [1] (🏊)       person swimming
+	{runeRange{0x1F408, 0x1F408}, wbprExtendedPictographic}, // E0.7   [1] (🐈)       cat
+	{runeRange{0x1F465, 0x1F465}, wbprExtendedPictographic}, // E1.0   [1] (👥)       busts in silhouette
+	{runeRange{0x1F4FD, 0x1F4FD}, wbprExtendedPictographic}, // E0.7   [1] (📽️)       film projector
+	{runeRange{0x1F550, 0x1F55B}, wbprExtendedPictographic}, // E0.6  [12] (🕐..🕛)    one o’clock..twelve o’clock
+	{runeRange{0x1F5A4, 0x1F5A4}, wbprExtendedPictographic}, // E3.0   [1] (🖤)       black heart
+	{runeRange{0x1F5E2, 0x1F5E2}, wbprExtendedPictographic}, // E0.0   [1] (🗢)       LIPS
+	{runeRange{0x1F60F, 0x1F60F}, wbprExtendedPictographic}, // E0.6   [1] (😏)       smirking face
+	{runeRange{0x1F61C, 0x1F61E}, wbprExtendedPictographic}, // E0.6   [3] (😜..😞)    winking face with tongue..disappointed face
+	{runeRange{0x1F630, 0x1F633}, wbprExtendedPictographic}, // E0.6   [4] (😰..😳)    anxious face with sweat..flushed face
+	{runeRange{0x1F681, 0x1F682}, wbprExtendedPictographic}, // E1.0   [2] (🚁..🚂)    helicopter..locomotive
+	{runeRange{0x1F68D, 0x1F68D}, wbprExtendedPictographic}, // E0.7   [1] (🚍)       oncoming bus
+	{runeRange{0x1F697, 0x1F697}, wbprExtendedPictographic}, // E0.6   [1] (🚗)       automobile
+	{runeRange{0x1F6A7, 0x1F6AD}, wbprExtendedPictographic}, // E0.6   [7] (🚧..🚭)    construction..no smoking
+	{runeRange{0x1F6C0, 0x1F6C0}, wbprExtendedPictographic}, // E0.6   [1] (🛀)       person taking bath
+	{runeRange{0x1F6D3, 0x1F6D4}, wbprExtendedPictographic}, // E0.0   [2] (🛓..🛔)    STUPA..PAGODA
+	{runeRange{0x1F6E9, 0x1F6E9}, wbprExtendedPictographic}, // E0.7   [1] (🛩️)       small airplane
+	{runeRange{0x1F6F7, 0x1F6F8}, wbprExtendedPictographic}, // E5.0   [2] (🛷..🛸)    sled..flying saucer
+	{runeRange{0x1F7EC, 0x1F7EF}, wbprExtendedPictographic}, // E0.0   [4] (🟬..🟯)    <reserved-1F7EC>..<reserved-1F7EF>
+	{runeRange{0x1F90C, 0x1F90C}, wbprExtendedPictographic}, // E13.0  [1] (🤌)       pinched fingers
+	{runeRange{0x1F931, 0x1F932}, wbprExtendedPictographic}, // E5.0   [2] (🤱..🤲)    breast-feeding..palms up together
+	{runeRange{0x1F950, 0x1F95E}, wbprExtendedPictographic}, // E3.0  [15] (🥐..🥞)    croissant..pancakes
+	{runeRange{0x1F97A, 0x1F97A}, wbprExtendedPictographic}, // E11.0  [1] (🥺)       pleading face
+	{runeRange{0x1F9A5, 0x1F9AA}, wbprExtendedPictographic}, // E12.0  [6] (🦥..🦪)    sloth..oyster
+	{runeRange{0x1F9CB, 0x1F9CB}, wbprExtendedPictographic}, // E13.0  [1] (🧋)       bubble tea
+	{runeRange{0x1FA75, 0x1FA77}, wbprExtendedPictographic}, // E15.0  [3] (🩵..🩷)    light blue heart..pink heart
+	{runeRange{0x1FA90, 0x1FA95}, wbprExtendedPictographic}, // E12.0  [6] (🪐..🪕)    ringed planet..banjo
+	{runeRange{0x1FABF, 0x1FABF}, wbprExtendedPictographic}, // E15.0  [1] (🪿)       goose
+	{runeRange{0x1FADC, 0x1FADF}, wbprExtendedPictographic}, // E0.0   [4] (🫜..🫟)    <reserved-1FADC>..<reserved-1FADF>
 	{runeRange{0x1FC00, 0x1FFFD}, wbprExtendedPictographic}, // E0.0[1022] (🰀..🿽)    <reserved-1FC00>..<reserved-1FFFD>
-	{runeRange{0xE0001, 0xE0001}, wbprFormat},               // Cf       LANGUAGE TAG
+	{runeRange{0x0020, 0x0020}, wbprWSegSpace},              // Zs       SPACE
+	{runeRange{0x0041, 0x005A}, wbprALetter},                // L&  [26] LATIN CAPITAL LETTER A..LATIN CAPITAL LETTER Z
+	{runeRange{0x00B5, 0x00B5}, wbprALetter},                // L&       MICRO SIGN
+	{runeRange{0x01C0, 0x01C3}, wbprALetter},                // Lo   [4] LATIN LETTER DENTAL CLICK..LATIN LETTER RETROFLEX CLICK
+	{runeRange{0x02DE, 0x02DF}, wbprALetter},                // Sk   [2] MODIFIER LETTER RHOTIC HOOK..MODIFIER LETTER CROSS ACCENT
+	{runeRange{0x0370, 0x0373}, wbprALetter},                // L&   [4] GREEK CAPITAL LETTER HETA..GREEK SMALL LETTER ARCHAIC SAMPI
+	{runeRange{0x0387, 0x0387}, wbprMidLetter},              // Po       GREEK ANO TELEIA
+	{runeRange{0x048A, 0x052F}, wbprALetter},                // L& [166] CYRILLIC CAPITAL LETTER SHORT I WITH TAIL..CYRILLIC SMALL LETTER EL WITH DESCENDER
+	{runeRange{0x058A, 0x058A}, wbprALetter},                // Pd       ARMENIAN HYPHEN
+	{runeRange{0x05F3, 0x05F3}, wbprALetter},                // Po       HEBREW PUNCTUATION GERESH
+	{runeRange{0x0641, 0x064A}, wbprALetter},                // Lo  [10] ARABIC LETTER FEH..ARABIC LETTER YEH
+	{runeRange{0x06D5, 0x06D5}, wbprALetter},                // Lo       ARABIC LETTER AE
+	{runeRange{0x06F0, 0x06F9}, wbprNumeric},                // Nd  [10] EXTENDED ARABIC-INDIC DIGIT ZERO..EXTENDED ARABIC-INDIC DIGIT NINE
+	{runeRange{0x074D, 0x07A5}, wbprALetter},                // Lo  [89] SYRIAC LETTER SOGDIAN ZHAIN..THAANA LETTER WAAVU
+	{runeRange{0x07FA, 0x07FA}, wbprALetter},                // Lm       NKO LAJANYALAN
+	{runeRange{0x0828, 0x0828}, wbprALetter},                // Lm       SAMARITAN MODIFIER LETTER I
+	{runeRange{0x0898, 0x089F}, wbprExtend},                 // Mn   [8] ARABIC SMALL HIGH WORD AL-JUZ..ARABIC HALF MADDA OVER MADDA
+	{runeRange{0x093A, 0x093A}, wbprExtend},                 // Mn       DEVANAGARI VOWEL SIGN OE
+	{runeRange{0x094E, 0x094F}, wbprExtend},                 // Mc   [2] DEVANAGARI VOWEL SIGN PRISHTHAMATRA E..DEVANAGARI VOWEL SIGN AW
+	{runeRange{0x0981, 0x0981}, wbprExtend},                 // Mn       BENGALI SIGN CANDRABINDU
+	{runeRange{0x09BC, 0x09BC}, wbprExtend},                 // Mn       BENGALI SIGN NUKTA
+	{runeRange{0x09D7, 0x09D7}, wbprExtend},                 // Mc       BENGALI AU LENGTH MARK
+	{runeRange{0x0A01, 0x0A02}, wbprExtend},                 // Mn   [2] GURMUKHI SIGN ADAK BINDI..GURMUKHI SIGN BINDI
+	{runeRange{0x0A38, 0x0A39}, wbprALetter},                // Lo   [2] GURMUKHI LETTER SA..GURMUKHI LETTER HA
+	{runeRange{0x0A5E, 0x0A5E}, wbprALetter},                // Lo       GURMUKHI LETTER FA
+	{runeRange{0x0A8F, 0x0A91}, wbprALetter},                // Lo   [3] GUJARATI LETTER E..GUJARATI VOWEL CANDRA O
+	{runeRange{0x0AC1, 0x0AC5}, wbprExtend},                 // Mn   [5] GUJARATI VOWEL SIGN U..GUJARATI VOWEL SIGN CANDRA E
+	{runeRange{0x0AE6, 0x0AEF}, wbprNumeric},                // Nd  [10] GUJARATI DIGIT ZERO..GUJARATI DIGIT NINE
+	{runeRange{0x0B2A, 0x0B30}, wbprALetter},                // Lo   [7] ORIYA LETTER PA..ORIYA LETTER RA
+	{runeRange{0x0B41, 0x0B44}, wbprExtend},                 // Mn   [4] ORIYA VOWEL SIGN U..ORIYA VOWEL SIGN VOCALIC RR
+	{runeRange{0x0B62, 0x0B63}, wbprExtend},                 // Mn   [2] ORIYA VOWEL SIGN VOCALIC L..ORIYA VOWEL SIGN VOCALIC LL
+	{runeRange{0x0B99, 0x0B9A}, wbprALetter},                // Lo   [2] TAMIL LETTER NGA..TAMIL LETTER CA
+	{runeRange{0x0BC1, 0x0BC2}, wbprExtend},                 // Mc   [2] TAMIL VOWEL SIGN U..TAMIL VOWEL SIGN UU
+	{runeRange{0x0C01, 0x0C03}, wbprExtend},                 // Mc   [3] TELUGU SIGN CANDRABINDU..TELUGU SIGN VISARGA
+	{runeRange{0x0C3E, 0x0C40}, wbprExtend},                 // Mn   [3] TELUGU VOWEL SIGN AA..TELUGU VOWEL SIGN II
+	{runeRange{0x0C62, 0x0C63}, wbprExtend},                 // Mn   [2] TELUGU VOWEL SIGN VOCALIC L..TELUGU VOWEL SIGN VOCALIC LL
+	{runeRange{0x0CAA, 0x0CB3}, wbprALetter},                // Lo  [10] KANNADA LETTER PA..KANNADA LETTER LLA
+	{runeRange{0x0CC7, 0x0CC8}, wbprExtend},                 // Mc   [2] KANNADA VOWEL SIGN EE..KANNADA VOWEL SIGN AI
+	{runeRange{0x0CF1, 0x0CF2}, wbprALetter},                // Lo   [2] KANNADA SIGN JIHVAMULIYA..KANNADA SIGN UPADHMANIYA
+	{runeRange{0x0D3D, 0x0D3D}, wbprALetter},                // Lo       MALAYALAM SIGN AVAGRAHA
+	{runeRange{0x0D57, 0x0D57}, wbprExtend},                 // Mc       MALAYALAM AU LENGTH MARK
+	{runeRange{0x0D9A, 0x0DB1}, wbprALetter},                // Lo  [24] SINHALA LETTER ALPAPRAANA KAYANNA..SINHALA LETTER DANTAJA NAYANNA
+	{runeRange{0x0DD8, 0x0DDF}, wbprExtend},                 // Mc   [8] SINHALA VOWEL SIGN GAETTA-PILLA..SINHALA VOWEL SIGN GAYANUKITTA
+	{runeRange{0x0EB4, 0x0EBC}, wbprExtend},                 // Mn   [9] LAO VOWEL SIGN I..LAO SEMIVOWEL SIGN LO
+	{runeRange{0x0F39, 0x0F39}, wbprExtend},                 // Mn       TIBETAN MARK TSA -PHRU
+	{runeRange{0x0F88, 0x0F8C}, wbprALetter},                // Lo   [5] TIBETAN SIGN LCE TSA CAN..TIBETAN SIGN INVERTED MCHU CAN
+	{runeRange{0x1038, 0x1038}, wbprExtend},                 // Mc       MYANMAR SIGN VISARGA
+	{runeRange{0x1062, 0x1064}, wbprExtend},                 // Mc   [3] MYANMAR VOWEL SIGN SGAW KAREN EU..MYANMAR TONE MARK SGAW KAREN KE PHO
+	{runeRange{0x108F, 0x108F}, wbprExtend},                 // Mc       MYANMAR SIGN RUMAI PALAUNG TONE-5
+	{runeRange{0x10FC, 0x10FC}, wbprALetter},                // Lm       MODIFIER LETTER GEORGIAN NAR
+	{runeRange{0x128A, 0x128D}, wbprALetter},                // Lo   [4] ETHIOPIC SYLLABLE XWI..ETHIOPIC SYLLABLE XWE
+	{runeRange{0x1312, 0x1315}, wbprALetter},                // Lo   [4] ETHIOPIC SYLLABLE GWI..ETHIOPIC SYLLABLE GWE
+	{runeRange{0x1680, 0x1680}, wbprWSegSpace},              // Zs       OGHAM SPACE MARK
+	{runeRange{0x171F, 0x1731}, wbprALetter},                // Lo  [19] TAGALOG LETTER ARCHAIC RA..HANUNOO LETTER HA
+	{runeRange{0x17B4, 0x17B5}, wbprExtend},                 // Mn   [2] KHMER VOWEL INHERENT AQ..KHMER VOWEL INHERENT AA
+	{runeRange{0x17E0, 0x17E9}, wbprNumeric},                // Nd  [10] KHMER DIGIT ZERO..KHMER DIGIT NINE
+	{runeRange{0x1880, 0x1884}, wbprALetter},                // Lo   [5] MONGOLIAN LETTER ALI GALI ANUSVARA ONE..MONGOLIAN LETTER ALI GALI INVERTED UBADAMA
+	{runeRange{0x1923, 0x1926}, wbprExtend},                 // Mc   [4] LIMBU VOWEL SIGN EE..LIMBU VOWEL SIGN AU
+	{runeRange{0x19D0, 0x19D9}, wbprNumeric},                // Nd  [10] NEW TAI LUE DIGIT ZERO..NEW TAI LUE DIGIT NINE
+	{runeRange{0x1A58, 0x1A5E}, wbprExtend},                 // Mn   [7] TAI THAM SIGN MAI KANG LAI..TAI THAM CONSONANT SIGN SA
+	{runeRange{0x1A7F, 0x1A7F}, wbprExtend},                 // Mn       TAI THAM COMBINING CRYPTOGRAMMIC DOT
+	{runeRange{0x1B05, 0x1B33}, wbprALetter},                // Lo  [47] BALINESE LETTER AKARA..BALINESE LETTER HA
+	{runeRange{0x1B43, 0x1B44}, wbprExtend},                 // Mc   [2] BALINESE VOWEL SIGN PEPET TEDUNG..BALINESE ADEG ADEG
+	{runeRange{0x1BA2, 0x1BA5}, wbprExtend},                 // Mn   [4] SUNDANESE CONSONANT SIGN PANYAKRA..SUNDANESE VOWEL SIGN PANYUKU
+	{runeRange{0x1BE6, 0x1BE6}, wbprExtend},                 // Mn       BATAK SIGN TOMPI
+	{runeRange{0x1C00, 0x1C23}, wbprALetter},                // Lo  [36] LEPCHA LETTER KA..LEPCHA LETTER A
+	{runeRange{0x1C5A, 0x1C77}, wbprALetter},                // Lo  [30] OL CHIKI LETTER LA..OL CHIKI LETTER OH
+	{runeRange{0x1CE2, 0x1CE8}, wbprExtend},                 // Mn   [7] VEDIC SIGN VISARGA SVARITA..VEDIC SIGN VISARGA ANUDATTA WITH TAIL
+	{runeRange{0x1CFA, 0x1CFA}, wbprALetter},                // Lo       VEDIC SIGN DOUBLE ANUSVARA ANTARGOMUKHA
+	{runeRange{0x1E00, 0x1F15}, wbprALetter},                // L& [278] LATIN CAPITAL LETTER A WITH RING BELOW..GREEK SMALL LETTER EPSILON WITH DASIA AND OXIA
+	{runeRange{0x1F5F, 0x1F7D}, wbprALetter},                // L&  [31] GREEK CAPITAL LETTER UPSILON WITH DASIA AND PERISPOMENI..GREEK SMALL LETTER OMEGA WITH OXIA
+	{runeRange{0x1FE0, 0x1FEC}, wbprALetter},                // L&  [13] GREEK SMALL LETTER UPSILON WITH VRACHY..GREEK CAPITAL LETTER RHO WITH DASIA
+	{runeRange{0x2018, 0x2018}, wbprMidNumLet},              // Pi       LEFT SINGLE QUOTATION MARK
+	{runeRange{0x203C, 0x203C}, wbprExtendedPictographic},   // E0.6   [1] (‼️)       double exclamation mark
+	{runeRange{0x2071, 0x2071}, wbprALetter},                // Lm       SUPERSCRIPT LATIN SMALL LETTER I
+	{runeRange{0x2102, 0x2102}, wbprALetter},                // L&       DOUBLE-STRUCK CAPITAL C
+	{runeRange{0x2128, 0x2128}, wbprALetter},                // L&       BLACK-LETTER CAPITAL Z
+	{runeRange{0x214E, 0x214E}, wbprALetter},                // L&       TURNED SMALL F
+	{runeRange{0x2388, 0x2388}, wbprExtendedPictographic},   // E0.0   [1] (⎈)       HELM SYMBOL
+	{runeRange{0x23F8, 0x23FA}, wbprExtendedPictographic},   // E0.7   [3] (⏸️..⏺️)    pause button..record button
+	{runeRange{0x2602, 0x2603}, wbprExtendedPictographic},   // E0.7   [2] (☂️..☃️)    umbrella..snowman
+	{runeRange{0x2614, 0x2615}, wbprExtendedPictographic},   // E0.6   [2] (☔..☕)    umbrella with rain drops..hot beverage
+	{runeRange{0x2622, 0x2623}, wbprExtendedPictographic},   // E1.0   [2] (☢️..☣️)    radioactive..biohazard
+	{runeRange{0x2630, 0x2637}, wbprExtendedPictographic},   // E0.0   [8] (☰..☷)    TRIGRAM FOR HEAVEN..TRIGRAM FOR EARTH
+	{runeRange{0x2648, 0x2653}, wbprExtendedPictographic},   // E0.6  [12] (♈..♓)    Aries..Pisces
+	{runeRange{0x2667, 0x2667}, wbprExtendedPictographic},   // E0.0   [1] (♧)       WHITE CLUB SUIT
+	{runeRange{0x2690, 0x2691}, wbprExtendedPictographic},   // E0.0   [2] (⚐..⚑)    WHITE FLAG..BLACK FLAG
+	{runeRange{0x269A, 0x269A}, wbprExtendedPictographic},   // E0.0   [1] (⚚)       STAFF OF HERMES
+	{runeRange{0x26AC, 0x26AF}, wbprExtendedPictographic},   // E0.0   [4] (⚬..⚯)    MEDIUM SMALL WHITE CIRCLE..UNMARRIED PARTNERSHIP SYMBOL
+	{runeRange{0x26C9, 0x26CD}, wbprExtendedPictographic},   // E0.0   [5] (⛉..⛍)    TURNED WHITE SHOGI PIECE..DISABLED CAR
+	{runeRange{0x26D5, 0x26E8}, wbprExtendedPictographic},   // E0.0  [20] (⛕..⛨)    ALTERNATE ONE-WAY LEFT WAY TRAFFIC..BLACK CROSS ON SHIELD
+	{runeRange{0x26F6, 0x26F6}, wbprExtendedPictographic},   // E0.0   [1] (⛶)       SQUARE FOUR CORNERS
+	{runeRange{0x2705, 0x2705}, wbprExtendedPictographic},   // E0.6   [1] (✅)       check mark button
+	{runeRange{0x2716, 0x2716}, wbprExtendedPictographic},   // E0.6   [1] (✖️)       multiply
+	{runeRange{0x274E, 0x274E}, wbprExtendedPictographic},   // E0.6   [1] (❎)       cross mark button
+	{runeRange{0x27B0, 0x27B0}, wbprExtendedPictographic},   // E0.6   [1] (➰)       curly loop
+	{runeRange{0x2C7C, 0x2C7D}, wbprALetter},                // Lm   [2] LATIN SUBSCRIPT SMALL LETTER J..MODIFIER LETTER CAPITAL V
+	{runeRange{0x2D30, 0x2D67}, wbprALetter},                // Lo  [56] TIFINAGH LETTER YA..TIFINAGH LETTER YO
+	{runeRange{0x2DC0, 0x2DC6}, wbprALetter},                // Lo   [7] ETHIOPIC SYLLABLE QYA..ETHIOPIC SYLLABLE QYO
+	{runeRange{0x302A, 0x302D}, wbprExtend},                 // Mn   [4] IDEOGRAPHIC LEVEL TONE MARK..IDEOGRAPHIC ENTERING TONE MARK
+	{runeRange{0x309B, 0x309C}, wbprKatakana},               // Sk   [2] KATAKANA-HIRAGANA VOICED SOUND MARK..KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK
+	{runeRange{0x31F0, 0x31FF}, wbprKatakana},               // Lo  [16] KATAKANA LETTER SMALL KU..KATAKANA LETTER SMALL RO
+	{runeRange{0xA4D0, 0xA4F7}, wbprALetter},                // Lo  [40] LISU LETTER BA..LISU LETTER OE
+	{runeRange{0xA66E, 0xA66E}, wbprALetter},                // Lo       CYRILLIC LETTER MULTIOCULAR O
+	{runeRange{0xA6A0, 0xA6E5}, wbprALetter},                // Lo  [70] BAMUM LETTER A..BAMUM LETTER KI
+	{runeRange{0xA771, 0xA787}, wbprALetter},                // L&  [23] LATIN SMALL LETTER DUM..LATIN SMALL LETTER INSULAR T
+	{runeRange{0xA7D5, 0xA7D9}, wbprALetter},                // L&   [5] LATIN SMALL LETTER DOUBLE WYNN..LATIN SMALL LETTER SIGMOID S
+	{runeRange{0xA803, 0xA805}, wbprALetter},                // Lo   [3] SYLOTI NAGRI LETTER U..SYLOTI NAGRI LETTER O
+	{runeRange{0xA82C, 0xA82C}, wbprExtend},                 // Mn       SYLOTI NAGRI SIGN ALTERNATE HASANTA
+	{runeRange{0xA8F2, 0xA8F7}, wbprALetter},                // Lo   [6] DEVANAGARI SIGN SPACING CANDRABINDU..DEVANAGARI SIGN CANDRABINDU AVAGRAHA
+	{runeRange{0xA947, 0xA951}, wbprExtend},                 // Mn  [11] REJANG VOWEL SIGN I..REJANG CONSONANT SIGN R
+	{runeRange{0xA9B6, 0xA9B9}, wbprExtend},                 // Mn   [4] JAVANESE VOWEL SIGN WULU..JAVANESE VOWEL SIGN SUKU MENDUT
+	{runeRange{0xAA00, 0xAA28}, wbprALetter},                // Lo  [41] CHAM LETTER A..CHAM LETTER HA
+	{runeRange{0xAA44, 0xAA4B}, wbprALetter},                // Lo   [8] CHAM LETTER FINAL CH..CHAM LETTER FINAL SS
+	{runeRange{0xAAB2, 0xAAB4}, wbprExtend},                 // Mn   [3] TAI VIET VOWEL I..TAI VIET VOWEL U
+	{runeRange{0xAAF2, 0xAAF2}, wbprALetter},                // Lo       MEETEI MAYEK ANJI
+	{runeRange{0xAB28, 0xAB2E}, wbprALetter},                // Lo   [7] ETHIOPIC SYLLABLE BBA..ETHIOPIC SYLLABLE BBO
+	{runeRange{0xABE3, 0xABE4}, wbprExtend},                 // Mc   [2] MEETEI MAYEK VOWEL SIGN ONAP..MEETEI MAYEK VOWEL SIGN INAP
+	{runeRange{0xAC00, 0xD7A3}, wbprALetter},                // Lo [11172] HANGUL SYLLABLE GA..HANGUL SYLLABLE HIH
+	{runeRange{0xFB2A, 0xFB36}, wbprHebrewLetter},           // Lo  [13] HEBREW LETTER SHIN WITH SHIN DOT..HEBREW LETTER ZAYIN WITH DAGESH
+	{runeRange{0xFD50, 0xFD8F}, wbprALetter},                // Lo  [64] ARABIC LIGATURE TEH WITH JEEM WITH MEEM INITIAL FORM..ARABIC LIGATURE MEEM WITH KHAH WITH MEEM INITIAL FORM
+	{runeRange{0xFE33, 0xFE34}, wbprExtendNumLet},           // Pc   [2] PRESENTATION FORM FOR VERTICAL LOW LINE..PRESENTATION FORM FOR VERTICAL WAVY LOW LINE
+	{runeRange{0xFEFF, 0xFEFF}, wbprFormat},                 // Cf       ZERO WIDTH NO-BREAK SPACE
+	{runeRange{0xFF3F, 0xFF3F}, wbprExtendNumLet},           // Pc       FULLWIDTH LOW LINE
+	{runeRange{0xFFCA, 0xFFCF}, wbprALetter},                // Lo   [6] HALFWIDTH HANGUL LETTER YEO..HALFWIDTH HANGUL LETTER OE
+	{runeRange{0x1003F, 0x1004D}, wbprALetter},              // Lo  [15] LINEAR B SYLLABLE B020 ZO..LINEAR B SYLLABLE B091 TWO
+	{runeRange{0x10300, 0x1031F}, wbprALetter},              // Lo  [32] OLD ITALIC LETTER A..OLD ITALIC LETTER ESS
+	{runeRange{0x103A0, 0x103C3}, wbprALetter},              // Lo  [36] OLD PERSIAN SIGN A..OLD PERSIAN SIGN HA
+	{runeRange{0x10500, 0x10527}, wbprALetter},              // Lo  [40] ELBASAN LETTER A..ELBASAN LETTER KHE
+	{runeRange{0x105B3, 0x105B9}, wbprALetter},              // L&   [7] VITHKUQI SMALL LETTER SE..VITHKUQI SMALL LETTER XE
+	{runeRange{0x10800, 0x10805}, wbprALetter},              // Lo   [6] CYPRIOT SYLLABLE A..CYPRIOT SYLLABLE JA
+	{runeRange{0x108E0, 0x108F2}, wbprALetter},              // Lo  [19] HATRAN LETTER ALEPH..HATRAN LETTER QOPH
+	{runeRange{0x10A05, 0x10A06}, wbprExtend},               // Mn   [2] KHAROSHTHI VOWEL SIGN E..KHAROSHTHI VOWEL SIGN O
+	{runeRange{0x10A80, 0x10A9C}, wbprALetter},              // Lo  [29] OLD NORTH ARABIAN LETTER HEH..OLD NORTH ARABIAN LETTER ZAH
+	{runeRange{0x10C00, 0x10C48}, wbprALetter},              // Lo  [73] OLD TURKIC LETTER ORKHON A..OLD TURKIC LETTER ORKHON BASH
+	{runeRange{0x10EB0, 0x10EB1}, wbprALetter},              // Lo   [2] YEZIDI LETTER LAM WITH DOT ABOVE..YEZIDI LETTER YOT WITH CIRCUMFLEX ABOVE
+	{runeRange{0x10FB0, 0x10FC4}, wbprALetter},              // Lo  [21] CHORASMIAN LETTER ALEPH..CHORASMIAN LETTER TAW
+	{runeRange{0x11070, 0x11070}, wbprExtend},               // Mn       BRAHMI SIGN OLD TAMIL VIRAMA
+	{runeRange{0x110B3, 0x110B6}, wbprExtend},               // Mn   [4] KAITHI VOWEL SIGN U..KAITHI VOWEL SIGN AI
+	{runeRange{0x11100, 0x11102}, wbprExtend},               // Mn   [3] CHAKMA SIGN CANDRABINDU..CHAKMA SIGN VISARGA
+	{runeRange{0x11147, 0x11147}, wbprALetter},              // Lo       CHAKMA LETTER VAA
+	{runeRange{0x111B6, 0x111BE}, wbprExtend},               // Mn   [9] SHARADA VOWEL SIGN U..SHARADA VOWEL SIGN O
+	{runeRange{0x111DC, 0x111DC}, wbprALetter},              // Lo       SHARADA HEADSTROKE
+	{runeRange{0x11236, 0x11237}, wbprExtend},               // Mn   [2] KHOJKI SIGN NUKTA..KHOJKI SIGN SHADDA
+	{runeRange{0x1129F, 0x112A8}, wbprALetter},              // Lo  [10] MULTANI LETTER BHA..MULTANI LETTER RHA
+	{runeRange{0x11305, 0x1130C}, wbprALetter},              // Lo   [8] GRANTHA LETTER A..GRANTHA LETTER VOCALIC L
+	{runeRange{0x1133E, 0x1133F}, wbprExtend},               // Mc   [2] GRANTHA VOWEL SIGN AA..GRANTHA VOWEL SIGN I
+	{runeRange{0x11362, 0x11363}, wbprExtend},               // Mc   [2] GRANTHA VOWEL SIGN VOCALIC L..GRANTHA VOWEL SIGN VOCALIC LL
+	{runeRange{0x11445, 0x11445}, wbprExtend},               // Mc       NEWA SIGN VISARGA
+	{runeRange{0x114B3, 0x114B8}, wbprExtend},               // Mn   [6] TIRHUTA VOWEL SIGN U..TIRHUTA VOWEL SIGN VOCALIC LL
+	{runeRange{0x114C7, 0x114C7}, wbprALetter},              // Lo       TIRHUTA OM
+	{runeRange{0x115BF, 0x115C0}, wbprExtend},               // Mn   [2] SIDDHAM SIGN VIRAMA..SIDDHAM SIGN NUKTA
+	{runeRange{0x1163E, 0x1163E}, wbprExtend},               // Mc       MODI SIGN VISARGA
+	{runeRange{0x116AE, 0x116AF}, wbprExtend},               // Mc   [2] TAKRI VOWEL SIGN I..TAKRI VOWEL SIGN II
+	{runeRange{0x11722, 0x11725}, wbprExtend},               // Mn   [4] AHOM VOWEL SIGN I..AHOM VOWEL SIGN UU
+	{runeRange{0x11839, 0x1183A}, wbprExtend},               // Mn   [2] DOGRA SIGN VIRAMA..DOGRA SIGN NUKTA
+	{runeRange{0x11930, 0x11935}, wbprExtend},               // Mc   [6] DIVES AKURU VOWEL SIGN AA..DIVES AKURU VOWEL SIGN E
+	{runeRange{0x11942, 0x11942}, wbprExtend},               // Mc       DIVES AKURU MEDIAL RA
+	{runeRange{0x119DC, 0x119DF}, wbprExtend},               // Mc   [4] NANDINAGARI VOWEL SIGN O..NANDINAGARI SIGN VISARGA
+	{runeRange{0x11A33, 0x11A38}, wbprExtend},               // Mn   [6] ZANABAZAR SQUARE FINAL CONSONANT MARK..ZANABAZAR SQUARE SIGN ANUSVARA
+	{runeRange{0x11A59, 0x11A5B}, wbprExtend},               // Mn   [3] SOYOMBO VOWEL SIGN VOCALIC R..SOYOMBO VOWEL LENGTH MARK
+	{runeRange{0x11C0A, 0x11C2E}, wbprALetter},              // Lo  [37] BHAIKSUKI LETTER E..BHAIKSUKI LETTER HA
+	{runeRange{0x11C72, 0x11C8F}, wbprALetter},              // Lo  [30] MARCHEN LETTER KA..MARCHEN LETTER A
+	{runeRange{0x11D00, 0x11D06}, wbprALetter},              // Lo   [7] MASARAM GONDI LETTER A..MASARAM GONDI LETTER E
+	{runeRange{0x11D47, 0x11D47}, wbprExtend},               // Mn       MASARAM GONDI RA-KARA
+	{runeRange{0x11D95, 0x11D95}, wbprExtend},               // Mn       GUNJALA GONDI SIGN ANUSVARA
+	{runeRange{0x11F00, 0x11F01}, wbprExtend},               // Mn   [2] KAWI SIGN CANDRABINDU..KAWI SIGN ANUSVARA
+	{runeRange{0x11F40, 0x11F40}, wbprExtend},               // Mn       KAWI VOWEL SIGN EU
+	{runeRange{0x12F90, 0x12FF0}, wbprALetter},              // Lo  [97] CYPRO-MINOAN SIGN CM001..CYPRO-MINOAN SIGN CM114
+	{runeRange{0x16A40, 0x16A5E}, wbprALetter},              // Lo  [31] MRO LETTER TA..MRO LETTER TEK
+	{runeRange{0x16B40, 0x16B43}, wbprALetter},              // Lm   [4] PAHAWH HMONG SIGN VOS SEEV..PAHAWH HMONG SIGN IB YAM
+	{runeRange{0x16F51, 0x16F87}, wbprExtend},               // Mc  [55] MIAO SIGN ASPIRATION..MIAO VOWEL SIGN UI
+	{runeRange{0x1AFF5, 0x1AFFB}, wbprKatakana},             // Lm   [7] KATAKANA LETTER MINNAN TONE-7..KATAKANA LETTER MINNAN NASALIZED TONE-5
+	{runeRange{0x1BC80, 0x1BC88}, wbprALetter},              // Lo   [9] DUPLOYAN AFFIX HIGH ACUTE..DUPLOYAN AFFIX HIGH VERTICAL
+	{runeRange{0x1D16D, 0x1D172}, wbprExtend},               // Mc   [6] MUSICAL SYMBOL COMBINING AUGMENTATION DOT..MUSICAL SYMBOL COMBINING FLAG-5
+	{runeRange{0x1D49E, 0x1D49F}, wbprALetter},              // L&   [2] MATHEMATICAL SCRIPT CAPITAL C..MATHEMATICAL SCRIPT CAPITAL D
+	{runeRange{0x1D507, 0x1D50A}, wbprALetter},              // L&   [4] MATHEMATICAL FRAKTUR CAPITAL D..MATHEMATICAL FRAKTUR CAPITAL G
+	{runeRange{0x1D552, 0x1D6A5}, wbprALetter},              // L& [340] MATHEMATICAL DOUBLE-STRUCK SMALL A..MATHEMATICAL ITALIC SMALL DOTLESS J
+	{runeRange{0x1D770, 0x1D788}, wbprALetter},              // L&  [25] MATHEMATICAL SANS-SERIF BOLD SMALL ALPHA..MATHEMATICAL SANS-SERIF BOLD SMALL OMEGA
+	{runeRange{0x1DA84, 0x1DA84}, wbprExtend},               // Mn       SIGNWRITING LOCATION HEAD NECK
+	{runeRange{0x1E008, 0x1E018}, wbprExtend},               // Mn  [17] COMBINING GLAGOLITIC LETTER ZEMLJA..COMBINING GLAGOLITIC LETTER HERU
+	{runeRange{0x1E137, 0x1E13D}, wbprALetter},              // Lm   [7] NYIAKENG PUACHUE HMONG SIGN FOR PERSON..NYIAKENG PUACHUE HMONG SYLLABLE LENGTHENER
+	{runeRange{0x1E4D0, 0x1E4EA}, wbprALetter},              // Lo  [27] NAG MUNDARI LETTER O..NAG MUNDARI LETTER ELL
+	{runeRange{0x1E800, 0x1E8C4}, wbprALetter},              // Lo [197] MENDE KIKAKUI SYLLABLE M001 KI..MENDE KIKAKUI SYLLABLE M060 NYON
+	{runeRange{0x1EE21, 0x1EE22}, wbprALetter},              // Lo   [2] ARABIC MATHEMATICAL INITIAL BEH..ARABIC MATHEMATICAL INITIAL JEEM
+	{runeRange{0x1EE47, 0x1EE47}, wbprALetter},              // Lo       ARABIC MATHEMATICAL TAILED HAH
+	{runeRange{0x1EE5B, 0x1EE5B}, wbprALetter},              // Lo       ARABIC MATHEMATICAL TAILED GHAIN
+	{runeRange{0x1EE79, 0x1EE7C}, wbprALetter},              // Lo   [4] ARABIC MATHEMATICAL STRETCHED DAD..ARABIC MATHEMATICAL STRETCHED DOTLESS BEH
+	{runeRange{0x1F004, 0x1F004}, wbprExtendedPictographic}, // E0.6   [1] (🀄)       mahjong red dragon
+	{runeRange{0x1F16C, 0x1F16F}, wbprExtendedPictographic}, // E0.0   [4] (🅬..🅯)    RAISED MR SIGN..CIRCLED HUMAN FIGURE
+	{runeRange{0x1F201, 0x1F202}, wbprExtendedPictographic}, // E0.6   [2] (🈁..🈂️)    Japanese “here” button..Japanese “service charge” button
+	{runeRange{0x1F252, 0x1F2FF}, wbprExtendedPictographic}, // E0.0 [174] (🉒..🋿)    <reserved-1F252>..<reserved-1F2FF>
+	{runeRange{0x1F316, 0x1F318}, wbprExtendedPictographic}, // E1.0   [3] (🌖..🌘)    waning gibbous moon..waning crescent moon
+	{runeRange{0x1F322, 0x1F323}, wbprExtendedPictographic}, // E0.0   [2] (🌢..🌣)    BLACK DROPLET..WHITE SUN
+	{runeRange{0x1F34B, 0x1F34B}, wbprExtendedPictographic}, // E1.0   [1] (🍋)       lemon
+	{runeRange{0x1F394, 0x1F395}, wbprExtendedPictographic}, // E0.0   [2] (🎔..🎕)    HEART WITH TIP ON THE LEFT..BOUQUET OF FLOWERS
+	{runeRange{0x1F3C6, 0x1F3C6}, wbprExtendedPictographic}, // E0.6   [1] (🏆)       trophy
+	{runeRange{0x1F3E0, 0x1F3E3}, wbprExtendedPictographic}, // E0.6   [4] (🏠..🏣)    house..Japanese post office
+	{runeRange{0x1F3F7, 0x1F3F7}, wbprExtendedPictographic}, // E0.7   [1] (🏷️)       label
+	{runeRange{0x1F411, 0x1F412}, wbprExtendedPictographic}, // E0.6   [2] (🐑..🐒)    ewe..monkey
+	{runeRange{0x1F43F, 0x1F43F}, wbprExtendedPictographic}, // E0.7   [1] (🐿️)       chipmunk
+	{runeRange{0x1F4AD, 0x1F4AD}, wbprExtendedPictographic}, // E1.0   [1] (💭)       thought balloon
+	{runeRange{0x1F4F5, 0x1F4F5}, wbprExtendedPictographic}, // E1.0   [1] (📵)       no mobile phones
+	{runeRange{0x1F504, 0x1F507}, wbprExtendedPictographic}, // E1.0   [4] (🔄..🔇)    counterclockwise arrows button..muted speaker
+	{runeRange{0x1F546, 0x1F548}, wbprExtendedPictographic}, // E0.0   [3] (🕆..🕈)    WHITE LATIN CROSS..CELTIC CROSS
+	{runeRange{0x1F571, 0x1F572}, wbprExtendedPictographic}, // E0.0   [2] (🕱..🕲)    BLACK SKULL AND CROSSBONES..NO PIRACY
+	{runeRange{0x1F590, 0x1F590}, wbprExtendedPictographic}, // E0.7   [1] (🖐️)       hand with fingers splayed
+	{runeRange{0x1F5A9, 0x1F5B0}, wbprExtendedPictographic}, // E0.0   [8] (🖩..🖰)    POCKET CALCULATOR..TWO BUTTON MOUSE
+	{runeRange{0x1F5D4, 0x1F5DB}, wbprExtendedPictographic}, // E0.0   [8] (🗔..🗛)    DESKTOP WINDOW..DECREASE FONT SIZE SYMBOL
+	{runeRange{0x1F5E9, 0x1F5EE}, wbprExtendedPictographic}, // E0.0   [6] (🗩..🗮)    RIGHT SPEECH BUBBLE..LEFT ANGER BUBBLE
+	{runeRange{0x1F601, 0x1F606}, wbprExtendedPictographic}, // E0.6   [6] (😁..😆)    beaming face with smiling eyes..grinning squinting face
+	{runeRange{0x1F615, 0x1F615}, wbprExtendedPictographic}, // E1.0   [1] (😕)       confused face
+	{runeRange{0x1F61A, 0x1F61A}, wbprExtendedPictographic}, // E0.6   [1] (😚)       kissing face with closed eyes
+	{runeRange{0x1F620, 0x1F625}, wbprExtendedPictographic}, // E0.6   [6] (😠..😥)    angry face..sad but relieved face
+	{runeRange{0x1F62D, 0x1F62D}, wbprExtendedPictographic}, // E0.6   [1] (😭)       loudly crying face
+	{runeRange{0x1F635, 0x1F635}, wbprExtendedPictographic}, // E0.6   [1] (😵)       face with crossed-out eyes
+	{runeRange{0x1F645, 0x1F64F}, wbprExtendedPictographic}, // E0.6  [11] (🙅..🙏)    person gesturing NO..folded hands
+	{runeRange{0x1F686, 0x1F686}, wbprExtendedPictographic}, // E1.0   [1] (🚆)       train
+	{runeRange{0x1F68A, 0x1F68B}, wbprExtendedPictographic}, // E1.0   [2] (🚊..🚋)    tram..tram car
+	{runeRange{0x1F68F, 0x1F68F}, wbprExtendedPictographic}, // E0.6   [1] (🚏)       bus stop
+	{runeRange{0x1F695, 0x1F695}, wbprExtendedPictographic}, // E0.6   [1] (🚕)       taxi
+	{runeRange{0x1F699, 0x1F69A}, wbprExtendedPictographic}, // E0.6   [2] (🚙..🚚)    sport utility vehicle..delivery truck
+	{runeRange{0x1F6A4, 0x1F6A5}, wbprExtendedPictographic}, // E0.6   [2] (🚤..🚥)    speedboat..horizontal traffic light
+	{runeRange{0x1F6B2, 0x1F6B2}, wbprExtendedPictographic}, // E0.6   [1] (🚲)       bicycle
+	{runeRange{0x1F6B9, 0x1F6BE}, wbprExtendedPictographic}, // E0.6   [6] (🚹..🚾)    men’s room..water closet
+	{runeRange{0x1F6C6, 0x1F6CA}, wbprExtendedPictographic}, // E0.0   [5] (🛆..🛊)    TRIANGLE WITH ROUNDED CORNERS..GIRLS SYMBOL
+	{runeRange{0x1F6D0, 0x1F6D0}, wbprExtendedPictographic}, // E1.0   [1] (🛐)       place of worship
+	{runeRange{0x1F6D6, 0x1F6D7}, wbprExtendedPictographic}, // E13.0  [2] (🛖..🛗)    hut..elevator
+	{runeRange{0x1F6E0, 0x1F6E5}, wbprExtendedPictographic}, // E0.7   [6] (🛠️..🛥️)    hammer and wrench..motor boat
+	{runeRange{0x1F6EB, 0x1F6EC}, wbprExtendedPictographic}, // E1.0   [2] (🛫..🛬)    airplane departure..airplane arrival
+	{runeRange{0x1F6F3, 0x1F6F3}, wbprExtendedPictographic}, // E0.7   [1] (🛳️)       passenger ship
+	{runeRange{0x1F6FA, 0x1F6FA}, wbprExtendedPictographic}, // E12.0  [1] (🛺)       auto rickshaw
+	{runeRange{0x1F7D5, 0x1F7DF}, wbprExtendedPictographic}, // E0.0  [11] (🟕..🟟)    CIRCLED TRIANGLE..<reserved-1F7DF>
+	{runeRange{0x1F7F1, 0x1F7FF}, wbprExtendedPictographic}, // E0.0  [15] (🟱..🟿)    <reserved-1F7F1>..<reserved-1F7FF>
+	{runeRange{0x1F888, 0x1F88F}, wbprExtendedPictographic}, // E0.0   [8] (🢈..🢏)    <reserved-1F888>..<reserved-1F88F>
+	{runeRange{0x1F910, 0x1F918}, wbprExtendedPictographic}, // E1.0   [9] (🤐..🤘)    zipper-mouth face..sign of the horns
+	{runeRange{0x1F928, 0x1F92F}, wbprExtendedPictographic}, // E5.0   [8] (🤨..🤯)    face with raised eyebrow..exploding head
+	{runeRange{0x1F93C, 0x1F93E}, wbprExtendedPictographic}, // E3.0   [3] (🤼..🤾)    people wrestling..person playing handball
+	{runeRange{0x1F94C, 0x1F94C}, wbprExtendedPictographic}, // E5.0   [1] (🥌)       curling stone
+	{runeRange{0x1F96C, 0x1F970}, wbprExtendedPictographic}, // E11.0  [5] (🥬..🥰)    leafy green..smiling face with hearts
+	{runeRange{0x1F977, 0x1F978}, wbprExtendedPictographic}, // E13.0  [2] (🥷..🥸)    ninja..disguised face
+	{runeRange{0x1F97C, 0x1F97F}, wbprExtendedPictographic}, // E11.0  [4] (🥼..🥿)    lab coat..flat shoe
+	{runeRange{0x1F998, 0x1F9A2}, wbprExtendedPictographic}, // E11.0 [11] (🦘..🦢)    kangaroo..swan
+	{runeRange{0x1F9AE, 0x1F9AF}, wbprExtendedPictographic}, // E12.0  [2] (🦮..🦯)    guide dog..white cane
+	{runeRange{0x1F9C1, 0x1F9C2}, wbprExtendedPictographic}, // E11.0  [2] (🧁..🧂)    cupcake..salt
+	{runeRange{0x1F9CD, 0x1F9CF}, wbprExtendedPictographic}, // E12.0  [3] (🧍..🧏)    person standing..deaf person
+	{runeRange{0x1FA70, 0x1FA73}, wbprExtendedPictographic}, // E12.0  [4] (🩰..🩳)    ballet shoes..shorts
+	{runeRange{0x1FA7B, 0x1FA7C}, wbprExtendedPictographic}, // E14.0  [2] (🩻..🩼)    x-ray..crutch
+	{runeRange{0x1FA87, 0x1FA88}, wbprExtendedPictographic}, // E15.0  [2] (🪇..🪈)    maracas..flute
+	{runeRange{0x1FAA9, 0x1FAAC}, wbprExtendedPictographic}, // E14.0  [4] (🪩..🪬)    mirror ball..hamsa
+	{runeRange{0x1FABB, 0x1FABD}, wbprExtendedPictographic}, // E15.0  [3] (🪻..🪽)    hyacinth..wing
+	{runeRange{0x1FAC3, 0x1FAC5}, wbprExtendedPictographic}, // E14.0  [3] (🫃..🫅)    pregnant man..person with crown
+	{runeRange{0x1FAD7, 0x1FAD9}, wbprExtendedPictographic}, // E14.0  [3] (🫗..🫙)    pouring liquid..jar
+	{runeRange{0x1FAE8, 0x1FAE8}, wbprExtendedPictographic}, // E15.0  [1] (🫨)       shaking face
+	{runeRange{0x1FAF9, 0x1FAFF}, wbprExtendedPictographic}, // E0.0   [7] (🫹..🫿)    <reserved-1FAF9>..<reserved-1FAFF>
 	{runeRange{0xE0020, 0xE007F}, wbprExtend},               // Cf  [96] TAG SPACE..CANCEL TAG
+	{runeRange{0x000B, 0x000C}, wbprNewline},                // Cc   [2] <control-000B>..<control-000C>
+	{runeRange{0x0027, 0x0027}, wbprSingleQuote},            // Po       APOSTROPHE
+	{runeRange{0x003A, 0x003A}, wbprMidLetter},              // Po       COLON
+	{runeRange{0x0061, 0x007A}, wbprALetter},                // L&  [26] LATIN SMALL LETTER A..LATIN SMALL LETTER Z
+	{runeRange{0x00AD, 0x00AD}, wbprFormat},                 // Cf       SOFT HYPHEN
+	{runeRange{0x00BA, 0x00BA}, wbprALetter},                // Lo       MASCULINE ORDINAL INDICATOR
+	{runeRange{0x01BB, 0x01BB}, wbprALetter},                // Lo       LATIN LETTER TWO WITH STROKE
+	{runeRange{0x0294, 0x0294}, wbprALetter},                // Lo       LATIN LETTER GLOTTAL STOP
+	{runeRange{0x02C6, 0x02D1}, wbprALetter},                // Lm  [12] MODIFIER LETTER CIRCUMFLEX ACCENT..MODIFIER LETTER HALF TRIANGULAR COLON
+	{runeRange{0x02E5, 0x02EB}, wbprALetter},                // Sk   [7] MODIFIER LETTER EXTRA-HIGH TONE BAR..MODIFIER LETTER YANG DEPARTING TONE MARK
+	{runeRange{0x02EF, 0x02FF}, wbprALetter},                // Sk  [17] MODIFIER LETTER LOW DOWN ARROWHEAD..MODIFIER LETTER LOW LEFT ARROW
+	{runeRange{0x0376, 0x0377}, wbprALetter},                // L&   [2] GREEK CAPITAL LETTER PAMPHYLIAN DIGAMMA..GREEK SMALL LETTER PAMPHYLIAN DIGAMMA
+	{runeRange{0x037F, 0x037F}, wbprALetter},                // L&       GREEK CAPITAL LETTER YOT
+	{runeRange{0x038C, 0x038C}, wbprALetter},                // L&       GREEK CAPITAL LETTER OMICRON WITH TONOS
+	{runeRange{0x0483, 0x0487}, wbprExtend},                 // Mn   [5] COMBINING CYRILLIC TITLO..COMBINING CYRILLIC POKRYTIE
+	{runeRange{0x0559, 0x0559}, wbprALetter},                // Lm       ARMENIAN MODIFIER LETTER LEFT HALF RING
+	{runeRange{0x0560, 0x0588}, wbprALetter},                // L&  [41] ARMENIAN SMALL LETTER TURNED AYB..ARMENIAN SMALL LETTER YI WITH STROKE
+	{runeRange{0x05BF, 0x05BF}, wbprExtend},                 // Mn       HEBREW POINT RAFE
+	{runeRange{0x05D0, 0x05EA}, wbprHebrewLetter},           // Lo  [27] HEBREW LETTER ALEF..HEBREW LETTER TAV
+	{runeRange{0x0600, 0x0605}, wbprFormat},                 // Cf   [6] ARABIC NUMBER SIGN..ARABIC NUMBER MARK ABOVE
+	{runeRange{0x0620, 0x063F}, wbprALetter},                // Lo  [32] ARABIC LETTER KASHMIRI YEH..ARABIC LETTER FARSI YEH WITH THREE DOTS ABOVE
+	{runeRange{0x0660, 0x0669}, wbprNumeric},                // Nd  [10] ARABIC-INDIC DIGIT ZERO..ARABIC-INDIC DIGIT NINE
+	{runeRange{0x0670, 0x0670}, wbprExtend},                 // Mn       ARABIC LETTER SUPERSCRIPT ALEF
+	{runeRange{0x06DD, 0x06DD}, wbprFormat},                 // Cf       ARABIC END OF AYAH
+	{runeRange{0x06EA, 0x06ED}, wbprExtend},                 // Mn   [4] ARABIC EMPTY CENTRE LOW STOP..ARABIC SMALL LOW MEEM
+	{runeRange{0x06FF, 0x06FF}, wbprALetter},                // Lo       ARABIC LETTER HEH WITH INVERTED V
+	{runeRange{0x0712, 0x072F}, wbprALetter},                // Lo  [30] SYRIAC LETTER BETH..SYRIAC LETTER PERSIAN DHALATH
+	{runeRange{0x07B1, 0x07B1}, wbprALetter},                // Lo       THAANA LETTER NAA
+	{runeRange{0x07F4, 0x07F5}, wbprALetter},                // Lm   [2] NKO HIGH TONE APOSTROPHE..NKO LOW TONE APOSTROPHE
+	{runeRange{0x0800, 0x0815}, wbprALetter},                // Lo  [22] SAMARITAN LETTER ALAF..SAMARITAN LETTER TAAF
+	{runeRange{0x0824, 0x0824}, wbprALetter},                // Lm       SAMARITAN MODIFIER LETTER SHORT A
+	{runeRange{0x0840, 0x0858}, wbprALetter},                // Lo  [25] MANDAIC LETTER HALQA..MANDAIC LETTER AIN
+	{runeRange{0x0889, 0x088E}, wbprALetter},                // Lo   [6] ARABIC LETTER NOON WITH INVERTED SMALL V..ARABIC VERTICAL TAIL
+	{runeRange{0x08C9, 0x08C9}, wbprALetter},                // Lm       ARABIC SMALL FARSI YEH
+	{runeRange{0x0903, 0x0903}, wbprExtend},                 // Mc       DEVANAGARI SIGN VISARGA
+	{runeRange{0x093C, 0x093C}, wbprExtend},                 // Mn       DEVANAGARI SIGN NUKTA
+	{runeRange{0x0949, 0x094C}, wbprExtend},                 // Mc   [4] DEVANAGARI VOWEL SIGN CANDRA O..DEVANAGARI VOWEL SIGN AU
+	{runeRange{0x0951, 0x0957}, wbprExtend},                 // Mn   [7] DEVANAGARI STRESS SIGN UDATTA..DEVANAGARI VOWEL SIGN UUE
+	{runeRange{0x0971, 0x0971}, wbprALetter},                // Lm       DEVANAGARI SIGN HIGH SPACING DOT
+	{runeRange{0x0985, 0x098C}, wbprALetter},                // Lo   [8] BENGALI LETTER A..BENGALI LETTER VOCALIC L
+	{runeRange{0x09B2, 0x09B2}, wbprALetter},                // Lo       BENGALI LETTER LA
+	{runeRange{0x09BE, 0x09C0}, wbprExtend},                 // Mc   [3] BENGALI VOWEL SIGN AA..BENGALI VOWEL SIGN II
+	{runeRange{0x09CD, 0x09CD}, wbprExtend},                 // Mn       BENGALI SIGN VIRAMA
+	{runeRange{0x09DF, 0x09E1}, wbprALetter},                // Lo   [3] BENGALI LETTER YYA..BENGALI LETTER VOCALIC LL
+	{runeRange{0x09FC, 0x09FC}, wbprALetter},                // Lo       BENGALI LETTER VEDIC ANUSVARA
+	{runeRange{0x0A05, 0x0A0A}, wbprALetter},                // Lo   [6] GURMUKHI LETTER A..GURMUKHI LETTER UU
+	{runeRange{0x0A32, 0x0A33}, wbprALetter},                // Lo   [2] GURMUKHI LETTER LA..GURMUKHI LETTER LLA
+	{runeRange{0x0A3E, 0x0A40}, wbprExtend},                 // Mc   [3] GURMUKHI VOWEL SIGN AA..GURMUKHI VOWEL SIGN II
+	{runeRange{0x0A51, 0x0A51}, wbprExtend},                 // Mn       GURMUKHI SIGN UDAAT
+	{runeRange{0x0A70, 0x0A71}, wbprExtend},                 // Mn   [2] GURMUKHI TIPPI..GURMUKHI ADDAK
+	{runeRange{0x0A83, 0x0A83}, wbprExtend},                 // Mc       GUJARATI SIGN VISARGA
+	{runeRange{0x0AAA, 0x0AB0}, wbprALetter},                // Lo   [7] GUJARATI LETTER PA..GUJARATI LETTER RA
+	{runeRange{0x0ABD, 0x0ABD}, wbprALetter},                // Lo       GUJARATI SIGN AVAGRAHA
+	{runeRange{0x0AC9, 0x0AC9}, wbprExtend},                 // Mc       GUJARATI VOWEL SIGN CANDRA O
+	{runeRange{0x0AE0, 0x0AE1}, wbprALetter},                // Lo   [2] GUJARATI LETTER VOCALIC RR..GUJARATI LETTER VOCALIC LL
+	{runeRange{0x0AFA, 0x0AFF}, wbprExtend},                 // Mn   [6] GUJARATI SIGN SUKUN..GUJARATI SIGN TWO-CIRCLE NUKTA ABOVE
+	{runeRange{0x0B0F, 0x0B10}, wbprALetter},                // Lo   [2] ORIYA LETTER E..ORIYA LETTER AI
+	{runeRange{0x0B35, 0x0B39}, wbprALetter},                // Lo   [5] ORIYA LETTER VA..ORIYA LETTER HA
+	{runeRange{0x0B3F, 0x0B3F}, wbprExtend},                 // Mn       ORIYA VOWEL SIGN I
+	{runeRange{0x0B4B, 0x0B4C}, wbprExtend},                 // Mc   [2] ORIYA VOWEL SIGN O..ORIYA VOWEL SIGN AU
+	{runeRange{0x0B5C, 0x0B5D}, wbprALetter},                // Lo   [2] ORIYA LETTER RRA..ORIYA LETTER RHA
+	{runeRange{0x0B71, 0x0B71}, wbprALetter},                // Lo       ORIYA LETTER WA
+	{runeRange{0x0B8E, 0x0B90}, wbprALetter},                // Lo   [3] TAMIL LETTER E..TAMIL LETTER AI
+	{runeRange{0x0B9E, 0x0B9F}, wbprALetter},                // Lo   [2] TAMIL LETTER NYA..TAMIL LETTER TTA
+	{runeRange{0x0BBE, 0x0BBF}, wbprExtend},                 // Mc   [2] TAMIL VOWEL SIGN AA..TAMIL VOWEL SIGN I
+	{runeRange{0x0BCA, 0x0BCC}, wbprExtend},                 // Mc   [3] TAMIL VOWEL SIGN O..TAMIL VOWEL SIGN AU
+	{runeRange{0x0BE6, 0x0BEF}, wbprNumeric},                // Nd  [10] TAMIL DIGIT ZERO..TAMIL DIGIT NINE
+	{runeRange{0x0C05, 0x0C0C}, wbprALetter},                // Lo   [8] TELUGU LETTER A..TELUGU LETTER VOCALIC L
+	{runeRange{0x0C3C, 0x0C3C}, wbprExtend},                 // Mn       TELUGU SIGN NUKTA
+	{runeRange{0x0C46, 0x0C48}, wbprExtend},                 // Mn   [3] TELUGU VOWEL SIGN E..TELUGU VOWEL SIGN AI
+	{runeRange{0x0C5D, 0x0C5D}, wbprALetter},                // Lo       TELUGU LETTER NAKAARA POLLU
+	{runeRange{0x0C80, 0x0C80}, wbprALetter},                // Lo       KANNADA SIGN SPACING CANDRABINDU
+	{runeRange{0x0C8E, 0x0C90}, wbprALetter},                // Lo   [3] KANNADA LETTER E..KANNADA LETTER AI
+	{runeRange{0x0CBC, 0x0CBC}, wbprExtend},                 // Mn       KANNADA SIGN NUKTA
+	{runeRange{0x0CC0, 0x0CC4}, wbprExtend},                 // Mc   [5] KANNADA VOWEL SIGN II..KANNADA VOWEL SIGN VOCALIC RR
+	{runeRange{0x0CCC, 0x0CCD}, wbprExtend},                 // Mn   [2] KANNADA VOWEL SIGN AU..KANNADA SIGN VIRAMA
+	{runeRange{0x0CE2, 0x0CE3}, wbprExtend},                 // Mn   [2] KANNADA VOWEL SIGN VOCALIC L..KANNADA VOWEL SIGN VOCALIC LL
+	{runeRange{0x0D00, 0x0D01}, wbprExtend},                 // Mn   [2] MALAYALAM SIGN COMBINING ANUSVARA ABOVE..MALAYALAM SIGN CANDRABINDU
+	{runeRange{0x0D12, 0x0D3A}, wbprALetter},                // Lo  [41] MALAYALAM LETTER O..MALAYALAM LETTER TTTA
+	{runeRange{0x0D41, 0x0D44}, wbprExtend},                 // Mn   [4] MALAYALAM VOWEL SIGN U..MALAYALAM VOWEL SIGN VOCALIC RR
+	{runeRange{0x0D4E, 0x0D4E}, wbprALetter},                // Lo       MALAYALAM LETTER DOT REPH
+	{runeRange{0x0D62, 0x0D63}, wbprExtend},                 // Mn   [2] MALAYALAM VOWEL SIGN VOCALIC L..MALAYALAM VOWEL SIGN VOCALIC LL
+	{runeRange{0x0D82, 0x0D83}, wbprExtend},                 // Mc   [2] SINHALA SIGN ANUSVARAYA..SINHALA SIGN VISARGAYA
+	{runeRange{0x0DBD, 0x0DBD}, wbprALetter},                // Lo       SINHALA LETTER DANTAJA LAYANNA
+	{runeRange{0x0DD2, 0x0DD4}, wbprExtend},                 // Mn   [3] SINHALA VOWEL SIGN KETTI IS-PILLA..SINHALA VOWEL SIGN KETTI PAA-PILLA
+	{runeRange{0x0DF2, 0x0DF3}, wbprExtend},                 // Mc   [2] SINHALA VOWEL SIGN DIGA GAETTA-PILLA..SINHALA VOWEL SIGN DIGA GAYANUKITTA
+	{runeRange{0x0E50, 0x0E59}, wbprNumeric},                // Nd  [10] THAI DIGIT ZERO..THAI DIGIT NINE
+	{runeRange{0x0ED0, 0x0ED9}, wbprNumeric},                // Nd  [10] LAO DIGIT ZERO..LAO DIGIT NINE
+	{runeRange{0x0F35, 0x0F35}, wbprExtend},                 // Mn       TIBETAN MARK NGAS BZUNG NYI ZLA
+	{runeRange{0x0F40, 0x0F47}, wbprALetter},                // Lo   [8] TIBETAN LETTER KA..TIBETAN LETTER JA
+	{runeRange{0x0F80, 0x0F84}, wbprExtend},                 // Mn   [5] TIBETAN VOWEL SIGN REVERSED I..TIBETAN MARK HALANTA
+	{runeRange{0x0F99, 0x0FBC}, wbprExtend},                 // Mn  [36] TIBETAN SUBJOINED LETTER NYA..TIBETAN SUBJOINED LETTER FIXED-FORM RA
+	{runeRange{0x1031, 0x1031}, wbprExtend},                 // Mc       MYANMAR VOWEL SIGN E
+	{runeRange{0x103B, 0x103C}, wbprExtend},                 // Mc   [2] MYANMAR CONSONANT SIGN MEDIAL YA..MYANMAR CONSONANT SIGN MEDIAL RA
+	{runeRange{0x1058, 0x1059}, wbprExtend},                 // Mn   [2] MYANMAR VOWEL SIGN VOCALIC L..MYANMAR VOWEL SIGN VOCALIC LL
+	{runeRange{0x1071, 0x1074}, wbprExtend},                 // Mn   [4] MYANMAR VOWEL SIGN GEBA KAREN I..MYANMAR VOWEL SIGN KAYAH EE
+	{runeRange{0x1087, 0x108C}, wbprExtend},                 // Mc   [6] MYANMAR SIGN SHAN TONE-2..MYANMAR SIGN SHAN COUNCIL TONE-3
+	{runeRange{0x109A, 0x109C}, wbprExtend},                 // Mc   [3] MYANMAR SIGN KHAMTI TONE-1..MYANMAR VOWEL SIGN AITON A
+	{runeRange{0x10CD, 0x10CD}, wbprALetter},                // L&       GEORGIAN CAPITAL LETTER AEN
+	{runeRange{0x1100, 0x1248}, wbprALetter},                // Lo [329] HANGUL CHOSEONG KIYEOK..ETHIOPIC SYLLABLE QWA
+	{runeRange{0x125A, 0x125D}, wbprALetter},                // Lo   [4] ETHIOPIC SYLLABLE QHWI..ETHIOPIC SYLLABLE QHWE
+	{runeRange{0x12B2, 0x12B5}, wbprALetter},                // Lo   [4] ETHIOPIC SYLLABLE KWI..ETHIOPIC SYLLABLE KWE
+	{runeRange{0x12C8, 0x12D6}, wbprALetter},                // Lo  [15] ETHIOPIC SYLLABLE WA..ETHIOPIC SYLLABLE PHARYNGEAL O
+	{runeRange{0x135D, 0x135F}, wbprExtend},                 // Mn   [3] ETHIOPIC COMBINING GEMINATION AND VOWEL LENGTH MARK..ETHIOPIC COMBINING GEMINATION MARK
+	{runeRange{0x1401, 0x166C}, wbprALetter},                // Lo [620] CANADIAN SYLLABICS E..CANADIAN SYLLABICS CARRIER TTSA
+	{runeRange{0x16A0, 0x16EA}, wbprALetter},                // Lo  [75] RUNIC LETTER FEHU FEOH FE F..RUNIC LETTER X
+	{runeRange{0x1712, 0x1714}, wbprExtend},                 // Mn   [3] TAGALOG VOWEL SIGN I..TAGALOG SIGN VIRAMA
+	{runeRange{0x1734, 0x1734}, wbprExtend},                 // Mc       HANUNOO SIGN PAMUDPOD
+	{runeRange{0x176E, 0x1770}, wbprALetter},                // Lo   [3] TAGBANWA LETTER LA..TAGBANWA LETTER SA
+	{runeRange{0x17B7, 0x17BD}, wbprExtend},                 // Mn   [7] KHMER VOWEL SIGN I..KHMER VOWEL SIGN UA
+	{runeRange{0x17C9, 0x17D3}, wbprExtend},                 // Mn  [11] KHMER SIGN MUUSIKATOAN..KHMER SIGN BATHAMASAT
+	{runeRange{0x180E, 0x180E}, wbprFormat},                 // Cf       MONGOLIAN VOWEL SEPARATOR
+	{runeRange{0x1843, 0x1843}, wbprALetter},                // Lm       MONGOLIAN LETTER TODO LONG VOWEL SIGN
+	{runeRange{0x1887, 0x18A8}, wbprALetter},                // Lo  [34] MONGOLIAN LETTER ALI GALI A..MONGOLIAN LETTER MANCHU ALI GALI BHA
+	{runeRange{0x1900, 0x191E}, wbprALetter},                // Lo  [31] LIMBU VOWEL-CARRIER LETTER..LIMBU LETTER TRA
+	{runeRange{0x1929, 0x192B}, wbprExtend},                 // Mc   [3] LIMBU SUBJOINED LETTER YA..LIMBU SUBJOINED LETTER WA
+	{runeRange{0x1939, 0x193B}, wbprExtend},                 // Mn   [3] LIMBU SIGN MUKPHRENG..LIMBU SIGN SA-I
+	{runeRange{0x1A17, 0x1A18}, wbprExtend},                 // Mn   [2] BUGINESE VOWEL SIGN I..BUGINESE VOWEL SIGN U
+	{runeRange{0x1A56, 0x1A56}, wbprExtend},                 // Mn       TAI THAM CONSONANT SIGN MEDIAL LA
+	{runeRange{0x1A61, 0x1A61}, wbprExtend},                 // Mc       TAI THAM VOWEL SIGN A
+	{runeRange{0x1A6D, 0x1A72}, wbprExtend},                 // Mc   [6] TAI THAM VOWEL SIGN OY..TAI THAM VOWEL SIGN THAM AI
+	{runeRange{0x1A90, 0x1A99}, wbprNumeric},                // Nd  [10] TAI THAM THAM DIGIT ZERO..TAI THAM THAM DIGIT NINE
+	{runeRange{0x1B00, 0x1B03}, wbprExtend},                 // Mn   [4] BALINESE SIGN ULU RICEM..BALINESE SIGN SURANG
+	{runeRange{0x1B35, 0x1B35}, wbprExtend},                 // Mc       BALINESE VOWEL SIGN TEDUNG
+	{runeRange{0x1B3D, 0x1B41}, wbprExtend},                 // Mc   [5] BALINESE VOWEL SIGN LA LENGA TEDUNG..BALINESE VOWEL SIGN TALING REPA TEDUNG
+	{runeRange{0x1B50, 0x1B59}, wbprNumeric},                // Nd  [10] BALINESE DIGIT ZERO..BALINESE DIGIT NINE
+	{runeRange{0x1B83, 0x1BA0}, wbprALetter},                // Lo  [30] SUNDANESE LETTER A..SUNDANESE LETTER HA
+	{runeRange{0x1BA8, 0x1BA9}, wbprExtend},                 // Mn   [2] SUNDANESE VOWEL SIGN PAMEPET..SUNDANESE VOWEL SIGN PANEULEUNG
+	{runeRange{0x1BB0, 0x1BB9}, wbprNumeric},                // Nd  [10] SUNDANESE DIGIT ZERO..SUNDANESE DIGIT NINE
+	{runeRange{0x1BE8, 0x1BE9}, wbprExtend},                 // Mn   [2] BATAK VOWEL SIGN PAKPAK E..BATAK VOWEL SIGN EE
+	{runeRange{0x1BEF, 0x1BF1}, wbprExtend},                 // Mn   [3] BATAK VOWEL SIGN U FOR SIMALUNGUN SA..BATAK CONSONANT SIGN H
+	{runeRange{0x1C2C, 0x1C33}, wbprExtend},                 // Mn   [8] LEPCHA VOWEL SIGN E..LEPCHA CONSONANT SIGN T
+	{runeRange{0x1C4D, 0x1C4F}, wbprALetter},                // Lo   [3] LEPCHA LETTER TTA..LEPCHA LETTER DDA
+	{runeRange{0x1C80, 0x1C88}, wbprALetter},                // L&   [9] CYRILLIC SMALL LETTER ROUNDED VE..CYRILLIC SMALL LETTER UNBLENDED UK
+	{runeRange{0x1CD4, 0x1CE0}, wbprExtend},                 // Mn  [13] VEDIC SIGN YAJURVEDIC MIDLINE SVARITA..VEDIC TONE RIGVEDIC KASHMIRI INDEPENDENT SVARITA
+	{runeRange{0x1CED, 0x1CED}, wbprExtend},                 // Mn       VEDIC SIGN TIRYAK
+	{runeRange{0x1CF7, 0x1CF7}, wbprExtend},                 // Mc       VEDIC SIGN ATIKRAMA
+	{runeRange{0x1D2C, 0x1D6A}, wbprALetter},                // Lm  [63] MODIFIER LETTER CAPITAL A..GREEK SUBSCRIPT SMALL LETTER CHI
+	{runeRange{0x1D9B, 0x1DBF}, wbprALetter},                // Lm  [37] MODIFIER LETTER SMALL TURNED ALPHA..MODIFIER LETTER SMALL THETA
+	{runeRange{0x1F20, 0x1F45}, wbprALetter},                // L&  [38] GREEK SMALL LETTER ETA WITH PSILI..GREEK SMALL LETTER OMICRON WITH DASIA AND OXIA
+	{runeRange{0x1F5B, 0x1F5B}, wbprALetter},                // L&       GREEK CAPITAL LETTER UPSILON WITH DASIA AND VARIA
+	{runeRange{0x1FB6, 0x1FBC}, wbprALetter},                // L&   [7] GREEK SMALL LETTER ALPHA WITH PERISPOMENI..GREEK CAPITAL LETTER ALPHA WITH PROSGEGRAMMENI
+	{runeRange{0x1FD0, 0x1FD3}, wbprALetter},                // L&   [4] GREEK SMALL LETTER IOTA WITH VRACHY..GREEK SMALL LETTER IOTA WITH DIALYTIKA AND OXIA
+	{runeRange{0x1FF6, 0x1FFC}, wbprALetter},                // L&   [7] GREEK SMALL LETTER OMEGA WITH PERISPOMENI..GREEK CAPITAL LETTER OMEGA WITH PROSGEGRAMMENI
+	{runeRange{0x200D, 0x200D}, wbprZWJ},                    // Cf       ZERO WIDTH JOINER
+	{runeRange{0x2024, 0x2024}, wbprMidNumLet},              // Po       ONE DOT LEADER
+	{runeRange{0x202A, 0x202E}, wbprFormat},                 // Cf   [5] LEFT-TO-RIGHT EMBEDDING..RIGHT-TO-LEFT OVERRIDE
+	{runeRange{0x2044, 0x2044}, wbprMidNum},                 // Sm       FRACTION SLASH
+	{runeRange{0x2060, 0x2064}, wbprFormat},                 // Cf   [5] WORD JOINER..INVISIBLE PLUS
+	{runeRange{0x2090, 0x209C}, wbprALetter},                // Lm  [13] LATIN SUBSCRIPT SMALL LETTER A..LATIN SUBSCRIPT SMALL LETTER T
+	{runeRange{0x20E2, 0x20E4}, wbprExtend},                 // Me   [3] COMBINING ENCLOSING SCREEN..COMBINING ENCLOSING UPWARD POINTING TRIANGLE
+	{runeRange{0x210A, 0x2113}, wbprALetter},                // L&  [10] SCRIPT SMALL G..SCRIPT SMALL L
+	{runeRange{0x2124, 0x2124}, wbprALetter},                // L&       DOUBLE-STRUCK CAPITAL Z
+	{runeRange{0x212F, 0x2134}, wbprALetter},                // L&   [6] SCRIPT SMALL E..SCRIPT SMALL O
+	{runeRange{0x213C, 0x213F}, wbprALetter},                // L&   [4] DOUBLE-STRUCK SMALL PI..DOUBLE-STRUCK CAPITAL PI
+	{runeRange{0x2183, 0x2184}, wbprALetter},                // L&   [2] ROMAN NUMERAL REVERSED ONE HUNDRED..LATIN SMALL LETTER REVERSED C
+	{runeRange{0x231A, 0x231B}, wbprExtendedPictographic},   // E0.6   [2] (⌚..⌛)    watch..hourglass done
+	{runeRange{0x23E9, 0x23EC}, wbprExtendedPictographic},   // E0.6   [4] (⏩..⏬)    fast-forward button..fast down button
+	{runeRange{0x23F1, 0x23F2}, wbprExtendedPictographic},   // E1.0   [2] (⏱️..⏲️)    stopwatch..timer clock
+	{runeRange{0x24C2, 0x24C2}, wbprExtendedPictographic},   // E0.6   [1] (Ⓜ️)       circled M
+	{runeRange{0x25FB, 0x25FE}, wbprExtendedPictographic},   // E0.6   [4] (◻️..◾)    white medium square..black medium-small square
+	{runeRange{0x2605, 0x2605}, wbprExtendedPictographic},   // E0.0   [1] (★)       BLACK STAR
+	{runeRange{0x2611, 0x2611}, wbprExtendedPictographic},   // E0.6   [1] (☑️)       check box with check
+	{runeRange{0x2618, 0x2618}, wbprExtendedPictographic},   // E1.0   [1] (☘️)       shamrock
+	{runeRange{0x2620, 0x2620}, wbprExtendedPictographic},   // E1.0   [1] (☠️)       skull and crossbones
+	{runeRange{0x2626, 0x2626}, wbprExtendedPictographic},   // E1.0   [1] (☦️)       orthodox cross
+	{runeRange{0x262E, 0x262E}, wbprExtendedPictographic},   // E1.0   [1] (☮️)       peace symbol
+	{runeRange{0x263A, 0x263A}, wbprExtendedPictographic},   // E0.6   [1] (☺️)       smiling face
+	{runeRange{0x2642, 0x2642}, wbprExtendedPictographic},   // E4.0   [1] (♂️)       male sign
+	{runeRange{0x265F, 0x265F}, wbprExtendedPictographic},   // E11.0  [1] (♟️)       chess pawn
+	{runeRange{0x2664, 0x2664}, wbprExtendedPictographic},   // E0.0   [1] (♤)       WHITE SPADE SUIT
+	{runeRange{0x2669, 0x267A}, wbprExtendedPictographic},   // E0.0  [18] (♩..♺)    QUARTER NOTE..RECYCLING SYMBOL FOR GENERIC MATERIALS
+	{runeRange{0x267F, 0x267F}, wbprExtendedPictographic},   // E0.6   [1] (♿)       wheelchair symbol
+	{runeRange{0x2693, 0x2693}, wbprExtendedPictographic},   // E0.6   [1] (⚓)       anchor
+	{runeRange{0x2698, 0x2698}, wbprExtendedPictographic},   // E0.0   [1] (⚘)       FLOWER
+	{runeRange{0x269D, 0x269F}, wbprExtendedPictographic},   // E0.0   [3] (⚝..⚟)    OUTLINED WHITE STAR..THREE LINES CONVERGING LEFT
+	{runeRange{0x26A8, 0x26A9}, wbprExtendedPictographic},   // E0.0   [2] (⚨..⚩)    VERTICAL MALE WITH STROKE SIGN..HORIZONTAL MALE WITH STROKE SIGN
+	{runeRange{0x26B2, 0x26BC}, wbprExtendedPictographic},   // E0.0  [11] (⚲..⚼)    NEUTER..SESQUIQUADRATE
+	{runeRange{0x26C6, 0x26C7}, wbprExtendedPictographic},   // E0.0   [2] (⛆..⛇)    RAIN..BLACK SNOWMAN
+	{runeRange{0x26CF, 0x26CF}, wbprExtendedPictographic},   // E0.7   [1] (⛏️)       pick
+	{runeRange{0x26D3, 0x26D3}, wbprExtendedPictographic},   // E0.7   [1] (⛓️)       chains
+	{runeRange{0x26EA, 0x26EA}, wbprExtendedPictographic},   // E0.6   [1] (⛪)       church
+	{runeRange{0x26F4, 0x26F4}, wbprExtendedPictographic},   // E0.7   [1] (⛴️)       ferry
+	{runeRange{0x26FA, 0x26FA}, wbprExtendedPictographic},   // E0.6   [1] (⛺)       tent
+	{runeRange{0x2702, 0x2702}, wbprExtendedPictographic},   // E0.6   [1] (✂️)       scissors
+	{runeRange{0x270D, 0x270D}, wbprExtendedPictographic},   // E0.7   [1] (✍️)       writing hand
+	{runeRange{0x2712, 0x2712}, wbprExtendedPictographic},   // E0.6   [1] (✒️)       black nib
+	{runeRange{0x2721, 0x2721}, wbprExtendedPictographic},   // E0.7   [1] (✡️)       star of David
+	{runeRange{0x2747, 0x2747}, wbprExtendedPictographic},   // E0.6   [1] (❇️)       sparkle
+	{runeRange{0x2757, 0x2757}, wbprExtendedPictographic},   // E0.6   [1] (❗)       red exclamation mark
+	{runeRange{0x2795, 0x2797}, wbprExtendedPictographic},   // E0.6   [3] (➕..➗)    plus..divide
+	{runeRange{0x2934, 0x2935}, wbprExtendedPictographic},   // E0.6   [2] (⤴️..⤵️)    right arrow curving up..right arrow curving down
+	{runeRange{0x2B55, 0x2B55}, wbprExtendedPictographic},   // E0.6   [1] (⭕)       hollow red circle
+	{runeRange{0x2CEB, 0x2CEE}, wbprALetter},                // L&   [4] COPTIC CAPITAL LETTER CRYPTOGRAMMIC SHEI..COPTIC SMALL LETTER CRYPTOGRAMMIC GANGIA
+	{runeRange{0x2D27, 0x2D27}, wbprALetter},                // L&       GEORGIAN SMALL LETTER YN
+	{runeRange{0x2D7F, 0x2D7F}, wbprExtend},                 // Mn       TIFINAGH CONSONANT JOINER
+	{runeRange{0x2DB0, 0x2DB6}, wbprALetter},                // Lo   [7] ETHIOPIC SYLLABLE ZZA..ETHIOPIC SYLLABLE ZZO
+	{runeRange{0x2DD0, 0x2DD6}, wbprALetter},                // Lo   [7] ETHIOPIC SYLLABLE XYA..ETHIOPIC SYLLABLE XYO
+	{runeRange{0x3000, 0x3000}, wbprWSegSpace},              // Zs       IDEOGRAPHIC SPACE
+	{runeRange{0x3030, 0x3030}, wbprExtendedPictographic},   // E0.6   [1] (〰️)       wavy dash
+	{runeRange{0x303D, 0x303D}, wbprExtendedPictographic},   // E0.6   [1] (〽️)       part alternation mark
+	{runeRange{0x30A1, 0x30FA}, wbprKatakana},               // Lo  [90] KATAKANA LETTER SMALL A..KATAKANA LETTER VO
+	{runeRange{0x3131, 0x318E}, wbprALetter},                // Lo  [94] HANGUL LETTER KIYEOK..HANGUL LETTER ARAEAE
+	{runeRange{0x3299, 0x3299}, wbprExtendedPictographic},   // E0.6   [1] (㊙️)       Japanese “secret” button
+	{runeRange{0xA015, 0xA015}, wbprALetter},                // Lm       YI SYLLABLE WU
+	{runeRange{0xA500, 0xA60B}, wbprALetter},                // Lo [268] VAI SYLLABLE EE..VAI SYLLABLE NG
+	{runeRange{0xA62A, 0xA62B}, wbprALetter},                // Lo   [2] VAI SYLLABLE NDOLE MA..VAI SYLLABLE NDOLE DO
+	{runeRange{0xA670, 0xA672}, wbprExtend},                 // Me   [3] COMBINING CYRILLIC TEN MILLIONS SIGN..COMBINING CYRILLIC THOUSAND MILLIONS SIGN
+	{runeRange{0xA69C, 0xA69D}, wbprALetter},                // Lm   [2] MODIFIER LETTER CYRILLIC HARD SIGN..MODIFIER LETTER CYRILLIC SOFT SIGN
+	{runeRange{0xA6F0, 0xA6F1}, wbprExtend},                 // Mn   [2] BAMUM COMBINING MARK KOQNDON..BAMUM COMBINING MARK TUKWENTIS
+	{runeRange{0xA722, 0xA76F}, wbprALetter},                // L&  [78] LATIN CAPITAL LETTER EGYPTOLOGICAL ALEF..LATIN SMALL LETTER CON
+	{runeRange{0xA789, 0xA78A}, wbprALetter},                // Sk   [2] MODIFIER LETTER COLON..MODIFIER LETTER SHORT EQUALS SIGN
+	{runeRange{0xA7D0, 0xA7D1}, wbprALetter},                // L&   [2] LATIN CAPITAL LETTER CLOSED INSULAR G..LATIN SMALL LETTER CLOSED INSULAR G
+	{runeRange{0xA7F5, 0xA7F6}, wbprALetter},                // L&   [2] LATIN CAPITAL LETTER REVERSED HALF H..LATIN SMALL LETTER REVERSED HALF H
+	{runeRange{0xA7FB, 0xA801}, wbprALetter},                // Lo   [7] LATIN EPIGRAPHIC LETTER REVERSED F..SYLOTI NAGRI LETTER I
+	{runeRange{0xA807, 0xA80A}, wbprALetter},                // Lo   [4] SYLOTI NAGRI LETTER KO..SYLOTI NAGRI LETTER GHO
+	{runeRange{0xA825, 0xA826}, wbprExtend},                 // Mn   [2] SYLOTI NAGRI VOWEL SIGN U..SYLOTI NAGRI VOWEL SIGN E
+	{runeRange{0xA880, 0xA881}, wbprExtend},                 // Mc   [2] SAURASHTRA SIGN ANUSVARA..SAURASHTRA SIGN VISARGA
+	{runeRange{0xA8D0, 0xA8D9}, wbprNumeric},                // Nd  [10] SAURASHTRA DIGIT ZERO..SAURASHTRA DIGIT NINE
+	{runeRange{0xA8FD, 0xA8FE}, wbprALetter},                // Lo   [2] DEVANAGARI JAIN OM..DEVANAGARI LETTER AY
+	{runeRange{0xA926, 0xA92D}, wbprExtend},                 // Mn   [8] KAYAH LI VOWEL UE..KAYAH LI TONE CALYA PLOPHU
+	{runeRange{0xA960, 0xA97C}, wbprALetter},                // Lo  [29] HANGUL CHOSEONG TIKEUT-MIEUM..HANGUL CHOSEONG SSANGYEORINHIEUH
+	{runeRange{0xA9B3, 0xA9B3}, wbprExtend},                 // Mn       JAVANESE SIGN CECAK TELU
+	{runeRange{0xA9BC, 0xA9BD}, wbprExtend},                 // Mn   [2] JAVANESE VOWEL SIGN PEPET..JAVANESE CONSONANT SIGN KERET
+	{runeRange{0xA9E5, 0xA9E5}, wbprExtend},                 // Mn       MYANMAR SIGN SHAN SAW
+	{runeRange{0xAA2F, 0xAA30}, wbprExtend},                 // Mc   [2] CHAM VOWEL SIGN O..CHAM VOWEL SIGN AI
+	{runeRange{0xAA40, 0xAA42}, wbprALetter},                // Lo   [3] CHAM LETTER FINAL K..CHAM LETTER FINAL NG
+	{runeRange{0xAA4D, 0xAA4D}, wbprExtend},                 // Mc       CHAM CONSONANT SIGN FINAL H
+	{runeRange{0xAA7D, 0xAA7D}, wbprExtend},                 // Mc       MYANMAR SIGN TAI LAING TONE-5
+	{runeRange{0xAABE, 0xAABF}, wbprExtend},                 // Mn   [2] TAI VIET VOWEL AM..TAI VIET TONE MAI EK
+	{runeRange{0xAAEC, 0xAAED}, wbprExtend},                 // Mn   [2] MEETEI MAYEK VOWEL SIGN UU..MEETEI MAYEK VOWEL SIGN AAI
+	{runeRange{0xAAF5, 0xAAF5}, wbprExtend},                 // Mc       MEETEI MAYEK VOWEL SIGN VISARGA
+	{runeRange{0xAB11, 0xAB16}, wbprALetter},                // Lo   [6] ETHIOPIC SYLLABLE DZU..ETHIOPIC SYLLABLE DZO
+	{runeRange{0xAB5B, 0xAB5B}, wbprALetter},                // Sk       MODIFIER BREVE WITH INVERTED BREVE
+	{runeRange{0xAB70, 0xABBF}, wbprALetter},                // L&  [80] CHEROKEE SMALL LETTER A..CHEROKEE SMALL LETTER YA
+	{runeRange{0xABE6, 0xABE7}, wbprExtend},                 // Mc   [2] MEETEI MAYEK VOWEL SIGN YENAP..MEETEI MAYEK VOWEL SIGN SOUNAP
+	{runeRange{0xABED, 0xABED}, wbprExtend},                 // Mn       MEETEI MAYEK APUN IYEK
+	{runeRange{0xD7CB, 0xD7FB}, wbprALetter},                // Lo  [49] HANGUL JONGSEONG NIEUN-RIEUL..HANGUL JONGSEONG PHIEUPH-THIEUTH
+	{runeRange{0xFB1E, 0xFB1E}, wbprExtend},                 // Mn       HEBREW POINT JUDEO-SPANISH VARIKA
+	{runeRange{0xFB3E, 0xFB3E}, wbprHebrewLetter},           // Lo       HEBREW LETTER MEM WITH DAGESH
+	{runeRange{0xFB50, 0xFBB1}, wbprALetter},                // Lo  [98] ARABIC LETTER ALEF WASLA ISOLATED FORM..ARABIC LETTER YEH BARREE WITH HAMZA ABOVE FINAL FORM
+	{runeRange{0xFDF0, 0xFDFB}, wbprALetter},                // Lo  [12] ARABIC LIGATURE SALLA USED AS KORANIC STOP SIGN ISOLATED FORM..ARABIC LIGATURE JALLAJALALOUHOU
+	{runeRange{0xFE14, 0xFE14}, wbprMidNum},                 // Po       PRESENTATION FORM FOR VERTICAL SEMICOLON
+	{runeRange{0xFE50, 0xFE50}, wbprMidNum},                 // Po       SMALL COMMA
+	{runeRange{0xFE70, 0xFE74}, wbprALetter},                // Lo   [5] ARABIC FATHATAN ISOLATED FORM..ARABIC KASRATAN ISOLATED FORM
+	{runeRange{0xFF0C, 0xFF0C}, wbprMidNum},                 // Po       FULLWIDTH COMMA
+	{runeRange{0xFF1B, 0xFF1B}, wbprMidNum},                 // Po       FULLWIDTH SEMICOLON
+	{runeRange{0xFF66, 0xFF6F}, wbprKatakana},               // Lo  [10] HALFWIDTH KATAKANA LETTER WO..HALFWIDTH KATAKANA LETTER SMALL TU
+	{runeRange{0xFFA0, 0xFFBE}, wbprALetter},                // Lo  [31] HALFWIDTH HANGUL FILLER..HALFWIDTH HANGUL LETTER HIEUH
+	{runeRange{0xFFDA, 0xFFDC}, wbprALetter},                // Lo   [3] HALFWIDTH HANGUL LETTER EU..HALFWIDTH HANGUL LETTER I
+	{runeRange{0x10028, 0x1003A}, wbprALetter},              // Lo  [19] LINEAR B SYLLABLE B060 RA..LINEAR B SYLLABLE B042 WO
+	{runeRange{0x10080, 0x100FA}, wbprALetter},              // Lo [123] LINEAR B IDEOGRAM B100 MAN..LINEAR B IDEOGRAM VESSEL B305
+	{runeRange{0x102A0, 0x102D0}, wbprALetter},              // Lo  [49] CARIAN LETTER A..CARIAN LETTER UUU3
+	{runeRange{0x10341, 0x10341}, wbprALetter},              // Nl       GOTHIC LETTER NINETY
+	{runeRange{0x10376, 0x1037A}, wbprExtend},               // Mn   [5] COMBINING OLD PERMIC LETTER AN..COMBINING OLD PERMIC LETTER SII
+	{runeRange{0x103D1, 0x103D5}, wbprALetter},              // Nl   [5] OLD PERSIAN NUMBER ONE..OLD PERSIAN NUMBER HUNDRED
+	{runeRange{0x104B0, 0x104D3}, wbprALetter},              // L&  [36] OSAGE CAPITAL LETTER A..OSAGE CAPITAL LETTER ZHA
+	{runeRange{0x10570, 0x1057A}, wbprALetter},              // L&  [11] VITHKUQI CAPITAL LETTER A..VITHKUQI CAPITAL LETTER GA
+	{runeRange{0x10597, 0x105A1}, wbprALetter},              // L&  [11] VITHKUQI SMALL LETTER A..VITHKUQI SMALL LETTER GA
+	{runeRange{0x10600, 0x10736}, wbprALetter},              // Lo [311] LINEAR A SIGN AB001..LINEAR A SIGN A664
+	{runeRange{0x10787, 0x107B0}, wbprALetter},              // Lm  [42] MODIFIER LETTER SMALL DZ DIGRAPH..MODIFIER LETTER SMALL V WITH RIGHT HOOK
+	{runeRange{0x1080A, 0x10835}, wbprALetter},              // Lo  [44] CYPRIOT SYLLABLE KA..CYPRIOT SYLLABLE WO
+	{runeRange{0x10860, 0x10876}, wbprALetter},              // Lo  [23] PALMYRENE LETTER ALEPH..PALMYRENE LETTER TAW
+	{runeRange{0x10900, 0x10915}, wbprALetter},              // Lo  [22] PHOENICIAN LETTER ALF..PHOENICIAN LETTER TAU
+	{runeRange{0x10A00, 0x10A00}, wbprALetter},              // Lo       KHAROSHTHI LETTER A
+	{runeRange{0x10A10, 0x10A13}, wbprALetter},              // Lo   [4] KHAROSHTHI LETTER KA..KHAROSHTHI LETTER GHA
+	{runeRange{0x10A3F, 0x10A3F}, wbprExtend},               // Mn       KHAROSHTHI VIRAMA
+	{runeRange{0x10AC9, 0x10AE4}, wbprALetter},              // Lo  [28] MANICHAEAN LETTER ZAYIN..MANICHAEAN LETTER TAW
+	{runeRange{0x10B60, 0x10B72}, wbprALetter},              // Lo  [19] INSCRIPTIONAL PAHLAVI LETTER ALEPH..INSCRIPTIONAL PAHLAVI LETTER TAW
+	{runeRange{0x10CC0, 0x10CF2}, wbprALetter},              // L&  [51] OLD HUNGARIAN SMALL LETTER A..OLD HUNGARIAN SMALL LETTER US
+	{runeRange{0x10E80, 0x10EA9}, wbprALetter},              // Lo  [42] YEZIDI LETTER ELIF..YEZIDI LETTER ET
+	{runeRange{0x10F00, 0x10F1C}, wbprALetter},              // Lo  [29] OLD SOGDIAN LETTER ALEPH..OLD SOGDIAN LETTER FINAL TAW WITH VERTICAL TAIL
+	{runeRange{0x10F70, 0x10F81}, wbprALetter},              // Lo  [18] OLD UYGHUR LETTER ALEPH..OLD UYGHUR LETTER LESH
+	{runeRange{0x11000, 0x11000}, wbprExtend},               // Mc       BRAHMI SIGN CANDRABINDU
+	{runeRange{0x11038, 0x11046}, wbprExtend},               // Mn  [15] BRAHMI VOWEL SIGN AA..BRAHMI VIRAMA
+	{runeRange{0x11073, 0x11074}, wbprExtend},               // Mn   [2] BRAHMI VOWEL SIGN OLD TAMIL SHORT E..BRAHMI VOWEL SIGN OLD TAMIL SHORT O
+	{runeRange{0x11083, 0x110AF}, wbprALetter},              // Lo  [45] KAITHI LETTER A..KAITHI LETTER HA
+	{runeRange{0x110B9, 0x110BA}, wbprExtend},               // Mn   [2] KAITHI SIGN VIRAMA..KAITHI SIGN NUKTA
+	{runeRange{0x110D0, 0x110E8}, wbprALetter},              // Lo  [25] SORA SOMPENG LETTER SAH..SORA SOMPENG LETTER MAE
+	{runeRange{0x11127, 0x1112B}, wbprExtend},               // Mn   [5] CHAKMA VOWEL SIGN A..CHAKMA VOWEL SIGN UU
+	{runeRange{0x11144, 0x11144}, wbprALetter},              // Lo       CHAKMA LETTER LHAA
+	{runeRange{0x11173, 0x11173}, wbprExtend},               // Mn       MAHAJANI SIGN NUKTA
+	{runeRange{0x11183, 0x111B2}, wbprALetter},              // Lo  [48] SHARADA LETTER A..SHARADA LETTER HA
+	{runeRange{0x111C1, 0x111C4}, wbprALetter},              // Lo   [4] SHARADA SIGN AVAGRAHA..SHARADA OM
+	{runeRange{0x111D0, 0x111D9}, wbprNumeric},              // Nd  [10] SHARADA DIGIT ZERO..SHARADA DIGIT NINE
+	{runeRange{0x11213, 0x1122B}, wbprALetter},              // Lo  [25] KHOJKI LETTER NYA..KHOJKI LETTER LLA
+	{runeRange{0x11234, 0x11234}, wbprExtend},               // Mn       KHOJKI SIGN ANUSVARA
+	{runeRange{0x1123F, 0x11240}, wbprALetter},              // Lo   [2] KHOJKI LETTER QA..KHOJKI LETTER SHORT I
+	{runeRange{0x1128A, 0x1128D}, wbprALetter},              // Lo   [4] MULTANI LETTER CA..MULTANI LETTER JJA
+	{runeRange{0x112DF, 0x112DF}, wbprExtend},               // Mn       KHUDAWADI SIGN ANUSVARA
+	{runeRange{0x11300, 0x11301}, wbprExtend},               // Mn   [2] GRANTHA SIGN COMBINING ANUSVARA ABOVE..GRANTHA SIGN CANDRABINDU
+	{runeRange{0x11313, 0x11328}, wbprALetter},              // Lo  [22] GRANTHA LETTER OO..GRANTHA LETTER NA
+	{runeRange{0x1133B, 0x1133C}, wbprExtend},               // Mn   [2] COMBINING BINDU BELOW..GRANTHA SIGN NUKTA
+	{runeRange{0x11341, 0x11344}, wbprExtend},               // Mc   [4] GRANTHA VOWEL SIGN U..GRANTHA VOWEL SIGN VOCALIC RR
+	{runeRange{0x11357, 0x11357}, wbprExtend},               // Mc       GRANTHA AU LENGTH MARK
+	{runeRange{0x11370, 0x11374}, wbprExtend},               // Mn   [5] COMBINING GRANTHA LETTER A..COMBINING GRANTHA LETTER PA
+	{runeRange{0x11440, 0x11441}, wbprExtend},               // Mc   [2] NEWA VOWEL SIGN O..NEWA VOWEL SIGN AU
+	{runeRange{0x11447, 0x1144A}, wbprALetter},              // Lo   [4] NEWA SIGN AVAGRAHA..NEWA SIDDHI
+	{runeRange{0x11480, 0x114AF}, wbprALetter},              // Lo  [48] TIRHUTA ANJI..TIRHUTA LETTER HA
+	{runeRange{0x114BA, 0x114BA}, wbprExtend},               // Mn       TIRHUTA VOWEL SIGN SHORT E
+	{runeRange{0x114C2, 0x114C3}, wbprExtend},               // Mn   [2] TIRHUTA SIGN VIRAMA..TIRHUTA SIGN NUKTA
+	{runeRange{0x11580, 0x115AE}, wbprALetter},              // Lo  [47] SIDDHAM LETTER A..SIDDHAM LETTER HA
+	{runeRange{0x115BC, 0x115BD}, wbprExtend},               // Mn   [2] SIDDHAM SIGN CANDRABINDU..SIDDHAM SIGN ANUSVARA
+	{runeRange{0x115DC, 0x115DD}, wbprExtend},               // Mn   [2] SIDDHAM VOWEL SIGN ALTERNATE U..SIDDHAM VOWEL SIGN ALTERNATE UU
+	{runeRange{0x1163B, 0x1163C}, wbprExtend},               // Mc   [2] MODI VOWEL SIGN O..MODI VOWEL SIGN AU
+	{runeRange{0x11644, 0x11644}, wbprALetter},              // Lo       MODI SIGN HUVA
+	{runeRange{0x116AC, 0x116AC}, wbprExtend},               // Mc       TAKRI SIGN VISARGA
+	{runeRange{0x116B6, 0x116B6}, wbprExtend},               // Mc       TAKRI SIGN VIRAMA
+	{runeRange{0x1171D, 0x1171F}, wbprExtend},               // Mn   [3] AHOM CONSONANT SIGN MEDIAL LA..AHOM CONSONANT SIGN MEDIAL LIGATING RA
+	{runeRange{0x11727, 0x1172B}, wbprExtend},               // Mn   [5] AHOM VOWEL SIGN AW..AHOM SIGN KILLER
+	{runeRange{0x1182F, 0x11837}, wbprExtend},               // Mn   [9] DOGRA VOWEL SIGN U..DOGRA SIGN ANUSVARA
+	{runeRange{0x118E0, 0x118E9}, wbprNumeric},              // Nd  [10] WARANG CITI DIGIT ZERO..WARANG CITI DIGIT NINE
+	{runeRange{0x11915, 0x11916}, wbprALetter},              // Lo   [2] DIVES AKURU LETTER NYA..DIVES AKURU LETTER TTA
+	{runeRange{0x1193B, 0x1193C}, wbprExtend},               // Mn   [2] DIVES AKURU SIGN ANUSVARA..DIVES AKURU SIGN CANDRABINDU
+	{runeRange{0x11940, 0x11940}, wbprExtend},               // Mc       DIVES AKURU MEDIAL YA
+	{runeRange{0x11950, 0x11959}, wbprNumeric},              // Nd  [10] DIVES AKURU DIGIT ZERO..DIVES AKURU DIGIT NINE
+	{runeRange{0x119D4, 0x119D7}, wbprExtend},               // Mn   [4] NANDINAGARI VOWEL SIGN U..NANDINAGARI VOWEL SIGN VOCALIC RR
+	{runeRange{0x119E1, 0x119E1}, wbprALetter},              // Lo       NANDINAGARI SIGN AVAGRAHA
+	{runeRange{0x11A01, 0x11A0A}, wbprExtend},               // Mn  [10] ZANABAZAR SQUARE VOWEL SIGN I..ZANABAZAR SQUARE VOWEL LENGTH MARK
+	{runeRange{0x11A3A, 0x11A3A}, wbprALetter},              // Lo       ZANABAZAR SQUARE CLUSTER-INITIAL LETTER RA
+	{runeRange{0x11A51, 0x11A56}, wbprExtend},               // Mn   [6] SOYOMBO VOWEL SIGN I..SOYOMBO VOWEL SIGN OE
+	{runeRange{0x11A8A, 0x11A96}, wbprExtend},               // Mn  [13] SOYOMBO FINAL CONSONANT SIGN G..SOYOMBO SIGN ANUSVARA
+	{runeRange{0x11AB0, 0x11AF8}, wbprALetter},              // Lo  [73] CANADIAN SYLLABICS NATTILIK HI..PAU CIN HAU GLOTTAL STOP FINAL
+	{runeRange{0x11C30, 0x11C36}, wbprExtend},               // Mn   [7] BHAIKSUKI VOWEL SIGN I..BHAIKSUKI VOWEL SIGN VOCALIC L
+	{runeRange{0x11C40, 0x11C40}, wbprALetter},              // Lo       BHAIKSUKI SIGN AVAGRAHA
+	{runeRange{0x11CA9, 0x11CA9}, wbprExtend},               // Mc       MARCHEN SUBJOINED LETTER YA
+	{runeRange{0x11CB4, 0x11CB4}, wbprExtend},               // Mc       MARCHEN VOWEL SIGN O
+	{runeRange{0x11D0B, 0x11D30}, wbprALetter},              // Lo  [38] MASARAM GONDI LETTER AU..MASARAM GONDI LETTER TRA
+	{runeRange{0x11D3F, 0x11D45}, wbprExtend},               // Mn   [7] MASARAM GONDI VOWEL SIGN AU..MASARAM GONDI VIRAMA
+	{runeRange{0x11D60, 0x11D65}, wbprALetter},              // Lo   [6] GUNJALA GONDI LETTER A..GUNJALA GONDI LETTER UU
+	{runeRange{0x11D90, 0x11D91}, wbprExtend},               // Mn   [2] GUNJALA GONDI VOWEL SIGN EE..GUNJALA GONDI VOWEL SIGN AI
+	{runeRange{0x11D97, 0x11D97}, wbprExtend},               // Mn       GUNJALA GONDI VIRAMA
+	{runeRange{0x11EF3, 0x11EF4}, wbprExtend},               // Mn   [2] MAKASAR VOWEL SIGN I..MAKASAR VOWEL SIGN U
+	{runeRange{0x11F03, 0x11F03}, wbprExtend},               // Mc       KAWI SIGN VISARGA
+	{runeRange{0x11F36, 0x11F3A}, wbprExtend},               // Mn   [5] KAWI VOWEL SIGN I..KAWI VOWEL SIGN VOCALIC R
+	{runeRange{0x11F42, 0x11F42}, wbprExtend},               // Mn       KAWI CONJOINER
+	{runeRange{0x12400, 0x1246E}, wbprALetter},              // Nl [111] CUNEIFORM NUMERIC SIGN TWO ASH..CUNEIFORM NUMERIC SIGN NINE U VARIANT FORM
+	{runeRange{0x13430, 0x1343F}, wbprFormat},               // Cf  [16] EGYPTIAN HIEROGLYPH VERTICAL JOINER..EGYPTIAN HIEROGLYPH END WALLED ENCLOSURE
+	{runeRange{0x14400, 0x14646}, wbprALetter},              // Lo [583] ANATOLIAN HIEROGLYPH A001..ANATOLIAN HIEROGLYPH A530
+	{runeRange{0x16A70, 0x16ABE}, wbprALetter},              // Lo  [79] TANGSA LETTER OZ..TANGSA LETTER ZA
+	{runeRange{0x16B00, 0x16B2F}, wbprALetter},              // Lo  [48] PAHAWH HMONG VOWEL KEEB..PAHAWH HMONG CONSONANT CAU
+	{runeRange{0x16B63, 0x16B77}, wbprALetter},              // Lo  [21] PAHAWH HMONG SIGN VOS LUB..PAHAWH HMONG SIGN CIM NRES TOS
+	{runeRange{0x16F4F, 0x16F4F}, wbprExtend},               // Mn       MIAO SIGN CONSONANT MODIFIER BAR
+	{runeRange{0x16F93, 0x16F9F}, wbprALetter},              // Lm  [13] MIAO LETTER TONE-2..MIAO LETTER REFORMED TONE-8
+	{runeRange{0x16FF0, 0x16FF1}, wbprExtend},               // Mc   [2] VIETNAMESE ALTERNATE READING MARK CA..VIETNAMESE ALTERNATE READING MARK NHAY
+	{runeRange{0x1B000, 0x1B000}, wbprKatakana},             // Lo       KATAKANA LETTER ARCHAIC E
+	{runeRange{0x1BC00, 0x1BC6A}, wbprALetter},              // Lo [107] DUPLOYAN LETTER H..DUPLOYAN LETTER VOCALIC M
+	{runeRange{0x1BC9D, 0x1BC9E}, wbprExtend},               // Mn   [2] DUPLOYAN THICK LETTER SELECTOR..DUPLOYAN DOUBLE MARK
+	{runeRange{0x1D165, 0x1D166}, wbprExtend},               // Mc   [2] MUSICAL SYMBOL COMBINING STEM..MUSICAL SYMBOL COMBINING SPRECHGESANG STEM
+	{runeRange{0x1D17B, 0x1D182}, wbprExtend},               // Mn   [8] MUSICAL SYMBOL COMBINING ACCENT..MUSICAL SYMBOL COMBINING LOURE
+	{runeRange{0x1D400, 0x1D454}, wbprALetter},              // L&  [85] MATHEMATICAL BOLD CAPITAL A..MATHEMATICAL ITALIC SMALL G
+	{runeRange{0x1D4A5, 0x1D4A6}, wbprALetter},              // L&   [2] MATHEMATICAL SCRIPT CAPITAL J..MATHEMATICAL SCRIPT CAPITAL K
+	{runeRange{0x1D4BD, 0x1D4C3}, wbprALetter},              // L&   [7] MATHEMATICAL SCRIPT SMALL H..MATHEMATICAL SCRIPT SMALL N
+	{runeRange{0x1D516, 0x1D51C}, wbprALetter},              // L&   [7] MATHEMATICAL FRAKTUR CAPITAL S..MATHEMATICAL FRAKTUR CAPITAL Y
+	{runeRange{0x1D546, 0x1D546}, wbprALetter},              // L&       MATHEMATICAL DOUBLE-STRUCK CAPITAL O
+	{runeRange{0x1D6C2, 0x1D6DA}, wbprALetter},              // L&  [25] MATHEMATICAL BOLD SMALL ALPHA..MATHEMATICAL BOLD SMALL OMEGA
+	{runeRange{0x1D736, 0x1D74E}, wbprALetter},              // L&  [25] MATHEMATICAL BOLD ITALIC SMALL ALPHA..MATHEMATICAL BOLD ITALIC SMALL OMEGA
+	{runeRange{0x1D7AA, 0x1D7C2}, wbprALetter},              // L&  [25] MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL ALPHA..MATHEMATICAL SANS-SERIF BOLD ITALIC SMALL OMEGA
+	{runeRange{0x1DA3B, 0x1DA6C}, wbprExtend},               // Mn  [50] SIGNWRITING MOUTH CLOSED NEUTRAL..SIGNWRITING EXCITEMENT
+	{runeRange{0x1DAA1, 0x1DAAF}, wbprExtend},               // Mn  [15] SIGNWRITING ROTATION MODIFIER-2..SIGNWRITING ROTATION MODIFIER-16
+	{runeRange{0x1DF25, 0x1DF2A}, wbprALetter},              // L&   [6] LATIN SMALL LETTER D WITH MID-HEIGHT LEFT HOOK..LATIN SMALL LETTER T WITH MID-HEIGHT LEFT HOOK
+	{runeRange{0x1E023, 0x1E024}, wbprExtend},               // Mn   [2] COMBINING GLAGOLITIC LETTER YU..COMBINING GLAGOLITIC LETTER SMALL YUS
+	{runeRange{0x1E100, 0x1E12C}, wbprALetter},              // Lo  [45] NYIAKENG PUACHUE HMONG LETTER MA..NYIAKENG PUACHUE HMONG LETTER W
+	{runeRange{0x1E14E, 0x1E14E}, wbprALetter},              // Lo       NYIAKENG PUACHUE HMONG LOGOGRAM NYAJ
+	{runeRange{0x1E2EC, 0x1E2EF}, wbprExtend},               // Mn   [4] WANCHO TONE TUP..WANCHO TONE KOINI
+	{runeRange{0x1E4EC, 0x1E4EF}, wbprExtend},               // Mn   [4] NAG MUNDARI SIGN MUHOR..NAG MUNDARI SIGN SUTUH
+	{runeRange{0x1E7ED, 0x1E7EE}, wbprALetter},              // Lo   [2] ETHIOPIC SYLLABLE GURAGE MWI..ETHIOPIC SYLLABLE GURAGE MWEE
+	{runeRange{0x1E900, 0x1E943}, wbprALetter},              // L&  [68] ADLAM CAPITAL LETTER ALIF..ADLAM SMALL LETTER SHA
+	{runeRange{0x1EE00, 0x1EE03}, wbprALetter},              // Lo   [4] ARABIC MATHEMATICAL ALEF..ARABIC MATHEMATICAL DAL
+	{runeRange{0x1EE27, 0x1EE27}, wbprALetter},              // Lo       ARABIC MATHEMATICAL INITIAL HAH
+	{runeRange{0x1EE3B, 0x1EE3B}, wbprALetter},              // Lo       ARABIC MATHEMATICAL INITIAL GHAIN
+	{runeRange{0x1EE4B, 0x1EE4B}, wbprALetter},              // Lo       ARABIC MATHEMATICAL TAILED LAM
+	{runeRange{0x1EE57, 0x1EE57}, wbprALetter},              // Lo       ARABIC MATHEMATICAL TAILED KHAH
+	{runeRange{0x1EE5F, 0x1EE5F}, wbprALetter},              // Lo       ARABIC MATHEMATICAL TAILED DOTLESS QAF
+	{runeRange{0x1EE6C, 0x1EE72}, wbprALetter},              // Lo   [7] ARABIC MATHEMATICAL STRETCHED MEEM..ARABIC MATHEMATICAL STRETCHED QAF
+	{runeRange{0x1EE80, 0x1EE89}, wbprALetter},              // Lo  [10] ARABIC MATHEMATICAL LOOPED ALEF..ARABIC MATHEMATICAL LOOPED YEH
+	{runeRange{0x1EEAB, 0x1EEBB}, wbprALetter},              // Lo  [17] ARABIC MATHEMATICAL DOUBLE-STRUCK LAM..ARABIC MATHEMATICAL DOUBLE-STRUCK GHAIN
+	{runeRange{0x1F0CF, 0x1F0CF}, wbprExtendedPictographic}, // E0.6   [1] (🃏)       joker
+	{runeRange{0x1F130, 0x1F149}, wbprALetter},              // So  [26] SQUARED LATIN CAPITAL LETTER A..SQUARED LATIN CAPITAL LETTER Z
+	{runeRange{0x1F170, 0x1F171}, wbprExtendedPictographic}, // E0.6   [2] (🅰️..🅱️)    A button (blood type)..B button (blood type)
+	{runeRange{0x1F1AD, 0x1F1E5}, wbprExtendedPictographic}, // E0.0  [57] (🆭..🇥)    MASK WORK SYMBOL..<reserved-1F1E5>
+	{runeRange{0x1F21A, 0x1F21A}, wbprExtendedPictographic}, // E0.6   [1] (🈚)       Japanese “free of charge” button
+	{runeRange{0x1F249, 0x1F24F}, wbprExtendedPictographic}, // E0.0   [7] (🉉..🉏)    <reserved-1F249>..<reserved-1F24F>
+	{runeRange{0x1F30D, 0x1F30E}, wbprExtendedPictographic}, // E0.7   [2] (🌍..🌎)    globe showing Europe-Africa..globe showing Americas
+	{runeRange{0x1F312, 0x1F312}, wbprExtendedPictographic}, // E1.0   [1] (🌒)       waxing crescent moon
+	{runeRange{0x1F31A, 0x1F31A}, wbprExtendedPictographic}, // E1.0   [1] (🌚)       new moon face
+	{runeRange{0x1F31F, 0x1F320}, wbprExtendedPictographic}, // E0.6   [2] (🌟..🌠)    glowing star..shooting star
+	{runeRange{0x1F32D, 0x1F32F}, wbprExtendedPictographic}, // E1.0   [3] (🌭..🌯)    hot dog..burrito
+	{runeRange{0x1F336, 0x1F336}, wbprExtendedPictographic}, // E0.7   [1] (🌶️)       hot pepper
+	{runeRange{0x1F350, 0x1F350}, wbprExtendedPictographic}, // E1.0   [1] (🍐)       pear
+	{runeRange{0x1F37E, 0x1F37F}, wbprExtendedPictographic}, // E1.0   [2] (🍾..🍿)    bottle with popping cork..popcorn
+	{runeRange{0x1F398, 0x1F398}, wbprExtendedPictographic}, // E0.0   [1] (🎘)       MUSICAL KEYBOARD WITH JACKS
+	{runeRange{0x1F3A0, 0x1F3C4}, wbprExtendedPictographic}, // E0.6  [37] (🎠..🏄)    carousel horse..person surfing
+	{runeRange{0x1F3C8, 0x1F3C8}, wbprExtendedPictographic}, // E0.6   [1] (🏈)       american football
+	{runeRange{0x1F3CF, 0x1F3D3}, wbprExtendedPictographic}, // E1.0   [5] (🏏..🏓)    cricket game..ping pong
+	{runeRange{0x1F3E5, 0x1F3F0}, wbprExtendedPictographic}, // E0.6  [12] (🏥..🏰)    hospital..castle
+	{runeRange{0x1F3F5, 0x1F3F5}, wbprExtendedPictographic}, // E0.7   [1] (🏵️)       rosette
+	{runeRange{0x1F3FB, 0x1F3FF}, wbprExtend},               // Sk   [5] EMOJI MODIFIER FITZPATRICK TYPE-1-2..EMOJI MODIFIER FITZPATRICK TYPE-6
+	{runeRange{0x1F40C, 0x1F40E}, wbprExtendedPictographic}, // E0.6   [3] (🐌..🐎)    snail..horse
+	{runeRange{0x1F414, 0x1F414}, wbprExtendedPictographic}, // E0.6   [1] (🐔)       chicken
+	{runeRange{0x1F42A, 0x1F42A}, wbprExtendedPictographic}, // E1.0   [1] (🐪)       camel
+	{runeRange{0x1F441, 0x1F441}, wbprExtendedPictographic}, // E0.7   [1] (👁️)       eye
+	{runeRange{0x1F46C, 0x1F46D}, wbprExtendedPictographic}, // E1.0   [2] (👬..👭)    men holding hands..women holding hands
+	{runeRange{0x1F4B6, 0x1F4B7}, wbprExtendedPictographic}, // E1.0   [2] (💶..💷)    euro banknote..pound banknote
+	{runeRange{0x1F4EF, 0x1F4EF}, wbprExtendedPictographic}, // E1.0   [1] (📯)       postal horn
+	{runeRange{0x1F4F8, 0x1F4F8}, wbprExtendedPictographic}, // E1.0   [1] (📸)       camera with flash
+	{runeRange{0x1F4FF, 0x1F502}, wbprExtendedPictographic}, // E1.0   [4] (📿..🔂)    prayer beads..repeat single button
+	{runeRange{0x1F509, 0x1F509}, wbprExtendedPictographic}, // E1.0   [1] (🔉)       speaker medium volume
+	{runeRange{0x1F52C, 0x1F52D}, wbprExtendedPictographic}, // E1.0   [2] (🔬..🔭)    microscope..telescope
+	{runeRange{0x1F54B, 0x1F54E}, wbprExtendedPictographic}, // E1.0   [4] (🕋..🕎)    kaaba..menorah
+	{runeRange{0x1F568, 0x1F56E}, wbprExtendedPictographic}, // E0.0   [7] (🕨..🕮)    RIGHT SPEAKER..BOOK
+	{runeRange{0x1F57A, 0x1F57A}, wbprExtendedPictographic}, // E3.0   [1] (🕺)       man dancing
+	{runeRange{0x1F58A, 0x1F58D}, wbprExtendedPictographic}, // E0.7   [4] (🖊️..🖍️)    pen..crayon
+	{runeRange{0x1F595, 0x1F596}, wbprExtendedPictographic}, // E1.0   [2] (🖕..🖖)    middle finger..vulcan salute
+	{runeRange{0x1F5A6, 0x1F5A7}, wbprExtendedPictographic}, // E0.0   [2] (🖦..🖧)    KEYBOARD AND MOUSE..THREE NETWORKED COMPUTERS
+	{runeRange{0x1F5B3, 0x1F5BB}, wbprExtendedPictographic}, // E0.0   [9] (🖳..🖻)    OLD PERSONAL COMPUTER..DOCUMENT WITH PICTURE
+	{runeRange{0x1F5C5, 0x1F5D0}, wbprExtendedPictographic}, // E0.0  [12] (🗅..🗐)    EMPTY NOTE..PAGES
+	{runeRange{0x1F5DF, 0x1F5E0}, wbprExtendedPictographic}, // E0.0   [2] (🗟..🗠)    PAGE WITH CIRCLED TEXT..STOCK CHART
+	{runeRange{0x1F5E4, 0x1F5E7}, wbprExtendedPictographic}, // E0.0   [4] (🗤..🗧)    THREE RAYS ABOVE..THREE RAYS RIGHT
+	{runeRange{0x1F5F0, 0x1F5F2}, wbprExtendedPictographic}, // E0.0   [3] (🗰..🗲)    MOOD BUBBLE..LIGHTNING MOOD
+	{runeRange{0x1F5FB, 0x1F5FF}, wbprExtendedPictographic}, // E0.6   [5] (🗻..🗿)    mount fuji..moai
+	{runeRange{0x1F609, 0x1F60D}, wbprExtendedPictographic}, // E0.6   [5] (😉..😍)    winking face..smiling face with heart-eyes
+	{runeRange{0x1F611, 0x1F611}, wbprExtendedPictographic}, // E1.0   [1] (😑)       expressionless face
+	{runeRange{0x1F617, 0x1F617}, wbprExtendedPictographic}, // E1.0   [1] (😗)       kissing face
+	{runeRange{0x1F619, 0x1F619}, wbprExtendedPictographic}, // E1.0   [1] (😙)       kissing face with smiling eyes
+	{runeRange{0x1F61B, 0x1F61B}, wbprExtendedPictographic}, // E1.0   [1] (😛)       face with tongue
+	{runeRange{0x1F61F, 0x1F61F}, wbprExtendedPictographic}, // E1.0   [1] (😟)       worried face
+	{runeRange{0x1F626, 0x1F627}, wbprExtendedPictographic}, // E1.0   [2] (😦..😧)    frowning face with open mouth..anguished face
+	{runeRange{0x1F62C, 0x1F62C}, wbprExtendedPictographic}, // E1.0   [1] (😬)       grimacing face
+	{runeRange{0x1F62E, 0x1F62F}, wbprExtendedPictographic}, // E1.0   [2] (😮..😯)    face with open mouth..hushed face
+	{runeRange{0x1F634, 0x1F634}, wbprExtendedPictographic}, // E1.0   [1] (😴)       sleeping face
+	{runeRange{0x1F636, 0x1F636}, wbprExtendedPictographic}, // E1.0   [1] (😶)       face without mouth
+	{runeRange{0x1F641, 0x1F644}, wbprExtendedPictographic}, // E1.0   [4] (🙁..🙄)    slightly frowning face..face with rolling eyes
+	{runeRange{0x1F680, 0x1F680}, wbprExtendedPictographic}, // E0.6   [1] (🚀)       rocket
+	{runeRange{0x1F683, 0x1F685}, wbprExtendedPictographic}, // E0.6   [3] (🚃..🚅)    railway car..bullet train
+	{runeRange{0x1F687, 0x1F687}, wbprExtendedPictographic}, // E0.6   [1] (🚇)       metro
+	{runeRange{0x1F689, 0x1F689}, wbprExtendedPictographic}, // E0.6   [1] (🚉)       station
+	{runeRange{0x1F68C, 0x1F68C}, wbprExtendedPictographic}, // E0.6   [1] (🚌)       bus
+	{runeRange{0x1F68E, 0x1F68E}, wbprExtendedPictographic}, // E1.0   [1] (🚎)       trolleybus
+	{runeRange{0x1F690, 0x1F690}, wbprExtendedPictographic}, // E1.0   [1] (🚐)       minibus
+	{runeRange{0x1F694, 0x1F694}, wbprExtendedPictographic}, // E0.7   [1] (🚔)       oncoming police car
+	{runeRange{0x1F696, 0x1F696}, wbprExtendedPictographic}, // E1.0   [1] (🚖)       oncoming taxi
+	{runeRange{0x1F698, 0x1F698}, wbprExtendedPictographic}, // E0.7   [1] (🚘)       oncoming automobile
+	{runeRange{0x1F69B, 0x1F6A1}, wbprExtendedPictographic}, // E1.0   [7] (🚛..🚡)    articulated lorry..aerial tramway
+	{runeRange{0x1F6A3, 0x1F6A3}, wbprExtendedPictographic}, // E1.0   [1] (🚣)       person rowing boat
+	{runeRange{0x1F6A6, 0x1F6A6}, wbprExtendedPictographic}, // E1.0   [1] (🚦)       vertical traffic light
+	{runeRange{0x1F6AE, 0x1F6B1}, wbprExtendedPictographic}, // E1.0   [4] (🚮..🚱)    litter in bin sign..non-potable water
+	{runeRange{0x1F6B3, 0x1F6B5}, wbprExtendedPictographic}, // E1.0   [3] (🚳..🚵)    no bicycles..person mountain biking
+	{runeRange{0x1F6B7, 0x1F6B8}, wbprExtendedPictographic}, // E1.0   [2] (🚷..🚸)    no pedestrians..children crossing
+	{runeRange{0x1F6BF, 0x1F6BF}, wbprExtendedPictographic}, // E1.0   [1] (🚿)       shower
+	{runeRange{0x1F6C1, 0x1F6C5}, wbprExtendedPictographic}, // E1.0   [5] (🛁..🛅)    bathtub..left luggage
+	{runeRange{0x1F6CB, 0x1F6CB}, wbprExtendedPictographic}, // E0.7   [1] (🛋️)       couch and lamp
+	{runeRange{0x1F6CD, 0x1F6CF}, wbprExtendedPictographic}, // E0.7   [3] (🛍️..🛏️)    shopping bags..bed
+	{runeRange{0x1F6D1, 0x1F6D2}, wbprExtendedPictographic}, // E3.0   [2] (🛑..🛒)    stop sign..shopping cart
+	{runeRange{0x1F6D5, 0x1F6D5}, wbprExtendedPictographic}, // E12.0  [1] (🛕)       hindu temple
+	{runeRange{0x1F6D8, 0x1F6DB}, wbprExtendedPictographic}, // E0.0   [4] (🛘..🛛)    <reserved-1F6D8>..<reserved-1F6DB>
+	{runeRange{0x1F6DD, 0x1F6DF}, wbprExtendedPictographic}, // E14.0  [3] (🛝..🛟)    playground slide..ring buoy
+	{runeRange{0x1F6E6, 0x1F6E8}, wbprExtendedPictographic}, // E0.0   [3] (🛦..🛨)    UP-POINTING MILITARY AIRPLANE..UP-POINTING SMALL AIRPLANE
+	{runeRange{0x1F6EA, 0x1F6EA}, wbprExtendedPictographic}, // E0.0   [1] (🛪)       NORTHEAST-POINTING AIRPLANE
+	{runeRange{0x1F6ED, 0x1F6EF}, wbprExtendedPictographic}, // E0.0   [3] (🛭..🛯)    <reserved-1F6ED>..<reserved-1F6EF>
+	{runeRange{0x1F6F1, 0x1F6F2}, wbprExtendedPictographic}, // E0.0   [2] (🛱..🛲)    ONCOMING FIRE ENGINE..DIESEL LOCOMOTIVE
+	{runeRange{0x1F6F4, 0x1F6F6}, wbprExtendedPictographic}, // E3.0   [3] (🛴..🛶)    kick scooter..canoe
+	{runeRange{0x1F6F9, 0x1F6F9}, wbprExtendedPictographic}, // E11.0  [1] (🛹)       skateboard
+	{runeRange{0x1F6FB, 0x1F6FC}, wbprExtendedPictographic}, // E13.0  [2] (🛻..🛼)    pickup truck..roller skate
+	{runeRange{0x1F774, 0x1F77F}, wbprExtendedPictographic}, // E0.0  [12] (🝴..🝿)    LOT OF FORTUNE..ORCUS
+	{runeRange{0x1F7E0, 0x1F7EB}, wbprExtendedPictographic}, // E12.0 [12] (🟠..🟫)    orange circle..brown square
+	{runeRange{0x1F7F0, 0x1F7F0}, wbprExtendedPictographic}, // E14.0  [1] (🟰)       heavy equals sign
+	{runeRange{0x1F80C, 0x1F80F}, wbprExtendedPictographic}, // E0.0   [4] (🠌..🠏)    <reserved-1F80C>..<reserved-1F80F>
+	{runeRange{0x1F85A, 0x1F85F}, wbprExtendedPictographic}, // E0.0   [6] (🡚..🡟)    <reserved-1F85A>..<reserved-1F85F>
+	{runeRange{0x1F8AE, 0x1F8FF}, wbprExtendedPictographic}, // E0.0  [82] (🢮..🣿)    <reserved-1F8AE>..<reserved-1F8FF>
+	{runeRange{0x1F90D, 0x1F90F}, wbprExtendedPictographic}, // E12.0  [3] (🤍..🤏)    white heart..pinching hand
+	{runeRange{0x1F919, 0x1F91E}, wbprExtendedPictographic}, // E3.0   [6] (🤙..🤞)    call me hand..crossed fingers
+	{runeRange{0x1F920, 0x1F927}, wbprExtendedPictographic}, // E3.0   [8] (🤠..🤧)    cowboy hat face..sneezing face
+	{runeRange{0x1F930, 0x1F930}, wbprExtendedPictographic}, // E3.0   [1] (🤰)       pregnant woman
+	{runeRange{0x1F933, 0x1F93A}, wbprExtendedPictographic}, // E3.0   [8] (🤳..🤺)    selfie..person fencing
+	{runeRange{0x1F93F, 0x1F93F}, wbprExtendedPictographic}, // E12.0  [1] (🤿)       diving mask
+	{runeRange{0x1F947, 0x1F94B}, wbprExtendedPictographic}, // E3.0   [5] (🥇..🥋)    1st place medal..martial arts uniform
+	{runeRange{0x1F94D, 0x1F94F}, wbprExtendedPictographic}, // E11.0  [3] (🥍..🥏)    lacrosse..flying disc
+	{runeRange{0x1F95F, 0x1F96B}, wbprExtendedPictographic}, // E5.0  [13] (🥟..🥫)    dumpling..canned food
+	{runeRange{0x1F971, 0x1F971}, wbprExtendedPictographic}, // E12.0  [1] (🥱)       yawning face
+	{runeRange{0x1F973, 0x1F976}, wbprExtendedPictographic}, // E11.0  [4] (🥳..🥶)    partying face..cold face
+	{runeRange{0x1F979, 0x1F979}, wbprExtendedPictographic}, // E14.0  [1] (🥹)       face holding back tears
+	{runeRange{0x1F97B, 0x1F97B}, wbprExtendedPictographic}, // E12.0  [1] (🥻)       sari
+	{runeRange{0x1F980, 0x1F984}, wbprExtendedPictographic}, // E1.0   [5] (🦀..🦄)    crab..unicorn
+	{runeRange{0x1F992, 0x1F997}, wbprExtendedPictographic}, // E5.0   [6] (🦒..🦗)    giraffe..cricket
+	{runeRange{0x1F9A3, 0x1F9A4}, wbprExtendedPictographic}, // E13.0  [2] (🦣..🦤)    mammoth..dodo
+	{runeRange{0x1F9AB, 0x1F9AD}, wbprExtendedPictographic}, // E13.0  [3] (🦫..🦭)    beaver..seal
+	{runeRange{0x1F9B0, 0x1F9B9}, wbprExtendedPictographic}, // E11.0 [10] (🦰..🦹)    red hair..supervillain
+	{runeRange{0x1F9C0, 0x1F9C0}, wbprExtendedPictographic}, // E1.0   [1] (🧀)       cheese wedge
+	{runeRange{0x1F9C3, 0x1F9CA}, wbprExtendedPictographic}, // E12.0  [8] (🧃..🧊)    beverage box..ice
+	{runeRange{0x1F9CC, 0x1F9CC}, wbprExtendedPictographic}, // E14.0  [1] (🧌)       troll
+	{runeRange{0x1F9D0, 0x1F9E6}, wbprExtendedPictographic}, // E5.0  [23] (🧐..🧦)    face with monocle..socks
+	{runeRange{0x1FA00, 0x1FA6F}, wbprExtendedPictographic}, // E0.0 [112] (🨀..🩯)    NEUTRAL CHESS KING..<reserved-1FA6F>
+	{runeRange{0x1FA74, 0x1FA74}, wbprExtendedPictographic}, // E13.0  [1] (🩴)       thong sandal
+	{runeRange{0x1FA78, 0x1FA7A}, wbprExtendedPictographic}, // E12.0  [3] (🩸..🩺)    drop of blood..stethoscope
+	{runeRange{0x1FA7D, 0x1FA7F}, wbprExtendedPictographic}, // E0.0   [3] (🩽..🩿)    <reserved-1FA7D>..<reserved-1FA7F>
+	{runeRange{0x1FA83, 0x1FA86}, wbprExtendedPictographic}, // E13.0  [4] (🪃..🪆)    boomerang..nesting dolls
+	{runeRange{0x1FA89, 0x1FA8F}, wbprExtendedPictographic}, // E0.0   [7] (🪉..🪏)    <reserved-1FA89>..<reserved-1FA8F>
+	{runeRange{0x1FA96, 0x1FAA8}, wbprExtendedPictographic}, // E13.0 [19] (🪖..🪨)    military helmet..rock
+	{runeRange{0x1FAAD, 0x1FAAF}, wbprExtendedPictographic}, // E15.0  [3] (🪭..🪯)    folding hand fan..khanda
+	{runeRange{0x1FAB7, 0x1FABA}, wbprExtendedPictographic}, // E14.0  [4] (🪷..🪺)    lotus..nest with eggs
+	{runeRange{0x1FABE, 0x1FABE}, wbprExtendedPictographic}, // E0.0   [1] (🪾)       <reserved-1FABE>
+	{runeRange{0x1FAC0, 0x1FAC2}, wbprExtendedPictographic}, // E13.0  [3] (🫀..🫂)    anatomical heart..people hugging
+	{runeRange{0x1FAC6, 0x1FACD}, wbprExtendedPictographic}, // E0.0   [8] (🫆..🫍)    <reserved-1FAC6>..<reserved-1FACD>
+	{runeRange{0x1FAD0, 0x1FAD6}, wbprExtendedPictographic}, // E13.0  [7] (🫐..🫖)    blueberries..teapot
+	{runeRange{0x1FADA, 0x1FADB}, wbprExtendedPictographic}, // E15.0  [2] (🫚..🫛)    ginger root..pea pod
+	{runeRange{0x1FAE0, 0x1FAE7}, wbprExtendedPictographic}, // E14.0  [8] (🫠..🫧)    melting face..bubbles
+	{runeRange{0x1FAE9, 0x1FAEF}, wbprExtendedPictographic}, // E0.0   [7] (🫩..🫯)    <reserved-1FAE9>..<reserved-1FAEF>
+	{runeRange{0x1FAF7, 0x1FAF8}, wbprExtendedPictographic}, // E15.0  [2] (🫷..🫸)    leftwards pushing hand..rightwards pushing hand
+	{runeRange{0x1FBF0, 0x1FBF9}, wbprNumeric},              // Nd  [10] SEGMENTED DIGIT ZERO..SEGMENTED DIGIT NINE
+	{runeRange{0xE0001, 0xE0001}, wbprFormat},               // Cf       LANGUAGE TAG
 	{runeRange{0xE0100, 0xE01EF}, wbprExtend},               // Mn [240] VARIATION SELECTOR-17..VARIATION SELECTOR-256
+	{runeRange{0x000A, 0x000A}, wbprLF},                     // Cc       <control-000A>
+	{runeRange{0x000D, 0x000D}, wbprCR},                     // Cc       <control-000D>
+	{runeRange{0x0022, 0x0022}, wbprDoubleQuote},            // Po       QUOTATION MARK
+	{runeRange{0x002C, 0x002C}, wbprMidNum},                 // Po       COMMA
+	{runeRange{0x0030, 0x0039}, wbprNumeric},                // Nd  [10] DIGIT ZERO..DIGIT NINE
+	{runeRange{0x003B, 0x003B}, wbprMidNum},                 // Po       SEMICOLON
+	{runeRange{0x005F, 0x005F}, wbprExtendNumLet},           // Pc       LOW LINE
+	{runeRange{0x0085, 0x0085}, wbprNewline},                // Cc       <control-0085>
+	{runeRange{0x00AA, 0x00AA}, wbprALetter},                // Lo       FEMININE ORDINAL INDICATOR
+	{runeRange{0x00AE, 0x00AE}, wbprExtendedPictographic},   // E0.6   [1] (®️)       registered
+	{runeRange{0x00B7, 0x00B7}, wbprMidLetter},              // Po       MIDDLE DOT
+	{runeRange{0x00C0, 0x00D6}, wbprALetter},                // L&  [23] LATIN CAPITAL LETTER A WITH GRAVE..LATIN CAPITAL LETTER O WITH DIAERESIS
+	{runeRange{0x00F8, 0x01BA}, wbprALetter},                // L& [195] LATIN SMALL LETTER O WITH STROKE..LATIN SMALL LETTER EZH WITH TAIL
+	{runeRange{0x01BC, 0x01BF}, wbprALetter},                // L&   [4] LATIN CAPITAL LETTER TONE FIVE..LATIN LETTER WYNN
+	{runeRange{0x01C4, 0x0293}, wbprALetter},                // L& [208] LATIN CAPITAL LETTER DZ WITH CARON..LATIN SMALL LETTER EZH WITH CURL
+	{runeRange{0x0295, 0x02AF}, wbprALetter},                // L&  [27] LATIN LETTER PHARYNGEAL VOICED FRICATIVE..LATIN SMALL LETTER TURNED H WITH FISHHOOK AND TAIL
+	{runeRange{0x02C2, 0x02C5}, wbprALetter},                // Sk   [4] MODIFIER LETTER LEFT ARROWHEAD..MODIFIER LETTER DOWN ARROWHEAD
+	{runeRange{0x02D2, 0x02D7}, wbprALetter},                // Sk   [6] MODIFIER LETTER CENTRED RIGHT HALF RING..MODIFIER LETTER MINUS SIGN
+	{runeRange{0x02E0, 0x02E4}, wbprALetter},                // Lm   [5] MODIFIER LETTER SMALL GAMMA..MODIFIER LETTER SMALL REVERSED GLOTTAL STOP
+	{runeRange{0x02EC, 0x02EC}, wbprALetter},                // Lm       MODIFIER LETTER VOICING
+	{runeRange{0x02EE, 0x02EE}, wbprALetter},                // Lm       MODIFIER LETTER DOUBLE APOSTROPHE
+	{runeRange{0x0300, 0x036F}, wbprExtend},                 // Mn [112] COMBINING GRAVE ACCENT..COMBINING LATIN SMALL LETTER X
+	{runeRange{0x0374, 0x0374}, wbprALetter},                // Lm       GREEK NUMERAL SIGN
+	{runeRange{0x037A, 0x037A}, wbprALetter},                // Lm       GREEK YPOGEGRAMMENI
+	{runeRange{0x037E, 0x037E}, wbprMidNum},                 // Po       GREEK QUESTION MARK
+	{runeRange{0x0386, 0x0386}, wbprALetter},                // L&       GREEK CAPITAL LETTER ALPHA WITH TONOS
+	{runeRange{0x0388, 0x038A}, wbprALetter},                // L&   [3] GREEK CAPITAL LETTER EPSILON WITH TONOS..GREEK CAPITAL LETTER IOTA WITH TONOS
+	{runeRange{0x038E, 0x03A1}, wbprALetter},                // L&  [20] GREEK CAPITAL LETTER UPSILON WITH TONOS..GREEK CAPITAL LETTER RHO
+	{runeRange{0x03F7, 0x0481}, wbprALetter},                // L& [139] GREEK CAPITAL LETTER SHO..CYRILLIC SMALL LETTER KOPPA
+	{runeRange{0x0488, 0x0489}, wbprExtend},                 // Me   [2] COMBINING CYRILLIC HUNDRED THOUSANDS SIGN..COMBINING CYRILLIC MILLIONS SIGN
+	{runeRange{0x0531, 0x0556}, wbprALetter},                // L&  [38] ARMENIAN CAPITAL LETTER AYB..ARMENIAN CAPITAL LETTER FEH
+	{runeRange{0x055A, 0x055C}, wbprALetter},                // Po   [3] ARMENIAN APOSTROPHE..ARMENIAN EXCLAMATION MARK
+	{runeRange{0x055F, 0x055F}, wbprMidLetter},              // Po       ARMENIAN ABBREVIATION MARK
+	{runeRange{0x0589, 0x0589}, wbprMidNum},                 // Po       ARMENIAN FULL STOP
+	{runeRange{0x0591, 0x05BD}, wbprExtend},                 // Mn  [45] HEBREW ACCENT ETNAHTA..HEBREW POINT METEG
+	{runeRange{0x05C1, 0x05C2}, wbprExtend},                 // Mn   [2] HEBREW POINT SHIN DOT..HEBREW POINT SIN DOT
+	{runeRange{0x05C7, 0x05C7}, wbprExtend},                 // Mn       HEBREW POINT QAMATS QATAN
+	{runeRange{0x05EF, 0x05F2}, wbprHebrewLetter},           // Lo   [4] HEBREW YOD TRIANGLE..HEBREW LIGATURE YIDDISH DOUBLE YOD
+	{runeRange{0x05F4, 0x05F4}, wbprMidLetter},              // Po       HEBREW PUNCTUATION GERSHAYIM
+	{runeRange{0x060C, 0x060D}, wbprMidNum},                 // Po   [2] ARABIC COMMA..ARABIC DATE SEPARATOR
+	{runeRange{0x061C, 0x061C}, wbprFormat},                 // Cf       ARABIC LETTER MARK
+	{runeRange{0x0640, 0x0640}, wbprALetter},                // Lm       ARABIC TATWEEL
+	{runeRange{0x064B, 0x065F}, wbprExtend},                 // Mn  [21] ARABIC FATHATAN..ARABIC WAVY HAMZA BELOW
+	{runeRange{0x066B, 0x066B}, wbprNumeric},                // Po       ARABIC DECIMAL SEPARATOR
+	{runeRange{0x066E, 0x066F}, wbprALetter},                // Lo   [2] ARABIC LETTER DOTLESS BEH..ARABIC LETTER DOTLESS QAF
+	{runeRange{0x0671, 0x06D3}, wbprALetter},                // Lo  [99] ARABIC LETTER ALEF WASLA..ARABIC LETTER YEH BARREE WITH HAMZA ABOVE
+	{runeRange{0x06D6, 0x06DC}, wbprExtend},                 // Mn   [7] ARABIC SMALL HIGH LIGATURE SAD WITH LAM WITH ALEF MAKSURA..ARABIC SMALL HIGH SEEN
+	{runeRange{0x06DF, 0x06E4}, wbprExtend},                 // Mn   [6] ARABIC SMALL HIGH ROUNDED ZERO..ARABIC SMALL HIGH MADDA
+	{runeRange{0x06E7, 0x06E8}, wbprExtend},                 // Mn   [2] ARABIC SMALL HIGH YEH..ARABIC SMALL HIGH NOON
+	{runeRange{0x06EE, 0x06EF}, wbprALetter},                // Lo   [2] ARABIC LETTER DAL WITH INVERTED V..ARABIC LETTER REH WITH INVERTED V
+	{runeRange{0x06FA, 0x06FC}, wbprALetter},                // Lo   [3] ARABIC LETTER SHEEN WITH DOT BELOW..ARABIC LETTER GHAIN WITH DOT BELOW
+	{runeRange{0x070F, 0x070F}, wbprFormat},                 // Cf       SYRIAC ABBREVIATION MARK
+	{runeRange{0x0711, 0x0711}, wbprExtend},                 // Mn       SYRIAC LETTER SUPERSCRIPT ALAPH
+	{runeRange{0x0730, 0x074A}, wbprExtend},                 // Mn  [27] SYRIAC PTHAHA ABOVE..SYRIAC BARREKH
+	{runeRange{0x07A6, 0x07B0}, wbprExtend},                 // Mn  [11] THAANA ABAFILI..THAANA SUKUN
+	{runeRange{0x07C0, 0x07C9}, wbprNumeric},                // Nd  [10] NKO DIGIT ZERO..NKO DIGIT NINE
+	{runeRange{0x07EB, 0x07F3}, wbprExtend},                 // Mn   [9] NKO COMBINING SHORT HIGH TONE..NKO COMBINING DOUBLE DOT ABOVE
+	{runeRange{0x07F8, 0x07F8}, wbprMidNum},                 // Po       NKO COMMA
+	{runeRange{0x07FD, 0x07FD}, wbprExtend},                 // Mn       NKO DANTAYALAN
+	{runeRange{0x0816, 0x0819}, wbprExtend},                 // Mn   [4] SAMARITAN MARK IN..SAMARITAN MARK DAGESH
+	{runeRange{0x081B, 0x0823}, wbprExtend},                 // Mn   [9] SAMARITAN MARK EPENTHETIC YUT..SAMARITAN VOWEL SIGN A
+	{runeRange{0x0825, 0x0827}, wbprExtend},                 // Mn   [3] SAMARITAN VOWEL SIGN SHORT A..SAMARITAN VOWEL SIGN U
+	{runeRange{0x0829, 0x082D}, wbprExtend},                 // Mn   [5] SAMARITAN VOWEL SIGN LONG I..SAMARITAN MARK NEQUDAA
+	{runeRange{0x0859, 0x085B}, wbprExtend},                 // Mn   [3] MANDAIC AFFRICATION MARK..MANDAIC GEMINATION MARK
+	{runeRange{0x0870, 0x0887}, wbprALetter},                // Lo  [24] ARABIC LETTER ALEF WITH ATTACHED FATHA..ARABIC BASELINE ROUND DOT
+	{runeRange{0x0890, 0x0891}, wbprFormat},                 // Cf   [2] ARABIC POUND MARK ABOVE..ARABIC PIASTRE MARK ABOVE
+	{runeRange{0x08A0, 0x08C8}, wbprALetter},                // Lo  [41] ARABIC LETTER BEH WITH SMALL V BELOW..ARABIC LETTER GRAF
+	{runeRange{0x08CA, 0x08E1}, wbprExtend},                 // Mn  [24] ARABIC SMALL HIGH FARSI YEH..ARABIC SMALL HIGH SIGN SAFHA
+	{runeRange{0x08E3, 0x0902}, wbprExtend},                 // Mn  [32] ARABIC TURNED DAMMA BELOW..DEVANAGARI SIGN ANUSVARA
+	{runeRange{0x0904, 0x0939}, wbprALetter},                // Lo  [54] DEVANAGARI LETTER SHORT A..DEVANAGARI LETTER HA
+	{runeRange{0x093B, 0x093B}, wbprExtend},                 // Mc       DEVANAGARI VOWEL SIGN OOE
+	{runeRange{0x093D, 0x093D}, wbprALetter},                // Lo       DEVANAGARI SIGN AVAGRAHA
+	{runeRange{0x0941, 0x0948}, wbprExtend},                 // Mn   [8] DEVANAGARI VOWEL SIGN U..DEVANAGARI VOWEL SIGN AI
+	{runeRange{0x094D, 0x094D}, wbprExtend},                 // Mn       DEVANAGARI SIGN VIRAMA
+	{runeRange{0x0950, 0x0950}, wbprALetter},                // Lo       DEVANAGARI OM
+	{runeRange{0x0958, 0x0961}, wbprALetter},                // Lo  [10] DEVANAGARI LETTER QA..DEVANAGARI LETTER VOCALIC LL
+	{runeRange{0x0966, 0x096F}, wbprNumeric},                // Nd  [10] DEVANAGARI DIGIT ZERO..DEVANAGARI DIGIT NINE
+	{runeRange{0x0972, 0x0980}, wbprALetter},                // Lo  [15] DEVANAGARI LETTER CANDRA A..BENGALI ANJI
+	{runeRange{0x0982, 0x0983}, wbprExtend},                 // Mc   [2] BENGALI SIGN ANUSVARA..BENGALI SIGN VISARGA
+	{runeRange{0x098F, 0x0990}, wbprALetter},                // Lo   [2] BENGALI LETTER E..BENGALI LETTER AI
+	{runeRange{0x09AA, 0x09B0}, wbprALetter},                // Lo   [7] BENGALI LETTER PA..BENGALI LETTER RA
+	{runeRange{0x09B6, 0x09B9}, wbprALetter},                // Lo   [4] BENGALI LETTER SHA..BENGALI LETTER HA
+	{runeRange{0x09BD, 0x09BD}, wbprALetter},                // Lo       BENGALI SIGN AVAGRAHA
+	{runeRange{0x09C1, 0x09C4}, wbprExtend},                 // Mn   [4] BENGALI VOWEL SIGN U..BENGALI VOWEL SIGN VOCALIC RR
+	{runeRange{0x09CB, 0x09CC}, wbprExtend},                 // Mc   [2] BENGALI VOWEL SIGN O..BENGALI VOWEL SIGN AU
+	{runeRange{0x09CE, 0x09CE}, wbprALetter},                // Lo       BENGALI LETTER KHANDA TA
+	{runeRange{0x09DC, 0x09DD}, wbprALetter},                // Lo   [2] BENGALI LETTER RRA..BENGALI LETTER RHA
+	{runeRange{0x09E2, 0x09E3}, wbprExtend},                 // Mn   [2] BENGALI VOWEL SIGN VOCALIC L..BENGALI VOWEL SIGN VOCALIC LL
+	{runeRange{0x09F0, 0x09F1}, wbprALetter},                // Lo   [2] BENGALI LETTER RA WITH MIDDLE DIAGONAL..BENGALI LETTER RA WITH LOWER DIAGONAL
+	{runeRange{0x09FE, 0x09FE}, wbprExtend},                 // Mn       BENGALI SANDHI MARK
+	{runeRange{0x0A03, 0x0A03}, wbprExtend},                 // Mc       GURMUKHI SIGN VISARGA
+	{runeRange{0x0A0F, 0x0A10}, wbprALetter},                // Lo   [2] GURMUKHI LETTER EE..GURMUKHI LETTER AI
+	{runeRange{0x0A2A, 0x0A30}, wbprALetter},                // Lo   [7] GURMUKHI LETTER PA..GURMUKHI LETTER RA
+	{runeRange{0x0A35, 0x0A36}, wbprALetter},                // Lo   [2] GURMUKHI LETTER VA..GURMUKHI LETTER SHA
+	{runeRange{0x0A3C, 0x0A3C}, wbprExtend},                 // Mn       GURMUKHI SIGN NUKTA
+	{runeRange{0x0A41, 0x0A42}, wbprExtend},                 // Mn   [2] GURMUKHI VOWEL SIGN U..GURMUKHI VOWEL SIGN UU
+	{runeRange{0x0A4B, 0x0A4D}, wbprExtend},                 // Mn   [3] GURMUKHI VOWEL SIGN OO..GURMUKHI SIGN VIRAMA
+	{runeRange{0x0A59, 0x0A5C}, wbprALetter},                // Lo   [4] GURMUKHI LETTER KHHA..GURMUKHI LETTER RRA
+	{runeRange{0x0A66, 0x0A6F}, wbprNumeric},                // Nd  [10] GURMUKHI DIGIT ZERO..GURMUKHI DIGIT NINE
+	{runeRange{0x0A72, 0x0A74}, wbprALetter},                // Lo   [3] GURMUKHI IRI..GURMUKHI EK ONKAR
+	{runeRange{0x0A81, 0x0A82}, wbprExtend},                 // Mn   [2] GUJARATI SIGN CANDRABINDU..GUJARATI SIGN ANUSVARA
+	{runeRange{0x0A85, 0x0A8D}, wbprALetter},                // Lo   [9] GUJARATI LETTER A..GUJARATI VOWEL CANDRA E
+	{runeRange{0x0A93, 0x0AA8}, wbprALetter},                // Lo  [22] GUJARATI LETTER O..GUJARATI LETTER NA
+	{runeRange{0x0AB2, 0x0AB3}, wbprALetter},                // Lo   [2] GUJARATI LETTER LA..GUJARATI LETTER LLA
+	{runeRange{0x0ABC, 0x0ABC}, wbprExtend},                 // Mn       GUJARATI SIGN NUKTA
+	{runeRange{0x0ABE, 0x0AC0}, wbprExtend},                 // Mc   [3] GUJARATI VOWEL SIGN AA..GUJARATI VOWEL SIGN II
+	{runeRange{0x0AC7, 0x0AC8}, wbprExtend},                 // Mn   [2] GUJARATI VOWEL SIGN E..GUJARATI VOWEL SIGN AI
+	{runeRange{0x0ACB, 0x0ACC}, wbprExtend},                 // Mc   [2] GUJARATI VOWEL SIGN O..GUJARATI VOWEL SIGN AU
+	{runeRange{0x0AD0, 0x0AD0}, wbprALetter},                // Lo       GUJARATI OM
+	{runeRange{0x0AE2, 0x0AE3}, wbprExtend},                 // Mn   [2] GUJARATI VOWEL SIGN VOCALIC L..GUJARATI VOWEL SIGN VOCALIC LL
+	{runeRange{0x0AF9, 0x0AF9}, wbprALetter},                // Lo       GUJARATI LETTER ZHA
+	{runeRange{0x0B01, 0x0B01}, wbprExtend},                 // Mn       ORIYA SIGN CANDRABINDU
+	{runeRange{0x0B05, 0x0B0C}, wbprALetter},                // Lo   [8] ORIYA LETTER A..ORIYA LETTER VOCALIC L
+	{runeRange{0x0B13, 0x0B28}, wbprALetter},                // Lo  [22] ORIYA LETTER O..ORIYA LETTER NA
+	{runeRange{0x0B32, 0x0B33}, wbprALetter},                // Lo   [2] ORIYA LETTER LA..ORIYA LETTER LLA
+	{runeRange{0x0B3C, 0x0B3C}, wbprExtend},                 // Mn       ORIYA SIGN NUKTA
+	{runeRange{0x0B3E, 0x0B3E}, wbprExtend},                 // Mc       ORIYA VOWEL SIGN AA
+	{runeRange{0x0B40, 0x0B40}, wbprExtend},                 // Mc       ORIYA VOWEL SIGN II
+	{runeRange{0x0B47, 0x0B48}, wbprExtend},                 // Mc   [2] ORIYA VOWEL SIGN E..ORIYA VOWEL SIGN AI
+	{runeRange{0x0B4D, 0x0B4D}, wbprExtend},                 // Mn       ORIYA SIGN VIRAMA
+	{runeRange{0x0B57, 0x0B57}, wbprExtend},                 // Mc       ORIYA AU LENGTH MARK
+	{runeRange{0x0B5F, 0x0B61}, wbprALetter},                // Lo   [3] ORIYA LETTER YYA..ORIYA LETTER VOCALIC LL
+	{runeRange{0x0B66, 0x0B6F}, wbprNumeric},                // Nd  [10] ORIYA DIGIT ZERO..ORIYA DIGIT NINE
+	{runeRange{0x0B82, 0x0B82}, wbprExtend},                 // Mn       TAMIL SIGN ANUSVARA
+	{runeRange{0x0B85, 0x0B8A}, wbprALetter},                // Lo   [6] TAMIL LETTER A..TAMIL LETTER UU
+	{runeRange{0x0B92, 0x0B95}, wbprALetter},                // Lo   [4] TAMIL LETTER O..TAMIL LETTER KA
+	{runeRange{0x0B9C, 0x0B9C}, wbprALetter},                // Lo       TAMIL LETTER JA
+	{runeRange{0x0BA3, 0x0BA4}, wbprALetter},                // Lo   [2] TAMIL LETTER NNA..TAMIL LETTER TA
+	{runeRange{0x0BAE, 0x0BB9}, wbprALetter},                // Lo  [12] TAMIL LETTER MA..TAMIL LETTER HA
+	{runeRange{0x0BC0, 0x0BC0}, wbprExtend},                 // Mn       TAMIL VOWEL SIGN II
+	{runeRange{0x0BC6, 0x0BC8}, wbprExtend},                 // Mc   [3] TAMIL VOWEL SIGN E..TAMIL VOWEL SIGN AI
+	{runeRange{0x0BCD, 0x0BCD}, wbprExtend},                 // Mn       TAMIL SIGN VIRAMA
+	{runeRange{0x0BD7, 0x0BD7}, wbprExtend},                 // Mc       TAMIL AU LENGTH MARK
+	{runeRange{0x0C00, 0x0C00}, wbprExtend},                 // Mn       TELUGU SIGN COMBINING CANDRABINDU ABOVE
+	{runeRange{0x0C04, 0x0C04}, wbprExtend},                 // Mn       TELUGU SIGN COMBINING ANUSVARA ABOVE
+	{runeRange{0x0C0E, 0x0C10}, wbprALetter},                // Lo   [3] TELUGU LETTER E..TELUGU LETTER AI
+	{runeRange{0x0C2A, 0x0C39}, wbprALetter},                // Lo  [16] TELUGU LETTER PA..TELUGU LETTER HA
+	{runeRange{0x0C3D, 0x0C3D}, wbprALetter},                // Lo       TELUGU SIGN AVAGRAHA
+	{runeRange{0x0C41, 0x0C44}, wbprExtend},                 // Mc   [4] TELUGU VOWEL SIGN U..TELUGU VOWEL SIGN VOCALIC RR
+	{runeRange{0x0C4A, 0x0C4D}, wbprExtend},                 // Mn   [4] TELUGU VOWEL SIGN O..TELUGU SIGN VIRAMA
+	{runeRange{0x0C58, 0x0C5A}, wbprALetter},                // Lo   [3] TELUGU LETTER TSA..TELUGU LETTER RRRA
+	{runeRange{0x0C60, 0x0C61}, wbprALetter},                // Lo   [2] TELUGU LETTER VOCALIC RR..TELUGU LETTER VOCALIC LL
+	{runeRange{0x0C66, 0x0C6F}, wbprNumeric},                // Nd  [10] TELUGU DIGIT ZERO..TELUGU DIGIT NINE
+	{runeRange{0x0C81, 0x0C81}, wbprExtend},                 // Mn       KANNADA SIGN CANDRABINDU
+	{runeRange{0x0C85, 0x0C8C}, wbprALetter},                // Lo   [8] KANNADA LETTER A..KANNADA LETTER VOCALIC L
+	{runeRange{0x0C92, 0x0CA8}, wbprALetter},                // Lo  [23] KANNADA LETTER O..KANNADA LETTER NA
+	{runeRange{0x0CB5, 0x0CB9}, wbprALetter},                // Lo   [5] KANNADA LETTER VA..KANNADA LETTER HA
+	{runeRange{0x0CBD, 0x0CBD}, wbprALetter},                // Lo       KANNADA SIGN AVAGRAHA
+	{runeRange{0x0CBF, 0x0CBF}, wbprExtend},                 // Mn       KANNADA VOWEL SIGN I
+	{runeRange{0x0CC6, 0x0CC6}, wbprExtend},                 // Mn       KANNADA VOWEL SIGN E
+	{runeRange{0x0CCA, 0x0CCB}, wbprExtend},                 // Mc   [2] KANNADA VOWEL SIGN O..KANNADA VOWEL SIGN OO
+	{runeRange{0x0CD5, 0x0CD6}, wbprExtend},                 // Mc   [2] KANNADA LENGTH MARK..KANNADA AI LENGTH MARK
+	{runeRange{0x0CE0, 0x0CE1}, wbprALetter},                // Lo   [2] KANNADA LETTER VOCALIC RR..KANNADA LETTER VOCALIC LL
+	{runeRange{0x0CE6, 0x0CEF}, wbprNumeric},                // Nd  [10] KANNADA DIGIT ZERO..KANNADA DIGIT NINE
+	{runeRange{0x0CF3, 0x0CF3}, wbprExtend},                 // Mc       KANNADA SIGN COMBINING ANUSVARA ABOVE RIGHT
+	{runeRange{0x0D02, 0x0D03}, wbprExtend},                 // Mc   [2] MALAYALAM SIGN ANUSVARA..MALAYALAM SIGN VISARGA
+	{runeRange{0x0D0E, 0x0D10}, wbprALetter},                // Lo   [3] MALAYALAM LETTER E..MALAYALAM LETTER AI
+	{runeRange{0x0D3B, 0x0D3C}, wbprExtend},                 // Mn   [2] MALAYALAM SIGN VERTICAL BAR VIRAMA..MALAYALAM SIGN CIRCULAR VIRAMA
+	{runeRange{0x0D3E, 0x0D40}, wbprExtend},                 // Mc   [3] MALAYALAM VOWEL SIGN AA..MALAYALAM VOWEL SIGN II
+	{runeRange{0x0D46, 0x0D48}, wbprExtend},                 // Mc   [3] MALAYALAM VOWEL SIGN E..MALAYALAM VOWEL SIGN AI
+	{runeRange{0x0D4D, 0x0D4D}, wbprExtend},                 // Mn       MALAYALAM SIGN VIRAMA
+	{runeRange{0x0D54, 0x0D56}, wbprALetter},                // Lo   [3] MALAYALAM LETTER CHILLU M..MALAYALAM LETTER CHILLU LLL
+	{runeRange{0x0D5F, 0x0D61}, wbprALetter},                // Lo   [3] MALAYALAM LETTER ARCHAIC II..MALAYALAM LETTER VOCALIC LL
+	{runeRange{0x0D66, 0x0D6F}, wbprNumeric},                // Nd  [10] MALAYALAM DIGIT ZERO..MALAYALAM DIGIT NINE
+	{runeRange{0x0D81, 0x0D81}, wbprExtend},                 // Mn       SINHALA SIGN CANDRABINDU
+	{runeRange{0x0D85, 0x0D96}, wbprALetter},                // Lo  [18] SINHALA LETTER AYANNA..SINHALA LETTER AUYANNA
+	{runeRange{0x0DB3, 0x0DBB}, wbprALetter},                // Lo   [9] SINHALA LETTER SANYAKA DAYANNA..SINHALA LETTER RAYANNA
+	{runeRange{0x0DC0, 0x0DC6}, wbprALetter},                // Lo   [7] SINHALA LETTER VAYANNA..SINHALA LETTER FAYANNA
+	{runeRange{0x0DCF, 0x0DD1}, wbprExtend},                 // Mc   [3] SINHALA VOWEL SIGN AELA-PILLA..SINHALA VOWEL SIGN DIGA AEDA-PILLA
+	{runeRange{0x0DD6, 0x0DD6}, wbprExtend},                 // Mn       SINHALA VOWEL SIGN DIGA PAA-PILLA
+	{runeRange{0x0DE6, 0x0DEF}, wbprNumeric},                // Nd  [10] SINHALA LITH DIGIT ZERO..SINHALA LITH DIGIT NINE
+	{runeRange{0x0E31, 0x0E31}, wbprExtend},                 // Mn       THAI CHARACTER MAI HAN-AKAT
+	{runeRange{0x0E47, 0x0E4E}, wbprExtend},                 // Mn   [8] THAI CHARACTER MAITAIKHU..THAI CHARACTER YAMAKKAN
+	{runeRange{0x0EB1, 0x0EB1}, wbprExtend},                 // Mn       LAO VOWEL SIGN MAI KAN
+	{runeRange{0x0EC8, 0x0ECE}, wbprExtend},                 // Mn   [7] LAO TONE MAI EK..LAO YAMAKKAN
+	{runeRange{0x0F00, 0x0F00}, wbprALetter},                // Lo       TIBETAN SYLLABLE OM
+	{runeRange{0x0F20, 0x0F29}, wbprNumeric},                // Nd  [10] TIBETAN DIGIT ZERO..TIBETAN DIGIT NINE
+	{runeRange{0x0F37, 0x0F37}, wbprExtend},                 // Mn       TIBETAN MARK NGAS BZUNG SGOR RTAGS
+	{runeRange{0x0F3E, 0x0F3F}, wbprExtend},                 // Mc   [2] TIBETAN SIGN YAR TSHES..TIBETAN SIGN MAR TSHES
+	{runeRange{0x0F49, 0x0F6C}, wbprALetter},                // Lo  [36] TIBETAN LETTER NYA..TIBETAN LETTER RRA
+	{runeRange{0x0F7F, 0x0F7F}, wbprExtend},                 // Mc       TIBETAN SIGN RNAM BCAD
+	{runeRange{0x0F86, 0x0F87}, wbprExtend},                 // Mn   [2] TIBETAN SIGN LCI RTAGS..TIBETAN SIGN YANG RTAGS
+	{runeRange{0x0F8D, 0x0F97}, wbprExtend},                 // Mn  [11] TIBETAN SUBJOINED SIGN LCE TSA CAN..TIBETAN SUBJOINED LETTER JA
+	{runeRange{0x0FC6, 0x0FC6}, wbprExtend},                 // Mn       TIBETAN SYMBOL PADMA GDAN
+	{runeRange{0x102D, 0x1030}, wbprExtend},                 // Mn   [4] MYANMAR VOWEL SIGN I..MYANMAR VOWEL SIGN UU
+	{runeRange{0x1032, 0x1037}, wbprExtend},                 // Mn   [6] MYANMAR VOWEL SIGN AI..MYANMAR SIGN DOT BELOW
+	{runeRange{0x1039, 0x103A}, wbprExtend},                 // Mn   [2] MYANMAR SIGN VIRAMA..MYANMAR SIGN ASAT
+	{runeRange{0x103D, 0x103E}, wbprExtend},                 // Mn   [2] MYANMAR CONSONANT SIGN MEDIAL WA..MYANMAR CONSONANT SIGN MEDIAL HA
+	{runeRange{0x1056, 0x1057}, wbprExtend},                 // Mc   [2] MYANMAR VOWEL SIGN VOCALIC R..MYANMAR VOWEL SIGN VOCALIC RR
+	{runeRange{0x105E, 0x1060}, wbprExtend},                 // Mn   [3] MYANMAR CONSONANT SIGN MON MEDIAL NA..MYANMAR CONSONANT SIGN MON MEDIAL LA
+	{runeRange{0x1067, 0x106D}, wbprExtend},                 // Mc   [7] MYANMAR VOWEL SIGN WESTERN PWO KAREN EU..MYANMAR SIGN WESTERN PWO KAREN TONE-5
+	{runeRange{0x1082, 0x1082}, wbprExtend},                 // Mn       MYANMAR CONSONANT SIGN SHAN MEDIAL WA
+	{runeRange{0x1085, 0x1086}, wbprExtend},                 // Mn   [2] MYANMAR VOWEL SIGN SHAN E ABOVE..MYANMAR VOWEL SIGN SHAN FINAL Y
+	{runeRange{0x108D, 0x108D}, wbprExtend},                 // Mn       MYANMAR SIGN SHAN COUNCIL EMPHATIC TONE
+	{runeRange{0x1090, 0x1099}, wbprNumeric},                // Nd  [10] MYANMAR SHAN DIGIT ZERO..MYANMAR SHAN DIGIT NINE
+	{runeRange{0x109D, 0x109D}, wbprExtend},                 // Mn       MYANMAR VOWEL SIGN AITON AI
+	{runeRange{0x10C7, 0x10C7}, wbprALetter},                // L&       GEORGIAN CAPITAL LETTER YN
+	{runeRange{0x10D0, 0x10FA}, wbprALetter},                // L&  [43] GEORGIAN LETTER AN..GEORGIAN LETTER AIN
+	{runeRange{0x10FD, 0x10FF}, wbprALetter},                // L&   [3] GEORGIAN LETTER AEN..GEORGIAN LETTER LABIAL SIGN
+	{runeRange{0x124A, 0x124D}, wbprALetter},                // Lo   [4] ETHIOPIC SYLLABLE QWI..ETHIOPIC SYLLABLE QWE
+	{runeRange{0x1258, 0x1258}, wbprALetter},                // Lo       ETHIOPIC SYLLABLE QHWA
+	{runeRange{0x1260, 0x1288}, wbprALetter},                // Lo  [41] ETHIOPIC SYLLABLE BA..ETHIOPIC SYLLABLE XWA
+	{runeRange{0x1290, 0x12B0}, wbprALetter},                // Lo  [33] ETHIOPIC SYLLABLE NA..ETHIOPIC SYLLABLE KWA
+	{runeRange{0x12B8, 0x12BE}, wbprALetter},                // Lo   [7] ETHIOPIC SYLLABLE KXA..ETHIOPIC SYLLABLE KXO
+	{runeRange{0x12C2, 0x12C5}, wbprALetter},                // Lo   [4] ETHIOPIC SYLLABLE KXWI..ETHIOPIC SYLLABLE KXWE
+	{runeRange{0x12D8, 0x1310}, wbprALetter},                // Lo  [57] ETHIOPIC SYLLABLE ZA..ETHIOPIC SYLLABLE GWA
+	{runeRange{0x1318, 0x135A}, wbprALetter},                // Lo  [67] ETHIOPIC SYLLABLE GGA..ETHIOPIC SYLLABLE FYA
+	{runeRange{0x1380, 0x138F}, wbprALetter},                // Lo  [16] ETHIOPIC SYLLABLE SEBATBEIT MWA..ETHIOPIC SYLLABLE PWE
+	{runeRange{0x13F8, 0x13FD}, wbprALetter},                // L&   [6] CHEROKEE SMALL LETTER YE..CHEROKEE SMALL LETTER MV
+	{runeRange{0x166F, 0x167F}, wbprALetter},                // Lo  [17] CANADIAN SYLLABICS QAI..CANADIAN SYLLABICS BLACKFOOT W
+	{runeRange{0x1681, 0x169A}, wbprALetter},                // Lo  [26] OGHAM LETTER BEITH..OGHAM LETTER PEITH
+	{runeRange{0x16EE, 0x16F0}, wbprALetter},                // Nl   [3] RUNIC ARLAUG SYMBOL..RUNIC BELGTHOR SYMBOL
+	{runeRange{0x1700, 0x1711}, wbprALetter},                // Lo  [18] TAGALOG LETTER A..TAGALOG LETTER HA
+	{runeRange{0x1715, 0x1715}, wbprExtend},                 // Mc       TAGALOG SIGN PAMUDPOD
+	{runeRange{0x1732, 0x1733}, wbprExtend},                 // Mn   [2] HANUNOO VOWEL SIGN I..HANUNOO VOWEL SIGN U
+	{runeRange{0x1740, 0x1751}, wbprALetter},                // Lo  [18] BUHID LETTER A..BUHID LETTER HA
+	{runeRange{0x1760, 0x176C}, wbprALetter},                // Lo  [13] TAGBANWA LETTER A..TAGBANWA LETTER YA
+	{runeRange{0x1772, 0x1773}, wbprExtend},                 // Mn   [2] TAGBANWA VOWEL SIGN I..TAGBANWA VOWEL SIGN U
+	{runeRange{0x17B6, 0x17B6}, wbprExtend},                 // Mc       KHMER VOWEL SIGN AA
+	{runeRange{0x17BE, 0x17C5}, wbprExtend},                 // Mc   [8] KHMER VOWEL SIGN OE..KHMER VOWEL SIGN AU
+	{runeRange{0x17C7, 0x17C8}, wbprExtend},                 // Mc   [2] KHMER SIGN REAHMUK..KHMER SIGN YUUKALEAPINTU
+	{runeRange{0x17DD, 0x17DD}, wbprExtend},                 // Mn       KHMER SIGN ATTHACAN
+	{runeRange{0x180B, 0x180D}, wbprExtend},                 // Mn   [3] MONGOLIAN FREE VARIATION SELECTOR ONE..MONGOLIAN FREE VARIATION SELECTOR THREE
+	{runeRange{0x180F, 0x180F}, wbprExtend},                 // Mn       MONGOLIAN FREE VARIATION SELECTOR FOUR
+	{runeRange{0x1820, 0x1842}, wbprALetter},                // Lo  [35] MONGOLIAN LETTER A..MONGOLIAN LETTER CHI
+	{runeRange{0x1844, 0x1878}, wbprALetter},                // Lo  [53] MONGOLIAN LETTER TODO E..MONGOLIAN LETTER CHA WITH TWO DOTS
+	{runeRange{0x1885, 0x1886}, wbprExtend},                 // Mn   [2] MONGOLIAN LETTER ALI GALI BALUDA..MONGOLIAN LETTER ALI GALI THREE BALUDA
+	{runeRange{0x18A9, 0x18A9}, wbprExtend},                 // Mn       MONGOLIAN LETTER ALI GALI DAGALGA
+	{runeRange{0x18B0, 0x18F5}, wbprALetter},                // Lo  [70] CANADIAN SYLLABICS OY..CANADIAN SYLLABICS CARRIER DENTAL S
+	{runeRange{0x1920, 0x1922}, wbprExtend},                 // Mn   [3] LIMBU VOWEL SIGN A..LIMBU VOWEL SIGN U
+	{runeRange{0x1927, 0x1928}, wbprExtend},                 // Mn   [2] LIMBU VOWEL SIGN E..LIMBU VOWEL SIGN O
+	{runeRange{0x1930, 0x1931}, wbprExtend},                 // Mc   [2] LIMBU SMALL LETTER KA..LIMBU SMALL LETTER NGA
+	{runeRange{0x1933, 0x1938}, wbprExtend},                 // Mc   [6] LIMBU SMALL LETTER TA..LIMBU SMALL LETTER LA
+	{runeRange{0x1946, 0x194F}, wbprNumeric},                // Nd  [10] LIMBU DIGIT ZERO..LIMBU DIGIT NINE
+	{runeRange{0x1A00, 0x1A16}, wbprALetter},                // Lo  [23] BUGINESE LETTER KA..BUGINESE LETTER HA
+	{runeRange{0x1A19, 0x1A1A}, wbprExtend},                 // Mc   [2] BUGINESE VOWEL SIGN E..BUGINESE VOWEL SIGN O
+	{runeRange{0x1A55, 0x1A55}, wbprExtend},                 // Mc       TAI THAM CONSONANT SIGN MEDIAL RA
+	{runeRange{0x1A57, 0x1A57}, wbprExtend},                 // Mc       TAI THAM CONSONANT SIGN LA TANG LAI
+	{runeRange{0x1A60, 0x1A60}, wbprExtend},                 // Mn       TAI THAM SIGN SAKOT
+	{runeRange{0x1A62, 0x1A62}, wbprExtend},                 // Mn       TAI THAM VOWEL SIGN MAI SAT
+	{runeRange{0x1A65, 0x1A6C}, wbprExtend},                 // Mn   [8] TAI THAM VOWEL SIGN I..TAI THAM VOWEL SIGN OA BELOW
+	{runeRange{0x1A73, 0x1A7C}, wbprExtend},                 // Mn  [10] TAI THAM VOWEL SIGN OA ABOVE..TAI THAM SIGN KHUEN-LUE KARAN
+	{runeRange{0x1A80, 0x1A89}, wbprNumeric},                // Nd  [10] TAI THAM HORA DIGIT ZERO..TAI THAM HORA DIGIT NINE
+	{runeRange{0x1AB0, 0x1ABD}, wbprExtend},                 // Mn  [14] COMBINING DOUBLED CIRCUMFLEX ACCENT..COMBINING PARENTHESES BELOW
+	{runeRange{0x1ABF, 0x1ACE}, wbprExtend},                 // Mn  [16] COMBINING LATIN SMALL LETTER W BELOW..COMBINING LATIN SMALL LETTER INSULAR T
+	{runeRange{0x1B04, 0x1B04}, wbprExtend},                 // Mc       BALINESE SIGN BISAH
+	{runeRange{0x1B34, 0x1B34}, wbprExtend},                 // Mn       BALINESE SIGN REREKAN
+	{runeRange{0x1B36, 0x1B3A}, wbprExtend},                 // Mn   [5] BALINESE VOWEL SIGN ULU..BALINESE VOWEL SIGN RA REPA
+	{runeRange{0x1B3C, 0x1B3C}, wbprExtend},                 // Mn       BALINESE VOWEL SIGN LA LENGA
+	{runeRange{0x1B42, 0x1B42}, wbprExtend},                 // Mn       BALINESE VOWEL SIGN PEPET
+	{runeRange{0x1B45, 0x1B4C}, wbprALetter},                // Lo   [8] BALINESE LETTER KAF SASAK..BALINESE LETTER ARCHAIC JNYA
+	{runeRange{0x1B6B, 0x1B73}, wbprExtend},                 // Mn   [9] BALINESE MUSICAL SYMBOL COMBINING TEGEH..BALINESE MUSICAL SYMBOL COMBINING GONG
+	{runeRange{0x1B82, 0x1B82}, wbprExtend},                 // Mc       SUNDANESE SIGN PANGWISAD
+	{runeRange{0x1BA1, 0x1BA1}, wbprExtend},                 // Mc       SUNDANESE CONSONANT SIGN PAMINGKAL
+	{runeRange{0x1BA6, 0x1BA7}, wbprExtend},                 // Mc   [2] SUNDANESE VOWEL SIGN PANAELAENG..SUNDANESE VOWEL SIGN PANOLONG
+	{runeRange{0x1BAA, 0x1BAA}, wbprExtend},                 // Mc       SUNDANESE SIGN PAMAAEH
+	{runeRange{0x1BAE, 0x1BAF}, wbprALetter},                // Lo   [2] SUNDANESE LETTER KHA..SUNDANESE LETTER SYA
+	{runeRange{0x1BBA, 0x1BE5}, wbprALetter},                // Lo  [44] SUNDANESE AVAGRAHA..BATAK LETTER U
+	{runeRange{0x1BE7, 0x1BE7}, wbprExtend},                 // Mc       BATAK VOWEL SIGN E
+	{runeRange{0x1BEA, 0x1BEC}, wbprExtend},                 // Mc   [3] BATAK VOWEL SIGN I..BATAK VOWEL SIGN O
+	{runeRange{0x1BEE, 0x1BEE}, wbprExtend},                 // Mc       BATAK VOWEL SIGN U
+	{runeRange{0x1BF2, 0x1BF3}, wbprExtend},                 // Mc   [2] BATAK PANGOLAT..BATAK PANONGONAN
+	{runeRange{0x1C24, 0x1C2B}, wbprExtend},                 // Mc   [8] LEPCHA SUBJOINED LETTER YA..LEPCHA VOWEL SIGN UU
+	{runeRange{0x1C34, 0x1C35}, wbprExtend},                 // Mc   [2] LEPCHA CONSONANT SIGN NYIN-DO..LEPCHA CONSONANT SIGN KANG
+	{runeRange{0x1C40, 0x1C49}, wbprNumeric},                // Nd  [10] LEPCHA DIGIT ZERO..LEPCHA DIGIT NINE
+	{runeRange{0x1C50, 0x1C59}, wbprNumeric},                // Nd  [10] OL CHIKI DIGIT ZERO..OL CHIKI DIGIT NINE
+	{runeRange{0x1C78, 0x1C7D}, wbprALetter},                // Lm   [6] OL CHIKI MU TTUDDAG..OL CHIKI AHAD
+	{runeRange{0x1C90, 0x1CBA}, wbprALetter},                // L&  [43] GEORGIAN MTAVRULI CAPITAL LETTER AN..GEORGIAN MTAVRULI CAPITAL LETTER AIN
+	{runeRange{0x1CD0, 0x1CD2}, wbprExtend},                 // Mn   [3] VEDIC TONE KARSHANA..VEDIC TONE PRENKHA
+	{runeRange{0x1CE1, 0x1CE1}, wbprExtend},                 // Mc       VEDIC TONE ATHARVAVEDIC INDEPENDENT SVARITA
+	{runeRange{0x1CE9, 0x1CEC}, wbprALetter},                // Lo   [4] VEDIC SIGN ANUSVARA ANTARGOMUKHA..VEDIC SIGN ANUSVARA VAMAGOMUKHA WITH TAIL
+	{runeRange{0x1CEE, 0x1CF3}, wbprALetter},                // Lo   [6] VEDIC SIGN HEXIFORM LONG ANUSVARA..VEDIC SIGN ROTATED ARDHAVISARGA
+	{runeRange{0x1CF5, 0x1CF6}, wbprALetter},                // Lo   [2] VEDIC SIGN JIHVAMULIYA..VEDIC SIGN UPADHMANIYA
+	{runeRange{0x1CF8, 0x1CF9}, wbprExtend},                 // Mn   [2] VEDIC TONE RING ABOVE..VEDIC TONE DOUBLE RING ABOVE
+	{runeRange{0x1D00, 0x1D2B}, wbprALetter},                // L&  [44] LATIN LETTER SMALL CAPITAL A..CYRILLIC LETTER SMALL CAPITAL EL
+	{runeRange{0x1D6B, 0x1D77}, wbprALetter},                // L&  [13] LATIN SMALL LETTER UE..LATIN SMALL LETTER TURNED G
+	{runeRange{0x1D79, 0x1D9A}, wbprALetter},                // L&  [34] LATIN SMALL LETTER INSULAR G..LATIN SMALL LETTER EZH WITH RETROFLEX HOOK
+	{runeRange{0x1DC0, 0x1DFF}, wbprExtend},                 // Mn  [64] COMBINING DOTTED GRAVE ACCENT..COMBINING RIGHT ARROWHEAD AND DOWN ARROWHEAD BELOW
+	{runeRange{0x1F18, 0x1F1D}, wbprALetter},                // L&   [6] GREEK CAPITAL LETTER EPSILON WITH PSILI..GREEK CAPITAL LETTER EPSILON WITH DASIA AND OXIA
+	{runeRange{0x1F48, 0x1F4D}, wbprALetter},                // L&   [6] GREEK CAPITAL LETTER OMICRON WITH PSILI..GREEK CAPITAL LETTER OMICRON WITH DASIA AND OXIA
+	{runeRange{0x1F59, 0x1F59}, wbprALetter},                // L&       GREEK CAPITAL LETTER UPSILON WITH DASIA
+	{runeRange{0x1F5D, 0x1F5D}, wbprALetter},                // L&       GREEK CAPITAL LETTER UPSILON WITH DASIA AND OXIA
+	{runeRange{0x1F80, 0x1FB4}, wbprALetter},                // L&  [53] GREEK SMALL LETTER ALPHA WITH PSILI AND YPOGEGRAMMENI..GREEK SMALL LETTER ALPHA WITH OXIA AND YPOGEGRAMMENI
+	{runeRange{0x1FBE, 0x1FBE}, wbprALetter},                // L&       GREEK PROSGEGRAMMENI
+	{runeRange{0x1FC6, 0x1FCC}, wbprALetter},                // L&   [7] GREEK SMALL LETTER ETA WITH PERISPOMENI..GREEK CAPITAL LETTER ETA WITH PROSGEGRAMMENI
+	{runeRange{0x1FD6, 0x1FDB}, wbprALetter},                // L&   [6] GREEK SMALL LETTER IOTA WITH PERISPOMENI..GREEK CAPITAL LETTER IOTA WITH OXIA
+	{runeRange{0x1FF2, 0x1FF4}, wbprALetter},                // L&   [3] GREEK SMALL LETTER OMEGA WITH VARIA AND YPOGEGRAMMENI..GREEK SMALL LETTER OMEGA WITH OXIA AND YPOGEGRAMMENI
+	{runeRange{0x2000, 0x2006}, wbprWSegSpace},              // Zs   [7] EN QUAD..SIX-PER-EM SPACE
+	{runeRange{0x200C, 0x200C}, wbprExtend},                 // Cf       ZERO WIDTH NON-JOINER
+	{runeRange{0x200E, 0x200F}, wbprFormat},                 // Cf   [2] LEFT-TO-RIGHT MARK..RIGHT-TO-LEFT MARK
+	{runeRange{0x2019, 0x2019}, wbprMidNumLet},              // Pf       RIGHT SINGLE QUOTATION MARK
+	{runeRange{0x2027, 0x2027}, wbprMidLetter},              // Po       HYPHENATION POINT
+	{runeRange{0x2029, 0x2029}, wbprNewline},                // Zp       PARAGRAPH SEPARATOR
+	{runeRange{0x202F, 0x202F}, wbprExtendNumLet},           // Zs       NARROW NO-BREAK SPACE
+	{runeRange{0x203F, 0x2040}, wbprExtendNumLet},           // Pc   [2] UNDERTIE..CHARACTER TIE
+	{runeRange{0x2049, 0x2049}, wbprExtendedPictographic},   // E0.6   [1] (⁉️)       exclamation question mark
+	{runeRange{0x205F, 0x205F}, wbprWSegSpace},              // Zs       MEDIUM MATHEMATICAL SPACE
+	{runeRange{0x2066, 0x206F}, wbprFormat},                 // Cf  [10] LEFT-TO-RIGHT ISOLATE..NOMINAL DIGIT SHAPES
+	{runeRange{0x207F, 0x207F}, wbprALetter},                // Lm       SUPERSCRIPT LATIN SMALL LETTER N
+	{runeRange{0x20D0, 0x20DC}, wbprExtend},                 // Mn  [13] COMBINING LEFT HARPOON ABOVE..COMBINING FOUR DOTS ABOVE
+	{runeRange{0x20E1, 0x20E1}, wbprExtend},                 // Mn       COMBINING LEFT RIGHT ARROW ABOVE
+	{runeRange{0x20E5, 0x20F0}, wbprExtend},                 // Mn  [12] COMBINING REVERSE SOLIDUS OVERLAY..COMBINING ASTERISK ABOVE
+	{runeRange{0x2107, 0x2107}, wbprALetter},                // L&       EULER CONSTANT
+	{runeRange{0x2115, 0x2115}, wbprALetter},                // L&       DOUBLE-STRUCK CAPITAL N
+	{runeRange{0x2122, 0x2122}, wbprExtendedPictographic},   // E0.6   [1] (™️)       trade mark
+	{runeRange{0x2126, 0x2126}, wbprALetter},                // L&       OHM SIGN
+	{runeRange{0x212A, 0x212D}, wbprALetter},                // L&   [4] KELVIN SIGN..BLACK-LETTER CAPITAL C
+	{runeRange{0x2135, 0x2138}, wbprALetter},                // Lo   [4] ALEF SYMBOL..DALET SYMBOL
+	{runeRange{0x2139, 0x2139}, wbprALetter},                // L&       INFORMATION SOURCE
+	{runeRange{0x2145, 0x2149}, wbprALetter},                // L&   [5] DOUBLE-STRUCK ITALIC CAPITAL D..DOUBLE-STRUCK ITALIC SMALL J
+	{runeRange{0x2160, 0x2182}, wbprALetter},                // Nl  [35] ROMAN NUMERAL ONE..ROMAN NUMERAL TEN THOUSAND
+	{runeRange{0x2185, 0x2188}, wbprALetter},                // Nl   [4] ROMAN NUMERAL SIX LATE FORM..ROMAN NUMERAL ONE HUNDRED THOUSAND
+	{runeRange{0x21A9, 0x21AA}, wbprExtendedPictographic},   // E0.6   [2] (↩️..↪️)    right arrow curving left..left arrow curving right
+	{runeRange{0x2328, 0x2328}, wbprExtendedPictographic},   // E1.0   [1] (⌨️)       keyboard
+	{runeRange{0x23CF, 0x23CF}, wbprExtendedPictographic},   // E1.0   [1] (⏏️)       eject button
+	{runeRange{0x23ED, 0x23EE}, wbprExtendedPictographic},   // E0.7   [2] (⏭️..⏮️)    next track button..last track button
+	{runeRange{0x23F0, 0x23F0}, wbprExtendedPictographic},   // E0.6   [1] (⏰)       alarm clock
+	{runeRange{0x23F3, 0x23F3}, wbprExtendedPictographic},   // E0.6   [1] (⏳)       hourglass not done
+	{runeRange{0x24B6, 0x24E9}, wbprALetter},                // So  [52] CIRCLED LATIN CAPITAL LETTER A..CIRCLED LATIN SMALL LETTER Z
+	{runeRange{0x25AA, 0x25AB}, wbprExtendedPictographic},   // E0.6   [2] (▪️..▫️)    black small square..white small square
+	{runeRange{0x25C0, 0x25C0}, wbprExtendedPictographic},   // E0.6   [1] (◀️)       reverse button
+	{runeRange{0x2600, 0x2601}, wbprExtendedPictographic},   // E0.6   [2] (☀️..☁️)    sun..cloud
+	{runeRange{0x2604, 0x2604}, wbprExtendedPictographic},   // E1.0   [1] (☄️)       comet
+	{runeRange{0x2607, 0x260D}, wbprExtendedPictographic},   // E0.0   [7] (☇..☍)    LIGHTNING..OPPOSITION
+	{runeRange{0x260F, 0x2610}, wbprExtendedPictographic},   // E0.0   [2] (☏..☐)    WHITE TELEPHONE..BALLOT BOX
+	{runeRange{0x2612, 0x2612}, wbprExtendedPictographic},   // E0.0   [1] (☒)       BALLOT BOX WITH X
+	{runeRange{0x2616, 0x2617}, wbprExtendedPictographic},   // E0.0   [2] (☖..☗)    WHITE SHOGI PIECE..BLACK SHOGI PIECE
+	{runeRange{0x2619, 0x261C}, wbprExtendedPictographic},   // E0.0   [4] (☙..☜)    REVERSED ROTATED FLORAL HEART BULLET..WHITE LEFT POINTING INDEX
+	{runeRange{0x261E, 0x261F}, wbprExtendedPictographic},   // E0.0   [2] (☞..☟)    WHITE RIGHT POINTING INDEX..WHITE DOWN POINTING INDEX
+	{runeRange{0x2621, 0x2621}, wbprExtendedPictographic},   // E0.0   [1] (☡)       CAUTION SIGN
+	{runeRange{0x2624, 0x2625}, wbprExtendedPictographic},   // E0.0   [2] (☤..☥)    CADUCEUS..ANKH
+	{runeRange{0x2627, 0x2629}, wbprExtendedPictographic},   // E0.0   [3] (☧..☩)    CHI RHO..CROSS OF JERUSALEM
+	{runeRange{0x262B, 0x262D}, wbprExtendedPictographic},   // E0.0   [3] (☫..☭)    FARSI SYMBOL..HAMMER AND SICKLE
+	{runeRange{0x262F, 0x262F}, wbprExtendedPictographic},   // E0.7   [1] (☯️)       yin yang
+	{runeRange{0x2638, 0x2639}, wbprExtendedPictographic},   // E0.7   [2] (☸️..☹️)    wheel of dharma..frowning face
+	{runeRange{0x263B, 0x263F}, wbprExtendedPictographic},   // E0.0   [5] (☻..☿)    BLACK SMILING FACE..MERCURY
+	{runeRange{0x2641, 0x2641}, wbprExtendedPictographic},   // E0.0   [1] (♁)       EARTH
+	{runeRange{0x2643, 0x2647}, wbprExtendedPictographic},   // E0.0   [5] (♃..♇)    JUPITER..PLUTO
+	{runeRange{0x2654, 0x265E}, wbprExtendedPictographic},   // E0.0  [11] (♔..♞)    WHITE CHESS KING..BLACK CHESS KNIGHT
+	{runeRange{0x2660, 0x2660}, wbprExtendedPictographic},   // E0.6   [1] (♠️)       spade suit
+	{runeRange{0x2663, 0x2663}, wbprExtendedPictographic},   // E0.6   [1] (♣️)       club suit
+	{runeRange{0x2665, 0x2666}, wbprExtendedPictographic},   // E0.6   [2] (♥️..♦️)    heart suit..diamond suit
+	{runeRange{0x2668, 0x2668}, wbprExtendedPictographic},   // E0.6   [1] (♨️)       hot springs
+	{runeRange{0x267B, 0x267B}, wbprExtendedPictographic},   // E0.6   [1] (♻️)       recycling symbol
+	{runeRange{0x267E, 0x267E}, wbprExtendedPictographic},   // E11.0  [1] (♾️)       infinity
+	{runeRange{0x2680, 0x2685}, wbprExtendedPictographic},   // E0.0   [6] (⚀..⚅)    DIE FACE-1..DIE FACE-6
+	{runeRange{0x2692, 0x2692}, wbprExtendedPictographic},   // E1.0   [1] (⚒️)       hammer and pick
+	{runeRange{0x2694, 0x2694}, wbprExtendedPictographic},   // E1.0   [1] (⚔️)       crossed swords
+	{runeRange{0x2696, 0x2697}, wbprExtendedPictographic},   // E1.0   [2] (⚖️..⚗️)    balance scale..alembic
+	{runeRange{0x2699, 0x2699}, wbprExtendedPictographic},   // E1.0   [1] (⚙️)       gear
+	{runeRange{0x269B, 0x269C}, wbprExtendedPictographic},   // E1.0   [2] (⚛️..⚜️)    atom symbol..fleur-de-lis
+	{runeRange{0x26A0, 0x26A1}, wbprExtendedPictographic},   // E0.6   [2] (⚠️..⚡)    warning..high voltage
+	{runeRange{0x26A7, 0x26A7}, wbprExtendedPictographic},   // E13.0  [1] (⚧️)       transgender symbol
+	{runeRange{0x26AA, 0x26AB}, wbprExtendedPictographic},   // E0.6   [2] (⚪..⚫)    white circle..black circle
+	{runeRange{0x26B0, 0x26B1}, wbprExtendedPictographic},   // E1.0   [2] (⚰️..⚱️)    coffin..funeral urn
+	{runeRange{0x26BD, 0x26BE}, wbprExtendedPictographic},   // E0.6   [2] (⚽..⚾)    soccer ball..baseball
+	{runeRange{0x26C4, 0x26C5}, wbprExtendedPictographic},   // E0.6   [2] (⛄..⛅)    snowman without snow..sun behind cloud
+	{runeRange{0x26C8, 0x26C8}, wbprExtendedPictographic},   // E0.7   [1] (⛈️)       cloud with lightning and rain
+	{runeRange{0x26CE, 0x26CE}, wbprExtendedPictographic},   // E0.6   [1] (⛎)       Ophiuchus
+	{runeRange{0x26D0, 0x26D0}, wbprExtendedPictographic},   // E0.0   [1] (⛐)       CAR SLIDING
+	{runeRange{0x26D2, 0x26D2}, wbprExtendedPictographic},   // E0.0   [1] (⛒)       CIRCLED CROSSING LANES
+	{runeRange{0x26D4, 0x26D4}, wbprExtendedPictographic},   // E0.6   [1] (⛔)       no entry
+	{runeRange{0x26E9, 0x26E9}, wbprExtendedPictographic},   // E0.7   [1] (⛩️)       shinto shrine
+	{runeRange{0x26EB, 0x26EF}, wbprExtendedPictographic},   // E0.0   [5] (⛫..⛯)    CASTLE..MAP SYMBOL FOR LIGHTHOUSE
+	{runeRange{0x26F2, 0x26F3}, wbprExtendedPictographic},   // E0.6   [2] (⛲..⛳)    fountain..flag in hole
+	{runeRange{0x26F5, 0x26F5}, wbprExtendedPictographic},   // E0.6   [1] (⛵)       sailboat
+	{runeRange{0x26F7, 0x26F9}, wbprExtendedPictographic},   // E0.7   [3] (⛷️..⛹️)    skier..person bouncing ball
+	{runeRange{0x26FB, 0x26FC}, wbprExtendedPictographic},   // E0.0   [2] (⛻..⛼)    JAPANESE BANK SYMBOL..HEADSTONE GRAVEYARD SYMBOL
+	{runeRange{0x26FE, 0x2701}, wbprExtendedPictographic},   // E0.0   [4] (⛾..✁)    CUP ON BLACK SQUARE..UPPER BLADE SCISSORS
+	{runeRange{0x2703, 0x2704}, wbprExtendedPictographic},   // E0.0   [2] (✃..✄)    LOWER BLADE SCISSORS..WHITE SCISSORS
+	{runeRange{0x2708, 0x270C}, wbprExtendedPictographic},   // E0.6   [5] (✈️..✌️)    airplane..victory hand
+	{runeRange{0x270E, 0x270E}, wbprExtendedPictographic},   // E0.0   [1] (✎)       LOWER RIGHT PENCIL
+	{runeRange{0x2710, 0x2711}, wbprExtendedPictographic},   // E0.0   [2] (✐..✑)    UPPER RIGHT PENCIL..WHITE NIB
+	{runeRange{0x2714, 0x2714}, wbprExtendedPictographic},   // E0.6   [1] (✔️)       check mark
+	{runeRange{0x271D, 0x271D}, wbprExtendedPictographic},   // E0.7   [1] (✝️)       latin cross
+	{runeRange{0x2728, 0x2728}, wbprExtendedPictographic},   // E0.6   [1] (✨)       sparkles
+	{runeRange{0x2744, 0x2744}, wbprExtendedPictographic},   // E0.6   [1] (❄️)       snowflake
+	{runeRange{0x274C, 0x274C}, wbprExtendedPictographic},   // E0.6   [1] (❌)       cross mark
+	{runeRange{0x2753, 0x2755}, wbprExtendedPictographic},   // E0.6   [3] (❓..❕)    red question mark..white exclamation mark
+	{runeRange{0x2763, 0x2763}, wbprExtendedPictographic},   // E1.0   [1] (❣️)       heart exclamation
+	{runeRange{0x2765, 0x2767}, wbprExtendedPictographic},   // E0.0   [3] (❥..❧)    ROTATED HEAVY BLACK HEART BULLET..ROTATED FLORAL HEART BULLET
+	{runeRange{0x27A1, 0x27A1}, wbprExtendedPictographic},   // E0.6   [1] (➡️)       right arrow
+	{runeRange{0x27BF, 0x27BF}, wbprExtendedPictographic},   // E1.0   [1] (➿)       double curly loop
+	{runeRange{0x2B05, 0x2B07}, wbprExtendedPictographic},   // E0.6   [3] (⬅️..⬇️)    left arrow..down arrow
+	{runeRange{0x2B50, 0x2B50}, wbprExtendedPictographic},   // E0.6   [1] (⭐)       star
+	{runeRange{0x2C00, 0x2C7B}, wbprALetter},                // L& [124] GLAGOLITIC CAPITAL LETTER AZU..LATIN LETTER SMALL CAPITAL TURNED E
+	{runeRange{0x2C7E, 0x2CE4}, wbprALetter},                // L& [103] LATIN CAPITAL LETTER S WITH SWASH TAIL..COPTIC SYMBOL KAI
+	{runeRange{0x2CEF, 0x2CF1}, wbprExtend},                 // Mn   [3] COPTIC COMBINING NI ABOVE..COPTIC COMBINING SPIRITUS LENIS
+	{runeRange{0x2D00, 0x2D25}, wbprALetter},                // L&  [38] GEORGIAN SMALL LETTER AN..GEORGIAN SMALL LETTER HOE
+	{runeRange{0x2D2D, 0x2D2D}, wbprALetter},                // L&       GEORGIAN SMALL LETTER AEN
+	{runeRange{0x2D6F, 0x2D6F}, wbprALetter},                // Lm       TIFINAGH MODIFIER LETTER LABIALIZATION MARK
+	{runeRange{0x2D80, 0x2D96}, wbprALetter},                // Lo  [23] ETHIOPIC SYLLABLE LOA..ETHIOPIC SYLLABLE GGWE
+	{runeRange{0x2DA8, 0x2DAE}, wbprALetter},                // Lo   [7] ETHIOPIC SYLLABLE CCA..ETHIOPIC SYLLABLE CCO
+	{runeRange{0x2DB8, 0x2DBE}, wbprALetter},                // Lo   [7] ETHIOPIC SYLLABLE CCHA..ETHIOPIC SYLLABLE CCHO
+	{runeRange{0x2DC8, 0x2DCE}, wbprALetter},                // Lo   [7] ETHIOPIC SYLLABLE KYA..ETHIOPIC SYLLABLE KYO
+	{runeRange{0x2DD8, 0x2DDE}, wbprALetter},                // Lo   [7] ETHIOPIC SYLLABLE GYA..ETHIOPIC SYLLABLE GYO
+	{runeRange{0x2E2F, 0x2E2F}, wbprALetter},                // Lm       VERTICAL TILDE
+	{runeRange{0x3005, 0x3005}, wbprALetter},                // Lm       IDEOGRAPHIC ITERATION MARK
+	{runeRange{0x302E, 0x302F}, wbprExtend},                 // Mc   [2] HANGUL SINGLE DOT TONE MARK..HANGUL DOUBLE DOT TONE MARK
+	{runeRange{0x3031, 0x3035}, wbprKatakana},               // Lm   [5] VERTICAL KANA REPEAT MARK..VERTICAL KANA REPEAT MARK LOWER HALF
+	{runeRange{0x303C, 0x303C}, wbprALetter},                // Lo       MASU MARK
+	{runeRange{0x3099, 0x309A}, wbprExtend},                 // Mn   [2] COMBINING KATAKANA-HIRAGANA VOICED SOUND MARK..COMBINING KATAKANA-HIRAGANA SEMI-VOICED SOUND MARK
+	{runeRange{0x30A0, 0x30A0}, wbprKatakana},               // Pd       KATAKANA-HIRAGANA DOUBLE HYPHEN
+	{runeRange{0x30FC, 0x30FE}, wbprKatakana},               // Lm   [3] KATAKANA-HIRAGANA PROLONGED SOUND MARK..KATAKANA VOICED ITERATION MARK
+	{runeRange{0x3105, 0x312F}, wbprALetter},                // Lo  [43] BOPOMOFO LETTER B..BOPOMOFO LETTER NN
+	{runeRange{0x31A0, 0x31BF}, wbprALetter},                // Lo  [32] BOPOMOFO LETTER BU..BOPOMOFO LETTER AH
+	{runeRange{0x3297, 0x3297}, wbprExtendedPictographic},   // E0.6   [1] (㊗️)       Japanese “congratulations” button
+	{runeRange{0x32D0, 0x32FE}, wbprKatakana},               // So  [47] CIRCLED KATAKANA A..CIRCLED KATAKANA WO
+	{runeRange{0xA000, 0xA014}, wbprALetter},                // Lo  [21] YI SYLLABLE IT..YI SYLLABLE E
+	{runeRange{0xA016, 0xA48C}, wbprALetter},                // Lo [1143] YI SYLLABLE BIT..YI SYLLABLE YYR
+	{runeRange{0xA4F8, 0xA4FD}, wbprALetter},                // Lm   [6] LISU LETTER TONE MYA TI..LISU LETTER TONE MYA JEU
+	{runeRange{0xA60C, 0xA60C}, wbprALetter},                // Lm       VAI SYLLABLE LENGTHENER
+	{runeRange{0xA620, 0xA629}, wbprNumeric},                // Nd  [10] VAI DIGIT ZERO..VAI DIGIT NINE
+	{runeRange{0xA640, 0xA66D}, wbprALetter},                // L&  [46] CYRILLIC CAPITAL LETTER ZEMLYA..CYRILLIC SMALL LETTER DOUBLE MONOCULAR O
+	{runeRange{0xA66F, 0xA66F}, wbprExtend},                 // Mn       COMBINING CYRILLIC VZMET
+	{runeRange{0xA674, 0xA67D}, wbprExtend},                 // Mn  [10] COMBINING CYRILLIC LETTER UKRAINIAN IE..COMBINING CYRILLIC PAYEROK
+	{runeRange{0xA680, 0xA69B}, wbprALetter},                // L&  [28] CYRILLIC CAPITAL LETTER DWE..CYRILLIC SMALL LETTER CROSSED O
+	{runeRange{0xA69E, 0xA69F}, wbprExtend},                 // Mn   [2] COMBINING CYRILLIC LETTER EF..COMBINING CYRILLIC LETTER IOTIFIED E
+	{runeRange{0xA6E6, 0xA6EF}, wbprALetter},                // Nl  [10] BAMUM LETTER MO..BAMUM LETTER KOGHOM
+	{runeRange{0xA708, 0xA716}, wbprALetter},                // Sk  [15] MODIFIER LETTER EXTRA-HIGH DOTTED TONE BAR..MODIFIER LETTER EXTRA-LOW LEFT-STEM TONE BAR
+	{runeRange{0xA720, 0xA721}, wbprALetter},                // Sk   [2] MODIFIER LETTER STRESS AND HIGH TONE..MODIFIER LETTER STRESS AND LOW TONE
+	{runeRange{0xA770, 0xA770}, wbprALetter},                // Lm       MODIFIER LETTER US
+	{runeRange{0xA788, 0xA788}, wbprALetter},                // Lm       MODIFIER LETTER LOW CIRCUMFLEX ACCENT
+	{runeRange{0xA78B, 0xA78E}, wbprALetter},                // L&   [4] LATIN CAPITAL LETTER SALTILLO..LATIN SMALL LETTER L WITH RETROFLEX HOOK AND BELT
+	{runeRange{0xA790, 0xA7CA}, wbprALetter},                // L&  [59] LATIN CAPITAL LETTER N WITH DESCENDER..LATIN SMALL LETTER S WITH SHORT STROKE OVERLAY
+	{runeRange{0xA7D3, 0xA7D3}, wbprALetter},                // L&       LATIN SMALL LETTER DOUBLE THORN
+	{runeRange{0xA7F2, 0xA7F4}, wbprALetter},                // Lm   [3] MODIFIER LETTER CAPITAL C..MODIFIER LETTER CAPITAL Q
+	{runeRange{0xA7F7, 0xA7F7}, wbprALetter},                // Lo       LATIN EPIGRAPHIC LETTER SIDEWAYS I
+	{runeRange{0xA7FA, 0xA7FA}, wbprALetter},                // L&       LATIN LETTER SMALL CAPITAL TURNED M
+	{runeRange{0xA802, 0xA802}, wbprExtend},                 // Mn       SYLOTI NAGRI SIGN DVISVARA
+	{runeRange{0xA806, 0xA806}, wbprExtend},                 // Mn       SYLOTI NAGRI SIGN HASANTA
+	{runeRange{0xA80B, 0xA80B}, wbprExtend},                 // Mn       SYLOTI NAGRI SIGN ANUSVARA
+	{runeRange{0xA823, 0xA824}, wbprExtend},                 // Mc   [2] SYLOTI NAGRI VOWEL SIGN A..SYLOTI NAGRI VOWEL SIGN I
+	{runeRange{0xA827, 0xA827}, wbprExtend},                 // Mc       SYLOTI NAGRI VOWEL SIGN OO
+	{runeRange{0xA840, 0xA873}, wbprALetter},                // Lo  [52] PHAGS-PA LETTER KA..PHAGS-PA LETTER CANDRABINDU
+	{runeRange{0xA882, 0xA8B3}, wbprALetter},                // Lo  [50] SAURASHTRA LETTER A..SAURASHTRA LETTER LLA
+	{runeRange{0xA8C4, 0xA8C5}, wbprExtend},                 // Mn   [2] SAURASHTRA SIGN VIRAMA..SAURASHTRA SIGN CANDRABINDU
+	{runeRange{0xA8E0, 0xA8F1}, wbprExtend},                 // Mn  [18] COMBINING DEVANAGARI DIGIT ZERO..COMBINING DEVANAGARI SIGN AVAGRAHA
+	{runeRange{0xA8FB, 0xA8FB}, wbprALetter},                // Lo       DEVANAGARI HEADSTROKE
+	{runeRange{0xA8FF, 0xA8FF}, wbprExtend},                 // Mn       DEVANAGARI VOWEL SIGN AY
+	{runeRange{0xA90A, 0xA925}, wbprALetter},                // Lo  [28] KAYAH LI LETTER KA..KAYAH LI LETTER OO
+	{runeRange{0xA930, 0xA946}, wbprALetter},                // Lo  [23] REJANG LETTER KA..REJANG LETTER A
+	{runeRange{0xA952, 0xA953}, wbprExtend},                 // Mc   [2] REJANG CONSONANT SIGN H..REJANG VIRAMA
+	{runeRange{0xA980, 0xA982}, wbprExtend},                 // Mn   [3] JAVANESE SIGN PANYANGGA..JAVANESE SIGN LAYAR
+	{runeRange{0xA984, 0xA9B2}, wbprALetter},                // Lo  [47] JAVANESE LETTER A..JAVANESE LETTER HA
+	{runeRange{0xA9B4, 0xA9B5}, wbprExtend},                 // Mc   [2] JAVANESE VOWEL SIGN TARUNG..JAVANESE VOWEL SIGN TOLONG
+	{runeRange{0xA9BA, 0xA9BB}, wbprExtend},                 // Mc   [2] JAVANESE VOWEL SIGN TALING..JAVANESE VOWEL SIGN DIRGA MURE
+	{runeRange{0xA9BE, 0xA9C0}, wbprExtend},                 // Mc   [3] JAVANESE CONSONANT SIGN PENGKAL..JAVANESE PANGKON
+	{runeRange{0xA9D0, 0xA9D9}, wbprNumeric},                // Nd  [10] JAVANESE DIGIT ZERO..JAVANESE DIGIT NINE
+	{runeRange{0xA9F0, 0xA9F9}, wbprNumeric},                // Nd  [10] MYANMAR TAI LAING DIGIT ZERO..MYANMAR TAI LAING DIGIT NINE
+	{runeRange{0xAA29, 0xAA2E}, wbprExtend},                 // Mn   [6] CHAM VOWEL SIGN AA..CHAM VOWEL SIGN OE
+	{runeRange{0xAA31, 0xAA32}, wbprExtend},                 // Mn   [2] CHAM VOWEL SIGN AU..CHAM VOWEL SIGN UE
+	{runeRange{0xAA35, 0xAA36}, wbprExtend},                 // Mn   [2] CHAM CONSONANT SIGN LA..CHAM CONSONANT SIGN WA
+	{runeRange{0xAA43, 0xAA43}, wbprExtend},                 // Mn       CHAM CONSONANT SIGN FINAL NG
+	{runeRange{0xAA4C, 0xAA4C}, wbprExtend},                 // Mn       CHAM CONSONANT SIGN FINAL M
+	{runeRange{0xAA50, 0xAA59}, wbprNumeric},                // Nd  [10] CHAM DIGIT ZERO..CHAM DIGIT NINE
+	{runeRange{0xAA7C, 0xAA7C}, wbprExtend},                 // Mn       MYANMAR SIGN TAI LAING TONE-2
+	{runeRange{0xAAB0, 0xAAB0}, wbprExtend},                 // Mn       TAI VIET MAI KANG
+	{runeRange{0xAAB7, 0xAAB8}, wbprExtend},                 // Mn   [2] TAI VIET MAI KHIT..TAI VIET VOWEL IA
+	{runeRange{0xAAC1, 0xAAC1}, wbprExtend},                 // Mn       TAI VIET TONE MAI THO
+	{runeRange{0xAAEB, 0xAAEB}, wbprExtend},                 // Mc       MEETEI MAYEK VOWEL SIGN II
+	{runeRange{0xAAEE, 0xAAEF}, wbprExtend},                 // Mc   [2] MEETEI MAYEK VOWEL SIGN AU..MEETEI MAYEK VOWEL SIGN AAU
+	{runeRange{0xAAF3, 0xAAF4}, wbprALetter},                // Lm   [2] MEETEI MAYEK SYLLABLE REPETITION MARK..MEETEI MAYEK WORD REPETITION MARK
+	{runeRange{0xAAF6, 0xAAF6}, wbprExtend},                 // Mn       MEETEI MAYEK VIRAMA
+	{runeRange{0xAB09, 0xAB0E}, wbprALetter},                // Lo   [6] ETHIOPIC SYLLABLE DDHU..ETHIOPIC SYLLABLE DDHO
+	{runeRange{0xAB20, 0xAB26}, wbprALetter},                // Lo   [7] ETHIOPIC SYLLABLE CCHHA..ETHIOPIC SYLLABLE CCHHO
+	{runeRange{0xAB30, 0xAB5A}, wbprALetter},                // L&  [43] LATIN SMALL LETTER BARRED ALPHA..LATIN SMALL LETTER Y WITH SHORT RIGHT LEG
+	{runeRange{0xAB5C, 0xAB5F}, wbprALetter},                // Lm   [4] MODIFIER LETTER SMALL HENG..MODIFIER LETTER SMALL U WITH LEFT HOOK
+	{runeRange{0xAB69, 0xAB69}, wbprALetter},                // Lm       MODIFIER LETTER SMALL TURNED W
+	{runeRange{0xABC0, 0xABE2}, wbprALetter},                // Lo  [35] MEETEI MAYEK LETTER KOK..MEETEI MAYEK LETTER I LONSUM
+	{runeRange{0xABE5, 0xABE5}, wbprExtend},                 // Mn       MEETEI MAYEK VOWEL SIGN ANAP
+	{runeRange{0xABE8, 0xABE8}, wbprExtend},                 // Mn       MEETEI MAYEK VOWEL SIGN UNAP
+	{runeRange{0xABEC, 0xABEC}, wbprExtend},                 // Mc       MEETEI MAYEK LUM IYEK
+	{runeRange{0xABF0, 0xABF9}, wbprNumeric},                // Nd  [10] MEETEI MAYEK DIGIT ZERO..MEETEI MAYEK DIGIT NINE
+	{runeRange{0xD7B0, 0xD7C6}, wbprALetter},                // Lo  [23] HANGUL JUNGSEONG O-YEO..HANGUL JUNGSEONG ARAEA-E
+	{runeRange{0xFB00, 0xFB06}, wbprALetter},                // L&   [7] LATIN SMALL LIGATURE FF..LATIN SMALL LIGATURE ST
+	{runeRange{0xFB1D, 0xFB1D}, wbprHebrewLetter},           // Lo       HEBREW LETTER YOD WITH HIRIQ
+	{runeRange{0xFB1F, 0xFB28}, wbprHebrewLetter},           // Lo  [10] HEBREW LIGATURE YIDDISH YOD YOD PATAH..HEBREW LETTER WIDE TAV
+	{runeRange{0xFB38, 0xFB3C}, wbprHebrewLetter},           // Lo   [5] HEBREW LETTER TET WITH DAGESH..HEBREW LETTER LAMED WITH DAGESH
+	{runeRange{0xFB40, 0xFB41}, wbprHebrewLetter},           // Lo   [2] HEBREW LETTER NUN WITH DAGESH..HEBREW LETTER SAMEKH WITH DAGESH
+	{runeRange{0xFB46, 0xFB4F}, wbprHebrewLetter},           // Lo  [10] HEBREW LETTER TSADI WITH DAGESH..HEBREW LIGATURE ALEF LAMED
+	{runeRange{0xFBD3, 0xFD3D}, wbprALetter},                // Lo [363] ARABIC LETTER NG ISOLATED FORM..ARABIC LIGATURE ALEF WITH FATHATAN ISOLATED FORM
+	{runeRange{0xFD92, 0xFDC7}, wbprALetter},                // Lo  [54] ARABIC LIGATURE MEEM WITH JEEM WITH KHAH INITIAL FORM..ARABIC LIGATURE NOON WITH JEEM WITH YEH FINAL FORM
+	{runeRange{0xFE00, 0xFE0F}, wbprExtend},                 // Mn  [16] VARIATION SELECTOR-1..VARIATION SELECTOR-16
+	{runeRange{0xFE13, 0xFE13}, wbprMidLetter},              // Po       PRESENTATION FORM FOR VERTICAL COLON
+	{runeRange{0xFE20, 0xFE2F}, wbprExtend},                 // Mn  [16] COMBINING LIGATURE LEFT HALF..COMBINING CYRILLIC TITLO RIGHT HALF
+	{runeRange{0xFE4D, 0xFE4F}, wbprExtendNumLet},           // Pc   [3] DASHED LOW LINE..WAVY LOW LINE
+	{runeRange{0xFE52, 0xFE52}, wbprMidNumLet},              // Po       SMALL FULL STOP
+	{runeRange{0xFE55, 0xFE55}, wbprMidLetter},              // Po       SMALL COLON
+	{runeRange{0xFE76, 0xFEFC}, wbprALetter},                // Lo [135] ARABIC FATHA ISOLATED FORM..ARABIC LIGATURE LAM WITH ALEF FINAL FORM
+	{runeRange{0xFF07, 0xFF07}, wbprMidNumLet},              // Po       FULLWIDTH APOSTROPHE
+	{runeRange{0xFF0E, 0xFF0E}, wbprMidNumLet},              // Po       FULLWIDTH FULL STOP
+	{runeRange{0xFF1A, 0xFF1A}, wbprMidLetter},              // Po       FULLWIDTH COLON
+	{runeRange{0xFF21, 0xFF3A}, wbprALetter},                // L&  [26] FULLWIDTH LATIN CAPITAL LETTER A..FULLWIDTH LATIN CAPITAL LETTER Z
+	{runeRange{0xFF41, 0xFF5A}, wbprALetter},                // L&  [26] FULLWIDTH LATIN SMALL LETTER A..FULLWIDTH LATIN SMALL LETTER Z
+	{runeRange{0xFF70, 0xFF70}, wbprKatakana},               // Lm       HALFWIDTH KATAKANA-HIRAGANA PROLONGED SOUND MARK
+	{runeRange{0xFF9E, 0xFF9F}, wbprExtend},                 // Lm   [2] HALFWIDTH KATAKANA VOICED SOUND MARK..HALFWIDTH KATAKANA SEMI-VOICED SOUND MARK
+	{runeRange{0xFFC2, 0xFFC7}, wbprALetter},                // Lo   [6] HALFWIDTH HANGUL LETTER A..HALFWIDTH HANGUL LETTER E
+	{runeRange{0xFFD2, 0xFFD7}, wbprALetter},                // Lo   [6] HALFWIDTH HANGUL LETTER YO..HALFWIDTH HANGUL LETTER YU
+	{runeRange{0xFFF9, 0xFFFB}, wbprFormat},                 // Cf   [3] INTERLINEAR ANNOTATION ANCHOR..INTERLINEAR ANNOTATION TERMINATOR
+	{runeRange{0x1000D, 0x10026}, wbprALetter},              // Lo  [26] LINEAR B SYLLABLE B036 JO..LINEAR B SYLLABLE B032 QO
+	{runeRange{0x1003C, 0x1003D}, wbprALetter},              // Lo   [2] LINEAR B SYLLABLE B017 ZA..LINEAR B SYLLABLE B074 ZE
+	{runeRange{0x10050, 0x1005D}, wbprALetter},              // Lo  [14] LINEAR B SYMBOL B018..LINEAR B SYMBOL B089
+	{runeRange{0x10140, 0x10174}, wbprALetter},              // Nl  [53] GREEK ACROPHONIC ATTIC ONE QUARTER..GREEK ACROPHONIC STRATIAN FIFTY MNAS
+	{runeRange{0x10280, 0x1029C}, wbprALetter},              // Lo  [29] LYCIAN LETTER A..LYCIAN LETTER X
+	{runeRange{0x102E0, 0x102E0}, wbprExtend},               // Mn       COPTIC EPACT THOUSANDS MARK
+	{runeRange{0x1032D, 0x10340}, wbprALetter},              // Lo  [20] OLD ITALIC LETTER YE..GOTHIC LETTER PAIRTHRA
+	{runeRange{0x10342, 0x10349}, wbprALetter},              // Lo   [8] GOTHIC LETTER RAIDA..GOTHIC LETTER OTHAL
+	{runeRange{0x10350, 0x10375}, wbprALetter},              // Lo  [38] OLD PERMIC LETTER AN..OLD PERMIC LETTER IA
+	{runeRange{0x10380, 0x1039D}, wbprALetter},              // Lo  [30] UGARITIC LETTER ALPA..UGARITIC LETTER SSU
+	{runeRange{0x103C8, 0x103CF}, wbprALetter},              // Lo   [8] OLD PERSIAN SIGN AURAMAZDAA..OLD PERSIAN SIGN BUUMISH
+	{runeRange{0x10400, 0x1044F}, wbprALetter},              // L&  [80] DESERET CAPITAL LETTER LONG I..DESERET SMALL LETTER EW
+	{runeRange{0x104A0, 0x104A9}, wbprNumeric},              // Nd  [10] OSMANYA DIGIT ZERO..OSMANYA DIGIT NINE
+	{runeRange{0x104D8, 0x104FB}, wbprALetter},              // L&  [36] OSAGE SMALL LETTER A..OSAGE SMALL LETTER ZHA
+	{runeRange{0x10530, 0x10563}, wbprALetter},              // Lo  [52] CAUCASIAN ALBANIAN LETTER ALT..CAUCASIAN ALBANIAN LETTER KIW
+	{runeRange{0x1057C, 0x1058A}, wbprALetter},              // L&  [15] VITHKUQI CAPITAL LETTER HA..VITHKUQI CAPITAL LETTER RE
+	{runeRange{0x10594, 0x10595}, wbprALetter},              // L&   [2] VITHKUQI CAPITAL LETTER Y..VITHKUQI CAPITAL LETTER ZE
+	{runeRange{0x105A3, 0x105B1}, wbprALetter},              // L&  [15] VITHKUQI SMALL LETTER HA..VITHKUQI SMALL LETTER RE
+	{runeRange{0x105BB, 0x105BC}, wbprALetter},              // L&   [2] VITHKUQI SMALL LETTER Y..VITHKUQI SMALL LETTER ZE
+	{runeRange{0x10740, 0x10755}, wbprALetter},              // Lo  [22] LINEAR A SIGN A701 A..LINEAR A SIGN A732 JE
+	{runeRange{0x10780, 0x10785}, wbprALetter},              // Lm   [6] MODIFIER LETTER SMALL CAPITAL AA..MODIFIER LETTER SMALL B WITH HOOK
+	{runeRange{0x107B2, 0x107BA}, wbprALetter},              // Lm   [9] MODIFIER LETTER SMALL CAPITAL Y..MODIFIER LETTER SMALL S WITH CURL
+	{runeRange{0x10808, 0x10808}, wbprALetter},              // Lo       CYPRIOT SYLLABLE JO
+	{runeRange{0x10837, 0x10838}, wbprALetter},              // Lo   [2] CYPRIOT SYLLABLE XA..CYPRIOT SYLLABLE XE
+	{runeRange{0x1083F, 0x10855}, wbprALetter},              // Lo  [23] CYPRIOT SYLLABLE ZO..IMPERIAL ARAMAIC LETTER TAW
+	{runeRange{0x10880, 0x1089E}, wbprALetter},              // Lo  [31] NABATAEAN LETTER FINAL ALEPH..NABATAEAN LETTER TAW
+	{runeRange{0x108F4, 0x108F5}, wbprALetter},              // Lo   [2] HATRAN LETTER SHIN..HATRAN LETTER TAW
+	{runeRange{0x10920, 0x10939}, wbprALetter},              // Lo  [26] LYDIAN LETTER A..LYDIAN LETTER C
+	{runeRange{0x109BE, 0x109BF}, wbprALetter},              // Lo   [2] MEROITIC CURSIVE LOGOGRAM RMT..MEROITIC CURSIVE LOGOGRAM IMN
+	{runeRange{0x10A01, 0x10A03}, wbprExtend},               // Mn   [3] KHAROSHTHI VOWEL SIGN I..KHAROSHTHI VOWEL SIGN VOCALIC R
+	{runeRange{0x10A0C, 0x10A0F}, wbprExtend},               // Mn   [4] KHAROSHTHI VOWEL LENGTH MARK..KHAROSHTHI SIGN VISARGA
+	{runeRange{0x10A15, 0x10A17}, wbprALetter},              // Lo   [3] KHAROSHTHI LETTER CA..KHAROSHTHI LETTER JA
+	{runeRange{0x10A38, 0x10A3A}, wbprExtend},               // Mn   [3] KHAROSHTHI SIGN BAR ABOVE..KHAROSHTHI SIGN DOT BELOW
+	{runeRange{0x10A60, 0x10A7C}, wbprALetter},              // Lo  [29] OLD SOUTH ARABIAN LETTER HE..OLD SOUTH ARABIAN LETTER THETH
+	{runeRange{0x10AC0, 0x10AC7}, wbprALetter},              // Lo   [8] MANICHAEAN LETTER ALEPH..MANICHAEAN LETTER WAW
+	{runeRange{0x10AE5, 0x10AE6}, wbprExtend},               // Mn   [2] MANICHAEAN ABBREVIATION MARK ABOVE..MANICHAEAN ABBREVIATION MARK BELOW
+	{runeRange{0x10B40, 0x10B55}, wbprALetter},              // Lo  [22] INSCRIPTIONAL PARTHIAN LETTER ALEPH..INSCRIPTIONAL PARTHIAN LETTER TAW
+	{runeRange{0x10B80, 0x10B91}, wbprALetter},              // Lo  [18] PSALTER PAHLAVI LETTER ALEPH..PSALTER PAHLAVI LETTER TAW
+	{runeRange{0x10C80, 0x10CB2}, wbprALetter},              // L&  [51] OLD HUNGARIAN CAPITAL LETTER A..OLD HUNGARIAN CAPITAL LETTER US
+	{runeRange{0x10D00, 0x10D23}, wbprALetter},              // Lo  [36] HANIFI ROHINGYA LETTER A..HANIFI ROHINGYA MARK NA KHONNA
+	{runeRange{0x10D30, 0x10D39}, wbprNumeric},              // Nd  [10] HANIFI ROHINGYA DIGIT ZERO..HANIFI ROHINGYA DIGIT NINE
+	{runeRange{0x10EAB, 0x10EAC}, wbprExtend},               // Mn   [2] YEZIDI COMBINING HAMZA MARK..YEZIDI COMBINING MADDA MARK
+	{runeRange{0x10EFD, 0x10EFF}, wbprExtend},               // Mn   [3] ARABIC SMALL LOW WORD SAKTA..ARABIC SMALL LOW WORD MADDA
+	{runeRange{0x10F27, 0x10F27}, wbprALetter},              // Lo       OLD SOGDIAN LIGATURE AYIN-DALETH
+	{runeRange{0x10F46, 0x10F50}, wbprExtend},               // Mn  [11] SOGDIAN COMBINING DOT BELOW..SOGDIAN COMBINING STROKE BELOW
+	{runeRange{0x10F82, 0x10F85}, wbprExtend},               // Mn   [4] OLD UYGHUR COMBINING DOT ABOVE..OLD UYGHUR COMBINING TWO DOTS BELOW
+	{runeRange{0x10FE0, 0x10FF6}, wbprALetter},              // Lo  [23] ELYMAIC LETTER ALEPH..ELYMAIC LIGATURE ZAYIN-YODH
+	{runeRange{0x11001, 0x11001}, wbprExtend},               // Mn       BRAHMI SIGN ANUSVARA
+	{runeRange{0x11003, 0x11037}, wbprALetter},              // Lo  [53] BRAHMI SIGN JIHVAMULIYA..BRAHMI LETTER OLD TAMIL NNNA
+	{runeRange{0x11066, 0x1106F}, wbprNumeric},              // Nd  [10] BRAHMI DIGIT ZERO..BRAHMI DIGIT NINE
+	{runeRange{0x11071, 0x11072}, wbprALetter},              // Lo   [2] BRAHMI LETTER OLD TAMIL SHORT E..BRAHMI LETTER OLD TAMIL SHORT O
+	{runeRange{0x11075, 0x11075}, wbprALetter},              // Lo       BRAHMI LETTER OLD TAMIL LLA
+	{runeRange{0x11082, 0x11082}, wbprExtend},               // Mc       KAITHI SIGN VISARGA
+	{runeRange{0x110B0, 0x110B2}, wbprExtend},               // Mc   [3] KAITHI VOWEL SIGN AA..KAITHI VOWEL SIGN II
+	{runeRange{0x110B7, 0x110B8}, wbprExtend},               // Mc   [2] KAITHI VOWEL SIGN O..KAITHI VOWEL SIGN AU
+	{runeRange{0x110BD, 0x110BD}, wbprFormat},               // Cf       KAITHI NUMBER SIGN
+	{runeRange{0x110CD, 0x110CD}, wbprFormat},               // Cf       KAITHI NUMBER SIGN ABOVE
+	{runeRange{0x110F0, 0x110F9}, wbprNumeric},              // Nd  [10] SORA SOMPENG DIGIT ZERO..SORA SOMPENG DIGIT NINE
+	{runeRange{0x11103, 0x11126}, wbprALetter},              // Lo  [36] CHAKMA LETTER AA..CHAKMA LETTER HAA
+	{runeRange{0x1112C, 0x1112C}, wbprExtend},               // Mc       CHAKMA VOWEL SIGN E
+	{runeRange{0x11136, 0x1113F}, wbprNumeric},              // Nd  [10] CHAKMA DIGIT ZERO..CHAKMA DIGIT NINE
+	{runeRange{0x11145, 0x11146}, wbprExtend},               // Mc   [2] CHAKMA VOWEL SIGN AA..CHAKMA VOWEL SIGN EI
+	{runeRange{0x11150, 0x11172}, wbprALetter},              // Lo  [35] MAHAJANI LETTER A..MAHAJANI LETTER RRA
+	{runeRange{0x11176, 0x11176}, wbprALetter},              // Lo       MAHAJANI LIGATURE SHRI
+	{runeRange{0x11182, 0x11182}, wbprExtend},               // Mc       SHARADA SIGN VISARGA
+	{runeRange{0x111B3, 0x111B5}, wbprExtend},               // Mc   [3] SHARADA VOWEL SIGN AA..SHARADA VOWEL SIGN II
+	{runeRange{0x111BF, 0x111C0}, wbprExtend},               // Mc   [2] SHARADA VOWEL SIGN AU..SHARADA SIGN VIRAMA
+	{runeRange{0x111C9, 0x111CC}, wbprExtend},               // Mn   [4] SHARADA SANDHI MARK..SHARADA EXTRA SHORT VOWEL MARK
+	{runeRange{0x111CF, 0x111CF}, wbprExtend},               // Mn       SHARADA SIGN INVERTED CANDRABINDU
+	{runeRange{0x111DA, 0x111DA}, wbprALetter},              // Lo       SHARADA EKAM
+	{runeRange{0x11200, 0x11211}, wbprALetter},              // Lo  [18] KHOJKI LETTER A..KHOJKI LETTER JJA
+	{runeRange{0x1122C, 0x1122E}, wbprExtend},               // Mc   [3] KHOJKI VOWEL SIGN AA..KHOJKI VOWEL SIGN II
+	{runeRange{0x11232, 0x11233}, wbprExtend},               // Mc   [2] KHOJKI VOWEL SIGN O..KHOJKI VOWEL SIGN AU
+	{runeRange{0x11235, 0x11235}, wbprExtend},               // Mc       KHOJKI SIGN VIRAMA
+	{runeRange{0x1123E, 0x1123E}, wbprExtend},               // Mn       KHOJKI SIGN SUKUN
+	{runeRange{0x11241, 0x11241}, wbprExtend},               // Mn       KHOJKI VOWEL SIGN VOCALIC R
+	{runeRange{0x11288, 0x11288}, wbprALetter},              // Lo       MULTANI LETTER GHA
+	{runeRange{0x1128F, 0x1129D}, wbprALetter},              // Lo  [15] MULTANI LETTER NYA..MULTANI LETTER BA
+	{runeRange{0x112B0, 0x112DE}, wbprALetter},              // Lo  [47] KHUDAWADI LETTER A..KHUDAWADI LETTER HA
+	{runeRange{0x112E0, 0x112E2}, wbprExtend},               // Mc   [3] KHUDAWADI VOWEL SIGN AA..KHUDAWADI VOWEL SIGN II
+	{runeRange{0x112F0, 0x112F9}, wbprNumeric},              // Nd  [10] KHUDAWADI DIGIT ZERO..KHUDAWADI DIGIT NINE
+	{runeRange{0x11302, 0x11303}, wbprExtend},               // Mc   [2] GRANTHA SIGN ANUSVARA..GRANTHA SIGN VISARGA
+	{runeRange{0x1130F, 0x11310}, wbprALetter},              // Lo   [2] GRANTHA LETTER EE..GRANTHA LETTER AI
+	{runeRange{0x1132A, 0x11330}, wbprALetter},              // Lo   [7] GRANTHA LETTER PA..GRANTHA LETTER RA
+	{runeRange{0x11335, 0x11339}, wbprALetter},              // Lo   [5] GRANTHA LETTER VA..GRANTHA LETTER HA
+	{runeRange{0x1133D, 0x1133D}, wbprALetter},              // Lo       GRANTHA SIGN AVAGRAHA
+	{runeRange{0x11340, 0x11340}, wbprExtend},               // Mn       GRANTHA VOWEL SIGN II
+	{runeRange{0x11347, 0x11348}, wbprExtend},               // Mc   [2] GRANTHA VOWEL SIGN EE..GRANTHA VOWEL SIGN AI
+	{runeRange{0x11350, 0x11350}, wbprALetter},              // Lo       GRANTHA OM
+	{runeRange{0x1135D, 0x11361}, wbprALetter},              // Lo   [5] GRANTHA SIGN PLUTA..GRANTHA LETTER VOCALIC LL
+	{runeRange{0x11366, 0x1136C}, wbprExtend},               // Mn   [7] COMBINING GRANTHA DIGIT ZERO..COMBINING GRANTHA DIGIT SIX
+	{runeRange{0x11400, 0x11434}, wbprALetter},              // Lo  [53] NEWA LETTER A..NEWA LETTER HA
+	{runeRange{0x11438, 0x1143F}, wbprExtend},               // Mn   [8] NEWA VOWEL SIGN U..NEWA VOWEL SIGN AI
+	{runeRange{0x11442, 0x11444}, wbprExtend},               // Mn   [3] NEWA SIGN VIRAMA..NEWA SIGN ANUSVARA
+	{runeRange{0x11446, 0x11446}, wbprExtend},               // Mn       NEWA SIGN NUKTA
+	{runeRange{0x11450, 0x11459}, wbprNumeric},              // Nd  [10] NEWA DIGIT ZERO..NEWA DIGIT NINE
+	{runeRange{0x1145F, 0x11461}, wbprALetter},              // Lo   [3] NEWA LETTER VEDIC ANUSVARA..NEWA SIGN UPADHMANIYA
+	{runeRange{0x114B0, 0x114B2}, wbprExtend},               // Mc   [3] TIRHUTA VOWEL SIGN AA..TIRHUTA VOWEL SIGN II
+	{runeRange{0x114B9, 0x114B9}, wbprExtend},               // Mc       TIRHUTA VOWEL SIGN E
+	{runeRange{0x114BB, 0x114BE}, wbprExtend},               // Mc   [4] TIRHUTA VOWEL SIGN AI..TIRHUTA VOWEL SIGN AU
+	{runeRange{0x114C1, 0x114C1}, wbprExtend},               // Mc       TIRHUTA SIGN VISARGA
+	{runeRange{0x114C4, 0x114C5}, wbprALetter},              // Lo   [2] TIRHUTA SIGN AVAGRAHA..TIRHUTA GVANG
+	{runeRange{0x114D0, 0x114D9}, wbprNumeric},              // Nd  [10] TIRHUTA DIGIT ZERO..TIRHUTA DIGIT NINE
+	{runeRange{0x115AF, 0x115B1}, wbprExtend},               // Mc   [3] SIDDHAM VOWEL SIGN AA..SIDDHAM VOWEL SIGN II
+	{runeRange{0x115B8, 0x115BB}, wbprExtend},               // Mc   [4] SIDDHAM VOWEL SIGN E..SIDDHAM VOWEL SIGN AU
+	{runeRange{0x115BE, 0x115BE}, wbprExtend},               // Mc       SIDDHAM SIGN VISARGA
+	{runeRange{0x115D8, 0x115DB}, wbprALetter},              // Lo   [4] SIDDHAM LETTER THREE-CIRCLE ALTERNATE I..SIDDHAM LETTER ALTERNATE U
+	{runeRange{0x11600, 0x1162F}, wbprALetter},              // Lo  [48] MODI LETTER A..MODI LETTER LLA
+	{runeRange{0x11633, 0x1163A}, wbprExtend},               // Mn   [8] MODI VOWEL SIGN U..MODI VOWEL SIGN AI
+	{runeRange{0x1163D, 0x1163D}, wbprExtend},               // Mn       MODI SIGN ANUSVARA
+	{runeRange{0x1163F, 0x11640}, wbprExtend},               // Mn   [2] MODI SIGN VIRAMA..MODI SIGN ARDHACANDRA
+	{runeRange{0x11650, 0x11659}, wbprNumeric},              // Nd  [10] MODI DIGIT ZERO..MODI DIGIT NINE
+	{runeRange{0x116AB, 0x116AB}, wbprExtend},               // Mn       TAKRI SIGN ANUSVARA
+	{runeRange{0x116AD, 0x116AD}, wbprExtend},               // Mn       TAKRI VOWEL SIGN AA
+	{runeRange{0x116B0, 0x116B5}, wbprExtend},               // Mn   [6] TAKRI VOWEL SIGN U..TAKRI VOWEL SIGN AU
+	{runeRange{0x116B7, 0x116B7}, wbprExtend},               // Mn       TAKRI SIGN NUKTA
+	{runeRange{0x116C0, 0x116C9}, wbprNumeric},              // Nd  [10] TAKRI DIGIT ZERO..TAKRI DIGIT NINE
+	{runeRange{0x11720, 0x11721}, wbprExtend},               // Mc   [2] AHOM VOWEL SIGN A..AHOM VOWEL SIGN AA
+	{runeRange{0x11726, 0x11726}, wbprExtend},               // Mc       AHOM VOWEL SIGN E
+	{runeRange{0x11730, 0x11739}, wbprNumeric},              // Nd  [10] AHOM DIGIT ZERO..AHOM DIGIT NINE
+	{runeRange{0x1182C, 0x1182E}, wbprExtend},               // Mc   [3] DOGRA VOWEL SIGN AA..DOGRA VOWEL SIGN II
+	{runeRange{0x11838, 0x11838}, wbprExtend},               // Mc       DOGRA SIGN VISARGA
+	{runeRange{0x118A0, 0x118DF}, wbprALetter},              // L&  [64] WARANG CITI CAPITAL LETTER NGAA..WARANG CITI SMALL LETTER VIYO
+	{runeRange{0x118FF, 0x11906}, wbprALetter},              // Lo   [8] WARANG CITI OM..DIVES AKURU LETTER E
+	{runeRange{0x1190C, 0x11913}, wbprALetter},              // Lo   [8] DIVES AKURU LETTER KA..DIVES AKURU LETTER JA
+	{runeRange{0x11918, 0x1192F}, wbprALetter},              // Lo  [24] DIVES AKURU LETTER DDA..DIVES AKURU LETTER ZA
+	{runeRange{0x11937, 0x11938}, wbprExtend},               // Mc   [2] DIVES AKURU VOWEL SIGN AI..DIVES AKURU VOWEL SIGN O
+	{runeRange{0x1193D, 0x1193D}, wbprExtend},               // Mc       DIVES AKURU SIGN HALANTA
+	{runeRange{0x1193F, 0x1193F}, wbprALetter},              // Lo       DIVES AKURU PREFIXED NASAL SIGN
+	{runeRange{0x11941, 0x11941}, wbprALetter},              // Lo       DIVES AKURU INITIAL RA
+	{runeRange{0x11943, 0x11943}, wbprExtend},               // Mn       DIVES AKURU SIGN NUKTA
+	{runeRange{0x119A0, 0x119A7}, wbprALetter},              // Lo   [8] NANDINAGARI LETTER A..NANDINAGARI LETTER VOCALIC RR
+	{runeRange{0x119D1, 0x119D3}, wbprExtend},               // Mc   [3] NANDINAGARI VOWEL SIGN AA..NANDINAGARI VOWEL SIGN II
+	{runeRange{0x119DA, 0x119DB}, wbprExtend},               // Mn   [2] NANDINAGARI VOWEL SIGN E..NANDINAGARI VOWEL SIGN AI
+	{runeRange{0x119E0, 0x119E0}, wbprExtend},               // Mn       NANDINAGARI SIGN VIRAMA
+	{runeRange{0x119E3, 0x119E3}, wbprALetter},              // Lo       NANDINAGARI HEADSTROKE
+	{runeRange{0x11A00, 0x11A00}, wbprALetter},              // Lo       ZANABAZAR SQUARE LETTER A
+	{runeRange{0x11A0B, 0x11A32}, wbprALetter},              // Lo  [40] ZANABAZAR SQUARE LETTER KA..ZANABAZAR SQUARE LETTER KSSA
+	{runeRange{0x11A39, 0x11A39}, wbprExtend},               // Mc       ZANABAZAR SQUARE SIGN VISARGA
+	{runeRange{0x11A3B, 0x11A3E}, wbprExtend},               // Mn   [4] ZANABAZAR SQUARE CLUSTER-FINAL LETTER YA..ZANABAZAR SQUARE CLUSTER-FINAL LETTER VA
+	{runeRange{0x11A50, 0x11A50}, wbprALetter},              // Lo       SOYOMBO LETTER A
+	{runeRange{0x11A57, 0x11A58}, wbprExtend},               // Mc   [2] SOYOMBO VOWEL SIGN AI..SOYOMBO VOWEL SIGN AU
+	{runeRange{0x11A5C, 0x11A89}, wbprALetter},              // Lo  [46] SOYOMBO LETTER KA..SOYOMBO CLUSTER-INITIAL LETTER SA
+	{runeRange{0x11A97, 0x11A97}, wbprExtend},               // Mc       SOYOMBO SIGN VISARGA
+	{runeRange{0x11A9D, 0x11A9D}, wbprALetter},              // Lo       SOYOMBO MARK PLUTA
+	{runeRange{0x11C00, 0x11C08}, wbprALetter},              // Lo   [9] BHAIKSUKI LETTER A..BHAIKSUKI LETTER VOCALIC L
+	{runeRange{0x11C2F, 0x11C2F}, wbprExtend},               // Mc       BHAIKSUKI VOWEL SIGN AA
+	{runeRange{0x11C38, 0x11C3D}, wbprExtend},               // Mn   [6] BHAIKSUKI VOWEL SIGN E..BHAIKSUKI SIGN ANUSVARA
+	{runeRange{0x11C3F, 0x11C3F}, wbprExtend},               // Mn       BHAIKSUKI SIGN VIRAMA
+	{runeRange{0x11C50, 0x11C59}, wbprNumeric},              // Nd  [10] BHAIKSUKI DIGIT ZERO..BHAIKSUKI DIGIT NINE
+	{runeRange{0x11C92, 0x11CA7}, wbprExtend},               // Mn  [22] MARCHEN SUBJOINED LETTER KA..MARCHEN SUBJOINED LETTER ZA
+	{runeRange{0x11CAA, 0x11CB0}, wbprExtend},               // Mn   [7] MARCHEN SUBJOINED LETTER RA..MARCHEN VOWEL SIGN AA
+	{runeRange{0x11CB2, 0x11CB3}, wbprExtend},               // Mn   [2] MARCHEN VOWEL SIGN U..MARCHEN VOWEL SIGN E
+	{runeRange{0x11CB5, 0x11CB6}, wbprExtend},               // Mn   [2] MARCHEN SIGN ANUSVARA..MARCHEN SIGN CANDRABINDU
+	{runeRange{0x11D08, 0x11D09}, wbprALetter},              // Lo   [2] MASARAM GONDI LETTER AI..MASARAM GONDI LETTER O
+	{runeRange{0x11D31, 0x11D36}, wbprExtend},               // Mn   [6] MASARAM GONDI VOWEL SIGN AA..MASARAM GONDI VOWEL SIGN VOCALIC R
+	{runeRange{0x11D3C, 0x11D3D}, wbprExtend},               // Mn   [2] MASARAM GONDI VOWEL SIGN AI..MASARAM GONDI VOWEL SIGN O
+	{runeRange{0x11D46, 0x11D46}, wbprALetter},              // Lo       MASARAM GONDI REPHA
+	{runeRange{0x11D50, 0x11D59}, wbprNumeric},              // Nd  [10] MASARAM GONDI DIGIT ZERO..MASARAM GONDI DIGIT NINE
+	{runeRange{0x11D67, 0x11D68}, wbprALetter},              // Lo   [2] GUNJALA GONDI LETTER EE..GUNJALA GONDI LETTER AI
+	{runeRange{0x11D8A, 0x11D8E}, wbprExtend},               // Mc   [5] GUNJALA GONDI VOWEL SIGN AA..GUNJALA GONDI VOWEL SIGN UU
+	{runeRange{0x11D93, 0x11D94}, wbprExtend},               // Mc   [2] GUNJALA GONDI VOWEL SIGN OO..GUNJALA GONDI VOWEL SIGN AU
+	{runeRange{0x11D96, 0x11D96}, wbprExtend},               // Mc       GUNJALA GONDI SIGN VISARGA
+	{runeRange{0x11D98, 0x11D98}, wbprALetter},              // Lo       GUNJALA GONDI OM
+	{runeRange{0x11EE0, 0x11EF2}, wbprALetter},              // Lo  [19] MAKASAR LETTER KA..MAKASAR ANGKA
+	{runeRange{0x11EF5, 0x11EF6}, wbprExtend},               // Mc   [2] MAKASAR VOWEL SIGN E..MAKASAR VOWEL SIGN O
+	{runeRange{0x11F02, 0x11F02}, wbprALetter},              // Lo       KAWI SIGN REPHA
+	{runeRange{0x11F04, 0x11F10}, wbprALetter},              // Lo  [13] KAWI LETTER A..KAWI LETTER O
+	{runeRange{0x11F34, 0x11F35}, wbprExtend},               // Mc   [2] KAWI VOWEL SIGN AA..KAWI VOWEL SIGN ALTERNATE AA
+	{runeRange{0x11F3E, 0x11F3F}, wbprExtend},               // Mc   [2] KAWI VOWEL SIGN E..KAWI VOWEL SIGN AI
+	{runeRange{0x11F41, 0x11F41}, wbprExtend},               // Mc       KAWI SIGN KILLER
+	{runeRange{0x11F50, 0x11F59}, wbprNumeric},              // Nd  [10] KAWI DIGIT ZERO..KAWI DIGIT NINE
+	{runeRange{0x12000, 0x12399}, wbprALetter},              // Lo [922] CUNEIFORM SIGN A..CUNEIFORM SIGN U U
+	{runeRange{0x12480, 0x12543}, wbprALetter},              // Lo [196] CUNEIFORM SIGN AB TIMES NUN TENU..CUNEIFORM SIGN ZU5 TIMES THREE DISH TENU
+	{runeRange{0x13000, 0x1342F}, wbprALetter},              // Lo [1072] EGYPTIAN HIEROGLYPH A001..EGYPTIAN HIEROGLYPH V011D
+	{runeRange{0x13440, 0x13440}, wbprExtend},               // Mn       EGYPTIAN HIEROGLYPH MIRROR HORIZONTALLY
+	{runeRange{0x13447, 0x13455}, wbprExtend},               // Mn  [15] EGYPTIAN HIEROGLYPH MODIFIER DAMAGED AT TOP START..EGYPTIAN HIEROGLYPH MODIFIER DAMAGED
+	{runeRange{0x16800, 0x16A38}, wbprALetter},              // Lo [569] BAMUM LETTER PHASE-A NGKUE MFON..BAMUM LETTER PHASE-F VUEQ
+	{runeRange{0x16A60, 0x16A69}, wbprNumeric},              // Nd  [10] MRO DIGIT ZERO..MRO DIGIT NINE
+	{runeRange{0x16AC0, 0x16AC9}, wbprNumeric},              // Nd  [10] TANGSA DIGIT ZERO..TANGSA DIGIT NINE
+	{runeRange{0x16AF0, 0x16AF4}, wbprExtend},               // Mn   [5] BASSA VAH COMBINING HIGH TONE..BASSA VAH COMBINING HIGH-LOW TONE
+	{runeRange{0x16B30, 0x16B36}, wbprExtend},               // Mn   [7] PAHAWH HMONG MARK CIM TUB..PAHAWH HMONG MARK CIM TAUM
+	{runeRange{0x16B50, 0x16B59}, wbprNumeric},              // Nd  [10] PAHAWH HMONG DIGIT ZERO..PAHAWH HMONG DIGIT NINE
+	{runeRange{0x16B7D, 0x16B8F}, wbprALetter},              // Lo  [19] PAHAWH HMONG CLAN SIGN TSHEEJ..PAHAWH HMONG CLAN SIGN VWJ
+	{runeRange{0x16F00, 0x16F4A}, wbprALetter},              // Lo  [75] MIAO LETTER PA..MIAO LETTER RTE
+	{runeRange{0x16F50, 0x16F50}, wbprALetter},              // Lo       MIAO LETTER NASALIZATION
+	{runeRange{0x16F8F, 0x16F92}, wbprExtend},               // Mn   [4] MIAO TONE RIGHT..MIAO TONE BELOW
+	{runeRange{0x16FE0, 0x16FE1}, wbprALetter},              // Lm   [2] TANGUT ITERATION MARK..NUSHU ITERATION MARK
+	{runeRange{0x16FE4, 0x16FE4}, wbprExtend},               // Mn       KHITAN SMALL SCRIPT FILLER
+	{runeRange{0x1AFF0, 0x1AFF3}, wbprKatakana},             // Lm   [4] KATAKANA LETTER MINNAN TONE-2..KATAKANA LETTER MINNAN TONE-5
+	{runeRange{0x1AFFD, 0x1AFFE}, wbprKatakana},             // Lm   [2] KATAKANA LETTER MINNAN NASALIZED TONE-7..KATAKANA LETTER MINNAN NASALIZED TONE-8
+	{runeRange{0x1B120, 0x1B122}, wbprKatakana},             // Lo   [3] KATAKANA LETTER ARCHAIC YI..KATAKANA LETTER ARCHAIC WU
+	{runeRange{0x1B164, 0x1B167}, wbprKatakana},             // Lo   [4] KATAKANA LETTER SMALL WI..KATAKANA LETTER SMALL N
+	{runeRange{0x1BC70, 0x1BC7C}, wbprALetter},              // Lo  [13] DUPLOYAN AFFIX LEFT HORIZONTAL SECANT..DUPLOYAN AFFIX ATTACHED TANGENT HOOK
+	{runeRange{0x1BC90, 0x1BC99}, wbprALetter},              // Lo  [10] DUPLOYAN AFFIX LOW ACUTE..DUPLOYAN AFFIX LOW ARROW
+	{runeRange{0x1BCA0, 0x1BCA3}, wbprFormat},               // Cf   [4] SHORTHAND FORMAT LETTER OVERLAP..SHORTHAND FORMAT UP STEP
+	{runeRange{0x1CF30, 0x1CF46}, wbprExtend},               // Mn  [23] ZNAMENNY COMBINING TONAL RANGE MARK MRACHNO..ZNAMENNY PRIZNAK MODIFIER ROG
+	{runeRange{0x1D167, 0x1D169}, wbprExtend},               // Mn   [3] MUSICAL SYMBOL COMBINING TREMOLO-1..MUSICAL SYMBOL COMBINING TREMOLO-3
+	{runeRange{0x1D173, 0x1D17A}, wbprFormat},               // Cf   [8] MUSICAL SYMBOL BEGIN BEAM..MUSICAL SYMBOL END PHRASE
+	{runeRange{0x1D185, 0x1D18B}, wbprExtend},               // Mn   [7] MUSICAL SYMBOL COMBINING DOIT..MUSICAL SYMBOL COMBINING TRIPLE TONGUE
+	{runeRange{0x1D242, 0x1D244}, wbprExtend},               // Mn   [3] COMBINING GREEK MUSICAL TRISEME..COMBINING GREEK MUSICAL PENTASEME
+	{runeRange{0x1D456, 0x1D49C}, wbprALetter},              // L&  [71] MATHEMATICAL ITALIC SMALL I..MATHEMATICAL SCRIPT CAPITAL A
+	{runeRange{0x1D4A2, 0x1D4A2}, wbprALetter},              // L&       MATHEMATICAL SCRIPT CAPITAL G
+	{runeRange{0x1D4A9, 0x1D4AC}, wbprALetter},              // L&   [4] MATHEMATICAL SCRIPT CAPITAL N..MATHEMATICAL SCRIPT CAPITAL Q
+	{runeRange{0x1D4BB, 0x1D4BB}, wbprALetter},              // L&       MATHEMATICAL SCRIPT SMALL F
+	{runeRange{0x1D4C5, 0x1D505}, wbprALetter},              // L&  [65] MATHEMATICAL SCRIPT SMALL P..MATHEMATICAL FRAKTUR CAPITAL B
+	{runeRange{0x1D50D, 0x1D514}, wbprALetter},              // L&   [8] MATHEMATICAL FRAKTUR CAPITAL J..MATHEMATICAL FRAKTUR CAPITAL Q
+	{runeRange{0x1D51E, 0x1D539}, wbprALetter},              // L&  [28] MATHEMATICAL FRAKTUR SMALL A..MATHEMATICAL DOUBLE-STRUCK CAPITAL B
+	{runeRange{0x1D540, 0x1D544}, wbprALetter},              // L&   [5] MATHEMATICAL DOUBLE-STRUCK CAPITAL I..MATHEMATICAL DOUBLE-STRUCK CAPITAL M
+	{runeRange{0x1D54A, 0x1D550}, wbprALetter},              // L&   [7] MATHEMATICAL DOUBLE-STRUCK CAPITAL S..MATHEMATICAL DOUBLE-STRUCK CAPITAL Y
+	{runeRange{0x1D6A8, 0x1D6C0}, wbprALetter},              // L&  [25] MATHEMATICAL BOLD CAPITAL ALPHA..MATHEMATICAL BOLD CAPITAL OMEGA
+	{runeRange{0x1D6DC, 0x1D6FA}, wbprALetter},              // L&  [31] MATHEMATICAL BOLD EPSILON SYMBOL..MATHEMATICAL ITALIC CAPITAL OMEGA
+	{runeRange{0x1D716, 0x1D734}, wbprALetter},              // L&  [31] MATHEMATICAL ITALIC EPSILON SYMBOL..MATHEMATICAL BOLD ITALIC CAPITAL OMEGA
+	{runeRange{0x1D750, 0x1D76E}, wbprALetter},              // L&  [31] MATHEMATICAL BOLD ITALIC EPSILON SYMBOL..MATHEMATICAL SANS-SERIF BOLD CAPITAL OMEGA
+	{runeRange{0x1D78A, 0x1D7A8}, wbprALetter},              // L&  [31] MATHEMATICAL SANS-SERIF BOLD EPSILON SYMBOL..MATHEMATICAL SANS-SERIF BOLD ITALIC CAPITAL OMEGA
+	{runeRange{0x1D7C4, 0x1D7CB}, wbprALetter},              // L&   [8] MATHEMATICAL SANS-SERIF BOLD ITALIC EPSILON SYMBOL..MATHEMATICAL BOLD SMALL DIGAMMA
+	{runeRange{0x1DA00, 0x1DA36}, wbprExtend},               // Mn  [55] SIGNWRITING HEAD RIM..SIGNWRITING AIR SUCKING IN
+	{runeRange{0x1DA75, 0x1DA75}, wbprExtend},               // Mn       SIGNWRITING UPPER BODY TILTING FROM HIP JOINTS
+	{runeRange{0x1DA9B, 0x1DA9F}, wbprExtend},               // Mn   [5] SIGNWRITING FILL MODIFIER-2..SIGNWRITING FILL MODIFIER-6
+	{runeRange{0x1DF00, 0x1DF09}, wbprALetter},              // L&  [10] LATIN SMALL LETTER FENG DIGRAPH WITH TRILL..LATIN SMALL LETTER T WITH HOOK AND RETROFLEX HOOK
+	{runeRange{0x1DF0B, 0x1DF1E}, wbprALetter},              // L&  [20] LATIN SMALL LETTER ESH WITH DOUBLE BAR..LATIN SMALL LETTER S WITH CURL
+	{runeRange{0x1E000, 0x1E006}, wbprExtend},               // Mn   [7] COMBINING GLAGOLITIC LETTER AZU..COMBINING GLAGOLITIC LETTER ZHIVETE
+	{runeRange{0x1E01B, 0x1E021}, wbprExtend},               // Mn   [7] COMBINING GLAGOLITIC LETTER SHTA..COMBINING GLAGOLITIC LETTER YATI
+	{runeRange{0x1E026, 0x1E02A}, wbprExtend},               // Mn   [5] COMBINING GLAGOLITIC LETTER YO..COMBINING GLAGOLITIC LETTER FITA
+	{runeRange{0x1E08F, 0x1E08F}, wbprExtend},               // Mn       COMBINING CYRILLIC SMALL LETTER BYELORUSSIAN-UKRAINIAN I
+	{runeRange{0x1E130, 0x1E136}, wbprExtend},               // Mn   [7] NYIAKENG PUACHUE HMONG TONE-B..NYIAKENG PUACHUE HMONG TONE-D
+	{runeRange{0x1E140, 0x1E149}, wbprNumeric},              // Nd  [10] NYIAKENG PUACHUE HMONG DIGIT ZERO..NYIAKENG PUACHUE HMONG DIGIT NINE
+	{runeRange{0x1E290, 0x1E2AD}, wbprALetter},              // Lo  [30] TOTO LETTER PA..TOTO LETTER A
+	{runeRange{0x1E2C0, 0x1E2EB}, wbprALetter},              // Lo  [44] WANCHO LETTER AA..WANCHO LETTER YIH
+	{runeRange{0x1E2F0, 0x1E2F9}, wbprNumeric},              // Nd  [10] WANCHO DIGIT ZERO..WANCHO DIGIT NINE
+	{runeRange{0x1E4EB, 0x1E4EB}, wbprALetter},              // Lm       NAG MUNDARI SIGN OJOD
+	{runeRange{0x1E4F0, 0x1E4F9}, wbprNumeric},              // Nd  [10] NAG MUNDARI DIGIT ZERO..NAG MUNDARI DIGIT NINE
+	{runeRange{0x1E7E8, 0x1E7EB}, wbprALetter},              // Lo   [4] ETHIOPIC SYLLABLE GURAGE HHWA..ETHIOPIC SYLLABLE HHWE
+	{runeRange{0x1E7F0, 0x1E7FE}, wbprALetter},              // Lo  [15] ETHIOPIC SYLLABLE GURAGE QWI..ETHIOPIC SYLLABLE GURAGE PWEE
+	{runeRange{0x1E8D0, 0x1E8D6}, wbprExtend},               // Mn   [7] MENDE KIKAKUI COMBINING NUMBER TEENS..MENDE KIKAKUI COMBINING NUMBER MILLIONS
+	{runeRange{0x1E944, 0x1E94A}, wbprExtend},               // Mn   [7] ADLAM ALIF LENGTHENER..ADLAM NUKTA
+	{runeRange{0x1E950, 0x1E959}, wbprNumeric},              // Nd  [10] ADLAM DIGIT ZERO..ADLAM DIGIT NINE
+	{runeRange{0x1EE05, 0x1EE1F}, wbprALetter},              // Lo  [27] ARABIC MATHEMATICAL WAW..ARABIC MATHEMATICAL DOTLESS QAF
+	{runeRange{0x1EE24, 0x1EE24}, wbprALetter},              // Lo       ARABIC MATHEMATICAL INITIAL HEH
+	{runeRange{0x1EE29, 0x1EE32}, wbprALetter},              // Lo  [10] ARABIC MATHEMATICAL INITIAL YEH..ARABIC MATHEMATICAL INITIAL QAF
+	{runeRange{0x1EE39, 0x1EE39}, wbprALetter},              // Lo       ARABIC MATHEMATICAL INITIAL DAD
+	{runeRange{0x1EE42, 0x1EE42}, wbprALetter},              // Lo       ARABIC MATHEMATICAL TAILED JEEM
+	{runeRange{0x1EE49, 0x1EE49}, wbprALetter},              // Lo       ARABIC MATHEMATICAL TAILED YEH
+	{runeRange{0x1EE4D, 0x1EE4F}, wbprALetter},              // Lo   [3] ARABIC MATHEMATICAL TAILED NOON..ARABIC MATHEMATICAL TAILED AIN
+	{runeRange{0x1EE54, 0x1EE54}, wbprALetter},              // Lo       ARABIC MATHEMATICAL TAILED SHEEN
+	{runeRange{0x1EE59, 0x1EE59}, wbprALetter},              // Lo       ARABIC MATHEMATICAL TAILED DAD
+	{runeRange{0x1EE5D, 0x1EE5D}, wbprALetter},              // Lo       ARABIC MATHEMATICAL TAILED DOTLESS NOON
+	{runeRange{0x1EE61, 0x1EE62}, wbprALetter},              // Lo   [2] ARABIC MATHEMATICAL STRETCHED BEH..ARABIC MATHEMATICAL STRETCHED JEEM
+	{runeRange{0x1EE67, 0x1EE6A}, wbprALetter},              // Lo   [4] ARABIC MATHEMATICAL STRETCHED HAH..ARABIC MATHEMATICAL STRETCHED KAF
+	{runeRange{0x1EE74, 0x1EE77}, wbprALetter},              // Lo   [4] ARABIC MATHEMATICAL STRETCHED SHEEN..ARABIC MATHEMATICAL STRETCHED KHAH
+	{runeRange{0x1EE7E, 0x1EE7E}, wbprALetter},              // Lo       ARABIC MATHEMATICAL STRETCHED DOTLESS FEH
+	{runeRange{0x1EE8B, 0x1EE9B}, wbprALetter},              // Lo  [17] ARABIC MATHEMATICAL LOOPED LAM..ARABIC MATHEMATICAL LOOPED GHAIN
+	{runeRange{0x1EEA5, 0x1EEA9}, wbprALetter},              // Lo   [5] ARABIC MATHEMATICAL DOUBLE-STRUCK WAW..ARABIC MATHEMATICAL DOUBLE-STRUCK YEH
+	{runeRange{0x1F000, 0x1F003}, wbprExtendedPictographic}, // E0.0   [4] (🀀..🀃)    MAHJONG TILE EAST WIND..MAHJONG TILE NORTH WIND
+	{runeRange{0x1F005, 0x1F0CE}, wbprExtendedPictographic}, // E0.0 [202] (🀅..🃎)    MAHJONG TILE GREEN DRAGON..PLAYING CARD KING OF DIAMONDS
+	{runeRange{0x1F0D0, 0x1F0FF}, wbprExtendedPictographic}, // E0.0  [48] (🃐..🃿)    <reserved-1F0D0>..<reserved-1F0FF>
+	{runeRange{0x1F12F, 0x1F12F}, wbprExtendedPictographic}, // E0.0   [1] (🄯)       COPYLEFT SYMBOL
+	{runeRange{0x1F150, 0x1F169}, wbprALetter},              // So  [26] NEGATIVE CIRCLED LATIN CAPITAL LETTER A..NEGATIVE CIRCLED LATIN CAPITAL LETTER Z
+	{runeRange{0x1F170, 0x1F189}, wbprALetter},              // So  [26] NEGATIVE SQUARED LATIN CAPITAL LETTER A..NEGATIVE SQUARED LATIN CAPITAL LETTER Z
+	{runeRange{0x1F17E, 0x1F17F}, wbprExtendedPictographic}, // E0.6   [2] (🅾️..🅿️)    O button (blood type)..P button
+	{runeRange{0x1F191, 0x1F19A}, wbprExtendedPictographic}, // E0.6  [10] (🆑..🆚)    CL button..VS button
+	{runeRange{0x1F1E6, 0x1F1FF}, wbprRegionalIndicator},    // So  [26] REGIONAL INDICATOR SYMBOL LETTER A..REGIONAL INDICATOR SYMBOL LETTER Z
+	{runeRange{0x1F203, 0x1F20F}, wbprExtendedPictographic}, // E0.0  [13] (🈃..🈏)    <reserved-1F203>..<reserved-1F20F>
+	{runeRange{0x1F22F, 0x1F22F}, wbprExtendedPictographic}, // E0.6   [1] (🈯)       Japanese “reserved” button
+	{runeRange{0x1F23C, 0x1F23F}, wbprExtendedPictographic}, // E0.0   [4] (🈼..🈿)    <reserved-1F23C>..<reserved-1F23F>
+	{runeRange{0x1F250, 0x1F251}, wbprExtendedPictographic}, // E0.6   [2] (🉐..🉑)    Japanese “bargain” button..Japanese “acceptable” button
+	{runeRange{0x1F300, 0x1F30C}, wbprExtendedPictographic}, // E0.6  [13] (🌀..🌌)    cyclone..milky way
+	{runeRange{0x1F30F, 0x1F30F}, wbprExtendedPictographic}, // E0.6   [1] (🌏)       globe showing Asia-Australia
+	{runeRange{0x1F311, 0x1F311}, wbprExtendedPictographic}, // E0.6   [1] (🌑)       new moon
+	{runeRange{0x1F313, 0x1F315}, wbprExtendedPictographic}, // E0.6   [3] (🌓..🌕)    first quarter moon..full moon
+	{runeRange{0x1F319, 0x1F319}, wbprExtendedPictographic}, // E0.6   [1] (🌙)       crescent moon
+	{runeRange{0x1F31B, 0x1F31B}, wbprExtendedPictographic}, // E0.6   [1] (🌛)       first quarter moon face
+	{runeRange{0x1F31D, 0x1F31E}, wbprExtendedPictographic}, // E1.0   [2] (🌝..🌞)    full moon face..sun with face
+	{runeRange{0x1F321, 0x1F321}, wbprExtendedPictographic}, // E0.7   [1] (🌡️)       thermometer
+	{runeRange{0x1F324, 0x1F32C}, wbprExtendedPictographic}, // E0.7   [9] (🌤️..🌬️)    sun behind small cloud..wind face
+	{runeRange{0x1F330, 0x1F331}, wbprExtendedPictographic}, // E0.6   [2] (🌰..🌱)    chestnut..seedling
+	{runeRange{0x1F334, 0x1F335}, wbprExtendedPictographic}, // E0.6   [2] (🌴..🌵)    palm tree..cactus
+	{runeRange{0x1F337, 0x1F34A}, wbprExtendedPictographic}, // E0.6  [20] (🌷..🍊)    tulip..tangerine
+	{runeRange{0x1F34C, 0x1F34F}, wbprExtendedPictographic}, // E0.6   [4] (🍌..🍏)    banana..green apple
+	{runeRange{0x1F351, 0x1F37B}, wbprExtendedPictographic}, // E0.6  [43] (🍑..🍻)    peach..clinking beer mugs
+	{runeRange{0x1F37D, 0x1F37D}, wbprExtendedPictographic}, // E0.7   [1] (🍽️)       fork and knife with plate
+	{runeRange{0x1F380, 0x1F393}, wbprExtendedPictographic}, // E0.6  [20] (🎀..🎓)    ribbon..graduation cap
+	{runeRange{0x1F396, 0x1F397}, wbprExtendedPictographic}, // E0.7   [2] (🎖️..🎗️)    military medal..reminder ribbon
+	{runeRange{0x1F399, 0x1F39B}, wbprExtendedPictographic}, // E0.7   [3] (🎙️..🎛️)    studio microphone..control knobs
+	{runeRange{0x1F39E, 0x1F39F}, wbprExtendedPictographic}, // E0.7   [2] (🎞️..🎟️)    film frames..admission tickets
+	{runeRange{0x1F3C5, 0x1F3C5}, wbprExtendedPictographic}, // E1.0   [1] (🏅)       sports medal
+	{runeRange{0x1F3C7, 0x1F3C7}, wbprExtendedPictographic}, // E1.0   [1] (🏇)       horse racing
+	{runeRange{0x1F3C9, 0x1F3C9}, wbprExtendedPictographic}, // E1.0   [1] (🏉)       rugby football
+	{runeRange{0x1F3CB, 0x1F3CE}, wbprExtendedPictographic}, // E0.7   [4] (🏋️..🏎️)    person lifting weights..racing car
+	{runeRange{0x1F3D4, 0x1F3DF}, wbprExtendedPictographic}, // E0.7  [12] (🏔️..🏟️)    snow-capped mountain..stadium
+	{runeRange{0x1F3E4, 0x1F3E4}, wbprExtendedPictographic}, // E1.0   [1] (🏤)       post office
+	{runeRange{0x1F3F1, 0x1F3F2}, wbprExtendedPictographic}, // E0.0   [2] (🏱..🏲)    WHITE PENNANT..BLACK PENNANT
+	{runeRange{0x1F3F4, 0x1F3F4}, wbprExtendedPictographic}, // E1.0   [1] (🏴)       black flag
+	{runeRange{0x1F3F6, 0x1F3F6}, wbprExtendedPictographic}, // E0.0   [1] (🏶)       BLACK ROSETTE
+	{runeRange{0x1F3F8, 0x1F3FA}, wbprExtendedPictographic}, // E1.0   [3] (🏸..🏺)    badminton..amphora
+	{runeRange{0x1F400, 0x1F407}, wbprExtendedPictographic}, // E1.0   [8] (🐀..🐇)    rat..rabbit
+	{runeRange{0x1F409, 0x1F40B}, wbprExtendedPictographic}, // E1.0   [3] (🐉..🐋)    dragon..whale
+	{runeRange{0x1F40F, 0x1F410}, wbprExtendedPictographic}, // E1.0   [2] (🐏..🐐)    ram..goat
+	{runeRange{0x1F413, 0x1F413}, wbprExtendedPictographic}, // E1.0   [1] (🐓)       rooster
+	{runeRange{0x1F415, 0x1F415}, wbprExtendedPictographic}, // E0.7   [1] (🐕)       dog
+	{runeRange{0x1F417, 0x1F429}, wbprExtendedPictographic}, // E0.6  [19] (🐗..🐩)    boar..poodle
+	{runeRange{0x1F42B, 0x1F43E}, wbprExtendedPictographic}, // E0.6  [20] (🐫..🐾)    two-hump camel..paw prints
+	{runeRange{0x1F440, 0x1F440}, wbprExtendedPictographic}, // E0.6   [1] (👀)       eyes
+	{runeRange{0x1F442, 0x1F464}, wbprExtendedPictographic}, // E0.6  [35] (👂..👤)    ear..bust in silhouette
+	{runeRange{0x1F466, 0x1F46B}, wbprExtendedPictographic}, // E0.6   [6] (👦..👫)    boy..woman and man holding hands
+	{runeRange{0x1F46E, 0x1F4AC}, wbprExtendedPictographic}, // E0.6  [63] (👮..💬)    police officer..speech balloon
+	{runeRange{0x1F4AE, 0x1F4B5}, wbprExtendedPictographic}, // E0.6   [8] (💮..💵)    white flower..dollar banknote
+	{runeRange{0x1F4B8, 0x1F4EB}, wbprExtendedPictographic}, // E0.6  [52] (💸..📫)    money with wings..closed mailbox with raised flag
+	{runeRange{0x1F4EE, 0x1F4EE}, wbprExtendedPictographic}, // E0.6   [1] (📮)       postbox
+	{runeRange{0x1F4F0, 0x1F4F4}, wbprExtendedPictographic}, // E0.6   [5] (📰..📴)    newspaper..mobile phone off
+	{runeRange{0x1F4F6, 0x1F4F7}, wbprExtendedPictographic}, // E0.6   [2] (📶..📷)    antenna bars..camera
+	{runeRange{0x1F4F9, 0x1F4FC}, wbprExtendedPictographic}, // E0.6   [4] (📹..📼)    video camera..videocassette
+	{runeRange{0x1F4FE, 0x1F4FE}, wbprExtendedPictographic}, // E0.0   [1] (📾)       PORTABLE STEREO
+	{runeRange{0x1F503, 0x1F503}, wbprExtendedPictographic}, // E0.6   [1] (🔃)       clockwise vertical arrows
+	{runeRange{0x1F508, 0x1F508}, wbprExtendedPictographic}, // E0.7   [1] (🔈)       speaker low volume
+	{runeRange{0x1F50A, 0x1F514}, wbprExtendedPictographic}, // E0.6  [11] (🔊..🔔)    speaker high volume..bell
+	{runeRange{0x1F516, 0x1F52B}, wbprExtendedPictographic}, // E0.6  [22] (🔖..🔫)    bookmark..water pistol
+	{runeRange{0x1F52E, 0x1F53D}, wbprExtendedPictographic}, // E0.6  [16] (🔮..🔽)    crystal ball..downwards button
+	{runeRange{0x1F549, 0x1F54A}, wbprExtendedPictographic}, // E0.7   [2] (🕉️..🕊️)    om..dove
+	{runeRange{0x1F54F, 0x1F54F}, wbprExtendedPictographic}, // E0.0   [1] (🕏)       BOWL OF HYGIEIA
+	{runeRange{0x1F55C, 0x1F567}, wbprExtendedPictographic}, // E0.7  [12] (🕜..🕧)    one-thirty..twelve-thirty
+	{runeRange{0x1F56F, 0x1F570}, wbprExtendedPictographic}, // E0.7   [2] (🕯️..🕰️)    candle..mantelpiece clock
+	{runeRange{0x1F573, 0x1F579}, wbprExtendedPictographic}, // E0.7   [7] (🕳️..🕹️)    hole..joystick
+	{runeRange{0x1F57B, 0x1F586}, wbprExtendedPictographic}, // E0.0  [12] (🕻..🖆)    LEFT HAND TELEPHONE RECEIVER..PEN OVER STAMPED ENVELOPE
+	{runeRange{0x1F588, 0x1F589}, wbprExtendedPictographic}, // E0.0   [2] (🖈..🖉)    BLACK PUSHPIN..LOWER LEFT PENCIL
+	{runeRange{0x1F58E, 0x1F58F}, wbprExtendedPictographic}, // E0.0   [2] (🖎..🖏)    LEFT WRITING HAND..TURNED OK HAND SIGN
+	{runeRange{0x1F591, 0x1F594}, wbprExtendedPictographic}, // E0.0   [4] (🖑..🖔)    REVERSED RAISED HAND WITH FINGERS SPLAYED..REVERSED VICTORY HAND
+	{runeRange{0x1F597, 0x1F5A3}, wbprExtendedPictographic}, // E0.0  [13] (🖗..🖣)    WHITE DOWN POINTING LEFT HAND INDEX..BLACK DOWN POINTING BACKHAND INDEX
+	{runeRange{0x1F5A5, 0x1F5A5}, wbprExtendedPictographic}, // E0.7   [1] (🖥️)       desktop computer
+	{runeRange{0x1F5A8, 0x1F5A8}, wbprExtendedPictographic}, // E0.7   [1] (🖨️)       printer
+	{runeRange{0x1F5B1, 0x1F5B2}, wbprExtendedPictographic}, // E0.7   [2] (🖱️..🖲️)    computer mouse..trackball
+	{runeRange{0x1F5BC, 0x1F5BC}, wbprExtendedPictographic}, // E0.7   [1] (🖼️)       framed picture
+	{runeRange{0x1F5C2, 0x1F5C4}, wbprExtendedPictographic}, // E0.7   [3] (🗂️..🗄️)    card index dividers..file cabinet
+	{runeRange{0x1F5D1, 0x1F5D3}, wbprExtendedPictographic}, // E0.7   [3] (🗑️..🗓️)    wastebasket..spiral calendar
+	{runeRange{0x1F5DC, 0x1F5DE}, wbprExtendedPictographic}, // E0.7   [3] (🗜️..🗞️)    clamp..rolled-up newspaper
+	{runeRange{0x1F5E1, 0x1F5E1}, wbprExtendedPictographic}, // E0.7   [1] (🗡️)       dagger
+	{runeRange{0x1F5E3, 0x1F5E3}, wbprExtendedPictographic}, // E0.7   [1] (🗣️)       speaking head
+	{runeRange{0x1F5E8, 0x1F5E8}, wbprExtendedPictographic}, // E2.0   [1] (🗨️)       left speech bubble
+	{runeRange{0x1F5EF, 0x1F5EF}, wbprExtendedPictographic}, // E0.7   [1] (🗯️)       right anger bubble
+	{runeRange{0x1F5F3, 0x1F5F3}, wbprExtendedPictographic}, // E0.7   [1] (🗳️)       ballot box with ballot
+	{runeRange{0x1F5FA, 0x1F5FA}, wbprExtendedPictographic}, // E0.7   [1] (🗺️)       world map
+	{runeRange{0x1F600, 0x1F600}, wbprExtendedPictographic}, // E1.0   [1] (😀)       grinning face
+	{runeRange{0x1F607, 0x1F608}, wbprExtendedPictographic}, // E1.0   [2] (😇..😈)    smiling face with halo..smiling face with horns
+	{runeRange{0x1F60E, 0x1F60E}, wbprExtendedPictographic}, // E1.0   [1] (😎)       smiling face with sunglasses
+	{runeRange{0x1F610, 0x1F610}, wbprExtendedPictographic}, // E0.7   [1] (😐)       neutral face
+	{runeRange{0x1F612, 0x1F614}, wbprExtendedPictographic}, // E0.6   [3] (😒..😔)    unamused face..pensive face
+	{runeRange{0x1F616, 0x1F616}, wbprExtendedPictographic}, // E0.6   [1] (😖)       confounded face
 }


### PR DESCRIPTION
- https://algorithmica.org/en/eytzinger
- https://postd.cc/cache-friendly-binary-search/ (written in Japanese)
- http://bannalia.blogspot.com/2015/06/cache-friendly-binary-search.html
  - https://postd.cc/cache-friendly-binary-search/ (Japanese translation)
- https://speakerdeck.com/kampersanda/binary-search-with-modern-processors?slide=31

```
goos: darwin
goarch: arm64
pkg: github.com/shogo82148/uniseg
                           │  .old.txt   │              .new.txt               │
                           │   sec/op    │   sec/op     vs base                │
GraphemesClass-10            8.553µ ± 0%   8.233µ ± 0%   -3.74% (p=0.000 n=10)
GraphemesFunctionBytes-10    3.059µ ± 1%   2.621µ ± 0%  -14.32% (p=0.000 n=10)
GraphemesFunctionString-10   3.039µ ± 0%   2.621µ ± 0%  -13.74% (p=0.000 n=10)
LineFunctionBytes-10         2.817µ ± 0%   2.908µ ± 0%   +3.21% (p=0.000 n=10)
LineFunctionString-10        2.844µ ± 0%   2.903µ ± 0%   +2.09% (p=0.000 n=10)
SentenceFunctionBytes-10     2.038µ ± 0%   1.701µ ± 0%  -16.56% (p=0.000 n=10)
SentenceFunctionString-10    2.057µ ± 0%   1.704µ ± 0%  -17.19% (p=0.000 n=10)
StepBytes-10                 8.209µ ± 0%   7.651µ ± 0%   -6.79% (p=0.000 n=10)
StepString-10                8.149µ ± 1%   7.640µ ± 0%   -6.25% (p=0.000 n=10)
WordFunctionBytes-10         1.876µ ± 0%   1.762µ ± 0%   -6.05% (p=0.000 n=10)
WordFunctionString-10        1.876µ ± 0%   1.749µ ± 0%   -6.77% (p=0.000 n=10)
geomean                      3.366µ        3.094µ        -8.07%

                           │   .old.txt   │              .new.txt               │
                           │     B/op     │    B/op     vs base                 │
GraphemesClass-10            0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
GraphemesFunctionBytes-10    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
GraphemesFunctionString-10   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
LineFunctionBytes-10         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
LineFunctionString-10        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SentenceFunctionBytes-10     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SentenceFunctionString-10    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
StepBytes-10                 0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
StepString-10                0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
WordFunctionBytes-10         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
WordFunctionString-10        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                 ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                           │   .old.txt   │              .new.txt               │
                           │  allocs/op   │ allocs/op   vs base                 │
GraphemesClass-10            0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
GraphemesFunctionBytes-10    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
GraphemesFunctionString-10   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
LineFunctionBytes-10         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
LineFunctionString-10        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SentenceFunctionBytes-10     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
SentenceFunctionString-10    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
StepBytes-10                 0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
StepString-10                0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
WordFunctionBytes-10         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
WordFunctionString-10        0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                 ²               +0.00%                ²
```