### PR TITLE
add Go 1.25 to the build matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,9 @@ jobs:
           - windows-latest
           - macos-latest
         go:
+          - "1.25"
+          - "1.24"
+          - "1.23"
           - "1.22"
           - "1.21"
           - "1.20"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * CI test matrix expanded to include Go 1.23, 1.24, and 1.25 across Linux, Windows, and macOS.
  * Enhances cross-platform and cross-version test coverage, improving confidence in compatibility with newer Go runtimes.
  * Helps surface version-specific regressions earlier without affecting runtime behavior of the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->